### PR TITLE
feat: add storage service tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,10 +2,7 @@
   "root": true,
   // TODO: Enable linting for documentation folder
   "ignorePatterns": ["documentation"],
-  "plugins": [
-    "@typescript-eslint",
-    "prettier"
-  ],
+  "plugins": ["@typescript-eslint", "prettier"],
   "parser": "@typescript-eslint/parser",
   "extends": [
     "eslint:recommended",
@@ -15,11 +12,13 @@
   "parserOptions": {
     "project": [
       "./packages/tsconfig.settings.json",
-      "./packages/*/tsconfig.json"
-    ]
+       "./packages/*/tsconfig.json"
+      ]
   },
   "rules": {
     "no-console": "warn",
+    "prefer-rest-params": "warn",
+    "@typescript-eslint/ban-ts-comment": "warn",
     // Off for now, but we should enable this in the future
     "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",
@@ -32,9 +31,7 @@
   },
   "overrides": [
     {
-      "files": [
-        "*.js"
-      ],
+      "files": ["*.js"],
       "rules": {
         "@typescript-eslint/no-var-requires": "off"
       }

--- a/packages/vc-test-suite/README.md
+++ b/packages/vc-test-suite/README.md
@@ -9,6 +9,7 @@ yarn install
 ## Setup
 
 There are two parts of the test suite: `Render Template 2024` and `QR Link Encryption`. To add your implementation to this test suite you will need to add 2 endpoints to your implementation manifest in `config.ts`:
+
 - A Render Template 2024 endpoint in the `RenderTemplate2024` property.
 - An Encrypted QR Link in the `QrLinkEncrypted` property.
 
@@ -31,3 +32,11 @@ yarn test
 ### View the Report:
 
 Open the generated report HTML file in the reports folder to check the results.
+
+## Developer
+
+### Run package tests
+
+```bash
+yarn test:package
+```

--- a/packages/vc-test-suite/__tests__/helpers.test.ts
+++ b/packages/vc-test-suite/__tests__/helpers.test.ts
@@ -1,0 +1,71 @@
+import { buildPayload, buildUrl } from '../helpers';
+
+describe('buildUrl', () => {
+  it('should build a URL with additional parameters', () => {
+    const result = buildUrl('https://example.com', { param1: 'value1', param2: 'value2' });
+    expect(result).toBe('https://example.com/?param1=value1&param2=value2');
+  });
+
+  it('should throw an error for empty baseUrl', () => {
+    expect(() => buildUrl('', {})).toThrow('baseUrl must be a non-empty string.');
+  });
+
+  it('should throw an error for baseUrl without protocol', () => {
+    expect(() => buildUrl('example.com', { param: 'value' })).toThrow(
+      'baseUrl must be a valid URL, including the protocol (e.g., http:// or https://).',
+    );
+  });
+
+  it('should throw an error for invalid baseUrl', () => {
+    expect(() => buildUrl('not a url', {})).toThrow(
+      'baseUrl must be a valid URL, including the protocol (e.g., http:// or https://).',
+    );
+  });
+
+  it('should throw an error if additionalParams is not a plain object', () => {
+    expect(() => buildUrl('https://example.com', [])).toThrow('additionalParams must be a plain object.');
+  });
+
+  it('should handle various value types in additionalParams, including objects and arrays', () => {
+    const result = buildUrl('https://example.com', {
+      string: 'value',
+      number: 123,
+      boolean: true,
+      null: null,
+      undefined: undefined,
+      object: { key1: 'value1', key2: 2 },
+      array: [1, 'two', { three: 3 }],
+    });
+    expect(result).toBe(
+      'https://example.com/?string=value&number=123&boolean=true&null=null&undefined=undefined&object=%7B%22key1%22%3A%22value1%22%2C%22key2%22%3A2%7D&array=%5B1%2C%22two%22%2C%7B%22three%22%3A3%7D%5D',
+    );
+  });
+});
+
+describe('buildPayload', () => {
+  it('should merge two objects correctly', () => {
+    const result = buildPayload({ a: 1, b: 2 }, { c: 3, d: 4 });
+    expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it('should override additional payload with base payload', () => {
+    const result = buildPayload({ a: 1, b: 2 }, { b: 3, c: 4 });
+    expect(result).toEqual({ a: 1, b: 2, c: 4 });
+  });
+
+  it('should throw an error if basePayload is not a plain object', () => {
+    expect(() => buildPayload([] as any, {})).toThrow('basePayload must be a plain object and cannot be null.');
+  });
+
+  it('should throw an error if additionalPayload is not a plain object', () => {
+    expect(() => buildPayload({}, [] as any)).toThrow('additionalPayload must be a plain object and cannot be null.');
+  });
+
+  it('should throw an error if basePayload is null', () => {
+    expect(() => buildPayload(null as any, {})).toThrow('basePayload must be a plain object and cannot be null.');
+  });
+
+  it('should throw an error if additionalPayload is null', () => {
+    expect(() => buildPayload({}, null as any)).toThrow('additionalPayload must be a plain object and cannot be null.');
+  });
+});

--- a/packages/vc-test-suite/__tests__/storage.helper.test.ts
+++ b/packages/vc-test-suite/__tests__/storage.helper.test.ts
@@ -1,0 +1,53 @@
+import crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { decryptData, generateGUID } from '../tests/Storage/helper';
+
+jest.mock('uuid');
+jest.mock('crypto');
+
+describe('generateGUID', () => {
+  it('should return a GUID', () => {
+    const mockUUID = '123e4567-e89b-12d3-a456-426614174000';
+    (uuidv4 as jest.Mock).mockReturnValue(mockUUID);
+
+    const result = generateGUID();
+    expect(result).toBe(mockUUID);
+    expect(uuidv4).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('decryptData', () => {
+  const mockEncryptedData = {
+    cipherText: 'mockCipherText',
+    iv: 'mockIV',
+    tag: 'mockTag',
+  };
+  const mockKey = 'mockKey';
+  const mockDecrypted = 'decrypted data';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (crypto.createDecipheriv as jest.Mock).mockReturnValue({
+      setAuthTag: jest.fn(),
+      update: jest.fn().mockReturnValue('decrypted '),
+      final: jest.fn().mockReturnValue('data'),
+    });
+  });
+
+  it('should return decrypted data when given valid input', () => {
+    const result = decryptData(mockEncryptedData, mockKey);
+    expect(result).toBe(mockDecrypted);
+  });
+
+  it('should throw an error if decryption fails', () => {
+    (crypto.createDecipheriv as jest.Mock).mockReturnValue({
+      setAuthTag: jest.fn(),
+      update: jest.fn(),
+      final: jest.fn().mockImplementation(() => {
+        throw new Error('Decryption failed');
+      }),
+    });
+
+    expect(() => decryptData(mockEncryptedData, mockKey)).toThrow('Decryption failed');
+  });
+});

--- a/packages/vc-test-suite/config.ts
+++ b/packages/vc-test-suite/config.ts
@@ -11,5 +11,12 @@ export default {
       headers: {},
       method: 'POST',
     },
+    Storage: {
+      url: 'http://localhost:3334/v1/documents',
+      encryptionUrl: 'http://localhost:3334/v1/credentials',
+      headers: {},
+      additionalParams: {},
+      additionalPayload: { bucket: 'verifiable-credentials' },
+    },
   },
 };

--- a/packages/vc-test-suite/helpers.ts
+++ b/packages/vc-test-suite/helpers.ts
@@ -1,37 +1,112 @@
-export function reportRow(title, name, fn) {
+import { isPlainObject } from 'lodash';
+
+export function reportRow(title: string, name: string, fn: any) {
   it(title, async function () {
     // append test meta data to the it/test this.
+    // @ts-ignore
     this.test.cell = {
       columnId: name,
+      // @ts-ignore
       rowId: this.test.title,
     };
     // apply the test's this to the function that runs the test
     // eslint-disable-next-line prefer-rest-params
+    // @ts-ignore
     await fn.apply(this, arguments);
   });
 }
 
 export function setupMatrix(implementors: string[], columnLabel: string) {
   const summaries = new Set();
+  // @ts-ignore
   this.summary = summaries;
   // when the report sees a suite with report true it includes it
+  // @ts-ignore
   this.report = true;
   // this tells the reporter to use the matrix.hbs template to display the results
+  // @ts-ignore
   this.matrix = true;
   // this gives the names of the implementations that are being tested
+  // @ts-ignore
   this.implemented = implementors;
   // this gives the names of the implementations that are not being tested
+  // @ts-ignore
   this.notImplemented = [];
   // this will give the row label in the matrix
+  // @ts-ignore
   this.rowLabel = 'Test Name';
   // this is the column label in the matrix
+  // @ts-ignore
   this.columnLabel = columnLabel;
   //this is an array with items in the form {data: 'foo', detail: false, label: 'bar'}
-  const reportData = [];
+  const reportData: Record<string, any>[] = [];
   // reportData is displayed as code examples
+  // @ts-ignore
   this.reportData = reportData;
   // this is an array with items in the form {src: 'foo', meta: ['bar']}
   // the images will be displayed with the meta under them
-  const images = [];
+  const images: Record<string, any>[] = [];
+  // @ts-ignore
   this.images = images;
 }
+
+/**
+ * Builds a URL with additional query parameters.
+ * @param baseUrl - The base URL.
+ * @param additionalParams - Additional query parameters as key-value pairs.
+ * @returns The built URL as a string.
+ * @throws {Error} If baseUrl is not a valid URL or additionalParams is not a plain object.
+ */
+export const buildUrl = (baseUrl: string, additionalParams: Record<string, any>): string => {
+  // Validate baseUrl
+  if (typeof baseUrl !== 'string' || baseUrl.trim() === '') {
+    throw new Error('baseUrl must be a non-empty string.');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch (error) {
+    throw new Error('baseUrl must be a valid URL, including the protocol (e.g., http:// or https://).');
+  }
+
+  // Validate additionalParams
+  if (!isPlainObject(additionalParams)) {
+    throw new Error('additionalParams must be a plain object.');
+  }
+
+  // Add additional parameters
+  Object.entries(additionalParams).forEach(([key, value]) => {
+    let stringValue: string;
+    if (typeof value === 'object' && value !== null) {
+      stringValue = JSON.stringify(value);
+    } else {
+      stringValue = String(value);
+    }
+    url.searchParams.append(key, stringValue);
+  });
+
+  return url.toString();
+};
+
+/**
+ * Builds a payload by merging a base payload with additional payload.
+ * @param basePayload - The base payload object.
+ * @param additionalPayload - The additional payload object.
+ * @returns The merged payload object.
+ * @throws {Error} If either parameter is not a plain object or is null, with specific error messages for each.
+ */
+export const buildPayload = (
+  basePayload: Record<string, any>,
+  additionalPayload: Record<string, any>,
+): Record<string, any> => {
+  if (!isPlainObject(basePayload) || basePayload === null) {
+    throw new Error('basePayload must be a plain object and cannot be null.');
+  }
+
+  if (!isPlainObject(additionalPayload) || additionalPayload === null) {
+    throw new Error('additionalPayload must be a plain object and cannot be null.');
+  }
+
+  return { ...additionalPayload, ...basePayload };
+};

--- a/packages/vc-test-suite/httpService.ts
+++ b/packages/vc-test-suite/httpService.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 
 const defaultHeaders = {
   'Content-Type': 'application/json',
@@ -9,16 +9,6 @@ export const request = async (params: AxiosRequestConfig) => {
     headers: defaultHeaders,
   });
 
-  instance.interceptors.response.use(
-    (response: AxiosResponse) => {
-      return response;
-    },
-    (error) => {
-      return Promise.reject(error);
-    },
-  );
   const response = await instance.request(params);
-  if (response.status >= 200 && response.status < 300) {
-    return response.data;
-  }
+  return response;
 };

--- a/packages/vc-test-suite/jest.config.js
+++ b/packages/vc-test-suite/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/packages/vc-test-suite/package.json
+++ b/packages/vc-test-suite/package.json
@@ -13,7 +13,8 @@
     "url": "git+https://github.com/uncefact/tests-untp.git"
   },
   "scripts": {
-    "test": "mocha tests/ --reporter @digitalbazaar/mocha-w3c-interop-reporter --reporter-options reportDir=\"$PWD/reports\",respec=\"$PWD/respecConfig.json\",suiteLog='./suite.log',templateData=\"$PWD/reports/index.json\",title=\"VC test suite\" --timeout 15000 --preserve-symlinks"
+    "test": "mocha tests/ --reporter @digitalbazaar/mocha-w3c-interop-reporter --reporter-options reportDir=\"$PWD/reports\",respec=\"$PWD/respecConfig.json\",suiteLog='./suite.log',templateData=\"$PWD/reports/index.json\",title=\"VC test suite\" --timeout 15000 --preserve-symlinks",
+    "test:package": "jest"
   },
   "bugs": {
     "url": "https://github.com/uncefact/tests-untp/issues"

--- a/packages/vc-test-suite/tests/QrlinkEncrypted/qrlink-encrypted.test.ts
+++ b/packages/vc-test-suite/tests/QrlinkEncrypted/qrlink-encrypted.test.ts
@@ -1,9 +1,9 @@
-import chai from 'chai';
 import { decryptString } from '@govtechsg/oa-encryption';
-import { isURLEncoded, parseQRLink } from './helper';
-import { request } from '../../httpService';
-import { reportRow, setupMatrix } from '../../helpers';
+import chai from 'chai';
 import * as config from '../../config';
+import { reportRow, setupMatrix } from '../../helpers';
+import { request } from '../../httpService';
+import { isURLEncoded, parseQRLink } from './helper';
 
 const expect = chai.expect;
 
@@ -32,12 +32,12 @@ describe('QR Link Verification', function () {
   });
 
   reportRow('URI MUST be resolvable', config.default.implementationName, async function () {
-    const res = await request({
+    const { data } = await request({
       url: parsedLink.q.payload.uri,
       method,
     });
 
-    res.should.be.an('object');
+    data.should.be.an('object');
   });
 
   reportRow('Hash MUST exist and be a string', config.default.implementationName, function () {
@@ -65,16 +65,19 @@ describe('QR Link Verification', function () {
   });
 
   reportRow('Key MUST decrypt the encrypted credential', config.default.implementationName, async function () {
-    const res = await request({
+    const { data } = await request({
       url: parsedLink.q.payload.uri,
       method,
     });
+
     const stringifyVC = decryptString({
-      ...res.document,
+      ...data.document,
       key: parsedLink.q.payload.key,
       type: 'OPEN-ATTESTATION-TYPE-1',
     });
+
     const vc = JSON.parse(stringifyVC);
+
     expect(vc).to.be.an('object');
     vc.should.have.property('issuer');
     vc.should.have.property('credentialStatus');

--- a/packages/vc-test-suite/tests/RenderTemplate2024/render-template-2024.test.ts
+++ b/packages/vc-test-suite/tests/RenderTemplate2024/render-template-2024.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import assert from 'assert';
 import chai from 'chai';
+import * as config from '../../config';
 import { reportRow, setupMatrix } from '../../helpers';
 import { request } from '../../httpService';
-import * as config from '../../config';
 
 chai.should();
 
@@ -14,23 +14,25 @@ describe('RenderTemplate2024', function () {
   setupMatrix.call(this, [config.default.implementationName], 'Implementer');
 
   reportRow(
-    'should verify that each item in the documents array that is valid', config.default.implementationName,
+    'should verify that each item in the documents array that is valid',
+    config.default.implementationName,
     async () => {
       // Import the input data for the test from the specified JSON file.
       const input = require('./input/valid-request-payload-ok.json');
 
       // Send the input data to the service to get the rendered document response.
-      const result = await request({
+      const { data } = await request({
         method,
         url,
         data: input,
       });
 
-      result.should.eql({
+      data.should.eql({
         documents: [
           {
             type: 'RenderTemplate2024',
-            renderedTemplate: 'PHN0eWxlPkBtZWRpYSAobWluLXdpZHRoOiAxMDI0cHgpIHsubmFtZSB7Zm9udC13ZWlnaHQ6IGJvbGR9fTwvc3R5bGU+PHA+SmFuZSBEb2U8L3A+',
+            renderedTemplate:
+              'PHN0eWxlPkBtZWRpYSAobWluLXdpZHRoOiAxMDI0cHgpIHsubmFtZSB7Zm9udC13ZWlnaHQ6IGJvbGR9fTwvc3R5bGU+PHA+SmFuZSBEb2U8L3A+',
             name: 'template name',
           },
         ],
@@ -46,11 +48,13 @@ describe('RenderTemplate2024', function () {
       const input = require('./input/missing-credential-fail.json');
 
       // Send the input data to the service and expect it to fail.
-      await assert.rejects(request({
-        method,
-        url,
-        data: input,
-      }));
+      await assert.rejects(
+        request({
+          method,
+          url,
+          data: input,
+        }),
+      );
     },
   );
 
@@ -59,34 +63,39 @@ describe('RenderTemplate2024', function () {
     config.default.implementationName,
     async () => {
       // Send an empty payload to the service and expect it to fail.
-      await assert.rejects(request({
-        method,
-        url,
-        data: {},
-      }));
+      await assert.rejects(
+        request({
+          method,
+          url,
+          data: {},
+        }),
+      );
     },
   );
 
-  
-  reportRow("should verify that the 'name' field, if present, is a non-empty string", config.default.implementationName, async () => {
-    // Import the input data for the test from the specified JSON file.
-    const input = require('./input/name-field-empty-ok.json');
+  reportRow(
+    "should verify that the 'name' field, if present, is a non-empty string",
+    config.default.implementationName,
+    async () => {
+      // Import the input data for the test from the specified JSON file.
+      const input = require('./input/name-field-empty-ok.json');
 
-    // Send the input data to the service to get the rendered document response.
-    const result = await request({
-      method,
-      url,
-      data: input,
-    });
+      // Send the input data to the service to get the rendered document response.
+      const { data } = await request({
+        method,
+        url,
+        data: input,
+      });
 
-    // Verify each item in the returned documents array.
-    result.documents.forEach((document) => {
-      // Check that the name is a string.
-      document.name.should.be.a('string');
-      // Check that the name is not empty.
-      document.name.trim().should.not.equal('');
-    });
-  });
+      // Verify each item in the returned documents array.
+      data.documents.forEach((document) => {
+        // Check that the name is a string.
+        document.name.should.be.a('string');
+        // Check that the name is not empty.
+        document.name.trim().should.not.equal('');
+      });
+    },
+  );
 
   // TODO check grammar
   reportRow(
@@ -97,13 +106,13 @@ describe('RenderTemplate2024', function () {
       const input = require('./input/no-mediaQuery-in-renderMethod-ok.json');
 
       // Send the input data to the service to get the rendered document response.
-      const result = await request({
+      const { data } = await request({
         method,
         url,
         data: input,
       });
 
-      result.should.eql({
+      data.should.eql({
         documents: [
           {
             type: 'RenderTemplate2024',
@@ -122,19 +131,22 @@ describe('RenderTemplate2024', function () {
       const input = require('./input/additional-properties-ok.json');
 
       // Send the input data to the service to get the rendered document response.
-      const result = await request({
+      const { data } = await request({
         method,
         url,
         data: input,
       });
 
       // Verify each item in the returned documents array.
-      result.documents.forEach((document) => {
+      data.documents.forEach((document) => {
         // Check if the decoded renderedDocument matches the expected HTML with style.
-        JSON.stringify(document).should.equal(JSON.stringify({
-          "type": "RenderTemplate2024",
-          "renderedTemplate": "PHN0eWxlPkBtZWRpYSAobWluLXdpZHRoOiAxMDI0cHgpIHsubmFtZSB7Zm9udC13ZWlnaHQ6IGJvbGR9fTwvc3R5bGU+PHA+SmFuZSBEb2U8L3A+"
-        }));
+        JSON.stringify(document).should.equal(
+          JSON.stringify({
+            type: 'RenderTemplate2024',
+            renderedTemplate:
+              'PHN0eWxlPkBtZWRpYSAobWluLXdpZHRoOiAxMDI0cHgpIHsubmFtZSB7Zm9udC13ZWlnaHQ6IGJvbGR9fTwvc3R5bGU+PHA+SmFuZSBEb2U8L3A+',
+          }),
+        );
       });
     },
   );
@@ -147,11 +159,13 @@ describe('RenderTemplate2024', function () {
       const input = require('./input/missing-@context-fail.json');
 
       // Send the input data to the service and expect it to fail.
-      await assert.rejects(request({
-        method,
-        url,
-        data: input,
-      }));
+      await assert.rejects(
+        request({
+          method,
+          url,
+          data: input,
+        }),
+      );
     },
   );
 
@@ -163,11 +177,13 @@ describe('RenderTemplate2024', function () {
       const input = require('./input/missing-renderMethod-fail.json');
 
       // Send the input data to the service and expect it to fail.
-      await assert.rejects(request({
-        method,
-        url,
-        data: input,
-      }));
+      await assert.rejects(
+        request({
+          method,
+          url,
+          data: input,
+        }),
+      );
     },
   );
 });

--- a/packages/vc-test-suite/tests/Storage/helper.ts
+++ b/packages/vc-test-suite/tests/Storage/helper.ts
@@ -1,0 +1,30 @@
+import crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Generates a random GUID
+ * @returns {string} - Generated GUID
+ */
+export function generateGUID() {
+  return uuidv4();
+}
+
+interface EncryptedData {
+  cipherText: string;
+  iv: string;
+  tag: string;
+}
+
+/**
+ * Decrypts given data using AES-GCM
+ * @param {object} encryptedData - Object containing cipherText, IV, and tag
+ * @param {string} key - Decryption key
+ * @returns {string} - Decrypted data
+ */
+export function decryptData({ cipherText, iv, tag }: EncryptedData, key: string) {
+  const decipher = crypto.createDecipheriv('aes-256-gcm', Buffer.from(key, 'hex'), Buffer.from(iv, 'hex'));
+  decipher.setAuthTag(Buffer.from(tag, 'hex'));
+  let decrypted = decipher.update(cipherText, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}

--- a/packages/vc-test-suite/tests/Storage/storage.test.ts
+++ b/packages/vc-test-suite/tests/Storage/storage.test.ts
@@ -1,0 +1,274 @@
+import chai from 'chai';
+import config from '../../config';
+import { buildPayload, buildUrl, reportRow, setupMatrix } from '../../helpers';
+import { request } from '../../httpService';
+import { decryptData, generateGUID } from './helper';
+
+const expect = chai.expect;
+
+const storageConfig = config.testSuites.Storage;
+const { url, encryptionUrl, headers, additionalParams, additionalPayload } = storageConfig;
+
+describe('Storage Service', function () {
+  setupMatrix.call(this, [config.implementationName], 'Implementer');
+
+  reportRow('Store unencrypted credential and verify returned URI', config.implementationName, async () => {
+    const payload = buildPayload(
+      {
+        id: generateGUID(),
+        data: { test: 'Credential data' },
+      },
+      additionalPayload,
+    );
+
+    const response = await request({
+      url: buildUrl(url, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload,
+    });
+
+    expect(response.status).to.equal(201);
+    expect(response.data).to.have.property('uri');
+    expect(response.data.uri).to.be.a('string');
+
+    const fetchResponse = await request({
+      url: buildUrl(response.data.uri, additionalParams),
+      method: 'GET',
+      headers: headers,
+    });
+
+    expect(fetchResponse.status).to.equal(200);
+    expect(fetchResponse.data).to.deep.equal(payload.data);
+  });
+
+  reportRow('Handle GUID collision for unencrypted endpoint', config.implementationName, async () => {
+    const guid = generateGUID();
+    const payload1 = buildPayload(
+      {
+        id: guid,
+        data: 'First credential',
+      },
+      additionalPayload,
+    );
+    const payload2 = buildPayload(
+      {
+        id: guid,
+        data: 'Second credential',
+      },
+      additionalPayload,
+    );
+
+    const response1 = await request({
+      url: buildUrl(url, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload1,
+    });
+
+    expect(response1.status).to.equal(201);
+
+    const response2 = await request({
+      url: buildUrl(url, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload2,
+    });
+
+    expect(response2.status).to.equal(409);
+
+    const fetchResponse = await request({
+      url: buildUrl(response1.data.uri, additionalParams),
+      method: 'GET',
+      headers: headers,
+    });
+
+    expect(fetchResponse.status).to.equal(200);
+    expect(fetchResponse.data).to.deep.equal(payload1.data);
+  });
+
+  reportRow('Fetch unencrypted credential with public access', config.implementationName, async () => {
+    const payload = buildPayload(
+      {
+        id: generateGUID(),
+        data: { test: 'Fetch Credential Test' },
+      },
+      additionalPayload,
+    );
+
+    const storeResponse = await request({
+      url: buildUrl(url, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload,
+    });
+
+    expect(storeResponse.status).to.equal(201);
+    expect(storeResponse.data).to.have.property('uri');
+
+    const fetchResponse = await request({
+      url: buildUrl(storeResponse.data.uri, additionalParams),
+      method: 'GET',
+    });
+
+    expect(fetchResponse.status).to.equal(200);
+    expect(fetchResponse.data).to.deep.equal(payload.data);
+  });
+
+  reportRow('Encrypt, store, and verify data', config.implementationName, async () => {
+    const payload = buildPayload(
+      {
+        id: generateGUID(),
+        data: { test: 'Encryption Test Data' },
+      },
+      additionalPayload,
+    );
+
+    const response = await request({
+      url: buildUrl(encryptionUrl, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload,
+    });
+
+    expect(response.status).to.equal(201);
+    expect(response.data).to.have.property('uri');
+    expect(response.data).to.have.property('key');
+
+    const fetchResponse = await request({
+      url: buildUrl(response.data.uri, additionalParams),
+      method: 'GET',
+      headers: headers,
+    });
+
+    expect(fetchResponse.status).to.equal(200);
+    expect(fetchResponse.data).to.have.property('cipherText');
+    expect(fetchResponse.data).to.have.property('iv');
+    expect(fetchResponse.data).to.have.property('tag');
+    expect(fetchResponse.data).to.have.property('type');
+    expect(fetchResponse.data.type).to.equal('AES-GCM');
+
+    const decryptedData = JSON.parse(
+      decryptData(
+        {
+          cipherText: fetchResponse.data.cipherText,
+          iv: fetchResponse.data.iv,
+          tag: fetchResponse.data.tag,
+        },
+        response.data.key,
+      ),
+    );
+
+    expect(decryptedData).to.deep.equal(payload.data);
+  });
+
+  reportRow('Fetch encrypted credential with public access', config.implementationName, async () => {
+    const payload = buildPayload(
+      {
+        id: generateGUID(),
+        data: { test: 'Fetch and Decrypt Test Data' },
+      },
+      additionalPayload,
+    );
+
+    const storeResponse = await request({
+      url: buildUrl(encryptionUrl, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload,
+    });
+
+    expect(storeResponse.status).to.equal(201);
+    expect(storeResponse.data).to.have.property('uri');
+    expect(storeResponse.data).to.have.property('key');
+
+    const fetchResponse = await request({
+      url: buildUrl(storeResponse.data.uri, additionalParams),
+      method: 'GET',
+    });
+
+    expect(fetchResponse.status).to.equal(200);
+    expect(fetchResponse.data).to.have.property('cipherText');
+    expect(fetchResponse.data).to.have.property('iv');
+    expect(fetchResponse.data).to.have.property('tag');
+    expect(fetchResponse.data).to.have.property('type');
+    expect(fetchResponse.data.type).to.equal('AES-GCM');
+
+    const decryptedData = JSON.parse(
+      decryptData(
+        {
+          cipherText: fetchResponse.data.cipherText,
+          iv: fetchResponse.data.iv,
+          tag: fetchResponse.data.tag,
+        },
+        storeResponse.data.key,
+      ),
+    );
+
+    expect(decryptedData).to.deep.equal(payload.data);
+  });
+
+  reportRow('Handle GUID collision for encrypted endpoint', config.implementationName, async () => {
+    const guid = generateGUID();
+    const payload1 = buildPayload(
+      {
+        id: guid,
+        data: 'First encrypted credential',
+      },
+      additionalPayload,
+    );
+    const payload2 = buildPayload(
+      {
+        id: guid,
+        data: 'Second encrypted credential',
+      },
+      additionalPayload,
+    );
+
+    const response1 = await request({
+      url: buildUrl(encryptionUrl, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload1,
+    });
+
+    expect(response1.status).to.equal(201);
+    expect(response1.data).to.have.property('uri');
+    expect(response1.data).to.have.property('key');
+
+    const response2 = await request({
+      url: buildUrl(encryptionUrl, additionalParams),
+      method: 'POST',
+      headers: headers,
+      data: payload2,
+    });
+
+    expect(response2.status).to.equal(409);
+
+    const fetchResponse = await request({
+      url: buildUrl(response1.data.uri, additionalParams),
+      method: 'GET',
+      headers: headers,
+    });
+
+    expect(fetchResponse.status).to.equal(200);
+    expect(fetchResponse.data).to.have.property('cipherText');
+    expect(fetchResponse.data).to.have.property('iv');
+    expect(fetchResponse.data).to.have.property('tag');
+    expect(fetchResponse.data).to.have.property('type');
+    expect(fetchResponse.data.type).to.equal('AES-GCM');
+
+    const decryptedData = JSON.parse(
+      decryptData(
+        {
+          cipherText: fetchResponse.data.cipherText,
+          iv: fetchResponse.data.iv,
+          tag: fetchResponse.data.tag,
+        },
+        response1.data.key,
+      ),
+    );
+
+    expect(decryptedData).to.deep.equal(payload1.data);
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR adds storage service tests to the VC test suite. It includes new test cases for storing and retrieving both encrypted and unencrypted credentials, handling GUID collisions, and verifying public access to stored credentials.

## Mobile & Desktop Screenshots/Recordings
<img width="1762" alt="Screenshot 2024-08-09 at 12 31 57 PM" src="https://github.com/user-attachments/assets/7da847d3-3a61-4f29-a553-5761cad3b888">
<img width="1644" alt="Screenshot 2024-08-12 at 9 59 20 AM" src="https://github.com/user-attachments/assets/6dfcdeba-c148-4e8f-b3ce-f014755d3512">

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [x] 📜 README.md
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed