### PR TITLE
fix: update documentation start command

### DIFF
--- a/documentation/Dockerfile
+++ b/documentation/Dockerfile
@@ -13,15 +13,13 @@ COPY package.json yarn.lock ./
 
 RUN yarn install --frozen-lockfile
 
-# Build the documentation site
+# Copy the documentation site files
 COPY . .
-
-RUN yarn run build
 
 # Expose the port the documentation site will run on
 EXPOSE ${PORT}
 
-# Serve the documentation site
-CMD yarn serve --port $PORT --host 0.0.0.0
+# Start the documentation site
+CMD yarn start --port $PORT --host 0.0.0.0
 
 


### PR DESCRIPTION
## What type of PR is this?
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR addresses an issue with the documentation site setup in the Dockerfile. The changes aim to improve the development workflow when using `docker-compose up`. 

This PR accomplishes:
1. Fixes the documentation start command: Replaces `yarn serve` with `yarn start`.
2. Enables live updates: Allows developers to make changes to the documentation and see them reflected immediately within the container.
3. Resolves content display issue: Previously, mounting the documentation folder to propagate changes was overriding the build folder, resulting in no content being displayed. This PR corrects that problem.

These modifications ensure that:
- Developers can run `docker-compose up` and access a fully functional documentation site.
- Any changes made to the documentation are immediately reflected without requiring a rebuild.
- The site properly displays its content while still allowing for live updates.

## Mobile & Desktop Screenshots/Recordings
<img width="1644" alt="Screenshot 2024-08-14 at 4 16 29 PM" src="https://github.com/user-attachments/assets/c24808ee-081b-4fbe-9dd8-1aa84b8c5990">
<img width="1644" alt="Screenshot 2024-08-14 at 4 04 20 PM" src="https://github.com/user-attachments/assets/c092309f-f43c-4bc7-b5fd-24af3425ffe5">
<img width="1375" alt="Screenshot 2024-08-14 at 4 04 28 PM" src="https://github.com/user-attachments/assets/8c8d739d-36e2-4bb3-b310-120fcdb58db5">
<img width="1526" alt="Screenshot 2024-08-14 at 4 04 37 PM" src="https://github.com/user-attachments/assets/085e24cf-54c5-46bd-a929-72ebab1d2e60">
<img width="1644" alt="Screenshot 2024-08-14 at 4 05 39 PM" src="https://github.com/user-attachments/assets/50c2f255-97c9-4a06-90ac-ceb81d5c8c2d">
<img width="1375" alt="Screenshot 2024-08-14 at 4 05 43 PM" src="https://github.com/user-attachments/assets/d40b937d-9ef5-4a2c-ad8d-655f087f267e">
<img width="1526" alt="Screenshot 2024-08-14 at 4 05 48 PM" src="https://github.com/user-attachments/assets/5516226f-606b-4a02-8dc7-412ac67d19d7">

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
