### PR TITLE
ci: separate e2e tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 docker-compose.yaml
 .dockerignore
 **/Dockerfile
-**/node_modules
+**/node_modules/
 **/__test__
 **/coverage
 **/build
@@ -24,6 +24,7 @@ aws
 .DS_Store
 e2e/package.json
 e2e/yarn.lock
+e2e/node_modules/
 
 packages/mock-app/src/constants/app-config.json
 packages/components/src/constants/app-config.json

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,15 +51,6 @@ jobs:
             VC test suite, ./packages/vc-test-suite/coverage/coverage-summary.json
             UNTP Playground, ./packages/untp-playground/coverage/coverage-summary.json
 
-      # - name: Start E2E docker compose
-      #   run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d
-
-      # - name: Run E2E tests
-      #   run: yarn test:run-cypress
-
-      # - name: Stop docker compose
-      #   run: docker compose -f docker-compose.e2e.yml down
-
   build_docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,14 +51,14 @@ jobs:
             VC test suite, ./packages/vc-test-suite/coverage/coverage-summary.json
             UNTP Playground, ./packages/untp-playground/coverage/coverage-summary.json
 
-      - name: Start E2E docker compose
-        run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d
+      # - name: Start E2E docker compose
+      #   run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d
 
-      - name: Run E2E tests
-        run: yarn test:run-cypress
+      # - name: Run E2E tests
+      #   run: yarn test:run-cypress
 
-      - name: Stop docker compose
-        run: docker compose -f docker-compose.e2e.yml down
+      # - name: Stop docker compose
+      #   run: docker compose -f docker-compose.e2e.yml down
 
   build_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -21,13 +21,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'yarn'
 
       - name: Install dependencies
         run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           cd e2e && yarn install --immutable
 
       - name: Start E2E docker compose

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: E2E Test
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_and_build:
+  e2e-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -19,6 +19,16 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: |
+          cd e2e && yarn install --immutable
 
       - name: Start E2E docker compose
         run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches:
+      - next
+  push:
+    branches:
+      - next
+      - main
+  workflow_dispatch:
+
+jobs:
+  test_and_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Start E2E docker compose
+        run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d
+
+      - name: Run E2E tests
+        run: yarn test:run-cypress
+
+      - name: Stop docker compose
+        run: docker compose -f docker-compose.e2e.yml down

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Run tests
         run: yarn test
 
-      - name: Start E2E docker compose
-        run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d
+      # - name: Start E2E docker compose
+      #   run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d
 
-      - name: Run E2E tests
-        run: yarn test:run-cypress
+      # - name: Run E2E tests
+      #   run: yarn test:run-cypress
 
-      - name: Stop docker compose
-        run: docker compose -f docker-compose.e2e.yml down
+      # - name: Stop docker compose
+      #   run: docker compose -f docker-compose.e2e.yml down
 
   build_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,15 +41,6 @@ jobs:
       - name: Run tests
         run: yarn test
 
-      # - name: Start E2E docker compose
-      #   run: SEEDING=true docker compose -f docker-compose.e2e.yml up -d
-
-      # - name: Run E2E tests
-      #   run: yarn test:run-cypress
-
-      # - name: Stop docker compose
-      #   run: docker compose -f docker-compose.e2e.yml down
-
   build_docs:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ COPY package*.json yarn.lock ./
 
 # ---- Dependencies ----
 FROM base AS dependencies
+RUN df -h
+RUN ls -la
 COPY . .
+RUN df -h
+RUN ls -la
 RUN yarn install && yarn cache clean
 
 # ---- Build ----

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -147,6 +147,8 @@ services:
         CONFIG_FILE: ./e2e/cypress/fixtures/app-config.json
     ports:
       - '3003:80'
+    depends_on:
+      - untp-playground
 
 volumes:
   vckit-data:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR is an interim solution that separates the e2e tests from the build workflow in an attempt to reduce disk space usage, as we are hitting the worker's limit when one worker triggers a single workflow.

## Related Tickets & Documents


## Mobile & Desktop Screenshots/Recordings



## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

