### PR TITLE
fix: enhance error handling in context validation

### DIFF
--- a/packages/untp-playground/src/lib/contextValidation.ts
+++ b/packages/untp-playground/src/lib/contextValidation.ts
@@ -31,43 +31,49 @@ export async function validateContext(credential: Record<string, any>): Promise<
 
     return { valid: true, data: expanded };
   } catch (error: any) {
-    const checkSyntaxErrorResult = checkSyntaxError(error);
-    if (!checkSyntaxErrorResult.valid) {
-      return {
-        valid: false,
-        error: {
-          keyword: 'conflictingProperties',
-          message: checkSyntaxErrorResult.errorMessage as string,
-          instancePath: '@context',
-          params: {
-            conflictingProperty: checkSyntaxErrorResult.term,
-          }
-        },
-      }
-    }
+    console.log('Expand JSON-LD error:', error);
 
-    const checkInvalidContextResult = checkInvalidContext(error);
-    if (!checkInvalidContextResult.valid) {
-      return {
-        valid: false,
-        error: {
-          keyword: 'const',
-          message: checkInvalidContextResult.errorMessage as string,
-          instancePath: '@context',
-        },
-      };
-    }
-
-    const checkInvalidPropertiesResult = await checkInvalidProperties(error, credential);
-    if (!checkInvalidPropertiesResult.valid) {
-      return {
-        valid: false,
-        error: {
-          keyword: 'const',
-          message: checkInvalidPropertiesResult.errorMessage as string,
-          instancePath: checkInvalidPropertiesResult.invalidValues as string,
-        },
+    try {
+      const checkSyntaxErrorResult = checkSyntaxError(error);
+      if (!checkSyntaxErrorResult.valid) {
+        return {
+          valid: false,
+          error: {
+            keyword: 'conflictingProperties',
+            message: checkSyntaxErrorResult.errorMessage as string,
+            instancePath: '@context',
+            params: {
+              conflictingProperty: checkSyntaxErrorResult.term,
+            }
+          },
+        }
       }
+  
+      const checkInvalidContextResult = checkInvalidContext(error);
+      if (!checkInvalidContextResult.valid) {
+        return {
+          valid: false,
+          error: {
+            keyword: 'const',
+            message: checkInvalidContextResult.errorMessage as string,
+            instancePath: '@context',
+          },
+        };
+      }
+  
+      const checkInvalidPropertiesResult = await checkInvalidProperties(error, credential);
+      if (!checkInvalidPropertiesResult.valid) {
+        return {
+          valid: false,
+          error: {
+            keyword: 'const',
+            message: checkInvalidPropertiesResult.errorMessage as string,
+            instancePath: checkInvalidPropertiesResult.invalidValues as string,
+          },
+        }
+      }
+    } catch (error) {
+      console.log('Context validation error:', error);
     }
 
     return {
@@ -163,7 +169,7 @@ export function getDroppedProperties(originalObject: Record<string, any>, compac
       // If key does not exist in objB, record it
       if (!(key in objectB)) {
         uniqueKeys.push(currentPath.join('/'));
-      } else if (typeof objectA[key] === 'object' && objectA[key] !== null) {
+      } else if (typeof objectA[key] === 'object' && objectA[key] !== null && !Array.isArray(objectA[key])) {
         // Recursively search for unique keys
         findUniqueKeys(objectA[key], objectB[key], currentPath);
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR aims fix the silent failure occurring in the JSON-LD Document Expansion and Context Validation step of the UNTP Playground.

## Related Tickets & Documents

https://github.com/gs-gs/fa-ag-trace/issues/954

## Mobile & Desktop Screenshots/Recordings

Verify that the context validation error should be displayed on the UI instead of failing silently.
 
<img width="1167" alt="Screenshot 2025-02-18 at 11 21 01 AM" src="https://github.com/user-attachments/assets/0900a9c1-2f3d-40ef-aec1-b13c494e82cb" />

<img width="1167" alt="Screenshot 2025-02-18 at 11 21 09 AM" src="https://github.com/user-attachments/assets/df345039-af4e-4cb1-a9ed-643a9da8ca0f" />

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed