### PR TITLE
fix: untp playground build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Run E2E tests
         run: yarn test:run-cypress
+        env:
+          NODE_OPTIONS: "--no-experimental-require-module --no-experimental-detect-module" # See issue https://github.com/cypress-io/github-action/issues/1408
 
       - name: Stop docker compose
         run: docker compose -f docker-compose.e2e.yml down

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,7 +1,8 @@
 services:
   untp-playground:
     build:
-      context: packages/untp-playground
+      context: .
+      dockerfile: packages/untp-playground/Dockerfile
     ports:
       - '4000:3000'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
 
   untp-playground:
     build:
-      context: packages/untp-playground
+      context: .
+      dockerfile: packages/untp-playground/Dockerfile
     ports:
       - '4000:3000'
     volumes:

--- a/packages/untp-playground/Dockerfile
+++ b/packages/untp-playground/Dockerfile
@@ -12,7 +12,7 @@ ENV NEXT_PUBLIC_BASE_PATH=/
 ENV NEXT_PUBLIC_ASSET_PREFIX=/
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json ../../yarn.lock* ./
 RUN yarn install
 
 

--- a/packages/untp-playground/Dockerfile
+++ b/packages/untp-playground/Dockerfile
@@ -12,7 +12,7 @@ ENV NEXT_PUBLIC_BASE_PATH=/
 ENV NEXT_PUBLIC_ASSET_PREFIX=/
 
 # Install dependencies based on the preferred package manager
-COPY package.json ../../yarn.lock* ./
+COPY packages/untp-playground/package.json yarn.lock ./
 RUN yarn install
 
 
@@ -20,7 +20,7 @@ RUN yarn install
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+COPY packages/untp-playground/. .
 
 # Add build args without defaults
 ARG NEXT_PUBLIC_BASE_PATH

--- a/packages/untp-playground/Dockerfile
+++ b/packages/untp-playground/Dockerfile
@@ -13,7 +13,7 @@ ENV NEXT_PUBLIC_ASSET_PREFIX=/
 
 # Install dependencies based on the preferred package manager
 COPY packages/untp-playground/package.json yarn.lock ./
-RUN yarn install
+RUN yarn install --immutable
 
 
 # Rebuild the source code only when needed


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR resolves a build failure in the UNTP Playground when provisioning the service locally or in the pipeline using Docker/Docker Compose (see issue #265).

The issue arose because the Dockerfile referenced the Yarn lock file in the `untp-playground` package directory, but the repository structure places the Yarn lock file in the root directory, with dependencies listed in the `package.json` file within the packages directory.

I identified three possible solutions:

**Option 1**  
Copy the Yarn lock file into the `untp-playground` package within the workflow file. This simple solution fixes the pipeline issue but leaves local builds broken.

**Option 2**  
Use the Docker Compose [additional_contexts](https://docs.docker.com/reference/compose-file/build/#additional_contexts) attribute to include the root directory and reference it in the Playground’s Dockerfile to copy the Yarn lock file. While straightforward, this requires the latest Docker Compose version, which would complicate documentation.

**Option 3 (chosen)**  
Change the build context. The Yarn lock file lies outside the build context set in the Docker Compose file (`packages/untp-playground`). I updated the build context to the root directory and modified the Dockerfile to copy the lock file from the root and the `untp-playground` package.

I've also refined the copy command to only copy existing files and removed the wildcard suffix from `yarn.lock`. This ensures the pipeline fails if the lock file is missing.

### Additional Fix
I've also included a fix for the Cypress environment (I know, naughty me). The end-to-end (e2e) test step was failing due to a Node version update in GitHub Action workers, which has apparently enabled experimental features by default. These features caused issues when transpiling the Cypress config written in TypeScript (see [pipeline run](https://github.com/uncefact/tests-untp/actions/runs/14987679978/job/42104577783) and [issue](https://github.com/cypress-io/github-action/issues/1408)). The fix sets two experimental feature flags to `false` in the workflow:

```yaml
env:
  NODE_OPTIONS: "--no-experimental-require-module --no-experimental-detect-module"
```
Which resolves the issue (see [pipeline run](https://github.com/uncefact/tests-untp/actions/runs/14988287837/job/42106273807)).

The remaining e2e test failures in the pipeline will be resolved once the reference implementation’s data models are updated to v0.6.0.


## Related Tickets & Documents
fixes #265

## Mobile & Desktop Screenshots/Recordings
<img width="1822" alt="Screenshot 2025-05-13 at 1 41 29 pm" src="https://github.com/user-attachments/assets/76876d29-ee26-4b03-805d-a3a50ba4a3da" />
<img width="1695" alt="Screenshot 2025-05-13 at 12 16 53 pm" src="https://github.com/user-attachments/assets/1b148b97-ea92-447c-bf1a-0cca97bb76c3" />
<img width="1663" alt="Screenshot 2025-05-13 at 12 17 21 pm" src="https://github.com/user-attachments/assets/31c1e364-f630-405f-acce-3649a8806ce6" />


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed