### PR TITLE
test: update dia tests to v0.6.0

### DIFF
--- a/e2e/cypress/e2e/issue_workflow_test/DIA/issueDIA.cy.ts
+++ b/e2e/cypress/e2e/issue_workflow_test/DIA/issueDIA.cy.ts
@@ -11,7 +11,7 @@ class DIAIssueFlow extends IssuePage {
   }
 
   testUNTPTestSuite() {
-    this.runUntpTest('digitalIdentityAnchor', 'v0.2.1', {}, 'WARN');
+    this.runUntpTest('digitalIdentityAnchor', 'v0.6.0');
   }
 }
 
@@ -26,15 +26,15 @@ describe('Issue DIA end-to-end testing flow', () => {
     diaTest.testAppConfig();
   });
 
-  it('should generate DCC', () => {
+  it('should generate DIA', () => {
     diaTest.testGenerateDCCWorkflow();
   });
 
-  it('Verify linkType for DCC', () => {
-    diaTest.verifyLinkType('http://localhost:3000/gs1/01/09359502000010');
+  it('Verify linkType for DIA', () => {
+    diaTest.verifyLinkType('http://localhost:3000/gs1/01/09359502000010?linkType=gs1:registryEntry');
   });
 
-  it('Runs testing UNTP test suite for DCC', () => {
+  it('Runs testing UNTP test suite for DIA', () => {
     diaTest.testUNTPTestSuite();
   });
 });

--- a/e2e/cypress/fixtures/app-config.json
+++ b/e2e/cypress/fixtures/app-config.json
@@ -524,27 +524,111 @@
               "type": "EntryData",
               "props": {
                 "schema": {
-                  "url": "https://jargon.sh/user/unece/DigitalIdentityAnchor/v/working/artefacts/jsonSchemas/RegisteredIdentity.json?class=RegisteredIdentity"
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "type": {
+                      "type": "array",
+                      "readOnly": true,
+                      "default": ["RegisteredIdentity"],
+                      "items": {
+                        "type": "string"
+                      },
+                      "allOf": [
+                        {
+                          "contains": {
+                            "const": "RegisteredIdentity",
+                            "minContains": 1
+                          }
+                        }
+                      ]
+                    },
+                    "id": {
+                      "example": "did:web:samplecompany.com/123456789",
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The DID that is controlled by the registered member and is linked to the registeredID through this Identity Anchor credential"
+                    },
+                    "name": {
+                      "example": "Sample business Ltd",
+                      "type": "string",
+                      "description": "The registered name of the entity within the identifier scheme.  Examples: product - EV battery 300Ah, Party - Sample Company Pty Ltd,  Facility - Green Acres battery factory"
+                    },
+                    "registeredId": {
+                      "example": 123456789,
+                      "type": "string",
+                      "description": "The registration number (alphanumeric) of the entity within the register. Unique within the register."
+                    },
+                    "idScheme": {
+                      "$ref": "#/$defs/IdentifierScheme",
+                      "description": "An identifier registration scheme for products, facilities, or organisations. Typically operated by a state, national or global authority."
+                    },
+                    "registerType": {
+                      "type": "string",
+                      "enum": ["Product", "Facility", "Business", "Trademark", "Land", "Accreditation"],
+                      "example": "Product",
+                      "description": "The thematic purpose of the register - organisations, facilities, products, trademarks, etc"
+                    },
+                    "registrationScopeList": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "description": "List of URIs the represent the role/scopes of membership for the register. For example [\"https://abr.business.gov.au/Help/EntityTypeDescription?Id=19\"]"
+                    }
+                  },
+                  "description": "The identity anchor is a mapping between a registery member identity and one or more decentralised identifiers owned by the member. It may also list a set of membership scopes.",
+                  "required": ["id", "name"],
+                  "$defs": {
+                    "IdentifierScheme": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": ["IdentifierScheme"],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "IdentifierScheme",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://id.gs1.org/01/",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The globally unique identifier of the registration scheme. The scheme should be registered and discoverable from vocabulary.uncefact.org/identifierSchemes"
+                        },
+                        "name": {
+                          "example": "Global Trade Identification Number (GTIN)",
+                          "type": "string",
+                          "description": "The name of the identifier scheme. "
+                        }
+                      },
+                      "description": "An identifier registration scheme for products, facilities, or organisations. Typically operated by a state, national or global authority."
+                    }
+                  }
                 },
                 "data": {
-                  "type": ["RegisteredIdentity", "Identifier"],
-                  "id": "https://id.gs1.org/01/09359502000010",
-                  "name": "Sample business Ltd",
-                  "registeredId": "0109359502000010",
+                  "type": ["RegisteredIdentity"],
+                  "id": "did:web:uncefact.github.io:project-vckit:test-and-development",
+                  "name": "Example Company",
+                  "registeredId": "09359502000010",
                   "idScheme": {
                     "type": ["IdentifierScheme"],
                     "id": "https://id.gs1.org/01/",
                     "name": "Global Trade Identification Number (GTIN)"
                   },
-                  "registerType": "Business",
-                  "registrationScopeList": ["https://jargon.sh", "https://jargon.sh"]
-                },
-                "style": {},
-                "className": "",
-                "constructData": {
-                  "mappingFields": [],
-                  "dummyFields": [],
-                  "generationFields": []
+                  "registerType": "Business"
                 }
               }
             },
@@ -563,18 +647,18 @@
                     "vckitAPIUrl": "http://localhost:3332/v2",
                     "issuer": {
                       "id": "did:web:uncefact.github.io:project-vckit:test-and-development",
-                      "name": "Orchard Facility"
+                      "name": "Example Company"
                     },
                     "headers": {
                       "Authorization": "Bearer test123"
                     }
                   },
                   "digitalIdentityAnchor": {
-                    "context": ["https://test.uncefact.org/vocabulary/untp/dia/0.2.1/"],
+                    "context": ["https://test.uncefact.org/vocabulary/untp/dia/0.6.0/"],
                     "renderTemplate": [
                       {
-                        "template": "<!DOCTYPE html> <html lang=\"en\"> <head> <meta charset=\"UTF-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> <link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap\" rel=\"stylesheet\"> <title>Digital Identity Anchor</title> <style> :root { --primary-colorsblue-10: rgba(247, 250, 253, 1); --primary-colorsgray-100: rgba(250, 250, 250, 1); --white: rgba(255, 255, 255, 1); --black: rgba(0, 0, 0, 1); --primary-colorsgray-300: rgba(237, 239, 240, 1); --primary-colorsgray-500: rgba(169, 177, 183, 1); --primary-colorsgray-600: rgba(85, 96, 110, 1); --primary-colorsblue-700: rgba(31, 90, 149, 1); --primary-colorsgray-700: rgba(35, 46, 61, 1); --primary-colorsblue-100: rgba(181, 213, 245, 0.5); --primary-colorsblue-100-full: rgba(181, 213, 245, 1); --primary-colorsblue-200: rgba(148, 196, 245, 1); --primary-colorsblue-400: rgba(79, 149, 221, 1); --primary-colorsblue-600: rgba(0, 110, 181, 1); --primary-colorsgray-400: rgba(212, 214, 216, 1); --primary-colorsgray-300: rgba(237, 239, 240, 1); --accent-colorslight-green: rgba(184, 236, 182, 1); --text-color-green: rgba(8, 50, 0, 1); --accent-colorslight-red: rgba(255, 188, 183, 1); --text-color-red: rgba(50, 0, 0, 1); } /* Globals CSS */ * { margin: 0; box-sizing: border-box; } body { font-family: 'Lato', sans-serif; } section { padding: 0 16px 0 16px; } a { text-decoration: none; } .facility-record { width: 100%; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; word-break: break-word; } .facility-record .contents { display: flex; flex-direction: column; gap: 24px; } .facility-record .traceability-header { display: flex; flex-direction: column; width: 100%; align-items: center; } .facility-record .TRACE-header { display: flex; flex-direction: column; width: 100%; align-items: flex-start; gap: 12px; padding: 32px 16px 20px 16px; background-color: var(--primary-colorsgray-700); } .facility-record .PP-title { width: 100%; font-weight: 500; color: var(--white); font-size: 16px; line-height: 22px; text-transform: uppercase; } .facility-record .name-description { display: flex; flex-direction: column; gap: 8px; } .facility-record .name-description h1 { font-weight: 900; color: var(--white); font-size: 30px; line-height: 32.5px; } .facility-record .name-description p { font-weight: 500; color: var(--white); font-size: 16px; line-height: 17.4px; } .facility-record .text-wrapper { align-self: stretch; font-weight: 900; color: var(--white); font-size: 30px; line-height: 32.5px; } .facility-record .issuing-organisation { padding: 0px 16px 16px; align-self: stretch; width: 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 4px; background-color: var(--primary-colorsgray-600); } .facility-record .data-two-columns { display: grid; grid-template-columns: 1fr 2fr; gap: 16px; padding: 10px 0px 12px; width: 100%; border-bottom-width: 1px; border-bottom-style: solid; } .facility-record .data-two-columns:last-child { border-bottom: none; } .facility-record .table-line { border-bottom: 1px solid #d4d6d8; } .facility-record .item-value a { color: #232E3D; } .facility-record .declarations { display: flex; flex-direction: column; gap: 12px; padding: 0px 16px; width: 100%; } .facility-record .declaration-title { font-size: 20px; font-weight: 700; line-height: 21.8px; color: var(--primary-colorsgray-700); } .facility-record .cards-conformities { display: flex; flex-direction: column; gap: 8px; } .facility-record .cards-conformity { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; min-width: 100%; padding: 16px 18px 16px 16px; position: relative; background-color: var(--white); border-radius: 4px; border: 1px solid; border-color: var(--primary-colorsgray-400); } .facility-record .frame { display: flex; align-items: center; justify-content: space-between; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .facility-record .div-2 { display: inline-flex; align-items: center; gap: 4px; position: relative; flex: 0 0 auto; } .facility-record .company-name { position: relative; width: fit-content; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .facility-record .tags-VC-badge-red { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-red); color: var(--text-color-red); border-radius: 8px; overflow: hidden; } .facility-record .tags-VC-badge-green { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-green); color: var(--text-color-green); border-radius: 8px; overflow: hidden; } .facility-record .verifiable { width: fit-content; font-weight: 600; font-size: 14px; line-height: 15.3px; } .facility-record .frame-2 { display: flex; flex-direction: column; align-items: center; gap: 4px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .facility-record .text-wrapper { position: relative; align-self: stretch; margin-top: -1px; font-weight: 400; color: var(--primary-colorsblue-700); font-size: 18px; line-height: 21.2px; } .facility-record .p { color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; align-self: stretch; font-weight: 400; color: #55606e; } .facility-record .span { font-weight: 400; font-size: 14px; line-height: 19.2px; } .facility-record .text-wrapper-3 { color: #55606e; } .facility-record .gray-bottom-line { border-bottom: 1px #55606E solid; width: fit-content; text-decoration: none; } .facility-record .frame-3 { display: flex; flex-direction: column; align-items: flex-start; justify-content: flex-end; gap: 8px; align-self: stretch; width: 100%; } .facility-record .frame-4 { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; flex: 1; flex-grow: 1; } .facility-record .typography-heading { display: inline-flex; align-items: center; justify-content: center; gap: 10px; } .facility-record .heading { flex: 1; color: var(--primary-colorsgray-700); font-size: 16px; font-weight: 400; line-height: 17.44px; } .facility-record .heading-2 { flex: 1; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .facility-record .cards-traceability { display: flex; align-items: center; justify-content: space-between; padding: 8px 0px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; border-radius: 4px; } .facility-record .frame-5 { display: inline-flex; align-items: center; gap: 8px; position: relative; flex: 0 0 auto; } .facility-record .company-name-wrapper { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; } .facility-record .company-name-2 { color: var(--black); font-size: 16px; line-height: 17.4px; align-self: stretch; font-weight: 400; } .facility-record .issuing-details { width: 100%; padding: 24px 16px 36px; display: flex; flex-direction: column; align-items: flex-start; gap: 4px; } .facility-record .typography-heading { display: inline-flex; align-items: center; justify-content: center; gap: 10px; } .facility-record .text-wrapper-2 { width: fit-content; font-weight: 700; color: var(--black); font-size: 20px; line-height: 21.8px; } .facility-record .div { display: inline-flex; flex-direction: column; align-items: flex-start; width: 100%; } .facility-record .data-two-columns-2 { display: grid; grid-template-columns: 1.4fr 3fr; gap: 16px; padding: 10px 0px 12px; width: 100%; border-bottom-width: 1px; border-bottom-style: solid; } .facility-record .border-bottom-gray-400 { border-color: var(--primary-colorsgray-400); } .facility-record .border-bottom-gray-500 { border-color: var(--primary-colorsgray-500); } .facility-record .border-bottom-blue-100 { border-color: var(--primary-colorsblue-100-full); } .facility-record .border-bottom-blue-200 { border-color: var(--primary-colorsblue-200); } .facility-record .label { font-weight: 400; color: var(--primary-colorsgray-300); font-size: 16px; line-height: 22px; } .facility-record .label-2 { font-weight: 400; color: var(--primary-colorsgray-600); font-size: 16px; line-height: 22px; } .facility-record .data-data-link { flex-direction: column; align-items: flex-start; gap: 6px; align-self: stretch; display: flex; flex: 1; flex-grow: 1; } .facility-record .div-wrapper { gap: 10px; display: inline-flex; align-items: flex-start; text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: var(--primary-colorsblue-400); text-underline-offset: 3px; } .facility-record .line { display: inline-flex; align-items: flex-start; gap: 10px; border-bottom-width: 2px; border-bottom-style: solid; border-color: var(--primary-colorsblue-200); } .facility-record .line-2 { width: fit-content; font-weight: 500; color: var(--white); font-size: 16px; line-height: 17.4px; } .facility-record .line-3 { width: fit-content; font-weight: 500; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 22px; } .facility-record .line-4 { display: inline-flex; align-items: flex-start; gap: 10px; border-bottom-width: 2px; border-bottom-style: solid; border-color: var(--primary-colorsblue-400); } .facility-record .data-data { display: flex; align-items: center; gap: 10px; align-self: stretch; flex-grow: 1; flex: 1; } .facility-record .data-data a { line-height: 22px; } .facility-record .data-data-2 a { margin-right: 10px; } .facility-record .data { flex: 1; font-weight: 500; color: var(--white); font-size: 16px; line-height: 17.4px; } .facility-record .data-2 { font-weight: 500; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 17.4px; flex: 1; } .blue-bottom-line, .blue-bottom-line:link { border-bottom: 2px hsl(210, 68%, 59%) solid; width: fit-content; justify-content: flex-start; align-items: flex-start; gap: 10px; display: inline-flex; cursor: pointer; text-decoration: none; color: #232E3D; } .blue-bottom-line-2, .blue-bottom-line-2:link { width: fit-content; color: var(--white); text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: var(--primary-colorsblue-200); text-underline-offset: 3px; } /* Media Queries for Mobiles */ @media (min-width: 50px) { .facility-record { min-width: 100%; } } div:has(.facility-record) .facility-record .declarations, div:has(.facility-record) .facility-record section { padding: 0px; } </style> </head> <body> <div class=\"facility-record\"> <div class=\"contents\"> <div class=\"traceability-header\"> <div class=\"TRACE-header\"> <div class=\"PP-title\">DIGITAL IDENTITY ANCHOR</div> <div class=\"name-description\"> <h1>{{credentialSubject.name}}</h1> <p>{{credentialSubject.id}}</p> </div> </div> <div class=\"issuing-organisation\"> <div class=\"div\"> <div class=\"data-two-columns border-bottom-gray-500\"> <div class=\"label\">{{credentialSubject.idScheme.name}}</div> <div class=\"label\"> <p>{{credentialSubject.registeredId}}</p> </div> </div> <div class=\"data-two-columns border-bottom-gray-500\"> <div class=\"label\">Type</div> <div class=\"label\"> <p>{{credentialSubject.registerType}}</p> </div> </div> </div> </div> </div> </div> <div class=\"issuing-details\"> <div class=\"typography-heading\"> <div class=\"text-wrapper-2\">Issuing details</div> </div> <div class=\"div\"> <div class=\"data-two-columns-2 border-bottom-gray-400\"> <div class=\"label-2\">Issued by</div> <div class=\"data-data-link\"> <div class=\"div-wrapper\"> <a href=\"{{issuer.id}}\" class=\"line-3\">{{issuer.name}}</a> </div> </div> </div> <div class=\"data-two-columns-2 border-bottom-gray-400\"> <div class=\"label-2\">Valid from</div> <div class=\"data-data\"> <div class=\"data-2\">{{validFrom}}</div> </div> </div> <div class=\"data-two-columns-2 border-bottom-gray-400\"> <div class=\"label-2\">Valid until</div> <div class=\"data-data\"> <div class=\"data-2\">{{validUntil}}</div> </div> </div> </div> </div> </div> </body> </html>",
-                        "type": "WebRenderingTemplate2022"
+                        "type": "WebRenderingTemplate2022",
+                        "template": "<!DOCTYPE html><html lang=\"en\"><head> <meta charset=\"UTF-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> <link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap\" rel=\"stylesheet\"> <title>Digital Identity Anchor</title> <style> :root { /* Brand Colors */ --color-primary: rgba(35, 46, 61, 1); /* Main header background; Default: rgba(35, 46, 61, 1) */ /* Neutrals */ --color-white: rgba(255, 255, 255, 1); /* Text color for titles, descriptions, and values in header and details sections, background color for issuing details; Default: rgba(255, 255, 255, 1) */ --color-black: rgba(0, 0, 0, 1); /* Text color for issuing details title; Default: rgba(0, 0, 0, 1) */ --color-gray-700: rgba(35, 46, 61, 1); /* Text color for issuer links and issuing details values; Default: rgba(35, 46, 61, 1) */ --color-gray-600: rgba(85, 96, 110, 1); /* Background color for identity details section, text color for issuing details labels; Default: rgba(85, 96, 110, 1) */ --color-gray-500: rgba(169, 177, 183, 1); /* Border color for identity details rows; Default: rgba(169, 177, 183, 1) */ --color-gray-400: rgba(212, 214, 216, 1); /* Border color for issuing details rows; Default: rgba(212, 214, 216, 1) */ --color-gray-300: rgba(237, 239, 240, 1); /* Text color for identity details labels; Default: rgba(237, 239, 240, 1) */ /* Semantic (Functional) Colors */ --color-link-underline-dark: rgba(79, 149, 221, 1); /* Underline color for issuer links; Default: rgba(79, 149, 221, 1) */ --color-link-underline-light: rgba(148, 196, 245, 1); /* Underline color for identifier scheme links; Default: rgba(148, 196, 245, 1) */ /* Font Variables */ --font-family: \"Lato\", sans-serif; /* Font family for all text; Default: Lato, sans-serif */ /* Font Weight Variables */ --font-weight-regular: 400; /* Font weight for labels; Default: 400 */ --font-weight-medium: 500; /* Font weight for titles, descriptions, values, and links; Default: 500 */ --font-weight-bold: 700; /* Font weight for issuing details title; Default: 700 */ --font-weight-black: 900; /* Font weight for main title; Default: 900 */ } /* Global CSS */ * { margin: 0; box-sizing: border-box; } body { font-family: var(--font-family); } section { padding: 0 16px; } a { text-decoration: none; } .identity-anchor { width: 100%; margin: 0 auto; display: flex; flex-direction: column; } .identity-anchor-header { display: flex; flex-direction: column; width: 100%; align-items: center; } .identity-header { display: flex; flex-direction: column; width: 100%; align-items: flex-start; gap: 12px; padding: 32px 16px 20px; background-color: var(--color-primary); } .identity-anchor .identity-title { width: 100%; font-weight: var(--font-weight-medium); color: var(--color-white); font-size: 16px; line-height: 22px; text-transform: uppercase; } .identity-anchor .name-description { display: flex; flex-direction: column; gap: 8px; } .identity-anchor .name-description h1 { font-weight: var(--font-weight-black); color: var(--color-white); font-size: 30px; line-height: 32.5px; } .identity-anchor .name-description p { font-weight: var(--font-weight-medium); color: var(--color-white); font-size: 16px; line-height: 17.4px; } .identity-anchor .identity-details-section { padding: 0 16px 16px; align-self: stretch; width: 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 4px; background-color: var(--color-gray-600); } .identity-anchor .grid-row { display: grid; grid-template-columns: 1fr 2fr; gap: 16px; padding: 10px 0 12px; width: 100%; border-bottom-width: 1px; border-bottom-style: solid; } .identity-anchor .grid-row:last-child { border-bottom: none; } .identity-anchor .border-bottom-gray-500 { border-color: var(--color-gray-500); } .identity-anchor .label { font-weight: var(--font-weight-regular); color: var(--color-gray-300); font-size: 16px; line-height: 22px; } .identity-anchor .grid-value { display: flex; align-items: center; gap: 10px; align-self: stretch; flex-grow: 1; flex: 1; } .identity-anchor .grid-value-text { font-weight: var(--font-weight-medium); color: var(--color-white); font-size: 16px; line-height: 17.4px; flex: 1; } .identity-anchor .issuing-details { width: 100%; padding: 24px 16px 36px; background-color: var(--color-white); display: flex; flex-direction: column; align-items: flex-start; gap: 4px; } .identity-anchor .typography-heading { display: inline-flex; align-items: center; justify-content: center; gap: 10px; } .identity-anchor .issuing-title { width: fit-content; font-weight: var(--font-weight-bold); color: var(--color-black); font-size: 20px; line-height: 21.8px; } .identity-anchor .identity-details { display: inline-flex; flex-direction: column; align-items: flex-start; width: 100%; } .identity-anchor .grid-row-alt { display: grid; grid-template-columns: 1.4fr 3fr; gap: 16px; padding: 10px 0 12px; width: 100%; border-bottom-width: 1px; border-bottom-style: solid; } .identity-anchor .border-bottom-gray-400 { border-color: var(--color-gray-400); } .identity-anchor .label-alt { font-weight: var(--font-weight-regular); color: var(--color-gray-600); font-size: 16px; line-height: 22px; } .identity-anchor .grid-value-link { flex-direction: column; align-items: flex-start; gap: 6px; align-self: stretch; display: flex; flex: 1; flex-grow: 1; } .identity-anchor .div-wrapper { gap: 10px; display: inline-flex; align-items: flex-start; text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: var(--color-link-underline-dark); text-underline-offset: 3px; } .identity-anchor .issuer-link { width: fit-content; font-weight: var(--font-weight-medium); color: var(--color-gray-700); font-size: 16px; line-height: 22px; } .identity-anchor .grid-value-text-alt { font-weight: var(--font-weight-medium); color: var(--color-gray-700); font-size: 16px; line-height: 17.4px; flex: 1; } .blue-bottom-line-2, .blue-bottom-line-2:link { width: fit-content; color: var(--color-white); text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: var(--color-link-underline-light); text-underline-offset: 3px; } /* Media Queries for Desktops */ @media (min-width: 1200px) { .identity-anchor { max-width: 1200px; } } </style></head><body> <div class=\"identity-anchor\"> <div class=\"identity-anchor-header\"> <header class=\"identity-header\"> <div class=\"identity-title\">DIGITAL IDENTITY ANCHOR</div> <div class=\"name-description\"> <h1>{{credentialSubject.name}}</h1> <p>{{credentialSubject.id}}</p> </div> </header> <section class=\"identity-details-section\"> <div class=\"identity-details\"> {{#if credentialSubject.idScheme.name}} <div class=\"grid-row border-bottom-gray-500\"> <div class=\"label\">Identifier Scheme</div> <div class=\"grid-value\"> {{#if credentialSubject.idScheme.id}} <a href=\"{{credentialSubject.idScheme.id}}\" class=\"blue-bottom-line-2\" aria-label=\"Visit {{credentialSubject.idScheme.name}}\">{{credentialSubject.idScheme.name}}</a> {{else}} <div class=\"grid-value-text\">{{credentialSubject.idScheme.name}}</div> {{/if}} </div> </div> {{/if}} {{#if credentialSubject.registeredId}} <div class=\"grid-row border-bottom-gray-500\"> <div class=\"label\">Registered ID</div> <div class=\"grid-value\"> <div class=\"grid-value-text\">{{credentialSubject.registeredId}}</div> </div> </div> {{/if}} {{#if credentialSubject.registerType}} <div class=\"grid-row border-bottom-gray-500\"> <div class=\"label\">Register Type</div> <div class=\"grid-value\"> <div class=\"grid-value-text\">{{credentialSubject.registerType}}</div> </div> </div> {{/if}} </div> </section> </div> <section class=\"issuing-details\"> <div class=\"typography-heading\"> <h2 class=\"issuing-title\">Issuing Details</h2> </div> <div class=\"identity-details\"> <div class=\"grid-row-alt border-bottom-gray-400\"> <div class=\"label-alt\">Issued by</div> <div class=\"grid-value-link\"> <div class=\"div-wrapper\"> <a href=\"{{issuer.id}}\" class=\"issuer-link\" aria-label=\"Visit {{issuer.name}}\">{{issuer.name}}</a> </div> </div> </div> {{#if validFrom}} <div class=\"grid-row-alt border-bottom-gray-400\"> <div class=\"label-alt\">Valid from</div> <div class=\"grid-value\"> <div class=\"grid-value-text-alt\">{{validFrom}}</div> </div> </div> {{/if}} {{#if validUntil}} <div class=\"grid-row-alt border-bottom-gray-400\"> <div class=\"label-alt\">Valid until</div> <div class=\"grid-value\"> <div class=\"grid-value-text-alt\">{{validUntil}}</div> </div> </div> {{/if}} </div> </section> </div></body></html>"
                       }
                     ],
                     "type": ["DigitalIdentityAnchor"],
@@ -599,7 +683,12 @@
                       }
                     }
                   },
-                  "identifierKeyPath": "/id"
+                  "identifierKeyPath": {
+                    "primary": {
+                      "ai": "01",
+                      "path": "/registeredId"
+                    }
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR updates the existing e2e tests for the Digital Identity Anchor, specifically:
- Update the app configuration to:
    - Use the latest v0.6.0 DIA data model/render template
    - Extract the registered ID from the DIA as opposed to using the value of the credentials id
- Update the name of some test steps from DCC > DIA
- Construct the appropriate IDR link for the verifyLinkType test case, as opposed to validating that the default link type is accessible (false positive test case)
- Update the schema validation configuration to use the v0.6.0 schema

**NOTE**: 
- This PR has a dependency on PR #276 being merged.

- While making the updates, I've identified a false positive within the ["Render DIA end-to-end testing flow"](https://github.com/uncefact/tests-untp/blob/next/e2e/cypress/e2e/vc_render/render_dia.cy.ts) test cases, specifically the ["should render template when content is exist"](https://github.com/uncefact/tests-untp/blob/bf7b7c627007227bce3538e0e3b807599674bac1/e2e/cypress/e2e/vc_render/render_dfr.cy.ts#L43) test case where it's passing even though the credential isn't rendering due to the issue PR [#279](https://github.com/uncefact/project-vckit/pull/279) addresses. A subsequent PR will be raised to address this [issue](https://github.com/uncefact/tests-untp/issues/272).

## Mobile & Desktop Screenshots/Recordings
<img width="1703" alt="Screenshot 2025-05-28 at 1 52 30 pm" src="https://github.com/user-attachments/assets/fdecbe75-7c2e-4faa-bf9d-cdb0b0fe0876" />
<img width="1703" alt="Screenshot 2025-05-28 at 1 52 45 pm" src="https://github.com/user-attachments/assets/9ca1f0e7-e384-4aea-b2fc-c89dcd4f66bd" />

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed