### PR TITLE
fix: update the getDlrPassport function to extract link resolver from `sustainabilityInfo` instead of `certificationInfo` link type

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
 
   mock-global-gs1-resolver-object-store:
     image: quay.io/minio/minio:RELEASE.2024-08-17T01-24-54Z-cpuv1
-    command: server /data --console-address ":9091"
+    command: server /data --console-address ":9090"
     ports:
       - '9001:9000'
       - '9091:9090'

--- a/packages/services/src/identityProviders/GS1Provider.ts
+++ b/packages/services/src/identityProviders/GS1Provider.ts
@@ -6,6 +6,7 @@ export enum GS1ServiceEnum {
   certificationInfo = 'voc/certificationInfo',
   verificationService = 'voc/verificationService',
   serviceInfo = 'voc/serviceInfo',
+  sustainabilityInfo = 'voc/sustainabilityInfo'
 }
 
 export class GS1Provider implements IdentityProviderStrategy {

--- a/packages/services/src/linkResolver.service.ts
+++ b/packages/services/src/linkResolver.service.ts
@@ -242,14 +242,14 @@ export const getDlrPassport = async <T>(dlrUrl: string): Promise<T | null> => {
 
   // Find certificate passports in the DLR data
   const certificatePassports = dlrData?.linkset?.find(
-    (linkSetItem: any) => linkSetItem[`${rootDlrDomain}/${GS1ServiceEnum.certificationInfo}`],
+    (linkSetItem: any) => linkSetItem[`${rootDlrDomain}/${GS1ServiceEnum.sustainabilityInfo}`],
   );
   if (!certificatePassports) {
     return null;
   }
 
   // Extract passport infos from certificate passports
-  const dlrPassports = certificatePassports[`${rootDlrDomain}/${GS1ServiceEnum.certificationInfo}`];
+  const dlrPassports = certificatePassports[`${rootDlrDomain}/${GS1ServiceEnum.sustainabilityInfo}`];
   if (!dlrPassports) {
     return null;
   }


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR updates the `getDlrPassport` function to extract the DPP link resolver from the `sustainabilityInfo` linkType instead of the `certificationInfo` linkType. This change ensures that the Scanning page can navigate to the correct DPP link resolver and the Verify page can successfully load and render the DPP template.

Additionally, it fixes the Mock GS1 MinIO console address on port 9090, allowing successful access to the Mock GS1 MinIO console.

## Related Tickets & Documents

https://github.com/gs-gs/fa-ag-trace/issues/800

## Mobile & Desktop Screenshots/Recordings

- Issue a new DPP:

<img width="1391" alt="image" src="https://github.com/user-attachments/assets/200e957c-630b-4885-9622-22c31be2da23">

--- 

- Scan the barcode and navigate to the Verify page:

https://github.com/user-attachments/assets/26b51f8e-504b-403f-929c-b83bdd69d979

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?


<!-- note: PRs with deleted sections will be marked invalid -->

