### PR TITLE
fix: mock apps build

### DIFF
--- a/app-config.acrs.json
+++ b/app-config.acrs.json
@@ -710,8 +710,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:143f-2406-2d40-4106-2b10-38c6-9732-f2d9-bb1c.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -1193,8 +1196,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:143f-2406-2d40-4106-2b10-38c6-9732-f2d9-bb1c.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -1929,8 +1935,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:143f-2406-2d40-4106-2b10-38c6-9732-f2d9-bb1c.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -2413,8 +2422,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:143f-2406-2d40-4106-2b10-38c6-9732-f2d9-bb1c.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -2544,8 +2556,11 @@
                     "dlrQualifierPath": ""
                   },
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:143f-2406-2d40-4106-2b10-38c6-9732-f2d9-bb1c.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dlr": {
                     "dlrAPIUrl": "http://localhost:3000",

--- a/app-config.json
+++ b/app-config.json
@@ -704,7 +704,10 @@
                 {
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -893,7 +896,10 @@
                 {
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisObjectEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -1068,7 +1074,10 @@
                 {
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisAssociationEvent": {
                     "context": [
@@ -1287,7 +1296,10 @@
                 {
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "digitalIdentityAnchor": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -3014,7 +3026,10 @@
                 {
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "digitalConformityCredential": {
                     "context": [
@@ -4210,7 +4225,10 @@
                 {
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "digitalFacilityRecord": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -4683,7 +4701,10 @@
                 {
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -5434,8 +5455,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -5917,8 +5941,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -6669,8 +6696,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -7152,8 +7182,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -7904,8 +7937,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -8387,8 +8423,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],

--- a/app-config.seeding.json
+++ b/app-config.seeding.json
@@ -703,8 +703,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -1196,8 +1199,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -1948,8 +1954,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -2431,8 +2440,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -3183,8 +3195,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -3666,8 +3681,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],
@@ -4418,8 +4436,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -4901,8 +4922,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:9cb5-115-79-137-238.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],

--- a/app-config.truff.json
+++ b/app-config.truff.json
@@ -693,8 +693,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:143f-2406-2d40-4106-2b10-38c6-9732-f2d9-bb1c.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "dpp": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],
@@ -1174,8 +1177,11 @@
               "parameters": [
                 {
                   "vckit": {
-                    "vckitAPIUrl": "http://localhost:3332/v1",
-                    "issuer": "did:web:143f-2406-2d40-4106-2b10-38c6-9732-f2d9-bb1c.ngrok-free.app"
+                    "vckitAPIUrl": "http://localhost:3332/v2",
+                    "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                    "headers": {
+                      "Authorization": "Bearer test123"
+                    }
                   },
                   "epcisTransactionEvent": {
                     "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/transaction-event-ld.json"],

--- a/documentation/docs/mock-apps/common/vckit.md
+++ b/documentation/docs/mock-apps/common/vckit.md
@@ -13,7 +13,8 @@ The `VCkit` object contains configuration details for the [Verifiable Credential
 
 ## Definition
 
-| Property | Required | Description | Type |
-|----------|----------|-------------|------|
-| vckitAPIUrl | Yes | URL for the VCKit API | String |
-| issuer | Yes | Issuer identifier for the Verifiable Credential | String |
+| Property    | Required | Description                                                                       | Type   |
+| ----------- | -------- | --------------------------------------------------------------------------------- | ------ |
+| vckitAPIUrl | Yes      | URL for the VCKit API                                                             | String |
+| issuer      | Yes      | Issuer identifier for the Verifiable Credential                                   | String |
+| headers     | No       | Custom headers to be included in the request to the Verifiable Credential service | Object |

--- a/documentation/docs/mock-apps/configuration/service-config.md
+++ b/documentation/docs/mock-apps/configuration/service-config.md
@@ -45,7 +45,10 @@ graph TD
         {
           "vckit": {
             "vckitAPIUrl": "http://localhost:3332/v2",
-            "issuer": "did:web:example.com"
+            "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+            "headers": {
+              "Authorization": "Bearer test123"
+            }
           },
           "dpp": {
             "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],

--- a/documentation/docs/mock-apps/services/index.md
+++ b/documentation/docs/mock-apps/services/index.md
@@ -56,7 +56,10 @@ graph TD
         {
           "vckit": {
             "vckitAPIUrl": "http://localhost:3332/v2",
-            "issuer": "did:web:example.com"
+            "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+            "headers": {
+              "Authorization": "Bearer test123"
+            }
           },
           "dpp": {
             "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],

--- a/documentation/docs/mock-apps/services/process-aggregation-event.md
+++ b/documentation/docs/mock-apps/services/process-aggregation-event.md
@@ -40,8 +40,11 @@ P-->>C: Return VC and resolver URL
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "epcisAggregationEvent": {
         "context": ["https://www.w3.org/2018/credentials/v1", "https://gs1.org/voc/"],

--- a/documentation/docs/mock-apps/services/process-association-event.md
+++ b/documentation/docs/mock-apps/services/process-association-event.md
@@ -40,8 +40,11 @@ P-->>C: Return association event VC and resolver URL
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "epcisAssociationEvent": {
         "context": [

--- a/documentation/docs/mock-apps/services/process-digital-conformity-credential.md
+++ b/documentation/docs/mock-apps/services/process-digital-conformity-credential.md
@@ -40,8 +40,11 @@ P-->>C: Return digital conformity credential VC and resolver URL
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "digitalConformityCredential": {
         "context": [

--- a/documentation/docs/mock-apps/services/process-digital-facility-record.md
+++ b/documentation/docs/mock-apps/services/process-digital-facility-record.md
@@ -40,8 +40,11 @@ P-->>C: Return digital facility record VC and resolver URL
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "digitalFacilityRecord": {
         "context": ["https://www.w3.org/2018/credentials/v1", "https://gs1.org/voc/"],

--- a/documentation/docs/mock-apps/services/process-digital-identity-anchor.md
+++ b/documentation/docs/mock-apps/services/process-digital-identity-anchor.md
@@ -40,8 +40,11 @@ P-->>C: Return digital identity anchor VC and resolver URL
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "digitalIdentityAnchor": {
         "context": ["https://www.w3.org/2018/credentials/v1", "https://gs1.org/voc/"],

--- a/documentation/docs/mock-apps/services/process-dpp.md
+++ b/documentation/docs/mock-apps/services/process-dpp.md
@@ -58,7 +58,10 @@ P-->>C: Return VC and resolver URL
     {
       "vckit": {
         "vckitAPIUrl": "http://localhost:3332/v2",
-        "issuer": "did:web:example.com:steel-mill-1"
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "dpp": {
         "context": ["https://dpp-json-ld.s3.ap-southeast-2.amazonaws.com/dppld.json"],

--- a/documentation/docs/mock-apps/services/process-object-event.md
+++ b/documentation/docs/mock-apps/services/process-object-event.md
@@ -40,8 +40,11 @@ P-->>C: Return object event VC and resolver URL
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "epcisObjectEvent": {
         "context": ["https://www.w3.org/2018/credentials/v1", "https://gs1.org/voc/"],

--- a/documentation/docs/mock-apps/services/process-transaction-event.md
+++ b/documentation/docs/mock-apps/services/process-transaction-event.md
@@ -42,8 +42,11 @@ P-->>C: Return VC and resolver URL
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "epcisTransactionEvent": {
         "context": ["https://www.w3.org/2018/credentials/v1", "https://gs1.org/voc/"],

--- a/documentation/docs/mock-apps/services/process-transformation-event.md
+++ b/documentation/docs/mock-apps/services/process-transformation-event.md
@@ -47,8 +47,11 @@ P-->>C: Return EPCIS VC
   "parameters": [
     {
       "vckit": {
-        "vckitAPIUrl": "https://api.vckit.example.com",
-        "issuer": "did:example:123456789abcdefghi"
+        "vckitAPIUrl": "http://localhost:3332/v2",
+        "issuer": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "headers": {
+          "Authorization": "Bearer test123"
+        }
       },
       "epcisTransformationEvent": {
         "context": ["https://www.w3.org/2018/credentials/v1", "https://gs1.org/voc/"],

--- a/packages/services/src/__tests__/epcisEvents/associationEvent.test.ts
+++ b/packages/services/src/__tests__/epcisEvents/associationEvent.test.ts
@@ -191,4 +191,41 @@ describe('processAssociationEvent', () => {
       'Association event data not found',
     );
   });
+
+  it('should process association event with custom verifiable credential service headers', async () => {
+    const mockHeaders = { 'X-Custom-Header': 'test-value' };
+    const contextWithHeaders = {
+      ...context,
+      vckit: {
+        ...context.vckit,
+        headers: mockHeaders,
+      },
+    };
+
+    (vckitService.issueVC as jest.Mock).mockImplementation(() => ({
+      credentialSubject: { id: 'https://example.com/123' },
+    }));
+    (uploadData as jest.Mock).mockResolvedValue('https://exampleStorage.com/vc.json');
+
+    jest
+      .spyOn(validateContext, 'validateAssociationEventContext')
+      .mockReturnValueOnce({ ok: true, value: contextWithHeaders } as unknown as Result<IAssociationEventContext>);
+    jest
+      .spyOn(linkResolverService, 'getLinkResolverIdentifier')
+      .mockReturnValue({ identifier: '0123456789', qualifierPath: '/10/ABC123' });
+    jest.spyOn(linkResolverService, 'getLinkResolverIdentifierFromURI').mockReturnValueOnce({
+      identifier: '0105012345678900',
+      qualifierPath: '/21/951350380',
+      elementString: '010501234567890021951350380',
+    });
+    jest.spyOn(linkResolverService, 'registerLinkResolver').mockResolvedValue('https://example.com/link-resolver');
+
+    await processAssociationEvent(associationEvent, contextWithHeaders);
+
+    expect(vckitService.issueVC).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: mockHeaders,
+      }),
+    );
+  });
 });

--- a/packages/services/src/__tests__/epcisEvents/objectEvent.test.ts
+++ b/packages/services/src/__tests__/epcisEvents/objectEvent.test.ts
@@ -121,4 +121,41 @@ describe('processObjectEvent', () => {
       'Object event data not found',
     );
   });
+
+  it('should process object event with custom verifiable credential service headers', async () => {
+    const mockHeaders = { 'X-Custom-Header': 'test-value' };
+    const contextWithHeaders = {
+      ...context,
+      vckit: {
+        ...context.vckit,
+        headers: mockHeaders,
+      },
+    };
+
+    (vckitService.issueVC as jest.Mock).mockImplementation(() => ({
+      credentialSubject: { id: 'https://example.com/123' },
+    }));
+    (uploadData as jest.Mock).mockResolvedValue('https://exampleStorage.com/vc.json');
+
+    jest
+      .spyOn(validateContext, 'validateObjectEventContext')
+      .mockReturnValueOnce({ ok: true, value: contextWithHeaders } as unknown as Result<IObjectEventContext>);
+    jest
+      .spyOn(linkResolverService, 'getLinkResolverIdentifier')
+      .mockReturnValue({ identifier: '0123456789', qualifierPath: '/10/ABC123' });
+    jest.spyOn(linkResolverService, 'getLinkResolverIdentifierFromURI').mockReturnValueOnce({
+      identifier: '0123456789',
+      qualifierPath: '/10/ABC123',
+      elementString: '01012345678910ABC123',
+    });
+    jest.spyOn(linkResolverService, 'registerLinkResolver').mockResolvedValue('https://example.com/link-resolver');
+
+    await processObjectEvent(objectEvent, contextWithHeaders);
+
+    expect(vckitService.issueVC).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: mockHeaders,
+      }),
+    );
+  });
 });

--- a/packages/services/src/__tests__/processDigitalConformityCredential.test.ts
+++ b/packages/services/src/__tests__/processDigitalConformityCredential.test.ts
@@ -98,4 +98,39 @@ describe('processDigitalConformityCredential', () => {
       async () => await processDigitalConformityCredential(invalidDigitalConformityCredentialData, context),
     ).rejects.toThrow('digitalConformityCredential data not found');
   });
+
+  it('should process digital conformity credential with custom verifiable credential service headers', async () => {
+    const mockHeaders = { 'X-Custom-Header': 'test-value' };
+    const contextWithHeaders = {
+      ...context,
+      vckit: {
+        ...context.vckit,
+        headers: mockHeaders,
+      },
+    };
+
+    (vckitService.issueVC as jest.Mock).mockImplementation(() => ({
+      credentialSubject: { id: 'https://example.com/123' },
+    }));
+    (uploadData as jest.Mock).mockResolvedValue('https://exampleStorage.com/vc.json');
+
+    jest
+      .spyOn(validateContext, 'validateDigitalConformityCredentialContext')
+      .mockReturnValueOnce({
+        ok: true,
+        value: contextWithHeaders,
+      } as unknown as Result<IDigitalConformityCredentialContext>);
+    jest
+      .spyOn(linkResolverService, 'getLinkResolverIdentifier')
+      .mockReturnValue({ identifier: '0123456789', qualifierPath: '/' });
+    jest.spyOn(linkResolverService, 'registerLinkResolver').mockResolvedValue('https://example.com/link-resolver');
+
+    await processDigitalConformityCredential(digitalConformityCredentialData, contextWithHeaders);
+
+    expect(vckitService.issueVC).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: mockHeaders,
+      }),
+    );
+  });
 });

--- a/packages/services/src/__tests__/processDigitalIdentityAnchor.test.ts
+++ b/packages/services/src/__tests__/processDigitalIdentityAnchor.test.ts
@@ -98,4 +98,36 @@ describe('processDigitalIdentityAnchor', () => {
       'digitalIdentityAnchor data not found',
     );
   });
+
+  it('should process digital identity anchor with custom verifiable credential service headers', async () => {
+    const mockHeaders = { 'X-Custom-Header': 'test-value' };
+    const contextWithHeaders = {
+      ...context,
+      vckit: {
+        ...context.vckit,
+        headers: mockHeaders,
+      },
+    };
+
+    (vckitService.issueVC as jest.Mock).mockImplementation(() => ({
+      credentialSubject: { id: 'https://example.com/123' },
+    }));
+    (uploadData as jest.Mock).mockResolvedValue('https://exampleStorage.com/vc.json');
+
+    jest
+      .spyOn(validateContext, 'validateDigitalIdentityAnchorContext')
+      .mockReturnValueOnce({ ok: true, value: contextWithHeaders } as unknown as Result<IDigitalIdentityAnchorContext>);
+    jest
+      .spyOn(linkResolverService, 'getLinkResolverIdentifier')
+      .mockReturnValue({ identifier: '0123456789', qualifierPath: '/' });
+    jest.spyOn(linkResolverService, 'registerLinkResolver').mockResolvedValue('https://example.com/link-resolver');
+
+    await processDigitalIdentityAnchor(digitalIdentityAnchorData, contextWithHeaders);
+
+    expect(vckitService.issueVC).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: mockHeaders,
+      }),
+    );
+  });
 });

--- a/packages/services/src/epcisEvents/aggregationEvent.ts
+++ b/packages/services/src/epcisEvents/aggregationEvent.ts
@@ -40,6 +40,7 @@ export const processAggregationEvent: IService = async (
   const aggregationVC = await issueVC({
     credentialSubject,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    headers: vckit.headers,
     issuer: vckit.issuer,
     context: epcisAggregationEvent.context,
     type: epcisAggregationEvent.type,

--- a/packages/services/src/epcisEvents/associationEvent.ts
+++ b/packages/services/src/epcisEvents/associationEvent.ts
@@ -37,6 +37,7 @@ export const processAssociationEvent: IService = async (
   const associationEventVc: VerifiableCredential = await issueVC({
     credentialSubject: associationEvent.data,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    headers: vckit.headers,
     issuer: vckit.issuer,
     context: epcisAssociationEvent.context,
     type: epcisAssociationEvent.type,

--- a/packages/services/src/epcisEvents/objectEvent.ts
+++ b/packages/services/src/epcisEvents/objectEvent.ts
@@ -37,6 +37,7 @@ export const processObjectEvent: IService = async (
   const objectEventVc: VerifiableCredential = await issueVC({
     credentialSubject: objectEvent.data,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    headers: vckit.headers,
     issuer: vckit.issuer,
     context: epcisObjectEvent.context,
     type: epcisObjectEvent.type,

--- a/packages/services/src/epcisEvents/transactionEvent.ts
+++ b/packages/services/src/epcisEvents/transactionEvent.ts
@@ -27,6 +27,7 @@ export const processTransactionEvent: IService = async (
   const vc: VerifiableCredential = await issueVC({
     credentialSubject: transactionEvent.data,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    headers: vckit.headers,
     issuer: vckit.issuer,
     context: epcisTransactionEvent.context,
     type: epcisTransactionEvent.type,

--- a/packages/services/src/epcisEvents/transformationEvent.ts
+++ b/packages/services/src/epcisEvents/transformationEvent.ts
@@ -162,6 +162,7 @@ export const issueEpcisTransformationEvent = async (
     issuer: vcKitContext.issuer,
     type: [...epcisTransformationEvent.type],
     vcKitAPIUrl: vcKitContext.vckitAPIUrl,
+    headers: vcKitContext.headers,
     restOfVC,
   });
 
@@ -204,6 +205,7 @@ export const issueDPP = async (
     issuer: vcKitContext.issuer,
     type: dppContext.type,
     vcKitAPIUrl: vcKitContext.vckitAPIUrl,
+    headers: vcKitContext.headers,
     credentialSubject: dppCredentialSubject,
     restOfVC,
   });

--- a/packages/services/src/epcisEvents/transformationEvent.ts
+++ b/packages/services/src/epcisEvents/transformationEvent.ts
@@ -52,11 +52,7 @@ export const processTransformationEvent: IService = async (
     );
 
     const storageContext = context.storage;
-    const transformantionEventLink = await uploadVC(
-      generateUUID(),
-      epcisVc,
-      storageContext,
-    );
+    const transformantionEventLink = await uploadVC(generateUUID(), epcisVc, storageContext);
 
     const dppContext = context.dpp;
 

--- a/packages/services/src/processDPP.service.ts
+++ b/packages/services/src/processDPP.service.ts
@@ -34,6 +34,7 @@ export const processDPP: IService = async (data: any, context: IDppContext): Pro
       issuer: vckitContext.issuer,
       type: [...dppContext.type],
       vcKitAPIUrl: vckitContext.vckitAPIUrl,
+      headers: vckitContext.headers,
       restOfVC,
     });
 

--- a/packages/services/src/processDigitalConformityCredential.service.ts
+++ b/packages/services/src/processDigitalConformityCredential.service.ts
@@ -36,6 +36,7 @@ export const processDigitalConformityCredential: IService = async (
   const vc: VerifiableCredential = await issueVC({
     credentialSubject: digitalConformityCredentialData.data,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    headers: vckit.headers,
     issuer: vckit.issuer,
     context: digitalConformityCredential.context,
     type: digitalConformityCredential.type,

--- a/packages/services/src/processDigitalFacilityRecord.service.ts
+++ b/packages/services/src/processDigitalFacilityRecord.service.ts
@@ -36,6 +36,7 @@ export const processDigitalFacilityRecord: IService = async (
   const vc: VerifiableCredential = await issueVC({
     credentialSubject: digitalFacilityRecordData.data,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    headers: vckit.headers,
     issuer: vckit.issuer,
     context: digitalFacilityRecord.context,
     type: digitalFacilityRecord.type,

--- a/packages/services/src/processDigitalIdentityAnchor.service.ts
+++ b/packages/services/src/processDigitalIdentityAnchor.service.ts
@@ -36,6 +36,7 @@ export const processDigitalIdentityAnchor: IService = async (
   const vc: VerifiableCredential = await issueVC({
     credentialSubject: digitalIdentityAnchorData.data,
     vcKitAPIUrl: vckit.vckitAPIUrl,
+    headers: vckit.headers,
     issuer: vckit.issuer,
     context: digitalIdentityAnchor.context,
     type: digitalIdentityAnchor.type,

--- a/packages/services/src/types/types.ts
+++ b/packages/services/src/types/types.ts
@@ -33,6 +33,7 @@ export interface IVerifyURLPayload {
 export interface IVCKitContext {
   issuer: string;
   vckitAPIUrl: string;
+  headers?: Record<string, string>;
 }
 
 export interface ICredential {


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes the issue with the mock apps build. The root cause was identified as the absence of the app-config.json file within the mock-app/src/constants directory during the build process. This file is usually copied when running yarn start from the root, but a build is required first, leading to failure.

The issue has been traced to the VCkit service, where the config file is now being imported directly to retrieve the API key, deviating from the previous approach of passing the config via props in the mock app’s root component. This PR aims to align with the established pattern of accessing config properties via props.

The related documentation has also been updated to reflect the change, along with additional tests.


## Mobile & Desktop Screenshots/Recordings
<img width="1902" alt="Screenshot 2024-10-23 at 12 31 26 AM" src="https://github.com/user-attachments/assets/30d57307-3710-4a07-a696-ecc3f88589c6">
<img width="1657" alt="Screenshot 2024-10-23 at 12 51 52 AM" src="https://github.com/user-attachments/assets/74edb53e-5df9-420e-bb65-0f1edd5dc3e6">
<img width="1657" alt="Screenshot 2024-10-23 at 12 54 11 AM" src="https://github.com/user-attachments/assets/dfcb8797-fb72-46a9-a9e8-5e7a839688f2">


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🦖 Documentation Site
- [ ] 🙅 no documentation needed
