### PR TITLE
fix(errors): error messages need to be escaped to ensure valid json.

### DIFF
--- a/packages/untp-test-suite/src/templates/mapper.ts
+++ b/packages/untp-test-suite/src/templates/mapper.ts
@@ -5,8 +5,8 @@ import _ from 'lodash';
 import { IFinalReport, IValidatedCredentials } from '../core/types/index.js';
 import { getCurrentDirPath, getCurrentFilePath } from '../utils/path.js';
 
-Handlebars.registerHelper('jsonStringify', (jsonObject: object) => {
-  if (!_.isObject(jsonObject) || _.isEmpty(jsonObject)) {
+Handlebars.registerHelper('jsonStringify', (jsonObject: object | string) => {
+  if (!(_.isObject(jsonObject) || _.isString(jsonObject)) || _.isEmpty(jsonObject)) {
     throw new Error(
       `An error occurred in the Handlebars registerHelper 'jsonStringify' function. Please provide a valid JSON object.`,
     );
@@ -16,7 +16,14 @@ Handlebars.registerHelper('jsonStringify', (jsonObject: object) => {
     return jsonObject.join(', ');
   }
 
-  return JSON.stringify(jsonObject);
+  if (_.isString(jsonObject)) {
+    // JSON.stringify will not only escape any invalid JSON chars from a string
+    // (such as \), but it will also wrap the string in quotes, so we remove
+    // those.
+    return JSON.stringify(jsonObject).slice(1, -1);
+  }
+
+  return JSON.stringify(jsonObject,);
 });
 
 export async function templateMapper(templateName: string, testSuiteResult: IValidatedCredentials | IFinalReport) {

--- a/packages/untp-test-suite/src/templates/templateMessages/errors.hbs
+++ b/packages/untp-test-suite/src/templates/templateMessages/errors.hbs
@@ -4,7 +4,7 @@
       {
         "fieldName": "{{instancePath}}",
         "errorType": "{{keyword}}",
-        "message": "{{instancePath}} field {{{message}}}.{{#if params.allowedValues}} Allowed values: {{{jsonStringify params.allowedValues}}}.{{/if}}"
+        "message": "{{instancePath}} field called {{{jsonStringify message}}}.{{#if params.allowedValues}} Allowed values: {{{jsonStringify params.allowedValues}}}.{{/if}}"
       }
       {{#unless @last}},{{/unless}}
     {{/each}}


### PR DESCRIPTION
If the error message includes a regex with, for example, backslashes (as is often the case with regexes), the untp test function fails to report on the results, instead erroring with invalid character when the error report is converted to a JSON object.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

While working on a [proposal for more extensible JSON schema from jargon](https://github.com/absoludity/tests-untp/pull/1) I found that I couldn't run `yarn run untp test` with a schema that included certain regexes (specifically, the XMLSCHEMA11-2 regex for datetime), but instead, would get:

```console
 yarn run untp test
yarn run v1.22.22
$ node build/interfaces/cli/cli.js test
Run Untp test suites failed
SyntaxError: Bad escaped character in JSON at position 261
Done in 0.66s.
```

It took me way too long (partly my own fault) to realise it wasn't an issue in my JSON schema nor was it an out-dated ajv or something else. I eventually tracked it down to unescaped backslashes from the regex being included in error messages, which were then passed as JSON strings *without* being escaped.

First I thought I'd simply ensure the template used `jsonStringify` on the error message, but that didn't seem to work. Then I realised I needed to run `yarn build` to ensure the templates were copied over to the build dir (perhaps this could happen automatically if they're outdated, like Makefile functionality?). After another loss of time I realised my template change wasn't even being included when I ran `yarn build && yarn run untp test` because of #204 . Once I fixed that, I could see that my updated template was being copied, but I'd get an error:

```console
$ yarn build && yarn run untp test
yarn run v1.22.22
$ tsc --build --clean && tsc && cp -r src/templates/templateMessages/ build/templates/templateMessages
Done in 2.46s.
yarn run v1.22.22
$ node build/interfaces/cli/cli.js test
Run Untp test suites failed
Error: Failed to run mapper template. An error occurred in the Handlebars registerHelper 'jsonStringify' function. Please provide a valid JSON object.
Done in 0.65s.
```

So it turns out, unlike `JSON.stringify()`, the `jsonStringify` template helper doesn't apply to strings. I then realised this wasn't a standard handlebars filter but a locally defined helper (it's been a while), so I then updated it to support strings like `JSON.stringify()` does and saw that it worked IRL, but my test still failed... it turns out the test defines a replica of the errors.hbs template? Keen to understand why we do that rather than reading the actual template so we're testing that, rather than a duplicate which could be different over time?

Anyway, end of the long story is that with this change, I can test a schema with a regex with backslashes and get:

```console
 yarn run untp test
yarn run v1.22.22
$ node build/interfaces/cli/cli.js test
Testing Credential: digitalConformityCredential
Version: v0.5.0
Path: credentials/conformityCredential/DigitalConformityCredential_instance-v0.5.0.json
Result: FAIL
Error: 
/validFrom field called must match pattern '-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))'.
---
...
Done in 0.65s.
```

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Nope

<!-- note: PRs with deleted sections will be marked invalid -->

