### PR TITLE
feat: enable vc service apikey

### DIFF
--- a/packages/services/src/epcisEvents/aggregationEvent.ts
+++ b/packages/services/src/epcisEvents/aggregationEvent.ts
@@ -1,13 +1,13 @@
 import { VerifiableCredential } from '@vckit/core-types';
-import { issueVC } from '../vckit.service.js';
-import { getStorageServiceLink } from '../storage.service.js';
-import { LinkType, getLinkResolverIdentifier, registerLinkResolver } from '../linkResolver.service.js';
-import { IService } from '../types/IService.js';
-import { ITraceabilityEvent, IAggregationEventContext } from './types.js';
-import { generateUUID } from '../utils/helpers.js';
-import { validateAggregationEventContext } from './validateContext.js';
-import { EPCISBusinessStepCode, EPCISEventAction, EPCISEventDisposition, EPCISEventType } from '../types/epcis.js';
 import JSONPointer from 'jsonpointer';
+import { LinkType, getLinkResolverIdentifier, registerLinkResolver } from '../linkResolver.service.js';
+import { getStorageServiceLink } from '../storage.service.js';
+import { EPCISBusinessStepCode, EPCISEventAction, EPCISEventDisposition, EPCISEventType } from '../types/epcis.js';
+import { IService } from '../types/IService.js';
+import { generateUUID } from '../utils/helpers.js';
+import { issueVC } from '../vckit.service.js';
+import { IAggregationEventContext, ITraceabilityEvent } from './types.js';
+import { validateAggregationEventContext } from './validateContext.js';
 
 export const processAggregationEvent: IService = async (
   aggregationEvent: ITraceabilityEvent,
@@ -41,6 +41,7 @@ export const processAggregationEvent: IService = async (
   const aggregationVC = await issueVC({
     credentialSubject,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    vcKitAPIKey: vckit?.vckitAPIKey,
     issuer: vckit.issuer,
     context: epcisAggregationEvent.context,
     type: epcisAggregationEvent.type,

--- a/packages/services/src/epcisEvents/transactionEvent.ts
+++ b/packages/services/src/epcisEvents/transactionEvent.ts
@@ -1,13 +1,13 @@
 import { VerifiableCredential } from '@vckit/core-types';
-import { IService } from '../types/index.js';
-import { issueVC } from '../vckit.service.js';
-import { ITraceabilityEvent, ITransactionEventContext } from './types.js';
-import { getStorageServiceLink } from '../storage.service.js';
-import { generateUUID } from '../utils/helpers.js';
-import { LinkType, getLinkResolverIdentifier, registerLinkResolver } from '../linkResolver.service.js';
-import { validateTransactionEventContext } from './validateContext.js';
 import JSONPointer from 'jsonpointer';
+import { LinkType, getLinkResolverIdentifier, registerLinkResolver } from '../linkResolver.service.js';
+import { getStorageServiceLink } from '../storage.service.js';
+import { IService } from '../types/index.js';
+import { generateUUID } from '../utils/helpers.js';
+import { issueVC } from '../vckit.service.js';
 import { deleteValuesFromLocalStorageByKeyPath } from './helpers.js';
+import { ITraceabilityEvent, ITransactionEventContext } from './types.js';
+import { validateTransactionEventContext } from './validateContext.js';
 
 export const processTransactionEvent: IService = async (
   transactionEvent: ITraceabilityEvent,
@@ -29,6 +29,7 @@ export const processTransactionEvent: IService = async (
   const vc: VerifiableCredential = await issueVC({
     credentialSubject: transactionEvent.data,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    vcKitAPIKey: vckit?.vckitAPIKey,
     issuer: vckit.issuer,
     context: epcisTransactionEvent.context,
     type: epcisTransactionEvent.type,

--- a/packages/services/src/epcisEvents/transformationEvent.ts
+++ b/packages/services/src/epcisEvents/transformationEvent.ts
@@ -1,17 +1,17 @@
 import { VerifiableCredential } from '@vckit/core-types';
-import _ from 'lodash';
 
-import { issueVC } from '../vckit.service.js';
-import { getStorageServiceLink } from '../storage.service.js';
 import {
   IdentificationKeyType,
   LinkType,
   getLinkResolverIdentifier,
   registerLinkResolver,
 } from '../linkResolver.service.js';
+import { getStorageServiceLink } from '../storage.service.js';
+import { issueVC } from '../vckit.service.js';
 
+import JSONPointer from 'jsonpointer';
 import { IService } from '../types/IService.js';
-import { IConfigDLR, ICredential, IEntityIssue, ITransformationEvent, IVCKitContext } from './types';
+import { StorageServiceConfig } from '../types/storage.js';
 import {
   IConstructObjectParameters,
   allowedIndexKeys,
@@ -21,9 +21,8 @@ import {
   randomIntegerString,
 } from '../utils/helpers.js';
 import { generateIdWithBatchLot, generateLinkResolver } from './helpers.js';
+import { IConfigDLR, ICredential, IEntityIssue, ITransformationEvent, IVCKitContext } from './types';
 import { validateContextTransformationEvent } from './validateContext.js';
-import { StorageServiceConfig } from '../types/storage.js';
-import JSONPointer from 'jsonpointer';
 
 /**
  * Process transformation event, issue epcis transformation event and dpp for each identifiers, then upload to storage and register link resolver for each dpp
@@ -156,6 +155,7 @@ export const issueEpcisTransformationEvent = async (
     issuer: vcKitContext.issuer,
     type: [...epcisTransformationEvent.type],
     vcKitAPIUrl: vcKitContext.vckitAPIUrl,
+    vcKitAPIKey: vcKitContext?.vckitAPIKey,
     restOfVC,
   });
 
@@ -198,6 +198,7 @@ export const issueDPP = async (
     issuer: vcKitContext.issuer,
     type: dppContext.type,
     vcKitAPIUrl: vcKitContext.vckitAPIUrl,
+    vcKitAPIKey: vcKitContext?.vckitAPIKey,
     credentialSubject: dppCredentialSubject,
     restOfVC,
   });

--- a/packages/services/src/epcisEvents/types.ts
+++ b/packages/services/src/epcisEvents/types.ts
@@ -5,6 +5,7 @@ import { IConstructObjectParameters } from '../utils/helpers';
 export interface IVCKitContext {
   issuer: string;
   vckitAPIUrl: string;
+  vckitAPIKey?: string;
 }
 
 export interface ICredential {

--- a/packages/services/src/processDPP.service.ts
+++ b/packages/services/src/processDPP.service.ts
@@ -1,13 +1,13 @@
 import { VerifiableCredential } from '@vckit/core-types';
-import { IService } from './types/index.js';
 import { IContext } from './epcisEvents/types.js';
+import { IService } from './types/index.js';
 import { generateUUID } from './utils/helpers.js';
 
+import JSONPointer from 'jsonpointer';
+import { validateContextDPP } from './epcisEvents/validateContext.js';
+import { LinkType, getLinkResolverIdentifier, registerLinkResolver } from './linkResolver.service.js';
 import { getStorageServiceLink } from './storage.service.js';
 import { issueVC } from './vckit.service.js';
-import { LinkType, getLinkResolverIdentifier, registerLinkResolver } from './linkResolver.service.js';
-import { validateContextDPP } from './epcisEvents/validateContext.js';
-import JSONPointer from 'jsonpointer';
 
 /**
  * Process DPP, issue VC, upload to storage and register link resolver
@@ -35,6 +35,7 @@ export const processDPP: IService = async (data: any, context: IContext): Promis
       issuer: vckitContext.issuer,
       type: [...dppContext.type],
       vcKitAPIUrl: vckitContext.vckitAPIUrl,
+      vcKitAPIKey: vckitContext?.vckitAPIKey,
       restOfVC,
     });
 

--- a/packages/services/src/vckit.service.ts
+++ b/packages/services/src/vckit.service.ts
@@ -17,6 +17,7 @@ export interface IArgIssueVC {
 }
 export interface IVcKitIssueVC extends CredentialPayload {
   vcKitAPIUrl: string;
+  vcKitAPIKey?: string;
 }
 
 /**
@@ -26,7 +27,8 @@ export interface IVcKitIssueVC extends CredentialPayload {
  * @param issuer - issuer for the vc
  * @param credentialSubject - credential subject for the vc
  * @param restOfVC - rest of the vc
- * @param vcKitAPIUrl - api url for the vc
+ * @param vcKitAPIUrl - api url for the VC service
+ * @param vcKitAPIKey - api key for the VC service
  * @returns VerifiableCredential
  *
  * @example
@@ -35,7 +37,7 @@ export interface IVcKitIssueVC extends CredentialPayload {
  * const issuer = 'did:example:123';
  * const credentialSubject = { id: 'did:example:123', name: 'John Doe' };
  * const restOfVC = { render: {}};
- * const vc = await integrateVckitIssueVC({ context, type, issuer, credentialSubject, restOfVC, vcKitAPIUrl });
+ * const vc = await integrateVckitIssueVC({ context, type, issuer, credentialSubject, restOfVC, vcKitAPIUrl, vcKitAPIKey });
  */
 export const issueVC = async ({
   context,
@@ -44,9 +46,14 @@ export const issueVC = async ({
   credentialSubject,
   restOfVC,
   vcKitAPIUrl,
+  vcKitAPIKey,
 }: IVcKitIssueVC): Promise<VerifiableCredential> => {
   const body = constructCredentialObject({ context, type, issuer, credentialSubject, ...restOfVC });
-  const response = await publicAPI.post<VerifiableCredential>(`${vcKitAPIUrl}/credentials/issue`, body);
+  const response = await publicAPI.post<VerifiableCredential>(`${vcKitAPIUrl}/credentials/issue`, body, {
+    headers: {
+      ...vcKitAPIKey && { "Authorization": `Bearer ${vcKitAPIKey}` }
+    }
+  });
   return response;
 };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR adds support for API key authentication in the VC service. It includes the following changes:

1. Updates the `issueVC` function in `vckit.service.ts` to accept an optional `vcKitAPIKey` parameter.
2. Modifies the API request in `issueVC` to include the API key in the Authorization header when provided.
3. Updates the interfaces to include the optional `vcKitAPIKey` parameter.
4. Propagates the `vcKitAPIKey` parameter through the relevant service functions.


## Mobile & Desktop Screenshots/Recordings
<img width="1868" alt="Screenshot 2024-08-06 at 7 53 30 PM" src="https://github.com/user-attachments/assets/c43909a4-cce9-4f17-9898-241ae3d19c8c">
<img width="1883" alt="Screenshot 2024-08-06 at 7 52 39 PM" src="https://github.com/user-attachments/assets/6ba03b38-69f1-4152-8dc0-ef3f3951bb61">


## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed...
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed