### PR TITLE
test: add JSON-LD expansion and validation e2e tests

### DIFF
--- a/e2e/cypress/e2e/untp-playground/jsonld-expansion-validation.cy.ts
+++ b/e2e/cypress/e2e/untp-playground/jsonld-expansion-validation.cy.ts
@@ -1,0 +1,96 @@
+import { VCDM_CONTEXT_URLS } from '../../../../packages/untp-playground/constants';
+
+describe('JSON-LD Expansion and Validation', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:4000');
+  });
+
+  const validCredential = {
+    '@context': ['https://www.w3.org/ns/credentials/v2', 'https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/'],
+    type: ['VerifiableCredential', 'DigitalProductPassport'],
+    issuer: {
+      id: 'did:example:123',
+      name: 'dev',
+    },
+    credentialSubject: {
+      name: 'John Doe',
+      id: 'did:example:123',
+      type: ['Product'],
+    },
+  };
+
+  const invalidJsonldSyntaxCredential = {
+    ...validCredential,
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://test.uncefact.org/vocabulary/untp/dpp/0.5.0/',
+      {
+        '': '',
+      },
+    ],
+  };
+
+  const unresolvableContextCredential = {
+    ...validCredential,
+    '@context': ['https://www.invalid.com'],
+  };
+
+  const invalidPropertiesCredential = {
+    ...validCredential,
+    credentialSubject: {
+      ...validCredential.credentialSubject,
+      invalid: 'invalid-value',
+    },
+  };
+
+  it('should validate context expansion and validation successfully', () => {
+    cy.uploadCredential(validCredential);
+    cy.expandGroup();
+    cy.checkValidationStatus('JSON-LD Document Expansion and Context Validation', 'success');
+  });
+
+  it('should show error for invalid JSON-LD syntax', () => {
+    cy.uploadCredential(invalidJsonldSyntaxCredential);
+    cy.expandGroup();
+    cy.checkValidationStatus('JSON-LD Document Expansion and Context Validation', 'failure');
+
+    cy.openErrorDetailsByStepName('JSON-LD Document Expansion and Context Validation');
+    cy.openValidationDetails('Fix validation error');
+
+    cy.checkValidationErrorMessages([
+      'Conflicting field: unknown',
+      'Failed to validate JSON-LD syntax.',
+      'Resolve the conflict by removing the conflicting field or updating it to a unique one.',
+    ]);
+  });
+
+  it('should show error for unresolvable context', () => {
+    cy.uploadCredential(unresolvableContextCredential);
+    cy.expandGroup();
+    cy.checkValidationStatus('JSON-LD Document Expansion and Context Validation', 'failure');
+
+    cy.openErrorDetailsByStepName('JSON-LD Document Expansion and Context Validation');
+    cy.openValidationDetails('Use the correct value');
+
+    cy.checkValidationErrorMessages([
+      'Incorrect value: @context',
+      'Invalid URL: "https://www.invalid.com". Failed to resolve context url.',
+      'Update the value(s) to the correct one(s) or remove the field(s).',
+    ]);
+  });
+
+  it('should show error for invalid properties', () => {
+    cy.uploadCredential(invalidPropertiesCredential);
+    cy.expandGroup();
+    cy.checkValidationStatus('JSON-LD Document Expansion and Context Validation', 'failure');
+
+    cy.openErrorDetailsByStepName('JSON-LD Document Expansion and Context Validation');
+    cy.openValidationDetails('Use the correct value');
+
+    cy.checkValidationErrorMessages([
+      'Incorrect value: credentialSubject/invalid',
+      'Properties "credentialSubject/invalid" are defined in the credential but missing from the context.',
+      'Update the value(s) to the correct one(s) or remove the field(s).',
+    ]);
+  });
+});

--- a/e2e/cypress/e2e/untp-playground/jsonld-expansion-validation.cy.ts
+++ b/e2e/cypress/e2e/untp-playground/jsonld-expansion-validation.cy.ts
@@ -55,12 +55,12 @@ describe('JSON-LD Expansion and Validation', () => {
     cy.checkValidationStatus('JSON-LD Document Expansion and Context Validation', 'failure');
 
     cy.openErrorDetailsByStepName('JSON-LD Document Expansion and Context Validation');
-    cy.openValidationDetails('Fix validation error');
+    cy.openValidationDetails('Use the correct value');
 
     cy.checkValidationErrorMessages([
-      'Conflicting field: unknown',
-      'Failed to validate JSON-LD syntax.',
-      'Resolve the conflict by removing the conflicting field or updating it to a unique one.',
+      'Incorrect value: @context',
+      'Invalid JSON-LD syntax; a term cannot be an empty string. Context: {"":""}',
+      'Update the value(s) to the correct one(s) or remove the field(s).',
     ]);
   });
 

--- a/e2e/cypress/support/commands/untp-playground.ts
+++ b/e2e/cypress/support/commands/untp-playground.ts
@@ -33,6 +33,11 @@ Cypress.Commands.add('openErrorDetails', () => {
   cy.contains('View Details').click();
 });
 
+// Command to open error details for a specific step
+Cypress.Commands.add('openErrorDetailsByStepName', (stepName: string) => {
+  cy.contains(stepName).parent().parent().contains('View Details').click();
+});
+
 // Command to validate that the confetti is visible
 Cypress.Commands.add('validateConfetti', () => {
   cy.get('canvas')
@@ -52,4 +57,16 @@ Cypress.Commands.add('checkVCDMVersionColor', (credentialType: string, expectedC
   cy.get(`[data-testid="${credentialType}-vcdm-version"]`)
     .should('have.class', colorClasses[expectedColor][0])
     .and('have.class', colorClasses[expectedColor][1]);
+});
+
+// Command to open validation details
+Cypress.Commands.add('openValidationDetails', (validationTitle: string = 'Fix validation error') => {
+  cy.contains(validationTitle).click();
+});
+
+// Command to check the error messages displayed on the validation errors tab
+Cypress.Commands.add('checkValidationErrorMessages', (errorMessages: string[]) => {
+  errorMessages.forEach((message) => {
+    cy.contains(message).should('be.visible');
+  });
 });

--- a/e2e/cypress/support/index.d.ts
+++ b/e2e/cypress/support/index.d.ts
@@ -25,6 +25,11 @@ interface PlaygroundChainable {
   openErrorDetails(): Cypress.Chainable<void>;
 
   /**
+   * Opens the error details for a specific step.
+   */
+  openErrorDetailsByStepName(stepName: string): Cypress.Chainable<void>;
+
+  /**
    * Validates that the confetti is visible.
    */
   validateConfetti(): Cypress.Chainable<void>;
@@ -33,6 +38,16 @@ interface PlaygroundChainable {
    * Checks the color of the VCDM version badge.
    */
   checkVCDMVersionColor(credentialType: string, expectedColor: 'green' | 'red'): Cypress.Chainable<void>;
+
+  /**
+   * Opens the validation details.
+   */
+  openValidationDetails(validationTitle: string): Cypress.Chainable<void>;
+
+  /**
+   * Checks the error messages displayed on validation errors tab.
+   */
+  checkValidationErrorMessages(errorMessages: string[]): Cypress.Chainable<void>;
 }
 
 interface IssueChainable {

--- a/packages/untp-playground/__tests__/lib/contextValidation.test.ts
+++ b/packages/untp-playground/__tests__/lib/contextValidation.test.ts
@@ -49,6 +49,7 @@ describe('contextValidation', () => {
       };
       const result = checkSyntaxError(error);
       expect(result).toEqual({
+        keyword: 'conflictingProperties',
         valid: false,
         term: 'id',
         errorMessage: 'Invalid JSON-LD syntax: redefine-protected-term. "id" is a protected term.'
@@ -57,10 +58,12 @@ describe('contextValidation', () => {
   
     it('should return valid: false with unknown term when jsonld.SyntaxError lacks details', () => {
       const error = {
-        name: 'jsonld.SyntaxError'
+        name: 'jsonld.SyntaxError',
+        message: 'Failed to validate JSON-LD syntax.'
       };
       const result = checkSyntaxError(error);
       expect(result).toEqual({
+        keyword: 'const',
         valid: false,
         term: 'unknown',
         errorMessage: 'Failed to validate JSON-LD syntax.'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR implements end-to-end tests for the [JSON-LD expansion validation step](https://github.com/gs-gs/fa-ag-trace/issues/908) in the UNTP playground. These tests ensure the feature functions correctly across all scenarios, including valid JSON-LD credential expansion and various invalid JSON-LD cases. Additionally, they verify that error messages are displayed correctly in the UI.

## Related Tickets & Documents

https://github.com/gs-gs/fa-ag-trace/issues/955

## Mobile & Desktop Screenshots/Recordings

Valid case:

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/fd6ed3e2-afc3-41a3-b4c8-d57abd1482a1" />

Missing "credentialSubject/invalid" property in the context:

<img width="2034" alt="Screenshot 2025-02-21 at 10 45 05 AM" src="https://github.com/user-attachments/assets/8c3bd384-9048-4511-9aa0-34b94c9245bb" />

Unresolvable/invalid context URL:

<img width="2034" alt="Screenshot 2025-02-21 at 10 45 49 AM" src="https://github.com/user-attachments/assets/a205d001-8860-4ec1-9edd-f106469399a3" />

Invalid term:

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/50b4ce6e-ac95-4958-bb7a-3e9f88c2a68b" />

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
