### PR TITLE
docs: update vc docs url

### DIFF
--- a/documentation/docs/mock-apps/configuration/index.md
+++ b/documentation/docs/mock-apps/configuration/index.md
@@ -22,7 +22,7 @@ Most of the service endpoints in the example configuration are already set to us
 
 ### Updating the Issuer
 
-You will need to update the `issuer` property value (did:web) inside the `vckit` object. This should be set to the identifier you created using the Verifiable Credential Service.
+You will need to update the `issuer` property value (did:web) inside the `vckit` object. This should be set to the identifier you created using the [Verifiable Credential Service](/docs/mock-apps/dependent-services/verifiable-credential-service).
 
 For example:
 

--- a/documentation/docs/mock-apps/dependent-services/verifiable-credential-service.md
+++ b/documentation/docs/mock-apps/dependent-services/verifiable-credential-service.md
@@ -35,7 +35,7 @@ If you're setting up your own instance of the Verifiable Credential Service, ple
 
 ### VCKit Documentation
 
-Please go through the VCKit documentation available [here](https://github.com/uncefact/project-vckit#start-the-documentation-page) to understand how to set up and use VCKit.
+Please go through the VCKit documentation available [here](https://uncefact.github.io/project-vckit/) to understand how to set up and use VCKit.
 
 ### Requirements
 
@@ -51,6 +51,6 @@ Make sure you have these components set up and running, and note the API address
 
 Regardless of which setup option you chose, you'll need to create an identifier (did:web) within the Verifiable Credential Service. This identifier is crucial for the proper functioning of the system.
 
-To create an identifier, you'll need to use the VCKit API. Refer to the [VCKit documentation](https://github.com/uncefact/project-vckit#start-the-documentation-page) for specific instructions on how to create a did:web identifier using their API endpoints.
+To create an identifier, you'll need to use the VCKit API. Refer to the [VCKit documentation](https://uncefact.github.io/project-vckit/docs/get-started/api-server-get-started/basic-operations) for specific instructions on how to create a did:web identifier using their API endpoints.
 
 In the next section, we will discuss the Storage Service and its role in the UNTP ecosystem.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR updates the VCKit documentation URLs in the mock apps configuration and verifiable credential service pages. It replaces the old GitHub repository link with the new documentation site URL.

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed