### PR TITLE
fix(build): Copy templates to correct directory during yarn build.

### DIFF
--- a/packages/untp-test-suite/package.json
+++ b/packages/untp-test-suite/package.json
@@ -23,7 +23,7 @@
     "untp": "node build/interfaces/cli/cli.js",
     "test": "jest",
     "test:integration": "node --experimental-vm-modules ../../node_modules/.bin/jest --config=jest.integration.config.js",
-    "build": "tsc --build --clean && tsc && cp -r src/templates/templateMessages/ build/templates/templateMessages",
+    "build": "tsc --build --clean && tsc && cp -r src/templates/templateMessages/ build/templates/",
     "watch": "tsc -b --watch",
     "lint": "eslint ."
   },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

I just came across this while trying to fix something else:

Without this change, `yarn build` copies the templates to the wrong location after the first build, so any changes are not included:

When nothing exists, it works perfectly, creating the `templateMessages` directory with the files as expected:
```console
(venv) {fix-build-cp-of-templates} ~/dev/gosource/tests-untp/packages/untp-test-suite$ rm build/templates/templateMessages -rf
(venv) {fix-build-cp-of-templates} ~/dev/gosource/tests-untp/packages/untp-test-suite$ yarn build && ls -l build/templates/templateMessages
yarn run v1.22.22
$ tsc --build --clean && tsc && cp -r src/templates/templateMessages/ build/templates/templateMessages
Done in 1.41s.
total 16
-rw-rw-r-- 1 michael michael 134 Jan 29 12:48 credentialResult.hbs
-rw-rw-r-- 1 michael michael 337 Jan 29 12:48 errors.hbs
-rw-rw-r-- 1 michael michael  76 Jan 29 12:48 finalReport.hbs
-rw-rw-r-- 1 michael michael 247 Jan 29 12:48 warnings.hbs
```

but make a change to a template, and re-run `yarn build`, and you'll find your template changes aren't included, because they've been copied to `build/templates/templateMessages/templateMessages` . A confusing subtlety of `cp -r` :/ . 

```console
 yarn build && ls -l build/templates/templateMessages
yarn run v1.22.22
$ tsc --build --clean && tsc && cp -r src/templates/templateMessages/ build/templates/templateMessages
Done in 1.40s.
total 20
-rw-rw-r-- 1 michael michael  134 Jan 29 12:48 credentialResult.hbs
-rw-rw-r-- 1 michael michael  337 Jan 29 12:48 errors.hbs
-rw-rw-r-- 1 michael michael   76 Jan 29 12:48 finalReport.hbs
drwxrwxr-x 2 michael michael 4096 Jan 29 12:50 templateMessages     # <--- the files are now in here and not used
-rw-rw-r-- 1 michael michael  247 Jan 29 12:48 warnings.hbs
```

With the change, it behaves as expected, always copying the files to the correct destination.

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?


<!-- note: PRs with deleted sections will be marked invalid -->

