### PR TITLE
DPP Schema 0.5.1 proposal fixing constant value requirements 

### DIFF
--- a/packages/untp-test-suite/credentials/productPassport/DigitalLivestockPassport-decoded-invalid.json
+++ b/packages/untp-test-suite/credentials/productPassport/DigitalLivestockPassport-decoded-invalid.json
@@ -1,0 +1,226 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://gs-gs.github.io/aatp/assets/files/aatp-dlp-context-0.4.0-7ed6f0cf85aa7626c480bd85212de2e4.jsonld"
+    ],
+    "type": [
+        "DigitalLivestockPassport",
+        "VerifiableCredential"
+    ],
+    "issuer": {
+        "id": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "name": "Green Valley Cattle Co Pty Ltd"
+    },
+    "credentialSubject": {
+        "type": [
+            "BovineAnimal",
+            "Product"
+        ],
+        "id": "https://nlis.com.au/QBIX0987XBS01234",
+        "name": "Grass-fed Angus",
+        "registeredId": "QDBH0132XBS01234",
+        "countryOfProduction": "AU",
+        "idScheme": {
+            "type": [
+                "IdentifierScheme"
+            ],
+            "id": "https://nlis.com.au/",
+            "name": "National Livestock Identification System (NLIS)"
+        },
+        "productImage": {
+            "type": [
+                "Link"
+            ],
+            "linkURL": "https://imagedelivery.net/KrqWw3MfFI3Up2T0vHiP1g/c30d43f0-01a3-4e95-e83f-dfdbff154f00/public",
+            "linkName": "Angus Cattle Image",
+            "linkType": "https://test.uncefact.org/vocabulary/linkTypes/image"
+        },
+        "batchNumber": "Mob-2024-12",
+        "description": "Grass-fed Angus from Green Valley Station, certified organic, raised under carbon-neutral practices",
+        "productCategory": [
+            {
+                "type": [
+                    "Classification"
+                ],
+                "id": "https://unstats.un.org/unsd/classifications/Econ/cpc/02111",
+                "code": "02111",
+                "name": "Bovine animals, live",
+                "schemeID": "https://unstats.un.org/unsd/classifications/Econ/cpc",
+                "schemeName": "United Nations Central Product Classification (CPC), Version 2.1"
+            }
+        ],
+        "producedByParty": {
+            "type": [
+                "Identifier"
+            ],
+            "id": "https://idr.aatp.showthething.com/ato/abn/87654321012?linkType=ato:registryEntry",
+            "name": "Green Valley Cattle Co Pty Ltd",
+            "registeredId": "87654321012",
+            "idScheme": {
+                "type": [
+                    "IdentifierScheme"
+                ],
+                "id": "https://abr.business.gov.au",
+                "name": "ABN"
+            }
+        },
+        "producedAtFacility": {
+            "type": [
+                "Identifier"
+            ],
+            "id": "https://idr.aatp.showthething.com/dpird/pic/QBIX0987/?linkType=dpird:locationInfo",
+            "name": "Green Valley Station",
+            "registeredId": "QBIX0987",
+            "idScheme": {
+                "type": [
+                    "IdentifierScheme"
+                ],
+                "id": "https://daf.qld.gov.au/pic/",
+                "name": "Queensland Property Identification Code (PIC)"
+            }
+        },
+        "productionDate": "2024-01-15",
+        "granularityLevel": "item",
+        "characteristics": {
+            "type": [
+                "BovineCharcteristics"
+            ],
+            "sex": "M",
+            "sexCharacteristic": "SC",
+            "breed": [
+                "AA"
+            ],
+            "liveWeight": 450,
+            "fatScore": "3",
+            "muscleScore": "A",
+            "frameSize": "6",
+            "maturity": "early"
+        },
+        "healthTreatment": [
+            {
+                "type": [
+                    "HealthTreatment"
+                ],
+                "icarDiseaseCategory": "1",
+                "treatmentDate": "2024-02-15",
+                "productId": "https://portal.apvma.gov.au/pubcris/53973",
+                "productBatchId": "BT202312",
+                "productExpiry": "2025-12-31",
+                "productName": "Standard Vaccination Protocol",
+                "doseRate": {
+                    "type": [
+                        "Measure"
+                    ],
+                    "value": 5,
+                    "unit": "MLT"
+                },
+                "witholdingPeriod": 21
+            }
+        ],
+        "conformityClaim": [
+            {
+                "type": [
+                    "Claim",
+                    "Declaration"
+                ],
+                "id": "https://example-farm.com.au/livestock/QDBH0132XBS01234/claims/organic",
+                "assessmentDate": "2024-03-15",
+                "conformance": true,
+                "conformityTopic": "environment.biodiversity",
+                "conformityEvidence": {
+                    "type": [
+                        "SecureLink",
+                        "Link"
+                    ],
+                    "linkURL": "https://example-farm.com.au/certifications/2024/organic",
+                    "linkName": "Organic Certification",
+                    "linkType": "https://vocabulary.uncefact.org/linkTypes/dcc",
+                    "hashDigest": "a239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                    "hashMethod": "SHA-256",
+                    "encryptionMethod": "none"
+                }
+            },
+            {
+                "type": [
+                    "Claim",
+                    "Declaration"
+                ],
+                "id": "https://cibolabs.com.au/attestations/2024/eudr/gv-123456",
+                "assessmentDate": "2024-03-15",
+                "conformance": true,
+                "conformityTopic": "environment.deforestation",
+                "conformityEvidence": {
+                    "type": [
+                        "SecureLink",
+                        "Link"
+                    ],
+                    "linkURL": "https://idr.aatp.showthething.com/dpird/pic/QBIX0987/?linkType=dpird:certificationInfo",
+                    "linkName": "EUDR Compliance Certificate",
+                    "linkType": "https://vocabulary.uncefact.org/linkTypes/dcc",
+                    "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                    "hashMethod": "SHA-256",
+                    "encryptionMethod": "none"
+                }
+            }
+        ],
+        "emissionsScorecard": {
+            "type": [
+                "EmissionsPerformance"
+            ],
+            "carbonFootprint": 12.5,
+            "declaredUnit": "KGM",
+            "operationalScope": "CradleToGate",
+            "primarySourcedRatio": 0.85,
+            "reportingStandard": {
+                "type": [
+                    "Standard"
+                ],
+                "id": "https://cer.gov.au/schemes/australian-carbon-credit-unit-scheme/accu-scheme-methods/beef-cattle-herd-management-method",
+                "name": "Beef Cattle Herd Management Method",
+                "issuingParty": {
+                    "type": [
+                        "Identifier"
+                    ],
+                    "id": "https://cer.gov.au",
+                    "name": "Clean Energy Regulator"
+                },
+                "issueDate": "2023-01-01"
+            }
+        },
+        "traceabilityInformation": {
+            "type": [
+                "TraceabilityPerformance"
+            ],
+            "valueChainProcess": "Breeding",
+            "verifiedRatio": 1,
+            "traceabilityEvent": [
+                {
+                    "type": [
+                        "SecureLink",
+                        "Link"
+                    ],
+                    "linkURL": "https://example-farm.com.au/livestock/QDBH0132XBS01234/events/birth",
+                    "linkName": "Birth Registration Event",
+                    "linkType": "https://vocabulary.uncefact.org/linkTypes/traceability-event",
+                    "hashDigest": "b239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                    "hashMethod": "SHA-256",
+                    "encryptionMethod": "AES"
+                }
+            ]
+        }
+    },
+    "credentialStatus": {
+        "id": "https://vckit.aatp.showthething.com/credentials/status/bitstring-status-list/1#77",
+        "type": "BitstringStatusListEntry",
+        "statusPurpose": "revocation",
+        "statusListIndex": 77,
+        "statusListCredential": "https://vckit.aatp.showthething.com/credentials/status/bitstring-status-list/1"
+    },
+    "id": "urn:uuid:4aebaeda-3bbf-469f-a70d-e949bc2c1405",
+    "render": [
+        {
+            "template": "<!DOCTYPE html> <html lang=\"en\"> <head> <meta charset=\"UTF-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> <link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap\" rel=\"stylesheet\"> <title>Digital Livestock Passport</title> <style> :root { --image-src: url('{{credentialSubject.productImage.linkURL}}'); --highlight: rgba(0, 99, 83, 1); --primary-colorsblue-400: rgba(79, 149, 221, 1); --primary-colorsblue-50: rgba(210, 229, 249, 1); --primary-colorsblue-10: rgba(247, 250, 253, 1); --white: rgba(255, 255, 255, 1); --black: rgba(0, 0, 0, 1); --primary-colorsgray-400: rgba(212, 214, 216, 1); --primary-colorsgray-600: rgba(85, 96, 110, 1); --primary-colorsblue-700: rgba(31, 90, 149, 1); --primary-colorsgray-700: rgba(35, 46, 61, 1); --accent-colorslight-green: rgba(184, 236, 182, 1); --text-color-green: rgba(8, 50, 0, 1); --accent-colorslight-red: rgba(255, 188, 183, 1); --text-color-red: rgba(50, 0, 0, 1); } * { margin: 0; padding: 0; box-sizing: border-box; } body { font-family: 'Lato', sans-serif; } section { padding: 0 16px 0 16px; } .section-title { font-size: 18px; font-weight: 700; line-height: 19.62px; color: #000000; } .section-description { margin-top: 12px; font-size: 16px; line-height: 18.88px; color: #000000; font-weight: 400; } .table { display: flex; flex-direction: column; justify-content: center; gap: 10px; } .table-item { display: grid; grid-template-columns: 1fr 2fr; column-gap: 16px; align-items: center; padding-bottom: 10px; border-bottom: 1px solid #d4d6d8; } .table-item span { font-size: 16px; font-weight: 400; line-height: 22px; color: var(--primary-colorsgray-600); } .table-item p, .table-item a, .table-item a:link { font-size: 16px; font-weight: 500; line-height: 22px; color: var(--primary-colorsgray-700); } .table-line { border-bottom: 1px solid #d4d6d8; } .item-title { display: flex; font-size: 16px; font-weight: 400; line-height: 17.44px; color: #55606E; text-transform: capitalize; } .item-value { display: flex; flex-direction: column; font-size: 16px; font-weight: 500; line-height: 17.44px; color: #232E3D; } .item-value a, .item-value span { color: #232E3D; } .annotation { display: flex; gap: 4px; font-size: 14px; font-weight: 400; line-height: 15.26px; color: #55606E; } .annotation span { padding-top: 2px; } .mobile { min-width: 150px; width: 100%; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; word-break: break-word; } .header { min-height: 320px; } .header-image { background: linear-gradient(248.36deg, rgba(0, 0, 0, 0.18) 7.6%, rgba(0, 0, 0, 0.6) 70.52%), var(--image-src); background-size: cover; background-position: center; min-height: 232px; position: relative; } .header-image-top-left { position: absolute; top: 25px; left: 15px; font-weight: 500; font-size: 16px; line-height: 22px; color: #ffffff; } .header-image-bottom-left { position: absolute; bottom: 18px; left: 15px; color: #ffffff; } .header-image-bottom-left h1 { font-size: 30px; font-weight: 900; line-height: 32.5px; } .header-batch { padding: 12px 16px 16px 16px; background-color: #F7FAFD; display: grid; grid-template-columns: 1.2fr 1fr; grid-auto-flow: row; row-gap: 12px; } .header-batch-item { display: flex; align-items: center; gap: 6px; } .header-batch-item a { color: #232E3D; font-size: 14px; line-height: 15.25px; font-weight: 500; } .header-batch a { padding: 0 2px; font-size: 14px; font-weight: 400; line-height: 19.25px; text-decoration: none; color: #000000; } .information { display: flex; flex-direction: column; gap: 8px; } .information-text { font-size: 19px; font-weight: 300; line-height: 22.42px; } .information-show-more { display: flex; flex-direction: column; gap: 10px; font-size: 14px; font-weight: 500; line-height: 22px; } .information-show-more a { color: var(--primary-colorsgray-700); } .passport { display: flex; flex-direction: column; gap: 24px; } .passport-header { display: flex; justify-content: space-between; align-items: center; } .passport-box { display: grid; grid-template-columns: 1fr 1fr; border: #D4D6D8 1px dotted; border-radius: 5px; overflow: hidden; } .passport-box-item { display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 12px 16px 12px 16px; border: #D4D6D8 1px dotted; outline-offset: -1px; min-height: 94px; color: #1F5A95; } .passport-box-item h3 { font-size: 40px; font-weight: 900; line-height: 43.33px; letter-spacing: 2px; } .passport-box-item p { margin-top: 8px; font-size: 15px; font-weight: 600; line-height: 18.88px; } .passport-box-item:last-child { background-color: #F7FAFD; } .passport-issued-by-header { display: flex; flex-direction: column; gap: 12px; } .passport-issued-by-header h3 { margin-top: 2px; font-size: 20px; font-weight: 700; line-height: 21.8px; } .passport-issued-by-header p { font-size: 16px; font-weight: 400; line-height: 19.25px; color: #55606E; } .passport-annotation { font-size: 14px; font-weight: 400; line-height: 15.26px; color: #55606E; } .traceability-cards { display: flex; flex-direction: column; gap: 12px; } .traceability-card { display: grid; grid-template-columns: 3fr 1fr; justify-content: space-between; align-items: center; min-height: 40px; text-decoration: none; } .traceability-card-text { display: flex; align-items: center; gap: 8px; font-size: 16px; font-weight: 400; line-height: 17.44px; color: #000000; } .traceability-card-view-details, .traceability-card-view-details:link { display: flex; justify-content: flex-end; align-items: center; gap: 8px; } .emission-score-card { display: flex; flex-direction: column; gap: 12px; } .mission-score-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .mission-score-description { font-size: 16px; font-weight: 400; line-height: 18.88px; color: #000000; } .score { display: flex; flex-direction: column; gap: 6px; } .score-unit { font-size: 40px; font-weight: 900; line-height: 43.33px; color: #1F5A95; letter-spacing: 2px; } .score-name { font-size: 16px; font-weight: 400; line-height: 17.44px; color: #55606E; } .declarations { display: flex; flex-direction: column; gap: 12px; } .declaration-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .cards-conformities { display: flex; flex-direction: column; gap: 8px; } .cards-conformity { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; width: 100%; padding: 16px 18px 16px 16px; position: relative; background-color: var(--white); border-radius: 4px; border: 1px solid; border-color: var(--primary-colorsgray-400); } .frame { display: flex; align-items: center; justify-content: space-between; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .div { display: inline-flex; align-items: center; gap: 4px; position: relative; flex: 0 0 auto; } .company-name { position: relative; width: fit-content; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .tags-VC-badge-red { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-red); color: var(--text-color-red); border-radius: 8px; overflow: hidden; } .tags-VC-badge-green { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-green); color: var(--text-color-green); border-radius: 8px; overflow: hidden; } .verifiable { width: fit-content; font-weight: 600; font-size: 14px; line-height: 15.3px; } .mobile .frame-2 { display: flex; flex-direction: column; align-items: center; gap: 4px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .text-wrapper { position: relative; align-self: stretch; margin-top: -1px; font-weight: 400; color: var(--primary-colorsblue-700); font-size: 18px; line-height: 21.2px; } .p { color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; align-self: stretch; font-weight: 400; color: #55606e; } .span { font-weight: 400; font-size: 14px; line-height: 19.2px; } .text-wrapper-2 { color: #55606e; } .frame-3 { display: inline-flex; flex-direction: column; align-items: flex-start; position: relative; flex: 0 0 auto; margin-right: -2px; border-bottom-width: 1px; border-bottom-style: solid; border-color: var(--white); } .frame-4 { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 4px; padding: 4px 0px; position: relative; flex: 0 0 auto; border-top-width: 1px; border-top-style: solid; border-color: var(--white); } .typography-heading { display: flex; align-items: center; justify-content: center; gap: 10px; } .heading { position: relative; flex: 1; font-weight: 400; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 17.4px; } .heading-2 { position: relative; flex: 1; margin-top: -0.5px; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .cards-traceability { display: flex; align-items: center; justify-content: space-between; padding: 8px 0px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; border-radius: 4px; text-decoration: none; } .history-information { display: flex; flex-direction: column; gap: 12px; } .history-value-chain-item { display: flex; flex-direction: column; gap: 8px; } .history-value-chain { display: flex; flex-direction: column; gap: 4px; } .history-value-chain p { font-size: 18px; font-weight: 400; line-height: 21.24px; color: #1F5A95; } .verified-ratio { background-color: #D2E5F9; width: fit-content; padding: 2px 4px; } .verified-ratio p { font-size: 14px; font-weight: 400; line-height: 19.25px; color: var(--black); } .frame-5 { display: inline-flex; align-items: center; gap: 8px; position: relative; flex: 0 0 auto; } .company-name-wrapper { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; position: relative; } .company-name-2 { color: var(--black); font-size: 16px; line-height: 17.4px; position: relative; align-self: stretch; font-weight: 400; } .img { position: relative; flex: 0 0 auto; margin-right: -1px; } .production { display: none; flex-direction: column; gap: 12px; } .production:has(.table-item) { display: flex; } .production-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .product-table, .product-table:link, .product-table:visited, .product-table:active { color: #232E3D; } .composition-box { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; } .composition-box-item { display: grid; grid-template-columns: 1fr auto; justify-content: space-between; border: 1px solid #d4d6d8; border-radius: 4px; padding: 16px; } .composition-percent { font-size: 16px; font-weight: 500; line-height: 21.92px; color: #000000; } .composition-title { font-size: 16px; font-weight: 600; line-height: 17.44px; color: #000000; } .composition-tag { display: flex; } .composition-tag-item { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #000000; background-color: #D2E5F9; padding: 2px 4px 2px 4px; margin-right: 4px; } .composition-box-first-column { display: grid; grid-template-columns: 40px 1fr; gap: 12px; } .composition-box-second-column { display: flex; flex-direction: column; gap: 6px; } .composition-box-second-column a { color: #232E3D; line-height: 22px; } .composition-box-third-column { display: flex; justify-content: end; gap: 12px; } .composition-box-third-column svg { margin: 1px 10px 0 0; } .passport-issued-by { display: flex; flex-direction: column; gap: 12px; } .history { display: flex; flex-direction: column; gap: 12px; } .history-event { display: flex; flex-direction: column; } .history-item { border-bottom: 1px solid #d4d6d8; padding: 10px 0 12px 0; display: grid; grid-template-columns: 1fr auto; gap: 16px; justify-content: space-between; } .history-item span { font-size: 16px; font-weight: 400; line-height: 17.44px; color: #000000; } .history-item a { font-size: 16px; font-weight: 500; line-height: 17.44px; color: var(--primary-colorsgray-700); text-decoration-color: #4f95dd; text-decoration-thickness: 2px; } .country-code { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #55606e; } .blue-bottom-line-thin, .blue-bottom-line-thin:link { border-bottom: 1px #4F95DD solid; width: fit-content; justify-content: flex-start; align-items: flex-start; gap: 10px; display: inline-flex; cursor: pointer; text-decoration: none; } .blue-bottom-line-thick, .blue-bottom-line-thick:link { width: fit-content; justify-content: flex-start; align-items: flex-start; gap: 10px; display: inline-flex; text-decoration-line: underline; text-decoration-thickness: 2px; text-decoration-color: #4F95DD; text-underline-offset: 3px; } .gray-bottom-line { border-bottom: 1px #55606E solid; width: fit-content; text-decoration: none; } .view-more-button { display: flex; justify-content: center; align-items: center; color: var(--primary-colorsblue-700); cursor: pointer; } footer { padding: 16px 16px 32px 16px; min-height: 60px; background-color: #F7FAFD; } footer p, footer a, footer a:link { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #232E3D; } </style> </head> <body> <div class=\"container\"> <!-- Mobile width 390px--> <div class=\"mobile\"> <header class=\"header\"> <div class=\"header-image\"> <p class=\"header-image-top-left\">PRODUCT PASSPORT</p> <div class=\"header-image-bottom-left\"> <h1>{{credentialSubject.name}}</h1> </div> </div> <div> <div class=\"header-batch\"> <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a href=\"{{credentialSubject.idScheme.id}}\" class=\"blue-bottom-line-thick\">ID: {{credentialSubject.registeredId}}</a> </div> <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a>Batch: {{credentialSubject.batchNumber}}</a> </div> </div> </div> </header> <section class=\"information\"> <div class=\"information-text\"> {{credentialSubject.description}} </div> <div class=\"information-show-more\"> {{#each credentialSubject.furtherInformation}} <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\">{{linkName}}</a> {{/each}} </div> </section> {{#if credentialSubject.characteristics}} <section class=\"production\"> <div class=\"production-title\">Characteristics</div> <div class=\"product-table table\"> <div class=\"table-item\"> <span class=\"item-title\">Sex</span> <p class=\"item-value\">{{credentialSubject.characteristics.sex}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Sex Characteristic</span> <p class=\"item-value\">{{credentialSubject.characteristics.sexCharacteristic}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Breed</span> <p class=\"item-value\"> {{#each credentialSubject.characteristics.breed}} {{this}}{{#unless @last}}, {{/unless}} {{/each}} </p> </div> <div class=\"table-item\"> <span class=\"item-title\">Live Weight</span> <p class=\"item-value\">{{credentialSubject.characteristics.liveWeight}} kg</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Carcass Weight</span> <p class=\"item-value\">{{credentialSubject.characteristics.carcassWeight}} kg</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Fat Score</span> <p class=\"item-value\">{{credentialSubject.characteristics.fatScore}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Muscle Score</span> <p class=\"item-value\">{{credentialSubject.characteristics.muscleScore}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Frame Size</span> <p class=\"item-value\">{{credentialSubject.characteristics.frameSize}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Maturity</span> <p class=\"item-value\">{{credentialSubject.characteristics.maturity}}</p> </div> </div> </section> {{/if}} <section class=\"production\"> <div class=\"production-title\">Production</div> <div class=\"product-table table\"> <div class=\"table-item\"> <span class=\"item-title\">Product category</span> <p class=\"item-value\"> {{#each credentialSubject.productCategory}} {{name}}{{#unless @last}}, {{/unless}} {{/each}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Produced by</span> <a href=\"{{credentialSubject.producedByParty.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.producedByParty.name}}</a> </div> <div class=\"table-item\"> <span class=\"item-title\">Produced at</span> <div class=\"item-value\"> <a href=\"{{credentialSubject.producedAtFacility.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.producedAtFacility.name}}</a> </div> </div> <div class=\"table-item\"> <span class=\"item-title\">Date produced</span> <p class=\"item-value\">{{credentialSubject.productionDate}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Country</span> <p class=\"item-value\">{{credentialSubject.countryOfProduction}}</p> </div> </div> </section> <section class=\"emission-score-card\"> <h3 class=\"mission-score-title\">Emissions Scorecard</h3> <p class=\"mission-score-description\">The Emissions Scorecard gives a clear snapshot of the product's greenhouse gas (GHG) emissions performance, providing a single indicator to assess its overall environmental impact.</p> <div class=\"score\"> <p class=\"score-unit\"> {{credentialSubject.emissionsScorecard.carbonFootprint}}{{credentialSubject.emissionsScorecard.declaredUnit}} </p> <p class=\"score-name\">Co2Eq</p> </div> <div class=\"table\"> <div class=\"table-item\"> <span class=\"item-title\">Scope includes</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.operationalScope}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Primary sourced ratio*</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.primarySourcedRatio}}% primary sources</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Reporting standard</span> <div class=\"item-value\"> <a href=\"{{credentialSubject.emissionsScorecard.reportingStandard.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.emissionsScorecard.reportingStandard.name}}</a> </div> </div> <div class=\"table-item\"> <span class=\"item-title\">Issue date</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.reportingStandard.issueDate}}</p> </div> </div> <div class=\"annotation\"> <span>*</span> <p>The Primary Sourced Ratio shows the percentage of scope 3 emissions data that is directly collected from actual sources, rather than being based on estimates.</p> </div> </section> <section class=\"declarations\"> <div class=\"declaration-title\">Declarations</div> <div class=\"cards-conformities\"> {{#each credentialSubject.conformityClaim}} <div class=\"cards-conformity\"> <div class=\"frame\"> <div class=\"div\"> <div class=\"company-name\">Conformance:</div> <div class=\"{{#if conformance}}tags-VC-badge-green{{else}}tags-VC-badge-red{{/if}}\"> <div class=\"verifiable\">{{#if conformance}}Yes{{else}}No{{/if}}</div> </div> </div> <div class=\"company-name\">Assessed: {{assessmentDate}}</div> </div> <div class=\"frame-2\"> <div class=\"text-wrapper\">{{conformityEvidence.linkName}}</div> <p class=\"p\"> <span class=\"span\">{{referenceRegulation.name}} administered in {{referenceRegulation.jurisdictionCountry}} by </span> <a href=\"{{referenceRegulation.administeredBy.id}}\" class=\"text-wrapper-2 gray-bottom-line\">{{referenceRegulation.administeredBy.name}}</a> </p> <p class=\"p\"> <span class=\"span\">{{referenceStandard.name}} issued by </span> <a href=\"{{referenceStandard.issuingParty.id}}\" class=\"text-wrapper-2 gray-bottom-line\">{{referenceStandard.issuingParty.name}}</a> </p> </div> <div class=\"frame-3\"> {{#each declaredValue}} <div class=\"frame-4\"> <div class=\"typography-heading\"> <p class=\"heading\">{{metricName}} is {{metricValue.value}}{{metricValue.unit}}</p> </div> <div class=\"typography-heading\"> <p class=\"heading-2\">Score: {{score}} | Accuracy {{accuracy}}</p> </div> </div> {{/each}} </div> <a href=\"{{conformityEvidence.linkURL}}\" class=\"cards-traceability\"> <div class=\"frame-5\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"#1F5A95\"></path> </svg> <div class=\"company-name-wrapper\"> <div class=\"company-name-2\">Evidence</div> </div> </div> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path> </svg> </a> </div> {{/each}} </div> </section> <section class=\"history\"> <div> <p class=\"section-title\">History</p> </div> <!-- Removed Supply chain due diligence report --> <div class=\"history-information\"> <div class=\"history-value-chain-item\"> <div class=\"history-value-chain\"> <p>{{credentialSubject.traceabilityInformation.valueChainProcess}}</p> <div class=\"verified-ratio\"> <p>Verified ratio {{credentialSubject.traceabilityInformation.verifiedRatio}}</p> </div> </div> <div id=\"history-items-390px\" class=\"history-event\"> {{#each credentialSubject.traceabilityInformation.traceabilityEvent}} <div class=\"history-item\"> <span>{{linkName}}</span> <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\">View</a> </div> {{/each}} </div> </div> </div> </section> <section class=\"passport-issued-by\"> <div> <h2 class=\"section-title\">Passport issued by</h2> </div> <div class=\"table\"> <div class=\"table-item\"> <span>Organisation</span> <p>{{issuer.name}}</p> </div> <div class=\"table-item\"> <span>Registered ID</span> <a href=\"{{issuer.id}}\" class=\"blue-bottom-line-thick\">{{issuer.id}}</a> </div> <div class=\"table-item\"> <span>Valid from</span> <p>{{validFrom}}</p> </div> <div class=\"table-item\"> <span>Valid to</span> <p>{{validUntil}}</p> </div> </div> </section> <footer> <p>This Digital Product Passport (DPP) is a digital record of the product's sustainability and environmental performance, ensuring transparency and accountability in line with UNTP standards. The DPP can be verified at any time using the QR code or visiting <a href=\"https://www.untp-certification.org\" class=\"gray-bottom-line\">www.untp-certification.org</a> with the passport ID.</p> </footer> </div> <!-- End mobile --> <!-- Desktop width 1440px --> <!-- Desktop version can be similarly updated following the above changes --> <!-- End desktop --> </div> </body> </html>",
+            "@type": "WebRenderingTemplate2022"
+        }
+    ]
+}

--- a/packages/untp-test-suite/credentials/productPassport/DigitalLivestockPassport-decoded-valid.json
+++ b/packages/untp-test-suite/credentials/productPassport/DigitalLivestockPassport-decoded-valid.json
@@ -1,6 +1,7 @@
 {
     "@context": [
         "https://www.w3.org/ns/credentials/v2",
+        "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/",
         "https://gs-gs.github.io/aatp/assets/files/aatp-dlp-context-0.4.0-7ed6f0cf85aa7626c480bd85212de2e4.jsonld"
     ],
     "type": [

--- a/packages/untp-test-suite/credentials/productPassport/DigitalLivestockPassport-decoded-valid.json
+++ b/packages/untp-test-suite/credentials/productPassport/DigitalLivestockPassport-decoded-valid.json
@@ -1,0 +1,227 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://gs-gs.github.io/aatp/assets/files/aatp-dlp-context-0.4.0-7ed6f0cf85aa7626c480bd85212de2e4.jsonld"
+    ],
+    "type": [
+        "DigitalLivestockPassport",
+        "DigitalProductPassport",
+        "VerifiableCredential"
+    ],
+    "issuer": {
+        "id": "did:web:uncefact.github.io:project-vckit:test-and-development",
+        "name": "Green Valley Cattle Co Pty Ltd"
+    },
+    "credentialSubject": {
+        "type": [
+            "BovineAnimal",
+            "Product"
+        ],
+        "id": "https://nlis.com.au/QBIX0987XBS01234",
+        "name": "Grass-fed Angus",
+        "registeredId": "QDBH0132XBS01234",
+        "countryOfProduction": "AU",
+        "idScheme": {
+            "type": [
+                "IdentifierScheme"
+            ],
+            "id": "https://nlis.com.au/",
+            "name": "National Livestock Identification System (NLIS)"
+        },
+        "productImage": {
+            "type": [
+                "Link"
+            ],
+            "linkURL": "https://imagedelivery.net/KrqWw3MfFI3Up2T0vHiP1g/c30d43f0-01a3-4e95-e83f-dfdbff154f00/public",
+            "linkName": "Angus Cattle Image",
+            "linkType": "https://test.uncefact.org/vocabulary/linkTypes/image"
+        },
+        "batchNumber": "Mob-2024-12",
+        "description": "Grass-fed Angus from Green Valley Station, certified organic, raised under carbon-neutral practices",
+        "productCategory": [
+            {
+                "type": [
+                    "Classification"
+                ],
+                "id": "https://unstats.un.org/unsd/classifications/Econ/cpc/02111",
+                "code": "02111",
+                "name": "Bovine animals, live",
+                "schemeID": "https://unstats.un.org/unsd/classifications/Econ/cpc",
+                "schemeName": "United Nations Central Product Classification (CPC), Version 2.1"
+            }
+        ],
+        "producedByParty": {
+            "type": [
+                "Identifier"
+            ],
+            "id": "https://idr.aatp.showthething.com/ato/abn/87654321012?linkType=ato:registryEntry",
+            "name": "Green Valley Cattle Co Pty Ltd",
+            "registeredId": "87654321012",
+            "idScheme": {
+                "type": [
+                    "IdentifierScheme"
+                ],
+                "id": "https://abr.business.gov.au",
+                "name": "ABN"
+            }
+        },
+        "producedAtFacility": {
+            "type": [
+                "Identifier"
+            ],
+            "id": "https://idr.aatp.showthething.com/dpird/pic/QBIX0987/?linkType=dpird:locationInfo",
+            "name": "Green Valley Station",
+            "registeredId": "QBIX0987",
+            "idScheme": {
+                "type": [
+                    "IdentifierScheme"
+                ],
+                "id": "https://daf.qld.gov.au/pic/",
+                "name": "Queensland Property Identification Code (PIC)"
+            }
+        },
+        "productionDate": "2024-01-15",
+        "granularityLevel": "item",
+        "characteristics": {
+            "type": [
+                "BovineCharcteristics"
+            ],
+            "sex": "M",
+            "sexCharacteristic": "SC",
+            "breed": [
+                "AA"
+            ],
+            "liveWeight": 450,
+            "fatScore": "3",
+            "muscleScore": "A",
+            "frameSize": "6",
+            "maturity": "early"
+        },
+        "healthTreatment": [
+            {
+                "type": [
+                    "HealthTreatment"
+                ],
+                "icarDiseaseCategory": "1",
+                "treatmentDate": "2024-02-15",
+                "productId": "https://portal.apvma.gov.au/pubcris/53973",
+                "productBatchId": "BT202312",
+                "productExpiry": "2025-12-31",
+                "productName": "Standard Vaccination Protocol",
+                "doseRate": {
+                    "type": [
+                        "Measure"
+                    ],
+                    "value": 5,
+                    "unit": "MLT"
+                },
+                "witholdingPeriod": 21
+            }
+        ],
+        "conformityClaim": [
+            {
+                "type": [
+                    "Claim",
+                    "Declaration"
+                ],
+                "id": "https://example-farm.com.au/livestock/QDBH0132XBS01234/claims/organic",
+                "assessmentDate": "2024-03-15",
+                "conformance": true,
+                "conformityTopic": "environment.biodiversity",
+                "conformityEvidence": {
+                    "type": [
+                        "SecureLink",
+                        "Link"
+                    ],
+                    "linkURL": "https://example-farm.com.au/certifications/2024/organic",
+                    "linkName": "Organic Certification",
+                    "linkType": "https://vocabulary.uncefact.org/linkTypes/dcc",
+                    "hashDigest": "a239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                    "hashMethod": "SHA-256",
+                    "encryptionMethod": "none"
+                }
+            },
+            {
+                "type": [
+                    "Claim",
+                    "Declaration"
+                ],
+                "id": "https://cibolabs.com.au/attestations/2024/eudr/gv-123456",
+                "assessmentDate": "2024-03-15",
+                "conformance": true,
+                "conformityTopic": "environment.deforestation",
+                "conformityEvidence": {
+                    "type": [
+                        "SecureLink",
+                        "Link"
+                    ],
+                    "linkURL": "https://idr.aatp.showthething.com/dpird/pic/QBIX0987/?linkType=dpird:certificationInfo",
+                    "linkName": "EUDR Compliance Certificate",
+                    "linkType": "https://vocabulary.uncefact.org/linkTypes/dcc",
+                    "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                    "hashMethod": "SHA-256",
+                    "encryptionMethod": "none"
+                }
+            }
+        ],
+        "emissionsScorecard": {
+            "type": [
+                "EmissionsPerformance"
+            ],
+            "carbonFootprint": 12.5,
+            "declaredUnit": "KGM",
+            "operationalScope": "CradleToGate",
+            "primarySourcedRatio": 0.85,
+            "reportingStandard": {
+                "type": [
+                    "Standard"
+                ],
+                "id": "https://cer.gov.au/schemes/australian-carbon-credit-unit-scheme/accu-scheme-methods/beef-cattle-herd-management-method",
+                "name": "Beef Cattle Herd Management Method",
+                "issuingParty": {
+                    "type": [
+                        "Identifier"
+                    ],
+                    "id": "https://cer.gov.au",
+                    "name": "Clean Energy Regulator"
+                },
+                "issueDate": "2023-01-01"
+            }
+        },
+        "traceabilityInformation": {
+            "type": [
+                "TraceabilityPerformance"
+            ],
+            "valueChainProcess": "Breeding",
+            "verifiedRatio": 1,
+            "traceabilityEvent": [
+                {
+                    "type": [
+                        "SecureLink",
+                        "Link"
+                    ],
+                    "linkURL": "https://example-farm.com.au/livestock/QDBH0132XBS01234/events/birth",
+                    "linkName": "Birth Registration Event",
+                    "linkType": "https://vocabulary.uncefact.org/linkTypes/traceability-event",
+                    "hashDigest": "b239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                    "hashMethod": "SHA-256",
+                    "encryptionMethod": "AES"
+                }
+            ]
+        }
+    },
+    "credentialStatus": {
+        "id": "https://vckit.aatp.showthething.com/credentials/status/bitstring-status-list/1#77",
+        "type": "BitstringStatusListEntry",
+        "statusPurpose": "revocation",
+        "statusListIndex": 77,
+        "statusListCredential": "https://vckit.aatp.showthething.com/credentials/status/bitstring-status-list/1"
+    },
+    "id": "urn:uuid:4aebaeda-3bbf-469f-a70d-e949bc2c1405",
+    "render": [
+        {
+            "template": "<!DOCTYPE html> <html lang=\"en\"> <head> <meta charset=\"UTF-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> <link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap\" rel=\"stylesheet\"> <title>Digital Livestock Passport</title> <style> :root { --image-src: url('{{credentialSubject.productImage.linkURL}}'); --highlight: rgba(0, 99, 83, 1); --primary-colorsblue-400: rgba(79, 149, 221, 1); --primary-colorsblue-50: rgba(210, 229, 249, 1); --primary-colorsblue-10: rgba(247, 250, 253, 1); --white: rgba(255, 255, 255, 1); --black: rgba(0, 0, 0, 1); --primary-colorsgray-400: rgba(212, 214, 216, 1); --primary-colorsgray-600: rgba(85, 96, 110, 1); --primary-colorsblue-700: rgba(31, 90, 149, 1); --primary-colorsgray-700: rgba(35, 46, 61, 1); --accent-colorslight-green: rgba(184, 236, 182, 1); --text-color-green: rgba(8, 50, 0, 1); --accent-colorslight-red: rgba(255, 188, 183, 1); --text-color-red: rgba(50, 0, 0, 1); } * { margin: 0; padding: 0; box-sizing: border-box; } body { font-family: 'Lato', sans-serif; } section { padding: 0 16px 0 16px; } .section-title { font-size: 18px; font-weight: 700; line-height: 19.62px; color: #000000; } .section-description { margin-top: 12px; font-size: 16px; line-height: 18.88px; color: #000000; font-weight: 400; } .table { display: flex; flex-direction: column; justify-content: center; gap: 10px; } .table-item { display: grid; grid-template-columns: 1fr 2fr; column-gap: 16px; align-items: center; padding-bottom: 10px; border-bottom: 1px solid #d4d6d8; } .table-item span { font-size: 16px; font-weight: 400; line-height: 22px; color: var(--primary-colorsgray-600); } .table-item p, .table-item a, .table-item a:link { font-size: 16px; font-weight: 500; line-height: 22px; color: var(--primary-colorsgray-700); } .table-line { border-bottom: 1px solid #d4d6d8; } .item-title { display: flex; font-size: 16px; font-weight: 400; line-height: 17.44px; color: #55606E; text-transform: capitalize; } .item-value { display: flex; flex-direction: column; font-size: 16px; font-weight: 500; line-height: 17.44px; color: #232E3D; } .item-value a, .item-value span { color: #232E3D; } .annotation { display: flex; gap: 4px; font-size: 14px; font-weight: 400; line-height: 15.26px; color: #55606E; } .annotation span { padding-top: 2px; } .mobile { min-width: 150px; width: 100%; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; word-break: break-word; } .header { min-height: 320px; } .header-image { background: linear-gradient(248.36deg, rgba(0, 0, 0, 0.18) 7.6%, rgba(0, 0, 0, 0.6) 70.52%), var(--image-src); background-size: cover; background-position: center; min-height: 232px; position: relative; } .header-image-top-left { position: absolute; top: 25px; left: 15px; font-weight: 500; font-size: 16px; line-height: 22px; color: #ffffff; } .header-image-bottom-left { position: absolute; bottom: 18px; left: 15px; color: #ffffff; } .header-image-bottom-left h1 { font-size: 30px; font-weight: 900; line-height: 32.5px; } .header-batch { padding: 12px 16px 16px 16px; background-color: #F7FAFD; display: grid; grid-template-columns: 1.2fr 1fr; grid-auto-flow: row; row-gap: 12px; } .header-batch-item { display: flex; align-items: center; gap: 6px; } .header-batch-item a { color: #232E3D; font-size: 14px; line-height: 15.25px; font-weight: 500; } .header-batch a { padding: 0 2px; font-size: 14px; font-weight: 400; line-height: 19.25px; text-decoration: none; color: #000000; } .information { display: flex; flex-direction: column; gap: 8px; } .information-text { font-size: 19px; font-weight: 300; line-height: 22.42px; } .information-show-more { display: flex; flex-direction: column; gap: 10px; font-size: 14px; font-weight: 500; line-height: 22px; } .information-show-more a { color: var(--primary-colorsgray-700); } .passport { display: flex; flex-direction: column; gap: 24px; } .passport-header { display: flex; justify-content: space-between; align-items: center; } .passport-box { display: grid; grid-template-columns: 1fr 1fr; border: #D4D6D8 1px dotted; border-radius: 5px; overflow: hidden; } .passport-box-item { display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 12px 16px 12px 16px; border: #D4D6D8 1px dotted; outline-offset: -1px; min-height: 94px; color: #1F5A95; } .passport-box-item h3 { font-size: 40px; font-weight: 900; line-height: 43.33px; letter-spacing: 2px; } .passport-box-item p { margin-top: 8px; font-size: 15px; font-weight: 600; line-height: 18.88px; } .passport-box-item:last-child { background-color: #F7FAFD; } .passport-issued-by-header { display: flex; flex-direction: column; gap: 12px; } .passport-issued-by-header h3 { margin-top: 2px; font-size: 20px; font-weight: 700; line-height: 21.8px; } .passport-issued-by-header p { font-size: 16px; font-weight: 400; line-height: 19.25px; color: #55606E; } .passport-annotation { font-size: 14px; font-weight: 400; line-height: 15.26px; color: #55606E; } .traceability-cards { display: flex; flex-direction: column; gap: 12px; } .traceability-card { display: grid; grid-template-columns: 3fr 1fr; justify-content: space-between; align-items: center; min-height: 40px; text-decoration: none; } .traceability-card-text { display: flex; align-items: center; gap: 8px; font-size: 16px; font-weight: 400; line-height: 17.44px; color: #000000; } .traceability-card-view-details, .traceability-card-view-details:link { display: flex; justify-content: flex-end; align-items: center; gap: 8px; } .emission-score-card { display: flex; flex-direction: column; gap: 12px; } .mission-score-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .mission-score-description { font-size: 16px; font-weight: 400; line-height: 18.88px; color: #000000; } .score { display: flex; flex-direction: column; gap: 6px; } .score-unit { font-size: 40px; font-weight: 900; line-height: 43.33px; color: #1F5A95; letter-spacing: 2px; } .score-name { font-size: 16px; font-weight: 400; line-height: 17.44px; color: #55606E; } .declarations { display: flex; flex-direction: column; gap: 12px; } .declaration-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .cards-conformities { display: flex; flex-direction: column; gap: 8px; } .cards-conformity { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; width: 100%; padding: 16px 18px 16px 16px; position: relative; background-color: var(--white); border-radius: 4px; border: 1px solid; border-color: var(--primary-colorsgray-400); } .frame { display: flex; align-items: center; justify-content: space-between; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .div { display: inline-flex; align-items: center; gap: 4px; position: relative; flex: 0 0 auto; } .company-name { position: relative; width: fit-content; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .tags-VC-badge-red { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-red); color: var(--text-color-red); border-radius: 8px; overflow: hidden; } .tags-VC-badge-green { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-green); color: var(--text-color-green); border-radius: 8px; overflow: hidden; } .verifiable { width: fit-content; font-weight: 600; font-size: 14px; line-height: 15.3px; } .mobile .frame-2 { display: flex; flex-direction: column; align-items: center; gap: 4px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .text-wrapper { position: relative; align-self: stretch; margin-top: -1px; font-weight: 400; color: var(--primary-colorsblue-700); font-size: 18px; line-height: 21.2px; } .p { color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; align-self: stretch; font-weight: 400; color: #55606e; } .span { font-weight: 400; font-size: 14px; line-height: 19.2px; } .text-wrapper-2 { color: #55606e; } .frame-3 { display: inline-flex; flex-direction: column; align-items: flex-start; position: relative; flex: 0 0 auto; margin-right: -2px; border-bottom-width: 1px; border-bottom-style: solid; border-color: var(--white); } .frame-4 { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 4px; padding: 4px 0px; position: relative; flex: 0 0 auto; border-top-width: 1px; border-top-style: solid; border-color: var(--white); } .typography-heading { display: flex; align-items: center; justify-content: center; gap: 10px; } .heading { position: relative; flex: 1; font-weight: 400; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 17.4px; } .heading-2 { position: relative; flex: 1; margin-top: -0.5px; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .cards-traceability { display: flex; align-items: center; justify-content: space-between; padding: 8px 0px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; border-radius: 4px; text-decoration: none; } .history-information { display: flex; flex-direction: column; gap: 12px; } .history-value-chain-item { display: flex; flex-direction: column; gap: 8px; } .history-value-chain { display: flex; flex-direction: column; gap: 4px; } .history-value-chain p { font-size: 18px; font-weight: 400; line-height: 21.24px; color: #1F5A95; } .verified-ratio { background-color: #D2E5F9; width: fit-content; padding: 2px 4px; } .verified-ratio p { font-size: 14px; font-weight: 400; line-height: 19.25px; color: var(--black); } .frame-5 { display: inline-flex; align-items: center; gap: 8px; position: relative; flex: 0 0 auto; } .company-name-wrapper { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; position: relative; } .company-name-2 { color: var(--black); font-size: 16px; line-height: 17.4px; position: relative; align-self: stretch; font-weight: 400; } .img { position: relative; flex: 0 0 auto; margin-right: -1px; } .production { display: none; flex-direction: column; gap: 12px; } .production:has(.table-item) { display: flex; } .production-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .product-table, .product-table:link, .product-table:visited, .product-table:active { color: #232E3D; } .composition-box { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; } .composition-box-item { display: grid; grid-template-columns: 1fr auto; justify-content: space-between; border: 1px solid #d4d6d8; border-radius: 4px; padding: 16px; } .composition-percent { font-size: 16px; font-weight: 500; line-height: 21.92px; color: #000000; } .composition-title { font-size: 16px; font-weight: 600; line-height: 17.44px; color: #000000; } .composition-tag { display: flex; } .composition-tag-item { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #000000; background-color: #D2E5F9; padding: 2px 4px 2px 4px; margin-right: 4px; } .composition-box-first-column { display: grid; grid-template-columns: 40px 1fr; gap: 12px; } .composition-box-second-column { display: flex; flex-direction: column; gap: 6px; } .composition-box-second-column a { color: #232E3D; line-height: 22px; } .composition-box-third-column { display: flex; justify-content: end; gap: 12px; } .composition-box-third-column svg { margin: 1px 10px 0 0; } .passport-issued-by { display: flex; flex-direction: column; gap: 12px; } .history { display: flex; flex-direction: column; gap: 12px; } .history-event { display: flex; flex-direction: column; } .history-item { border-bottom: 1px solid #d4d6d8; padding: 10px 0 12px 0; display: grid; grid-template-columns: 1fr auto; gap: 16px; justify-content: space-between; } .history-item span { font-size: 16px; font-weight: 400; line-height: 17.44px; color: #000000; } .history-item a { font-size: 16px; font-weight: 500; line-height: 17.44px; color: var(--primary-colorsgray-700); text-decoration-color: #4f95dd; text-decoration-thickness: 2px; } .country-code { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #55606e; } .blue-bottom-line-thin, .blue-bottom-line-thin:link { border-bottom: 1px #4F95DD solid; width: fit-content; justify-content: flex-start; align-items: flex-start; gap: 10px; display: inline-flex; cursor: pointer; text-decoration: none; } .blue-bottom-line-thick, .blue-bottom-line-thick:link { width: fit-content; justify-content: flex-start; align-items: flex-start; gap: 10px; display: inline-flex; text-decoration-line: underline; text-decoration-thickness: 2px; text-decoration-color: #4F95DD; text-underline-offset: 3px; } .gray-bottom-line { border-bottom: 1px #55606E solid; width: fit-content; text-decoration: none; } .view-more-button { display: flex; justify-content: center; align-items: center; color: var(--primary-colorsblue-700); cursor: pointer; } footer { padding: 16px 16px 32px 16px; min-height: 60px; background-color: #F7FAFD; } footer p, footer a, footer a:link { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #232E3D; } </style> </head> <body> <div class=\"container\"> <!-- Mobile width 390px--> <div class=\"mobile\"> <header class=\"header\"> <div class=\"header-image\"> <p class=\"header-image-top-left\">PRODUCT PASSPORT</p> <div class=\"header-image-bottom-left\"> <h1>{{credentialSubject.name}}</h1> </div> </div> <div> <div class=\"header-batch\"> <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a href=\"{{credentialSubject.idScheme.id}}\" class=\"blue-bottom-line-thick\">ID: {{credentialSubject.registeredId}}</a> </div> <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a>Batch: {{credentialSubject.batchNumber}}</a> </div> </div> </div> </header> <section class=\"information\"> <div class=\"information-text\"> {{credentialSubject.description}} </div> <div class=\"information-show-more\"> {{#each credentialSubject.furtherInformation}} <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\">{{linkName}}</a> {{/each}} </div> </section> {{#if credentialSubject.characteristics}} <section class=\"production\"> <div class=\"production-title\">Characteristics</div> <div class=\"product-table table\"> <div class=\"table-item\"> <span class=\"item-title\">Sex</span> <p class=\"item-value\">{{credentialSubject.characteristics.sex}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Sex Characteristic</span> <p class=\"item-value\">{{credentialSubject.characteristics.sexCharacteristic}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Breed</span> <p class=\"item-value\"> {{#each credentialSubject.characteristics.breed}} {{this}}{{#unless @last}}, {{/unless}} {{/each}} </p> </div> <div class=\"table-item\"> <span class=\"item-title\">Live Weight</span> <p class=\"item-value\">{{credentialSubject.characteristics.liveWeight}} kg</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Carcass Weight</span> <p class=\"item-value\">{{credentialSubject.characteristics.carcassWeight}} kg</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Fat Score</span> <p class=\"item-value\">{{credentialSubject.characteristics.fatScore}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Muscle Score</span> <p class=\"item-value\">{{credentialSubject.characteristics.muscleScore}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Frame Size</span> <p class=\"item-value\">{{credentialSubject.characteristics.frameSize}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Maturity</span> <p class=\"item-value\">{{credentialSubject.characteristics.maturity}}</p> </div> </div> </section> {{/if}} <section class=\"production\"> <div class=\"production-title\">Production</div> <div class=\"product-table table\"> <div class=\"table-item\"> <span class=\"item-title\">Product category</span> <p class=\"item-value\"> {{#each credentialSubject.productCategory}} {{name}}{{#unless @last}}, {{/unless}} {{/each}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Produced by</span> <a href=\"{{credentialSubject.producedByParty.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.producedByParty.name}}</a> </div> <div class=\"table-item\"> <span class=\"item-title\">Produced at</span> <div class=\"item-value\"> <a href=\"{{credentialSubject.producedAtFacility.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.producedAtFacility.name}}</a> </div> </div> <div class=\"table-item\"> <span class=\"item-title\">Date produced</span> <p class=\"item-value\">{{credentialSubject.productionDate}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Country</span> <p class=\"item-value\">{{credentialSubject.countryOfProduction}}</p> </div> </div> </section> <section class=\"emission-score-card\"> <h3 class=\"mission-score-title\">Emissions Scorecard</h3> <p class=\"mission-score-description\">The Emissions Scorecard gives a clear snapshot of the product's greenhouse gas (GHG) emissions performance, providing a single indicator to assess its overall environmental impact.</p> <div class=\"score\"> <p class=\"score-unit\"> {{credentialSubject.emissionsScorecard.carbonFootprint}}{{credentialSubject.emissionsScorecard.declaredUnit}} </p> <p class=\"score-name\">Co2Eq</p> </div> <div class=\"table\"> <div class=\"table-item\"> <span class=\"item-title\">Scope includes</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.operationalScope}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Primary sourced ratio*</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.primarySourcedRatio}}% primary sources</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Reporting standard</span> <div class=\"item-value\"> <a href=\"{{credentialSubject.emissionsScorecard.reportingStandard.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.emissionsScorecard.reportingStandard.name}}</a> </div> </div> <div class=\"table-item\"> <span class=\"item-title\">Issue date</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.reportingStandard.issueDate}}</p> </div> </div> <div class=\"annotation\"> <span>*</span> <p>The Primary Sourced Ratio shows the percentage of scope 3 emissions data that is directly collected from actual sources, rather than being based on estimates.</p> </div> </section> <section class=\"declarations\"> <div class=\"declaration-title\">Declarations</div> <div class=\"cards-conformities\"> {{#each credentialSubject.conformityClaim}} <div class=\"cards-conformity\"> <div class=\"frame\"> <div class=\"div\"> <div class=\"company-name\">Conformance:</div> <div class=\"{{#if conformance}}tags-VC-badge-green{{else}}tags-VC-badge-red{{/if}}\"> <div class=\"verifiable\">{{#if conformance}}Yes{{else}}No{{/if}}</div> </div> </div> <div class=\"company-name\">Assessed: {{assessmentDate}}</div> </div> <div class=\"frame-2\"> <div class=\"text-wrapper\">{{conformityEvidence.linkName}}</div> <p class=\"p\"> <span class=\"span\">{{referenceRegulation.name}} administered in {{referenceRegulation.jurisdictionCountry}} by </span> <a href=\"{{referenceRegulation.administeredBy.id}}\" class=\"text-wrapper-2 gray-bottom-line\">{{referenceRegulation.administeredBy.name}}</a> </p> <p class=\"p\"> <span class=\"span\">{{referenceStandard.name}} issued by </span> <a href=\"{{referenceStandard.issuingParty.id}}\" class=\"text-wrapper-2 gray-bottom-line\">{{referenceStandard.issuingParty.name}}</a> </p> </div> <div class=\"frame-3\"> {{#each declaredValue}} <div class=\"frame-4\"> <div class=\"typography-heading\"> <p class=\"heading\">{{metricName}} is {{metricValue.value}}{{metricValue.unit}}</p> </div> <div class=\"typography-heading\"> <p class=\"heading-2\">Score: {{score}} | Accuracy {{accuracy}}</p> </div> </div> {{/each}} </div> <a href=\"{{conformityEvidence.linkURL}}\" class=\"cards-traceability\"> <div class=\"frame-5\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"#1F5A95\"></path> </svg> <div class=\"company-name-wrapper\"> <div class=\"company-name-2\">Evidence</div> </div> </div> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path> </svg> </a> </div> {{/each}} </div> </section> <section class=\"history\"> <div> <p class=\"section-title\">History</p> </div> <!-- Removed Supply chain due diligence report --> <div class=\"history-information\"> <div class=\"history-value-chain-item\"> <div class=\"history-value-chain\"> <p>{{credentialSubject.traceabilityInformation.valueChainProcess}}</p> <div class=\"verified-ratio\"> <p>Verified ratio {{credentialSubject.traceabilityInformation.verifiedRatio}}</p> </div> </div> <div id=\"history-items-390px\" class=\"history-event\"> {{#each credentialSubject.traceabilityInformation.traceabilityEvent}} <div class=\"history-item\"> <span>{{linkName}}</span> <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\">View</a> </div> {{/each}} </div> </div> </div> </section> <section class=\"passport-issued-by\"> <div> <h2 class=\"section-title\">Passport issued by</h2> </div> <div class=\"table\"> <div class=\"table-item\"> <span>Organisation</span> <p>{{issuer.name}}</p> </div> <div class=\"table-item\"> <span>Registered ID</span> <a href=\"{{issuer.id}}\" class=\"blue-bottom-line-thick\">{{issuer.id}}</a> </div> <div class=\"table-item\"> <span>Valid from</span> <p>{{validFrom}}</p> </div> <div class=\"table-item\"> <span>Valid to</span> <p>{{validUntil}}</p> </div> </div> </section> <footer> <p>This Digital Product Passport (DPP) is a digital record of the product's sustainability and environmental performance, ensuring transparency and accountability in line with UNTP standards. The DPP can be verified at any time using the QR code or visiting <a href=\"https://www.untp-certification.org\" class=\"gray-bottom-line\">www.untp-certification.org</a> with the passport ID.</p> </footer> </div> <!-- End mobile --> <!-- Desktop width 1440px --> <!-- Desktop version can be similarly updated following the above changes --> <!-- End desktop --> </div> </body> </html>",
+            "@type": "WebRenderingTemplate2022"
+        }
+    ]
+}

--- a/packages/untp-test-suite/src/schemas/digitalProductPassport/v0.5.1/schema.json
+++ b/packages/untp-test-suite/src/schemas/digitalProductPassport/v0.5.1/schema.json
@@ -1,0 +1,1104 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "type": {
+      "type": "array",
+      "readOnly": true,
+      "const": [
+        "DigitalProductPassport",
+        "VerifiableCredential"
+      ],
+      "default": [
+        "DigitalProductPassport",
+        "VerifiableCredential"
+      ],
+      "items": {
+        "type": "string",
+        "enum": [
+          "DigitalProductPassport",
+          "VerifiableCredential"
+        ]
+      }
+    },
+    "@context": {
+      "example": "https://test.uncefact.org/vocabulary/untp/dpp/dpp-context.jsonld",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/"
+        ]
+      },
+      "description": "A list of JSON-LD context URIs that define the semantic meaning of properties within the credential. ",
+      "readOnly": true,
+      "const": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/"
+      ],
+      "default": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/"
+      ]
+    },
+    "id": {
+      "example": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
+      "type": "string",
+      "format": "uri",
+      "description": "A unique identifier (URI) assigned to the product passport. May be a UUID"
+    },
+    "issuer": {
+      "$ref": "#/$defs/CredentialIssuer",
+      "description": "The organisation that is the issuer of this VC. Note that the \"id\" property MUST be a W3C DID.  Other identifiers such as tax registration numbers can be listed in the \"otherIdentifiers\" property."
+    },
+    "validFrom": {
+      "example": "2024-03-15T12:00:00",
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time from which the credential is valid."
+    },
+    "validUntil": {
+      "example": "2034-03-15T12:00:00",
+      "type": "string",
+      "format": "date-time",
+      "description": "The expiry date (if applicable) of this verifiable credential."
+    },
+    "credentialSubject": {
+      "$ref": "#/$defs/Product",
+      "description": "The subject of a digital product passport credential is the identified product.  "
+    }
+  },
+  "description": "The Product Passport is a comprehensive data structure that encapsulates various details pertaining to a product, including its identification details, who issued it, batch information, provenance information, circularity information and a set of verifiable product conformity & sustainability claims. ",
+  "required": [
+    "@context",
+    "id",
+    "issuer"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "CredentialIssuer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "CredentialIssuer"
+          ],
+          "default": [
+            "CredentialIssuer"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "CredentialIssuer"
+            ]
+          }
+        },
+        "id": {
+          "example": "did:web:identifiers.example-company.com:12345",
+          "type": "string",
+          "format": "uri",
+          "description": "The W3C DID of the issuer - should be a did:web or did:tdw"
+        },
+        "name": {
+          "example": "Example Company Pty Ltd",
+          "type": "string",
+          "description": "The name of the issuer person or organisation"
+        },
+        "otherIdentifier": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Identifier"
+          },
+          "description": "An optional list of other registered identifiers for this credential issuer "
+        }
+      },
+      "description": "The issuer party (person or organisation) of a verifiable credential.",
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "Identifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Identifier"
+          ],
+          "default": [
+            "Identifier"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Identifier"
+            ]
+          }
+        },
+        "id": {
+          "example": "https://id.gs1.org/01/09520123456788/21/12345",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique ID of the entity as a resolvable URL according to ISO 18975. ExamplesProduct - id.gs1.org/01/09520123456788/21/12345  Party - abr.business.gov.au/ABN/View?abn=90664869327. Facility - did:web:facilities.example-company.com:123. "
+        },
+        "name": {
+          "example": "EV battery 300Ah.",
+          "type": "string",
+          "description": "The registered name of the entity within the identifier scheme.  Examples: product - EV battery 300Ah, Party - Sample Company Pty Ltd,  Facility - Green Acres battery factory"
+        },
+        "registeredId": {
+          "example": "90664869327",
+          "type": "string",
+          "description": "The registration number (alphanumeric) of the entity within the register. Unique within the register."
+        },
+        "idScheme": {
+          "$ref": "#/$defs/IdentifierScheme",
+          "description": "The identifier scheme.  Examples : Product - id.gs1.org/01,  Party - business.gov.au/abn,  Facility - did:web:facilities.acme.com. "
+        }
+      },
+      "description": "The ID and Name of an identified entity such as a product, facility, party, standard, etc.  If the identifier is a W3C DID then the corresponding DID document SHOULD include a serviceEndpoint of type \"IdentityResolver\". If the identifier is not a W3C DID then the id property SHOULD be an identity resolver URL.",
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "IdentifierScheme": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "IdentifierScheme"
+          ],
+          "default": [
+            "IdentifierScheme"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "IdentifierScheme"
+            ]
+          }
+        },
+        "id": {
+          "example": "https://id.gs1.org/01/",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique identifier of the registration scheme. The scheme should be registered and discoverable from vocabulary.uncefact.org/identifierSchemes"
+        },
+        "name": {
+          "example": "Global Trade Identification Number (GTIN)",
+          "type": "string",
+          "description": "The name of the identifier scheme. "
+        }
+      },
+      "description": "An identifier registration scheme for products, facilities, or organisations. Typically operated by a state, national or global authority."
+    },
+    "Product": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Product"
+          ],
+          "default": [
+            "Product"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Product"
+            ]
+          }
+        },
+        "id": {
+          "example": "https://id.gs1.org/01/09520123456788/21/12345",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique ID of the product as a URI. Ideally as a resolvable URL according to ISO 18975. "
+        },
+        "name": {
+          "example": "EV battery 300Ah.",
+          "type": "string",
+          "description": "The registered name of the product within the identifier scheme. "
+        },
+        "registeredId": {
+          "example": "09520123456788.21.12345",
+          "type": "string",
+          "description": "The registration number (alphanumeric) of the entity within the register. Unique within the register."
+        },
+        "idScheme": {
+          "$ref": "#/$defs/IdentifierScheme",
+          "description": "The identifier scheme for this product.  Eg a GS1 GTIN or an AU Livestock NLIS, or similar. If self issued then use the party ID of the issuer.  "
+        },
+        "serialNumber": {
+          "example": "12345678",
+          "type": "string",
+          "description": "A number or code representing a specific serialised item of the product. Unique within product class."
+        },
+        "batchNumber": {
+          "example": "6789",
+          "type": "string",
+          "description": "Identifier of the specific production batch of the product.  Unique within the product class."
+        },
+        "productImage": {
+          "$ref": "#/$defs/Link",
+          "description": "Reference information (location, type, name) of an image of the product."
+        },
+        "description": {
+          "example": "400Ah 24v LiFePO4 battery",
+          "type": "string",
+          "description": "A textual description providing details about the product."
+        },
+        "productCategory": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": "A code representing the product's class, typically using the UN CPC (United Nations Central Product Classification) https://unstats.un.org/unsd/classifications/Econ/cpc"
+        },
+        "furtherInformation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Link"
+          },
+          "description": "A URL pointing to further human readable information about the product."
+        },
+        "producedByParty": {
+          "$ref": "#/$defs/Identifier",
+          "description": "The Party entity that manufactured the product."
+        },
+        "producedAtFacility": {
+          "$ref": "#/$defs/Identifier",
+          "description": "The Facility where the product batch was produced / manufactured."
+        },
+        "dimensions": {
+          "$ref": "#/$defs/Dimension",
+          "description": "The physical dimensions of the product. Not every dimension is relevant to every products.  For example bulk materials may have weight and volume but not length, with, or height.\"weight\":{\"value\":10, \"unit\":\"KGM\"}"
+        },
+        "productionDate": {
+          "example": "2024-04-25",
+          "type": "string",
+          "format": "date",
+          "description": "The ISO 8601 date on which the product batch or individual serialised item was manufactured."
+        },
+        "countryOfProduction": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId",
+          "description": "The country in which this item was produced / manufactured.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId\n    "
+        },
+        "granularityLevel": {
+          "type": "string",
+          "enum": [
+            "item",
+            "batch",
+            "model"
+          ],
+          "example": "item",
+          "description": "Code to indicate the granularity of this digital product passport - item level, batch level or product class level."
+        },
+        "dueDiligenceDeclaration": {
+          "$ref": "#/$defs/Link",
+          "description": "The due diligence declaration that conforms with the regulations of the market into which the product is sold."
+        },
+        "materialsProvenance": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Material"
+          },
+          "description": "An array of Provenance objects providing details on the origin and mass fraction of components or ingredients of the product batch. "
+        },
+        "conformityClaim": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Claim"
+          },
+          "description": "An array of claim objects representing various product conformity claims about the product / batch.  These can be sustainability claims, circularity claims, or any other claim type within the conformity topic list."
+        },
+        "circularityScorecard": {
+          "$ref": "#/$defs/CircularityPerformance",
+          "description": "A circularity performance scorecard"
+        },
+        "emissionsScorecard": {
+          "$ref": "#/$defs/EmissionsPerformance",
+          "description": "An emissions performance scorecard"
+        },
+        "traceabilityInformation": {
+          "$ref": "#/$defs/TraceabilityPerformance",
+          "description": "An array of traceability events grouped by value chain process.  Where actual traceability events are unavailable or carry sensitive information, passport publishers may specify the extent to which the traceability information has been independently verified. "
+        }
+      },
+      "description": "The ProductInformation class encapsulates detailed information regarding a specific product, including its identification details, manufacturer, and other pertinent details.  ",
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "Link": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Link"
+          ],
+          "default": [
+            "Link"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Link"
+            ]
+          }
+        },
+        "linkURL": {
+          "example": "https://files.example-certifier.com/1234567.json",
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the target resource. "
+        },
+        "linkName": {
+          "example": "GBA rule book conformity certificate",
+          "type": "string",
+          "description": "A display name for the target resource "
+        },
+        "linkType": {
+          "example": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+          "type": "string",
+          "description": "The type of the target resource - drawn from a controlled vocabulary "
+        }
+      },
+      "description": "A structure to provide a URL link plus metadata associated with the link."
+    },
+    "Classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Classification"
+          ],
+          "default": [
+            "Classification"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Classification"
+            ]
+          }
+        },
+        "id": {
+          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique URI representing the specific classifier value"
+        },
+        "code": {
+          "example": "46410",
+          "type": "string",
+          "description": "classification code within the scheme"
+        },
+        "name": {
+          "example": "Primary cells and primary batteries",
+          "type": "string",
+          "description": "Name of the classification represented by the code"
+        },
+        "schemeID": {
+          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+          "type": "string",
+          "format": "uri",
+          "description": "Classification scheme ID"
+        },
+        "schemeName": {
+          "example": "UN Central Product Classification (CPC)",
+          "type": "string",
+          "description": "The name of the classification scheme"
+        }
+      },
+      "description": "A classification scheme and code / name representing a category value for a product, entity, or facility.",
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "Dimension": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Dimension"
+          ],
+          "default": [
+            "Dimension"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Dimension"
+            ]
+          }
+        },
+        "weight": {
+          "$ref": "#/$defs/Measure",
+          "description": "the weight of the product. EG {\"value\":10, \"unit\":\"KGM\"}"
+        },
+        "length": {
+          "$ref": "#/$defs/Measure",
+          "description": "The length of the product or packaging eg {\"value\":840, \"unit\":\"MMT\"}"
+        },
+        "width": {
+          "$ref": "#/$defs/Measure",
+          "description": "The width of the product or packaging. eg {\"value\":150, \"unit\":\"MMT\"}"
+        },
+        "height": {
+          "$ref": "#/$defs/Measure",
+          "description": "The height of the product or packaging. eg {\"value\":220, \"unit\":\"MMT\"}"
+        },
+        "volume": {
+          "$ref": "#/$defs/Measure",
+          "description": "The displacement volume of the product. eg {\"value\":7.5, \"unit\":\"LTR\"}"
+        }
+      },
+      "description": "Overall (length, width, height) dimensions and weight/volume of an item."
+    },
+    "Measure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Measure"
+          ],
+          "default": [
+            "Measure"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Measure"
+            ]
+          }
+        },
+        "value": {
+          "example": 10,
+          "type": "number",
+          "description": "The numeric value of the measure"
+        },
+        "unit": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode",
+          "description": "Unit of measure drawn from the UNECE Rec20 measure code list.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode\n    "
+        }
+      },
+      "description": "The measure class defines a numeric measured value (eg 10) and a coded unit of measure (eg KG).",
+      "required": [
+        "value",
+        "unit"
+      ]
+    },
+    "Material": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Material"
+          ],
+          "default": [
+            "Material"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Material"
+            ]
+          }
+        },
+        "name": {
+          "example": "Lithium Spodumene",
+          "type": "string",
+          "description": "Name of this material (eg \"Egyptian Cotton\")"
+        },
+        "originCountry": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId",
+          "description": "A ISO 3166-1 code representing the country of origin of the component or ingredient.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId\n    "
+        },
+        "materialType": {
+          "$ref": "#/$defs/Classification",
+          "description": "The type of this material - as a value drawn from a controlled vocabulary eg from UN Framework Classification for Resources (UNFC)."
+        },
+        "massFraction": {
+          "example": 0.2,
+          "type": "number",
+          "description": "The mass fraction of the product represented by this material. The sum of all mass fraction values for a given passport should be 1."
+        },
+        "massAmount": {
+          "$ref": "#/$defs/Measure",
+          "description": "The mass of the material component."
+        },
+        "recycledAmount": {
+          "example": 0.5,
+          "type": "number",
+          "description": "Mass fraction of this material that is recycled (eg 50% recycled Lithium)"
+        },
+        "hazardous": {
+          "example": "false",
+          "type": "boolean",
+          "description": "Indicates whether this material is hazardous. If true then the materialSafetyInformation property must be present"
+        },
+        "symbol": {
+          "type": "string",
+          "format": "binary",
+          "description": "Based 64 encoded binary used to represent a visual symbol for a given material. "
+        },
+        "materialSafetyInformation": {
+          "$ref": "#/$defs/Link",
+          "description": "Reference to further information about safe handling of this hazardous material (for example a link to a material safety data sheet)"
+        }
+      },
+      "description": "The material class encapsulates details about the origin or source of raw materials in a product, including the country of origin and the mass fraction.",
+      "required": [
+        "name"
+      ]
+    },
+    "Claim": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Claim",
+            "Declaration"
+          ],
+          "default": [
+            "Claim",
+            "Declaration"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Claim",
+              "Declaration"
+            ]
+          }
+        },
+        "assessmentDate": {
+          "example": "2024-03-15",
+          "type": "string",
+          "format": "date",
+          "description": "The date on which this assessment was made. "
+        },
+        "declaredValue": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "The list of specific values measured as part of this assessment (eg tensile strength)"
+        },
+        "id": {
+          "example": "https://products.example-company.com/09520123456788/declarations/12345",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the declaration. Often this will be an extension of the product.id or attestation.id. But could be a UUID."
+        },
+        "referenceStandard": {
+          "$ref": "#/$defs/Standard",
+          "description": "The reference to the standard that defines the specification / criteria"
+        },
+        "referenceRegulation": {
+          "$ref": "#/$defs/Regulation",
+          "description": "The reference to the regulation that defines the assessment criteria"
+        },
+        "assessmentCriteria": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Criterion"
+          },
+          "description": "The specification against which the assessment is made."
+        },
+        "declaredValues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "The list of specific values measured as part of this assessment (eg tensile strength)"
+        },
+        "conformance": {
+          "example": "true",
+          "type": "boolean",
+          "description": "An indicator of whether or not the claim or assesment conforms to the regulatory or standard criteria."
+        },
+        "conformityTopic": {
+          "type": "string",
+          "enum": [
+            "environment.energy",
+            "environment.emissions",
+            "environment.water",
+            "environment.waste",
+            "environment.deforestation",
+            "environment.biodiversity",
+            "circularity.content",
+            "circularity.design",
+            "social.labour",
+            "social.rights",
+            "social.community",
+            "social.safety",
+            "governance.ethics",
+            "governance.compliance",
+            "governance.transparency"
+          ],
+          "example": "environment.energy",
+          "description": "The conformity topic category for this assessment (eg vocabulary.uncefact.org/sustainability/emissions)"
+        },
+        "conformityEvidence": {
+          "$ref": "#/$defs/SecureLink",
+          "description": "A URI pointing to the evidence supporting the claim. SHOULD be a URL to a UNTP Digital Conformity Credential (DCC)"
+        }
+      },
+      "description": "A declaration of conformance with one or more criteria from a specific standard or regulation.  ",
+      "required": [
+        "id",
+        "conformance",
+        "conformityTopic"
+      ]
+    },
+    "Metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Metric"
+          ],
+          "default": [
+            "Metric"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Metric"
+            ]
+          }
+        },
+        "metricName": {
+          "example": "GHG emissions intensity",
+          "type": "string",
+          "description": "A human readable name for this metric (for example \"Tensile strength\")"
+        },
+        "metricValue": {
+          "$ref": "#/$defs/Measure",
+          "description": "A numeric value and unit of measure for this metric. Could be a measured value or a specified threshold. Eg {\"value\":400, \"unit\":\"MPA\"} as tensile strength of structural steel"
+        },
+        "score": {
+          "example": "BB",
+          "type": "string",
+          "description": "A score or rank associated with this measured metric."
+        },
+        "accuracy": {
+          "example": 0.05,
+          "type": "number",
+          "description": "A percentage represented as a numeric between 0 and 1 indicating the rage of accuracy of the claimed value (eg 0.05 means that the actual value is within 5% of the claimed value.)"
+        }
+      },
+      "description": "A specific measure of performance against the criteria that governs the claim.  Expressed as an array of metric (ie unit of measure) / value (ie the actual numeric value) pairs.  ",
+      "required": [
+        "metricName",
+        "metricValue"
+      ]
+    },
+    "Standard": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Standard"
+          ],
+          "default": [
+            "Standard"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Standard"
+            ]
+          }
+        },
+        "id": {
+          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the standard (eg https://www.iso.org/standard/60857.html)."
+        },
+        "name": {
+          "example": "GBA Battery Passport Greenhouse Gas Rulebook - V.2.0",
+          "type": "string",
+          "description": "The name of the standard"
+        },
+        "issuingParty": {
+          "$ref": "#/$defs/Identifier",
+          "description": "The party that issued the standard "
+        },
+        "issueDate": {
+          "example": "2023-12-05",
+          "type": "string",
+          "format": "date",
+          "description": "The date when the standard was issued."
+        }
+      },
+      "description": "A standard (eg ISO 14000) that specifies the criteria for conformance.",
+      "required": [
+        "issuingParty"
+      ]
+    },
+    "Regulation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Regulation"
+          ],
+          "default": [
+            "Regulation"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Regulation"
+            ]
+          }
+        },
+        "id": {
+          "example": "https://www.legislation.gov.au/F2008L02309/latest/versions",
+          "type": "string",
+          "format": "uri",
+          "description": "The globally unique identifier of this regulation. "
+        },
+        "name": {
+          "example": "NNational Greenhouse and Energy Reporting (Measurement) Determination",
+          "type": "string",
+          "description": "The name of the regulation or act."
+        },
+        "jurisdictionCountry": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId",
+          "description": "The legal jurisdiction (country) under which the regulation is issued.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId\n    "
+        },
+        "administeredBy": {
+          "$ref": "#/$defs/Identifier",
+          "description": "the issuing body of the regulation. For example Australian Government Department of Climate Change, Energy, the Environment and Water"
+        },
+        "effectiveDate": {
+          "example": "2024-03-20",
+          "type": "string",
+          "format": "date",
+          "description": "the date at which the regulation came into effect."
+        }
+      },
+      "description": "A regulation (eg EU deforestation regulation) that defines the criteria for assessment.",
+      "required": [
+        "administeredBy"
+      ]
+    },
+    "Criterion": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "Criterion"
+          ],
+          "default": [
+            "Criterion"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "Criterion"
+            ]
+          }
+        },
+        "id": {
+          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
+          "type": "string",
+          "format": "uri",
+          "description": "A unique identifier for the criterion within the standard  or regulation. For example CO2 emissions calculations for liquid fuel combustion."
+        },
+        "name": {
+          "example": "GBA Battery rule book v2.0 battery assembly guidelines.",
+          "type": "string",
+          "description": "A name that describes this criteria."
+        },
+        "thresholdValues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "A conformity threshold defined by the specification (eg minimum compressive strength) "
+        }
+      },
+      "description": "A specific rule or criterion within a standard or regulation. eg a carbon intensity calculation rule within an emissions standard.",
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "SecureLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "SecureLink",
+            "Link"
+          ],
+          "default": [
+            "SecureLink",
+            "Link"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "SecureLink",
+              "Link"
+            ]
+          }
+        },
+        "linkURL": {
+          "example": "https://files.example-certifier.com/1234567.json",
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the target resource. "
+        },
+        "linkName": {
+          "example": "GBA rule book conformity certificate",
+          "type": "string",
+          "description": "A display name for the target resource "
+        },
+        "linkType": {
+          "example": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+          "type": "string",
+          "description": "The type of the target resource - drawn from a controlled vocabulary "
+        },
+        "hashDigest": {
+          "example": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+          "type": "string",
+          "description": "The hash of the file."
+        },
+        "hashMethod": {
+          "type": "string",
+          "enum": [
+            "SHA-256",
+            "SHA-1"
+          ],
+          "example": "SHA-256",
+          "description": "The hashing algorithm used to create the target hash.  SHA-265 is the recommended standard"
+        },
+        "encryptionMethod": {
+          "type": "string",
+          "enum": [
+            "none",
+            "AES"
+          ],
+          "example": "none",
+          "description": "The symmetric encryption algorithm used to encrypt the link target.  AES is the recommended standard. Decryption keys are expected to be passed out of bounds."
+        }
+      },
+      "description": "A binary file that is hashed ()for tamper evidence) and optionally encrypted (for confidentiality)."
+    },
+    "CircularityPerformance": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "CircularityPerformance"
+          ],
+          "default": [
+            "CircularityPerformance"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "CircularityPerformance"
+            ]
+          }
+        },
+        "recyclingInformation": {
+          "$ref": "#/$defs/Link",
+          "description": "A URI pointing to recycling information for the product."
+        },
+        "repairInformation": {
+          "$ref": "#/$defs/Link",
+          "description": "A URI pointing to repair instructions for this product."
+        },
+        "recyclableContent": {
+          "example": 0.5,
+          "type": "number",
+          "format": "float",
+          "description": "The fraction of the this product (my mass) that has been designed to be recyclable / re-usable. This will be be the total fraction that can avoid waste / landfill."
+        },
+        "recycledContent": {
+          "example": 0.3,
+          "type": "number",
+          "format": "float",
+          "description": "The fraction (by mass) of recycled / repurposed, repaired content in this product.  This will be the total virgin content fraction."
+        },
+        "utilityFactor": {
+          "example": 1.2,
+          "type": "number",
+          "format": "float",
+          "description": "An indicator of durability defined as the lifetime (typically measures as usage cycles) for this product divided by the industry average. For example a battery with a 10,000 cycle lifetime where industry average is 5,000 cycles will have a durability factor of 2. If unknown set to 1 or omit.  "
+        },
+        "materialCircularityIndicator": {
+          "example": 0.67,
+          "type": "number",
+          "format": "float",
+          "description": "The overall circularity performance indicator for this product. Calculated as 1 - (V+W)/2D where - V = Virgin material proportion by mass (will be 1- recycled content) - W = Waste leakage proportion by mass (will be 1 - recyclableContent)  - D = Utility factor (set to 1 if unknown).  "
+        }
+      },
+      "description": "High level circularity information about this product.  Note that this does not substitute for detailed product circularity data sheet (PCDS) criteria which would be represented as a self-issued UNTP Digital Conformity Credential as a set of assessments against individual ISO PCDS criteria."
+    },
+    "EmissionsPerformance": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "EmissionsPerformance"
+          ],
+          "default": [
+            "EmissionsPerformance"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "EmissionsPerformance"
+            ]
+          }
+        },
+        "carbonFootprint": {
+          "example": 1.8,
+          "type": "number",
+          "format": "float",
+          "description": "The carbon footprint of the product in KgCO2e per declared unit."
+        },
+        "declaredUnit": {
+          "type": "string",
+          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode",
+          "description": "The unit of product (EA, KGM, LTR, etc) that is the basis for carbon footprint.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode\n    "
+        },
+        "operationalScope": {
+          "type": "string",
+          "enum": [
+            "None",
+            "CradleToGate",
+            "CradleToGrave"
+          ],
+          "example": "None",
+          "description": "The operational scope of the emissions performance. Only scope 1 & 2, or including upstream scope 3 (cradle to gate) or upstream and downstream scope 3 (cradle to grave)."
+        },
+        "primarySourcedRatio": {
+          "example": 0.3,
+          "type": "number",
+          "format": "float",
+          "description": "The ratio of emissions data from primary sources (ie from supplier / product specific information rather than secondary / industry averages)."
+        },
+        "reportingStandard": {
+          "$ref": "#/$defs/Standard",
+          "description": "The reporting standard (eg GHG Protocol, IFRS S2, ESRS, etc) against which this product emissions performance is assessed."
+        }
+      },
+      "description": "Product specific characteristics.  This class is an extension point for industry specific product characteristics or performance information such as clothing size or battery capacity.",
+      "required": [
+        "carbonFootprint",
+        "declaredUnit",
+        "operationalScope",
+        "primarySourcedRatio"
+      ]
+    },
+    "TraceabilityPerformance": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "array",
+          "readOnly": true,
+          "const": [
+            "TraceabilityPerformance"
+          ],
+          "default": [
+            "TraceabilityPerformance"
+          ],
+          "items": {
+            "type": "string",
+            "enum": [
+              "TraceabilityPerformance"
+            ]
+          }
+        },
+        "valueChainProcess": {
+          "example": "Spinning",
+          "type": "string",
+          "description": "Human readable name for the industry specific value chain process representing this traceability data set."
+        },
+        "verifiedRatio": {
+          "example": 0.5,
+          "type": "number",
+          "description": "The proportion (0 to 1) of materials in this value chain process that have been  traced using verifiable traceability event."
+        },
+        "traceabilityEvent": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SecureLink"
+          },
+          "description": "A list of secure links to digital traceability events that support this traceability performance statement. May be encrypted for confidentiality purposes. "
+        }
+      },
+      "description": "An array of secure links to TraceabilityEvent objects detailing EPCIS events related to the traceability of the product batch. Events are grouped by value chain process (eg \"Weaving\" in textiles supply chain)."
+    }
+  }
+}

--- a/packages/untp-test-suite/src/schemas/digitalProductPassport/v0.5.1/schema.json
+++ b/packages/untp-test-suite/src/schemas/digitalProductPassport/v0.5.1/schema.json
@@ -5,38 +5,46 @@
     "type": {
       "type": "array",
       "readOnly": true,
-      "const": [
-        "DigitalProductPassport",
-        "VerifiableCredential"
+      "allOf": [
+        {
+          "contains": {
+            "const": "VerifiableCredential"
+          }
+        },
+        {
+          "contains": {
+            "const": "DigitalProductPassport"
+          }
+        }
       ],
       "default": [
         "DigitalProductPassport",
         "VerifiableCredential"
       ],
       "items": {
-        "type": "string",
-        "enum": [
-          "DigitalProductPassport",
-          "VerifiableCredential"
-        ]
+        "type": "string"
       }
     },
     "@context": {
       "example": "https://test.uncefact.org/vocabulary/untp/dpp/dpp-context.jsonld",
       "type": "array",
+      "allOf": [
+        {
+          "contains": {
+            "const": "https://www.w3.org/ns/credentials/v2"
+          }
+        },
+        {
+          "contains": {
+            "const": "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/"
+          }
+        }
+      ],
       "items": {
-        "type": "string",
-        "enum": [
-          "https://www.w3.org/ns/credentials/v2",
-          "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/"
-        ]
+        "type": "string"
       },
       "description": "A list of JSON-LD context URIs that define the semantic meaning of properties within the credential. ",
       "readOnly": true,
-      "const": [
-        "https://www.w3.org/ns/credentials/v2",
-        "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/"
-      ],
       "default": [
         "https://www.w3.org/ns/credentials/v2",
         "https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/"
@@ -210,17 +218,14 @@
         "type": {
           "type": "array",
           "readOnly": true,
-          "const": [
-            "Product"
-          ],
+          "contains": {
+            "const": "Product"
+          },
           "default": [
             "Product"
           ],
           "items": {
-            "type": "string",
-            "enum": [
-              "Product"
-            ]
+            "type": "string"
           }
         },
         "id": {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

Running our 0.5.0 DPP schema validation for the [example Digital Product Passport for FoodAgility](https://aatp.foodagility.com/docs/specification/DigitalProductPassport#working-sample)  fails with:

```console
Testing Credential: digitalProductPassport
Version: v0.5.0
Path: credentials/productPassport/DigitalLivestockPassport-decoded-invalid.json
Result: FAIL
Error: 
/type field must be equal to constant.
/type/0 field must be equal to one of the allowed values. Allowed values: DigitalProductPassport, VerifiableCredential.
/@context field must be equal to constant.
/@context/1 field must be equal to one of the allowed values. Allowed values: https://www.w3.org/ns/credentials/v2, https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/.
/credentialSubject/type field must be equal to constant.
/credentialSubject/type/0 field must be equal to one of the allowed values. Allowed values: Product.
```

This (draft) PR defines a proposed schema change (for 0.5.1) that require the arrays to *contain* at least one (or two) specific values, rather than being constant. If there's agreement, we'll request this change in jargon (or better, wait for any other schema changes for the next release, before requesting the change in jargon).

I've included the decoded original example DPP from FoodAgility (decoded-invalid) as well as a slightly modified version (decoded-valid) so that they can both be tested with `yarn run untp test`. The updated version (decode-valid) ensures that
- the "type" includes "DigitalProductPassport" (in addition to "DigitalLivestockPassport"),
- the "context" field includes the [standard dpp context](https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/).

Note: the example DPP includes a context, [aatp-dlp-context](https://gs-gs.github.io/aatp/assets/files/aatp-dlp-context-0.4.0-7ed6f0cf85aa7626c480bd85212de2e4.jsonld) which appears to define the standard dpp context as well. It should be defining only the additional context for the DigitalLivestockPassport, I assume - I'll investigate that next. In the mean-time, it will be interesting to see if it fails the jsonld validation which @ashleythedeveloper is adding, or whether it will pass because it doesn't change or redefine those context values.

Note 2: The standard JSON-schema error messages used by the lib being used here, for the "contains", is not great. If, for example, the DPP's "type" field doesn't include the "DigitalProductPassport" value, the error is:

```console
Result: FAIL
Error: 
/type/0 field must be equal to constant.
/type/1 field must be equal to constant.
/type field must contain at least 1 valid item(s).
```

which is incorrect (the items in the array aren't const, rather one of them needs to contain the value "DigitalProductPassport" and none do). I'll investigate if this is the lib that we're using or whether it can be improved.

## Added tests?

- [x] 👍 yes (well, added test data for a proposed schema change, not code tests)
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Ref: https://github.com/gs-gs/fa-ag-trace/issues/905

<!-- note: PRs with deleted sections will be marked invalid -->

