### PR TITLE
test: update dpp tests to v0.6.0

### DIFF
--- a/e2e/constant.ts
+++ b/e2e/constant.ts
@@ -9,7 +9,7 @@ export const DIGITAL_CONFORMITY_CREDENTIAL = 'DigitalConformityCredential';
 export const DIGITAL_FACILITY_RECORD = 'DigitalFacilityRecord';
 export const DIGITAL_IDENTITY_ANCHOR = 'DigitalIdentityAnchor';
 
-export const ISSUE_DPP = 'Issue DPP';
+export const ISSUE_DPP = 'Generate DPP';
 export const ISSUE_DCC = 'Generate DCC';
 export const ISSUE_DFR = 'Generate DFR';
 export const ISSUE_DIA = 'Generate DIA';
@@ -20,7 +20,7 @@ export const ISSUE_TRACEABILITY_AGGREGATION_EVENT = 'Issue Traceability Aggregat
 export const MOVE_TO_NEXT_FACILITY = 'Move to Next Facility';
 
 export const TRACEABILITY_LINK_TYPE = 'http://localhost:3000/gs1/01/09359502000034/21/123456';
-export const DPP_LINK_TYPE = 'http://localhost:3000/gs1/01/09359502000034/10/6789?linkType=gs1:sustainabilityInfo';
+export const DPP_LINK_TYPE = 'http://localhost:3000/gs1/01/09520123456788/21/12345?linkType=gs1:sustainabilityInfo';
 export const DCC_LINK_TYPE = 'http://localhost:3000/gs1/01/09520123456788/10/6789/21/12345678?linkType=gs1:certificationInfo';
 export const DFR_LINK_TYPE = 'http://localhost:3000/gs1/gln/1321202290648?linkType=gs1:locationInfo';
 export const DIA_LINK_TYPE = 'http://localhost:3000/gs1/01/09359502000010?linkType=gs1:registryEntry';

--- a/e2e/cypress/e2e/issue_workflow_test/DPP/issueDPP.cy.ts
+++ b/e2e/cypress/e2e/issue_workflow_test/DPP/issueDPP.cy.ts
@@ -1,17 +1,18 @@
 import IssuePage from 'cypress/page/issuePage';
+import { DPP_LINK_TYPE } from '../../../../constant';
 
 class DPPIssueFlow extends IssuePage {
   testGenerateDPPWorkflow() {
     this.generateWorkflow(
       'Orchard Facility',
-      'Issue DPP',
+      'Generate DPP',
       'DigitalProductPassport',
       'apps',
     );
   }
 
   testUNTPTestSuite() {
-    this.runUntpTest('digitalProductPassport', 'v0.5.0');
+    this.runUntpTest('digitalProductPassport', 'v0.6.0');
   }
 }
 
@@ -31,8 +32,7 @@ describe('Issue DPP end-to-end testing flow', () => {
   });
 
   it('Verify linkType', () => {
-    const checkLinkTypeURL = 'http://localhost:3000/gs1/01/09359502000034/10/6789?linkType=gs1:sustainabilityInfo';
-    dppTest.verifyLinkType(checkLinkTypeURL);
+    dppTest.verifyLinkType(DPP_LINK_TYPE);
   });
 
   it('Runs testing UNTP test suite for DPP', () => {

--- a/e2e/cypress/fixtures/app-config.json
+++ b/e2e/cypress/fixtures/app-config.json
@@ -1789,201 +1789,1311 @@
       },
       "features": [
         {
-          "name": "Issue DPP",
-          "id": "produce_product",
+          "name": "Generate DPP",
+          "id": "produce_dpp",
           "components": [
             {
               "name": "JsonForm",
               "type": "EntryData",
               "props": {
                 "schema": {
-                  "url": "https://jargon.sh/user/unece/DigitalProductPassport/v/working/artefacts/jsonSchemas/Product.json?class=Product"
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "type": {
+                      "type": "array",
+                      "readOnly": true,
+                      "default": [
+                        "ProductPassport"
+                      ],
+                      "items": {
+                        "type": "string"
+                      },
+                      "allOf": [
+                        {
+                          "contains": {
+                            "const": "ProductPassport",
+                            "minContains": 1
+                          }
+                        }
+                      ]
+                    },
+                    "id": {
+                      "example": "example:product/1234",
+                      "type": "string",
+                      "format": "uri",
+                      "description": "An id is not required in the data but jargon requires for blue class which won't redefine credentialSubject"
+                    },
+                    "product": {
+                      "$ref": "#/$defs/Product",
+                      "description": "The ProductInformation class encapsulates detailed information regarding a specific product, including its identification details, manufacturer, and other pertinent details."
+                    },
+                    "granularityLevel": {
+                      "type": "string",
+                      "enum": [
+                        "item",
+                        "batch",
+                        "model"
+                      ],
+                      "example": "item",
+                      "description": "Code to indicate the granularity of this digital product passport - item level, batch level or product class level."
+                    },
+                    "conformityClaim": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/Claim"
+                      },
+                      "description": "An array of claim objects representing various product conformity claims about the product / batch.  These can be sustainability claims, circularity claims, or any other claim type within the conformity topic list."
+                    },
+                    "emissionsScorecard": {
+                      "$ref": "#/$defs/EmissionsPerformance",
+                      "description": "An emissions performance scorecard"
+                    },
+                    "traceabilityInformation": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/TraceabilityPerformance"
+                      },
+                      "description": "An array of traceability events grouped by value chain process.  Where actual traceability events are unavailable or carry sensitive information, passport publishers may specify the extent to which the traceability information has been independently verified. "
+                    },
+                    "circularityScorecard": {
+                      "$ref": "#/$defs/CircularityPerformance",
+                      "description": "A circularity performance scorecard"
+                    },
+                    "dueDiligenceDeclaration": {
+                      "$ref": "#/$defs/Link",
+                      "description": "The due diligence declaration that conforms with the regulations of the market into which the product is sold."
+                    },
+                    "materialsProvenance": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/Material"
+                      },
+                      "description": "An array of Provenance objects providing details on the origin and mass fraction of components or ingredients of the product batch. "
+                    }
+                  },
+                  "description": "The ProductClaim class encapsulates detailed information regarding a specific product, including its identification details, manufacturer, and other pertinent details, as well as information about the claims being made about the product. ",
+                  "$defs": {
+                    "Product": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Product"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Product",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://id.gs1.org/01/09520123456788/21/12345",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The globally unique ID of the product as a URI. Ideally as a resolvable URL according to ISO 18975. "
+                        },
+                        "name": {
+                          "example": "EV battery 300Ah.",
+                          "type": "string",
+                          "description": "The registered name of the product within the identifier scheme. "
+                        },
+                        "registeredId": {
+                          "example": "09520123456788.21.12345",
+                          "type": "string",
+                          "description": "The registration number (alphanumeric) of the entity within the register. Unique within the register."
+                        },
+                        "idScheme": {
+                          "$ref": "#/$defs/IdentifierScheme",
+                          "description": "The identifier scheme for this product.  Eg a GS1 GTIN or an AU Livestock NLIS, or similar. If self issued then use the party ID of the issuer.  "
+                        },
+                        "batchNumber": {
+                          "example": 6789,
+                          "type": "string",
+                          "description": "Identifier of the specific production batch of the product.  Unique within the product class."
+                        },
+                        "productImage": {
+                          "$ref": "#/$defs/Link",
+                          "description": "Reference information (location, type, name) of an image of the product."
+                        },
+                        "description": {
+                          "example": "400Ah 24v LiFePO4 battery",
+                          "type": "string",
+                          "description": "A textual description providing details about the product."
+                        },
+                        "characteristics": {
+                          "$ref": "#/$defs/Characteristics",
+                          "description": "A placeholder for indusutry / product category specific information. "
+                        },
+                        "productCategory": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/Classification"
+                          },
+                          "description": "A code representing the product's class, typically using the UN CPC (United Nations Central Product Classification) https://unstats.un.org/unsd/classifications/Econ/cpc"
+                        },
+                        "furtherInformation": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/Link"
+                          },
+                          "description": "A URL pointing to further human readable information about the product."
+                        },
+                        "producedByParty": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "example": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                              "type": "string",
+                              "format": "uri",
+                              "description": "The globally unique ID of the party as a URI, ideally as a resolvable ID. "
+                            },
+                            "name": {
+                              "example": "Sample Company Pty Ltd.",
+                              "type": "string",
+                              "description": "The registered name of the party within the identifier scheme."
+                            },
+                            "registeredId": {
+                              "example": 90664869327,
+                              "type": "string",
+                              "description": "The registration number (alphanumeric) of the Party within the register. Unique within the register."
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ],
+                          "description": "The Party entity that manufactured the product."
+                        },
+                        "producedAtFacility": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "example": "https://sample-facility-register.com/1234567",
+                              "type": "string",
+                              "format": "uri",
+                              "description": "The globally unique ID of the facility as URI, ideally as a resolvable URL."
+                            },
+                            "name": {
+                              "example": "Greenacres battery factory",
+                              "type": "string",
+                              "description": "The registered name of the facility within the identifier scheme.  "
+                            },
+                            "registeredId": {
+                              "example": 1234567,
+                              "type": "string",
+                              "description": "The registration number (alphanumeric) of the facility within the identifier scheme. Unique within the register."
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ],
+                          "description": "The Facility where the product batch was produced / manufactured."
+                        },
+                        "productionDate": {
+                          "example": "2024-04-25",
+                          "type": "string",
+                          "format": "date",
+                          "description": "The ISO 8601 date on which the product batch or individual serialised item was manufactured."
+                        },
+                        "countryOfProduction": {
+                          "type": "string",
+                          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId#",
+                          "description": "The country in which this item was produced / manufactured.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId#\n    "
+                        },
+                        "serialNumber": {
+                          "example": 12345678,
+                          "type": "string",
+                          "description": "A number or code representing a specific serialised item of the product. Unique within product class."
+                        },
+                        "dimensions": {
+                          "$ref": "#/$defs/Dimension",
+                          "description": "The physical dimensions of the product. Not every dimension is relevant to every products.  For example bulk materials may have weight and volume but not length, with, or height.\"weight\":{\"value\":10, \"unit\":\"KGM\"}"
+                        }
+                      },
+                      "description": "The ProductInformation class encapsulates detailed information regarding a specific product, including its identification details, manufacturer, and other pertinent details.",
+                      "required": [
+                        "id",
+                        "name"
+                      ]
+                    },
+                    "IdentifierScheme": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "IdentifierScheme"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "IdentifierScheme",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://id.gs1.org/01/",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The globally unique identifier of the registration scheme. The scheme should be registered and discoverable from vocabulary.uncefact.org/identifierSchemes"
+                        },
+                        "name": {
+                          "example": "Global Trade Identification Number (GTIN)",
+                          "type": "string",
+                          "description": "The name of the identifier scheme. "
+                        }
+                      },
+                      "description": "An identifier registration scheme for products, facilities, or organisations. Typically operated by a state, national or global authority."
+                    },
+                    "Link": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Link"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Link",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "linkURL": {
+                          "example": "https://files.example-certifier.com/1234567.json",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The URL of the target resource. "
+                        },
+                        "linkName": {
+                          "example": "GBA rule book conformity certificate",
+                          "type": "string",
+                          "description": "A display name for the target resource "
+                        },
+                        "linkType": {
+                          "example": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+                          "type": "string",
+                          "description": "The type of the target resource - drawn from a controlled vocabulary "
+                        }
+                      },
+                      "description": "A structure to provide a URL link plus metadata associated with the link."
+                    },
+                    "Characteristics": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Characteristics"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Characteristics",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "description": "Extension point for commodity specific characteristics like battery capacity, clothing size, etc."
+                    },
+                    "Classification": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Classification"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Classification",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The globally unique URI representing the specific classifier value"
+                        },
+                        "code": {
+                          "example": 46410,
+                          "type": "string",
+                          "description": "classification code within the scheme"
+                        },
+                        "name": {
+                          "example": "Primary cells and primary batteries",
+                          "type": "string",
+                          "description": "Name of the classification represented by the code"
+                        },
+                        "schemeID": {
+                          "example": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "Classification scheme ID"
+                        },
+                        "schemeName": {
+                          "example": "UN Central Product Classification (CPC)",
+                          "type": "string",
+                          "description": "The name of the classification scheme"
+                        }
+                      },
+                      "description": "A classification scheme and code / name representing a category value for a product, entity, or facility.",
+                      "required": [
+                        "id",
+                        "name"
+                      ]
+                    },
+                    "Dimension": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Dimension"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Dimension",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "weight": {
+                          "$ref": "#/$defs/Measure",
+                          "description": "the weight of the product. EG {\"value\":10, \"unit\":\"KGM\"}"
+                        },
+                        "length": {
+                          "$ref": "#/$defs/Measure",
+                          "description": "The length of the product or packaging eg {\"value\":840, \"unit\":\"MMT\"}"
+                        },
+                        "width": {
+                          "$ref": "#/$defs/Measure",
+                          "description": "The width of the product or packaging. eg {\"value\":150, \"unit\":\"MMT\"}"
+                        },
+                        "height": {
+                          "$ref": "#/$defs/Measure",
+                          "description": "The height of the product or packaging. eg {\"value\":220, \"unit\":\"MMT\"}"
+                        },
+                        "volume": {
+                          "$ref": "#/$defs/Measure",
+                          "description": "The displacement volume of the product. eg {\"value\":7.5, \"unit\":\"LTR\"}"
+                        }
+                      },
+                      "description": "Overall (length, width, height) dimensions and weight/volume of an item."
+                    },
+                    "Measure": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Measure"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Measure",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "value": {
+                          "example": 10,
+                          "type": "number",
+                          "description": "The numeric value of the measure"
+                        },
+                        "unit": {
+                          "type": "string",
+                          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode#",
+                          "description": "Unit of measure drawn from the UNECE Rec20 measure code list.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode#\n    "
+                        }
+                      },
+                      "description": "The measure class defines a numeric measured value (eg 10) and a coded unit of measure (eg KG).",
+                      "required": [
+                        "value",
+                        "unit"
+                      ]
+                    },
+                    "Claim": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Claim",
+                            "Declaration"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Claim",
+                                "minContains": 1
+                              }
+                            },
+                            {
+                              "contains": {
+                                "const": "Declaration",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://products.example-company.com/09520123456788/declarations/12345",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A unique identifier for the declaration. Often this will be an extension of the product.id or attestation.id. But could be a UUID."
+                        },
+                        "description": {
+                          "example": "A standardised disclosure of the battery's greenhouse gas emissions intensity, calculated in accordance with the Global Battery Alliance Battery Passport Greenhouse Gas Rulebook V.2.0.",
+                          "type": "string",
+                          "description": "A textual description of the declaration being made."
+                        },
+                        "referenceStandard": {
+                          "$ref": "#/$defs/Standard",
+                          "description": "The reference to the standard that defines the specification / criteria"
+                        },
+                        "referenceRegulation": {
+                          "$ref": "#/$defs/Regulation",
+                          "description": "The reference to the regulation that defines the assessment criteria"
+                        },
+                        "assessmentCriteria": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/Criterion"
+                          },
+                          "description": "The specification against which the assessment is made."
+                        },
+                        "assessmentDate": {
+                          "example": "2024-03-15",
+                          "type": "string",
+                          "format": "date",
+                          "description": "The date on which this assessment was made. "
+                        },
+                        "declaredValue": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/Metric"
+                          },
+                          "description": "The list of specific values measured as part of this assessment (eg tensile strength)"
+                        },
+                        "conformance": {
+                          "example": true,
+                          "type": "boolean",
+                          "description": "An indicator of whether or not the claim or assesment conforms to the regulatory or standard criteria."
+                        },
+                        "conformityTopic": {
+                          "type": "string",
+                          "enum": [
+                            "environment.energy",
+                            "environment.emissions",
+                            "environment.water",
+                            "environment.waste",
+                            "environment.deforestation",
+                            "environment.biodiversity",
+                            "circularity.content",
+                            "circularity.design",
+                            "social.labour",
+                            "social.rights",
+                            "social.community",
+                            "social.safety",
+                            "governance.ethics",
+                            "governance.compliance",
+                            "governance.transparency"
+                          ],
+                          "example": "environment.energy",
+                          "description": "The conformity topic category for this assessment (eg vocabulary.uncefact.org/sustainability/emissions)"
+                        },
+                        "conformityEvidence": {
+                          "$ref": "#/$defs/SecureLink",
+                          "description": "A URI pointing to the evidence supporting the claim. SHOULD be a URL to a UNTP Digital Conformity Credential (DCC)"
+                        }
+                      },
+                      "description": "A declaration of conformance with one or more criteria from a specific standard or regulation.  ",
+                      "required": [
+                        "id",
+                        "conformance",
+                        "conformityTopic"
+                      ]
+                    },
+                    "Standard": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Standard"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Standard",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A unique identifier for the standard (eg https://www.iso.org/standard/60857.html)."
+                        },
+                        "name": {
+                          "example": "GBA Battery Passport Greenhouse Gas Rulebook - V.2.0",
+                          "type": "string",
+                          "description": "The name of the standard"
+                        },
+                        "issuingParty": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "example": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                              "type": "string",
+                              "format": "uri",
+                              "description": "The globally unique ID of the party as a URI, ideally as a resolvable ID. "
+                            },
+                            "name": {
+                              "example": "Sample Company Pty Ltd.",
+                              "type": "string",
+                              "description": "The registered name of the party within the identifier scheme."
+                            },
+                            "registeredId": {
+                              "example": 90664869327,
+                              "type": "string",
+                              "description": "The registration number (alphanumeric) of the Party within the register. Unique within the register."
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ],
+                          "description": "The party that issued the standard "
+                        },
+                        "issueDate": {
+                          "example": "2023-12-05",
+                          "type": "string",
+                          "format": "date",
+                          "description": "The date when the standard was issued."
+                        }
+                      },
+                      "description": "A standard (eg ISO 14000) that specifies the criteria for conformance.",
+                      "required": [
+                        "issuingParty"
+                      ]
+                    },
+                    "Regulation": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Regulation"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Regulation",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://www.legislation.gov.au/F2008L02309/latest/versions",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The globally unique identifier of this regulation. "
+                        },
+                        "name": {
+                          "example": "NNational Greenhouse and Energy Reporting (Measurement) Determination",
+                          "type": "string",
+                          "description": "The name of the regulation or act."
+                        },
+                        "jurisdictionCountry": {
+                          "type": "string",
+                          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId#",
+                          "description": "The legal jurisdiction (country) under which the regulation is issued.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId#\n    "
+                        },
+                        "administeredBy": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "example": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                              "type": "string",
+                              "format": "uri",
+                              "description": "The globally unique ID of the party as a URI, ideally as a resolvable ID. "
+                            },
+                            "name": {
+                              "example": "Sample Company Pty Ltd.",
+                              "type": "string",
+                              "description": "The registered name of the party within the identifier scheme."
+                            },
+                            "registeredId": {
+                              "example": 90664869327,
+                              "type": "string",
+                              "description": "The registration number (alphanumeric) of the Party within the register. Unique within the register."
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ],
+                          "description": "the issuing body of the regulation. For example Australian Government Department of Climate Change, Energy, the Environment and Water"
+                        },
+                        "effectiveDate": {
+                          "example": "2024-03-20",
+                          "type": "string",
+                          "format": "date",
+                          "description": "the date at which the regulation came into effect."
+                        }
+                      },
+                      "description": "A regulation (eg EU deforestation regulation) that defines the criteria for assessment.",
+                      "required": [
+                        "administeredBy"
+                      ]
+                    },
+                    "Criterion": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Criterion"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Criterion",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "id": {
+                          "example": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A unique identifier for the criterion within the scheme, standard  or regulation. For example CO2 emissions calculations for liquid fuel combustion."
+                        },
+                        "name": {
+                          "example": "GBA Battery rule book v2.0 battery assembly guidelines.",
+                          "type": "string",
+                          "description": "A name that describes this criteria."
+                        },
+                        "description": {
+                          "example": "Battery is designed for easy disassembly and recycling at end-of-life.",
+                          "type": "string",
+                          "description": "A full text description of the criterion that clearly specifies how compliance is achieved and measured. "
+                        },
+                        "conformityTopic": {
+                          "type": "string",
+                          "enum": [
+                            "environment.energy",
+                            "environment.emissions",
+                            "environment.water",
+                            "environment.waste",
+                            "environment.deforestation",
+                            "environment.biodiversity",
+                            "circularity.content",
+                            "circularity.design",
+                            "social.labour",
+                            "social.rights",
+                            "social.community",
+                            "social.safety",
+                            "governance.ethics",
+                            "governance.compliance",
+                            "governance.transparency"
+                          ],
+                          "example": "environment.energy",
+                          "description": "A gloabl UN/CEFACT standard sustainability toipic code. "
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "proposed",
+                            "active",
+                            "deprecated"
+                          ],
+                          "example": "proposed",
+                          "description": "The lifecycle status of this criterion. "
+                        },
+                        "subCriterion": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/Criterion"
+                          },
+                          "description": "List of criterion that are subordinate to this criterion in the hierarchy."
+                        },
+                        "thresholdValue": {
+                          "$ref": "#/$defs/Metric",
+                          "description": "A threshold value that defines the minimum compliance level. "
+                        },
+                        "performanceLevel": {
+                          "example": "\"Category 3 recyclable with 73% recyclability\"",
+                          "type": "string",
+                          "description": "A performance category code to group criterion in a given hierarchyLevel according to pareformance"
+                        },
+                        "tags": {
+                          "type": "string",
+                          "description": "a category code to represent target stakeholder types or commodity types to which this criteron applies. "
+                        }
+                      },
+                      "description": "A specific rule or criterion within a standard or regulation. eg a carbon intensity calculation rule within an emissions standard.",
+                      "required": [
+                        "id",
+                        "name",
+                        "description",
+                        "conformityTopic",
+                        "status"
+                      ]
+                    },
+                    "Metric": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Metric"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Metric",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "metricName": {
+                          "example": "GHG emissions intensity",
+                          "type": "string",
+                          "description": "A human readable name for this metric (for example \"Tensile strength\")"
+                        },
+                        "metricValue": {
+                          "$ref": "#/$defs/Measure",
+                          "description": "A numeric value and unit of measure for this metric. Could be a measured value or a specified threshold. Eg {\"value\":400, \"unit\":\"MPA\"} as tensile strength of structural steel"
+                        },
+                        "score": {
+                          "example": "BB",
+                          "type": "string",
+                          "description": "A score or rank associated with this measured metric."
+                        },
+                        "accuracy": {
+                          "example": 0.05,
+                          "type": "number",
+                          "description": "A percentage represented as a numeric between 0 and 1 indicating the rage of accuracy of the claimed value (eg 0.05 means that the actual value is within 5% of the claimed value.)"
+                        }
+                      },
+                      "description": "A specific measure of performance against the criteria that governs the claim.  Expressed as an array of metric (ie unit of measure) / value (ie the actual numeric value) pairs.  ",
+                      "required": [
+                        "metricName",
+                        "metricValue"
+                      ]
+                    },
+                    "SecureLink": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "SecureLink",
+                            "Link"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "SecureLink",
+                                "minContains": 1
+                              }
+                            },
+                            {
+                              "contains": {
+                                "const": "Link",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "linkURL": {
+                          "example": "https://files.example-certifier.com/1234567.json",
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The URL of the target resource. "
+                        },
+                        "linkName": {
+                          "example": "GBA rule book conformity certificate",
+                          "type": "string",
+                          "description": "A display name for the target resource "
+                        },
+                        "linkType": {
+                          "example": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+                          "type": "string",
+                          "description": "The type of the target resource - drawn from a controlled vocabulary "
+                        },
+                        "hashDigest": {
+                          "example": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                          "type": "string",
+                          "description": "The hash of the file."
+                        },
+                        "hashMethod": {
+                          "type": "string",
+                          "enum": [
+                            "SHA-256",
+                            "SHA-1"
+                          ],
+                          "example": "SHA-256",
+                          "description": "The hashing algorithm used to create the target hash.  SHA-265 is the recommended standard"
+                        },
+                        "encryptionMethod": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "AES"
+                          ],
+                          "example": "none",
+                          "description": "The symmetric encryption algorithm used to encrypt the link target.  AES is the recommended standard. Decryption keys are expected to be passed out of bounds."
+                        }
+                      },
+                      "description": "A binary file that is hashed ()for tamper evidence) and optionally encrypted (for confidentiality)."
+                    },
+                    "EmissionsPerformance": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "EmissionsPerformance"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "EmissionsPerformance",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "carbonFootprint": {
+                          "example": 1.8,
+                          "type": "number",
+                          "format": "float",
+                          "description": "The carbon footprint of the product in KgCO2e per declared unit."
+                        },
+                        "declaredUnit": {
+                          "type": "string",
+                          "x-external-enumeration": "https://vocabulary.uncefact.org/UnitMeasureCode#",
+                          "description": "The unit of product (EA, KGM, LTR, etc) that is the basis for carbon footprint.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/UnitMeasureCode#\n    "
+                        },
+                        "operationalScope": {
+                          "type": "string",
+                          "enum": [
+                            "None",
+                            "CradleToGate",
+                            "CradleToGrave"
+                          ],
+                          "example": "None",
+                          "description": "The operational scope of the emissions performance. Only scope 1 & 2, or including upstream scope 3 (cradle to gate) or upstream and downstream scope 3 (cradle to grave)."
+                        },
+                        "primarySourcedRatio": {
+                          "example": 0.3,
+                          "type": "number",
+                          "format": "float",
+                          "description": "The ratio of emissions data from primary sources (ie from supplier / product specific information rather than secondary / industry averages)."
+                        },
+                        "reportingStandard": {
+                          "$ref": "#/$defs/Standard",
+                          "description": "The reporting standard (eg GHG Protocol, IFRS S2, ESRS, etc) against which this product emissions performance is assessed."
+                        }
+                      },
+                      "description": "Product specific characteristics.  This class is an extension point for industry specific product characteristics or performance information such as clothing size or battery capacity.",
+                      "required": [
+                        "carbonFootprint",
+                        "declaredUnit",
+                        "operationalScope",
+                        "primarySourcedRatio"
+                      ]
+                    },
+                    "TraceabilityPerformance": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "TraceabilityPerformance"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "TraceabilityPerformance",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "valueChainProcess": {
+                          "example": "Spinning",
+                          "type": "string",
+                          "description": "Human readable name for the industry specific value chain process representing this traceability data set."
+                        },
+                        "verifiedRatio": {
+                          "example": 0.5,
+                          "type": "number",
+                          "description": "The proportion (0 to 1) of materials in this value chain process that have been  traced using verifiable traceability event."
+                        },
+                        "traceabilityEvent": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/$defs/SecureLink"
+                          },
+                          "description": "A list of secure links to digital traceability events that support this traceability performance statement. May be encrypted for confidentiality purposes. "
+                        }
+                      },
+                      "description": "An array of secure links to TraceabilityEvent objects detailing EPCIS events related to the traceability of the product batch. Events are grouped by value chain process (eg \"Weaving\" in textiles supply chain)."
+                    },
+                    "CircularityPerformance": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "CircularityPerformance"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "CircularityPerformance",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "recyclingInformation": {
+                          "$ref": "#/$defs/Link",
+                          "description": "A URI pointing to recycling information for the product."
+                        },
+                        "repairInformation": {
+                          "$ref": "#/$defs/Link",
+                          "description": "A URI pointing to repair instructions for this product."
+                        },
+                        "recyclableContent": {
+                          "example": 0.5,
+                          "type": "number",
+                          "format": "float",
+                          "description": "The fraction of the this product (my mass) that has been designed to be recyclable / re-usable. This will be be the total fraction that can avoid waste / landfill."
+                        },
+                        "recycledContent": {
+                          "example": 0.3,
+                          "type": "number",
+                          "format": "float",
+                          "description": "The fraction (by mass) of recycled / repurposed, repaired content in this product.  This will be the total virgin content fraction."
+                        },
+                        "utilityFactor": {
+                          "example": 1.2,
+                          "type": "number",
+                          "format": "float",
+                          "description": "An indicator of durability defined as the lifetime (typically measures as usage cycles) for this product divided by the industry average. For example a battery with a 10,000 cycle lifetime where industry average is 5,000 cycles will have a durability factor of 2. If unknown set to 1 or omit.  "
+                        },
+                        "materialCircularityIndicator": {
+                          "example": 0.67,
+                          "type": "number",
+                          "format": "float",
+                          "description": "The overall circularity performance indicator for this product. Calculated as 1 - (V+W)/2D where - V = Virgin material proportion by mass (will be 1- recycled content) - W = Waste leakage proportion by mass (will be 1 - recyclableContent)  - D = Utility factor (set to 1 if unknown).  "
+                        }
+                      },
+                      "description": "High level circularity information about this product.  Note that this does not substitute for detailed product circularity data sheet (PCDS) criteria which would be represented as a self-issued UNTP Digital Conformity Credential as a set of assessments against individual ISO PCDS criteria."
+                    },
+                    "Material": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "array",
+                          "readOnly": true,
+                          "default": [
+                            "Material"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "allOf": [
+                            {
+                              "contains": {
+                                "const": "Material",
+                                "minContains": 1
+                              }
+                            }
+                          ]
+                        },
+                        "name": {
+                          "example": "Lithium Spodumene",
+                          "type": "string",
+                          "description": "Name of this material (eg \"Egyptian Cotton\")"
+                        },
+                        "originCountry": {
+                          "type": "string",
+                          "x-external-enumeration": "https://vocabulary.uncefact.org/CountryId#",
+                          "description": "A ISO 3166-1 code representing the country of origin of the component or ingredient.\n\n    This is an enumerated value, but the list of valid values are too big, or change too often to include here. You can access the list of allowable values at this URL:  https://vocabulary.uncefact.org/CountryId#\n    "
+                        },
+                        "materialType": {
+                          "$ref": "#/$defs/Classification",
+                          "description": "The type of this material - as a value drawn from a controlled vocabulary eg from UN Framework Classification for Resources (UNFC)."
+                        },
+                        "massFraction": {
+                          "example": 0.2,
+                          "type": "number",
+                          "description": "The mass fraction of the product represented by this material. The sum of all mass fraction values for a given passport should be 1."
+                        },
+                        "mass": {
+                          "$ref": "#/$defs/Measure",
+                          "description": "The mass of the material component."
+                        },
+                        "recycledMassFraction": {
+                          "example": 0.5,
+                          "type": "number",
+                          "description": "Mass fraction of this material that is recycled (eg 50% recycled Lithium)"
+                        },
+                        "hazardous": {
+                          "type": "boolean",
+                          "description": "Indicates whether this material is hazardous. If true then the materialSafetyInformation property must be present"
+                        },
+                        "symbol": {
+                          "type": "string",
+                          "format": "binary",
+                          "description": "Based 64 encoded binary used to represent a visual symbol for a given material. "
+                        },
+                        "materialSafetyInformation": {
+                          "$ref": "#/$defs/Link",
+                          "description": "Reference to further information about safe handling of this hazardous material (for example a link to a material safety data sheet)"
+                        }
+                      },
+                      "description": "The material class encapsulates details about the origin or source of raw materials in a product, including the country of origin and the mass fraction.",
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  }
                 },
                 "data": {
-                  "type": ["Product"],
-                  "id": "https://example.com/01/09359502000034",
-                  "name": "EcoCharge Lithium-Ion Battery",
-                  "registeredId": "09359502000034",
-                  "idScheme": {
-                    "type": ["IdentifierScheme"],
-                    "id": "https://id.gs1.org/01/",
-                    "name": "Global Trade Identification Number (GTIN)"
-                  },
-                  "serialNumber": "12345678",
-                  "batchNumber": "6789",
-                  "productImage": {
-                    "type": ["Link"],
-                    "linkURL": "https://c.animaapp.com/b3vf2M20/img/pp-header@2x.png",
-                    "linkName": "EV Battery 300Ah Image"
-                  },
-                  "description": "The EcoCharge EC-5000 Lithium-Ion Battery is a high-capacity, 5000mAh battery designed for performance and sustainability. Manufactured with responsibly sourced materials and a 95% recyclability rate, it reduces lifecycle emissions through eco-friendly production and verified recycling programs.",
-                  "productCategory": [
-                    {
-                      "type": ["Classification"],
-                      "id": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
-                      "code": "46410",
-                      "name": "Primary cells",
-                      "schemeID": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
-                      "schemeName": "UN Central Product Classification (CPC)"
+                  "type": ["ProductPassport"],
+                  "id": "example:product/1234",
+                  "product": {
+                    "type": ["Product"],
+                    "id": "https://id.gs1.org/01/09520123456788/21/12345",
+                    "name": "EV battery 300Ah",
+                    "registeredId": "09520123456788.21.12345",
+                    "idScheme": {
+                      "type": ["IdentifierScheme"],
+                      "id": "https://id.gs1.org/01/",
+                      "name": "Global Trade Identification Number (GTIN)"
                     },
-                    {
-                      "type": ["Classification"],
-                      "id": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
-                      "code": "46410",
-                      "name": "Primary batteries",
-                      "schemeID": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
-                      "schemeName": "UN Central Product Classification (CPC)"
-                    }
-                  ],
-                  "furtherInformation": [
-                    {
-                      "type": ["Link"],
-                      "linkURL": "https://example-company.com/product-information/1234567",
-                      "linkName": "Name of document that is further information"
+                    "batchNumber": "6789",
+                    "productImage": {
+                      "linkURL": "https://c.animaapp.com/b3vf2M20/img/pp-header@2x.png",
+                      "linkName": "GBA rule book conformity certificate",
+                      "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
                     },
-                    {
-                      "type": ["Link"],
-                      "linkURL": "https://example-company.com/product-information/1234567",
-                      "linkName": "Name of additional document that is further information"
-                    }
-                  ],
-                  "producedByParty": {
-                    "type": ["Identifier"],
-                    "id": "https://id.example-company.com/party/6789",
-                    "name": "Example Manufacturing Co."
-                  },
-                  "producedAtFacility": {
-                    "type": ["Identifier"],
-                    "id": "https://id.example-company.com/facility/123",
-                    "name": "Green Acres Battery Factory"
-                  },
-                  "dimensions": {
-                    "type": ["Dimension"],
-                    "weight": { "value": 10, "unit": "kg" },
-                    "length": { "value": 90, "unit": "mm" },
-                    "width": { "value": 60, "unit": "mm" },
-                    "height": { "value": 10, "unit": "mm" },
-                    "volume": { "value": 7.5, "unit": "L" }
-                  },
-                  "characteristic": {
-                    "Battery status": "Recycled",
-                    "Battery cell type": "Prismatic",
-                    "Number of cells per battery": "180",
-                    "Total energy": "100kwh"
-                  },
-                  "productionDate": "2024-04-24",
-                  "countryOfProduction": "Australia",
-                  "granularityLevel": "item",
-                  "dueDiligenceDeclaration": {
-                    "type": ["Link"],
-                    "linkURL": "https://example-company.com/due-diligence/1234567",
-                    "linkName": "Due Diligence Declaration"
-                  },
-                  "materialsProvenance": [
-                    {
-                      "type": ["Material"],
-                      "name": "Material",
-                      "originCountry": "AU",
-                      "materialType": {
+                    "description": "400Ah 24v LiFePO4 battery",
+                    "productCategory": [
+                      {
                         "type": ["Classification"],
-                        "id": "https://unfc.org/material-type/Lithium",
-                        "name": "Lithium"
-                      },
-                      "massFraction": 20,
-                      "massAmount": { "value": 1.0, "unit": "kg" },
-                      "recycledAmount": 0,
-                      "hazardous": false
-                    },
-                    {
-                      "type": ["Material"],
-                      "name": "Material",
-                      "originCountry": "AU",
-                      "materialType": {
-                        "type": ["Classification"],
-                        "id": "https://unfc.org/material-type/Lithium",
-                        "name": "Lithium"
-                      },
-                      "massFraction": 20,
-                      "massAmount": { "value": 1.0, "unit": "kg" },
-                      "recycledAmount": 10,
-                      "hazardous": true,
-                      "materialSafetyInformation": {
-                        "type": ["Link"],
-                        "linkURL": "https://example.com/safety-info/lithium-spodumene.pdf",
-                        "linkName": "Material Safety Data Sheet",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/safetyData"
+                        "id": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
+                        "code": "46410",
+                        "name": "Primary cells and primary batteries",
+                        "schemeID": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+                        "schemeName": "UN Central Product Classification (CPC)"
+                      }
+                    ],
+                    "furtherInformation": [
+                      {
+                        "linkURL": "https://files.example-certifier.com/1234567.json",
+                        "linkName": "GBA rule book conformity certificate",
+                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+                      }
+                    ],
+                    "producedByParty": {
+                      "id": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                      "name": "Example Company Pty Ltd.",
+                      "registeredId": "90664869327",
+                      "idScheme": {
+                        "type": ["IdentifierScheme"],
+                        "id": "https://id.gs1.org/01/",
+                        "name": "Global Trade Identification Number (GTIN)"
                       }
                     },
-                    {
-                      "type": ["Material"],
-                      "name": "Material",
-                      "originCountry": "AU",
-                      "materialType": {
-                        "type": ["Classification"],
-                        "id": "https://unfc.org/material-type/Lithium",
-                        "name": "Lithium"
-                      },
-                      "massFraction": 20,
-                      "massAmount": { "value": 1.0, "unit": "kg" },
-                      "recycledAmount": 0,
-                      "hazardous": false
+                    "producedAtFacility": {
+                      "id": "https://example-facility-register.com/1234567",
+                      "name": "Greenacres battery factory",
+                      "registeredId": "1234567",
+                      "idScheme": {
+                        "type": ["IdentifierScheme"],
+                        "id": "https://id.gs1.org/01/",
+                        "name": "Global Trade Identification Number (GTIN)"
+                      }
                     },
-                    {
-                      "type": ["Material"],
-                      "name": "Material",
-                      "originCountry": "AU",
-                      "materialType": {
-                        "type": ["Classification"],
-                        "id": "https://unfc.org/material-type/Lithium",
-                        "name": "Lithium"
+                    "productionDate": "2024-04-25",
+                    "countryOfProduction": "AU",
+                    "serialNumber": "12345678",
+                    "dimensions": {
+                      "weight": {
+                        "value": 10,
+                        "unit": "KGM"
                       },
-                      "massFraction": 20,
-                      "massAmount": { "value": 1.0, "unit": "kg" },
-                      "recycledAmount": 0,
-                      "hazardous": false
+                      "length": {
+                        "value": 10,
+                        "unit": "KGM"
+                      },
+                      "width": {
+                        "value": 10,
+                        "unit": "KGM"
+                      },
+                      "height": {
+                        "value": 10,
+                        "unit": "KGM"
+                      },
+                      "volume": {
+                        "value": 10,
+                        "unit": "KGM"
+                      }
                     }
-                  ],
+                  },
+                  "granularityLevel": "batch",
                   "conformityClaim": [
                     {
                       "type": ["Claim", "Declaration"],
-                      "assessmentDate": "2024-04-25",
-                      "declaredValue": [
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        },
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        }
-                      ],
                       "id": "https://products.example-company.com/09520123456788/declarations/12345",
+                      "description": "A standardised disclosure of the battery's greenhouse gas emissions intensity, calculated in accordance with the Global Battery Alliance Battery Passport Greenhouse Gas Rulebook V.2.0.",
                       "referenceStandard": {
                         "type": ["Standard"],
-                        "id": "https://www.iso.org/standard/60857.html",
-                        "name": "Standard",
+                        "id": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf",
+                        "name": "GBA Battery Passport Greenhouse Gas Rulebook - V.2.0",
                         "issuingParty": {
-                          "type": ["Identifier"],
-                          "id": "https://iso.org/issuing-party/123",
-                          "name": "International Organization"
+                          "id": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                          "name": "Example Company Pty Ltd.",
+                          "registeredId": "90664869327",
+                          "idScheme": {
+                            "type": ["IdentifierScheme"],
+                            "id": "https://id.gs1.org/01/",
+                            "name": "Global Trade Identification Number (GTIN)"
+                          }
                         },
-                        "issueDate": "2024-04-25"
+                        "issueDate": "2023-12-05"
                       },
                       "referenceRegulation": {
                         "type": ["Regulation"],
                         "id": "https://www.legislation.gov.au/F2008L02309/latest/versions",
-                        "name": "National Greenhouse",
-                        "jurisdictionCountry": "Australia",
+                        "name": "National Greenhouse and Energy Reporting (Measurement) Determination",
+                        "jurisdictionCountry": "AU",
                         "administeredBy": {
-                          "type": ["Identifier"],
-                          "id": "https://gov.au/admin-body/12345",
-                          "name": "Australian Government"
+                          "id": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                          "name": "Example Company Pty Ltd.",
+                          "registeredId": "90664869327",
+                          "idScheme": {
+                            "type": ["IdentifierScheme"],
+                            "id": "https://id.gs1.org/01/",
+                            "name": "Global Trade Identification Number (GTIN)"
+                          }
                         },
                         "effectiveDate": "2024-03-20"
                       },
@@ -1991,416 +3101,134 @@
                         {
                           "type": ["Criterion"],
                           "id": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
-                          "name": "Battery Assembly Guidelines",
-                          "thresholdValues": [
-                            {
-                              "type": ["Metric"],
-                              "metricName": "Minimum compressive strength",
-                              "metricValue": { "value": 500, "unit": "MPA" }
-                            }
-                          ]
+                          "name": "GBA Battery rule book v2.0 battery assembly guidelines.",
+                          "description": "Battery is designed for easy disassembly and recycling at end-of-life.",
+                          "conformityTopic": "social.rights",
+                          "status": "proposed",
+                          "subCriterion": [],
+                          "thresholdValue": {
+                            "metricName": "GHG emissions intensity",
+                            "metricValue": {
+                              "value": 10,
+                              "unit": "KGM"
+                            },
+                            "score": "BB",
+                            "accuracy": 0.05
+                          },
+                          "performanceLevel": "\"Category 3 recyclable with 73% recyclability\"",
+                          "tags": "The quick brown fox jumps over the lazy dog."
+                        }
+                      ],
+                      "assessmentDate": "2024-03-15",
+                      "declaredValue": [
+                        {
+                          "metricName": "GHG emissions intensity",
+                          "metricValue": {
+                            "value": 10,
+                            "unit": "KGM"
+                          },
+                          "score": "BB",
+                          "accuracy": 0.05
                         }
                       ],
                       "conformance": true,
-                      "conformityTopic": "environment.energy",
+                      "conformityTopic": "environment.emissions",
                       "conformityEvidence": {
-                        "type": ["SecureLink", "Link"],
-                        "linkURL": "https://example-certifier.com/evidence/1234567.json",
+                        "linkURL": "https://files.example-certifier.com/1234567.json",
+                        "linkName": "GBA rule book conformity certificate",
+                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
                         "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
                         "hashMethod": "SHA-256",
-                        "linkName": "Declaration link name",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "encryptionMethod": "AES"
-                      }
-                    },
-                    {
-                      "type": ["Claim", "Declaration"],
-                      "assessmentDate": "2024-04-25",
-                      "declaredValue": [
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        },
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        }
-                      ],
-                      "id": "https://products.example-company.com/09520123456788/declarations/12345",
-                      "referenceStandard": {
-                        "type": ["Standard"],
-                        "id": "https://www.iso.org/standard/60857.html",
-                        "name": "Standard",
-                        "issuingParty": {
-                          "type": ["Identifier"],
-                          "id": "https://iso.org/issuing-party/123",
-                          "name": "International Organization"
-                        },
-                        "issueDate": "2023-12-05"
-                      },
-                      "referenceRegulation": {
-                        "type": ["Regulation"],
-                        "id": "https://www.legislation.gov.au/F2008L02309/latest/versions",
-                        "name": "National Greenhouse",
-                        "jurisdictionCountry": "Australia",
-                        "administeredBy": {
-                          "type": ["Identifier"],
-                          "id": "https://gov.au/admin-body/12345",
-                          "name": "Australian Government"
-                        },
-                        "effectiveDate": "2024-03-20"
-                      },
-                      "assessmentCriteria": [
-                        {
-                          "type": ["Criterion"],
-                          "id": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
-                          "name": "Battery Assembly Guidelines",
-                          "thresholdValues": [
-                            {
-                              "type": ["Metric"],
-                              "metricName": "Minimum compressive strength",
-                              "metricValue": { "value": 500, "unit": "MPA" }
-                            }
-                          ]
-                        }
-                      ],
-                      "conformance": false,
-                      "conformityTopic": "environment.energy",
-                      "conformityEvidence": {
-                        "type": ["SecureLink", "Link"],
-                        "linkURL": "https://example-certifier.com/evidence/1234567.json",
-                        "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
-                        "hashMethod": "SHA-256",
-                        "linkName": "Declaration link name",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "encryptionMethod": "AES"
-                      }
-                    },
-                    {
-                      "type": ["Claim", "Declaration"],
-                      "assessmentDate": "2024-04-25",
-                      "declaredValue": [
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        },
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        }
-                      ],
-                      "id": "https://products.example-company.com/09520123456788/declarations/12345",
-                      "referenceStandard": {
-                        "type": ["Standard"],
-                        "id": "https://www.iso.org/standard/60857.html",
-                        "name": "Standard",
-                        "issuingParty": {
-                          "type": ["Identifier"],
-                          "id": "https://iso.org/issuing-party/123",
-                          "name": "International Organization"
-                        },
-                        "issueDate": "2023-12-05"
-                      },
-                      "referenceRegulation": {
-                        "type": ["Regulation"],
-                        "id": "https://www.legislation.gov.au/F2008L02309/latest/versions",
-                        "name": "National Greenhouse",
-                        "jurisdictionCountry": "Australia",
-                        "administeredBy": {
-                          "type": ["Identifier"],
-                          "id": "https://gov.au/admin-body/12345",
-                          "name": "Australian Government"
-                        },
-                        "effectiveDate": "2024-03-20"
-                      },
-                      "assessmentCriteria": [
-                        {
-                          "type": ["Criterion"],
-                          "id": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
-                          "name": "Battery Assembly Guidelines",
-                          "thresholdValues": [
-                            {
-                              "type": ["Metric"],
-                              "metricName": "Minimum compressive strength",
-                              "metricValue": { "value": 500, "unit": "MPA" }
-                            }
-                          ]
-                        }
-                      ],
-                      "conformance": false,
-                      "conformityTopic": "environment.energy",
-                      "conformityEvidence": {
-                        "type": ["SecureLink", "Link"],
-                        "linkURL": "https://example-certifier.com/evidence/1234567.json",
-                        "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
-                        "hashMethod": "SHA-256",
-                        "linkName": "Declaration link name",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "encryptionMethod": "AES"
-                      }
-                    },
-                    {
-                      "type": ["Claim", "Declaration"],
-                      "assessmentDate": "2024-04-25",
-                      "declaredValue": [
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        },
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        }
-                      ],
-                      "id": "https://products.example-company.com/09520123456788/declarations/12345",
-                      "referenceStandard": {
-                        "type": ["Standard"],
-                        "id": "https://www.iso.org/standard/60857.html",
-                        "name": "Standard",
-                        "issuingParty": {
-                          "type": ["Identifier"],
-                          "id": "https://iso.org/issuing-party/123",
-                          "name": "International Organization"
-                        },
-                        "issueDate": "2023-12-05"
-                      },
-                      "referenceRegulation": {
-                        "type": ["Regulation"],
-                        "id": "https://www.legislation.gov.au/F2008L02309/latest/versions",
-                        "name": "National Greenhouse",
-                        "jurisdictionCountry": "Australia",
-                        "administeredBy": {
-                          "type": ["Identifier"],
-                          "id": "https://gov.au/admin-body/12345",
-                          "name": "Australian Government"
-                        },
-                        "effectiveDate": "2024-03-20"
-                      },
-                      "assessmentCriteria": [
-                        {
-                          "type": ["Criterion"],
-                          "id": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
-                          "name": "Battery Assembly Guidelines",
-                          "thresholdValues": [
-                            {
-                              "type": ["Metric"],
-                              "metricName": "Minimum compressive strength",
-                              "metricValue": { "value": 500, "unit": "MPA" }
-                            }
-                          ]
-                        }
-                      ],
-                      "conformance": false,
-                      "conformityTopic": "environment.energy",
-                      "conformityEvidence": {
-                        "type": ["SecureLink", "Link"],
-                        "linkURL": "https://example-certifier.com/evidence/1234567.json",
-                        "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
-                        "hashMethod": "SHA-256",
-                        "linkName": "Declaration link name",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "encryptionMethod": "AES"
-                      }
-                    },
-                    {
-                      "type": ["Claim", "Declaration"],
-                      "assessmentDate": "2024-04-25",
-                      "declaredValue": [
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        },
-                        {
-                          "type": ["Metric"],
-                          "metricName": "GHG emissions intensity",
-                          "metricValue": { "value": 1.5, "unit": "kg" },
-                          "score": "1.2",
-                          "accuracy": 0.8
-                        }
-                      ],
-                      "id": "https://products.example-company.com/09520123456788/declarations/12345",
-                      "referenceStandard": {
-                        "type": ["Standard"],
-                        "id": "https://www.iso.org/standard/60857.html",
-                        "name": "Standard",
-                        "issuingParty": {
-                          "type": ["Identifier"],
-                          "id": "https://iso.org/issuing-party/123",
-                          "name": "International Organization"
-                        },
-                        "issueDate": "2023-12-05"
-                      },
-                      "referenceRegulation": {
-                        "type": ["Regulation"],
-                        "id": "https://www.legislation.gov.au/F2008L02309/latest/versions",
-                        "name": "National Greenhouse",
-                        "jurisdictionCountry": "Australia",
-                        "administeredBy": {
-                          "type": ["Identifier"],
-                          "id": "https://gov.au/admin-body/12345",
-                          "name": "Australian Government"
-                        },
-                        "effectiveDate": "2024-03-20"
-                      },
-                      "assessmentCriteria": [
-                        {
-                          "type": ["Criterion"],
-                          "id": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf#BatteryAssembly",
-                          "name": "Battery Assembly Guidelines",
-                          "thresholdValues": [
-                            {
-                              "type": ["Metric"],
-                              "metricName": "Minimum compressive strength",
-                              "metricValue": { "value": 500, "unit": "MPA" }
-                            }
-                          ]
-                        }
-                      ],
-                      "conformance": false,
-                      "conformityTopic": "environment.energy",
-                      "conformityEvidence": {
-                        "type": ["SecureLink", "Link"],
-                        "linkURL": "https://example-certifier.com/evidence/1234567.json",
-                        "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
-                        "hashMethod": "SHA-256",
-                        "linkName": "Declaration link name",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
                         "encryptionMethod": "AES"
                       }
                     }
                   ],
-                  "circularityScorecard": {
-                    "type": ["CircularityPerformance"],
-                    "recyclingInformation": {
-                      "type": ["Link"],
-                      "linkURL": "https://example-company.com/recycling/1234567",
-                      "linkName": "Recycling Information"
-                    },
-                    "repairInformation": {
-                      "type": ["Link"],
-                      "linkURL": "https://example-company.com/repair/1234567",
-                      "linkName": "Repair Instructions"
-                    },
-                    "recyclableContent": 67,
-                    "recycledContent": 86,
-                    "utilityFactor": 1.2,
-                    "materialCircularityIndicator": 0.67
-                  },
                   "emissionsScorecard": {
-                    "type": ["EmissionsPerformance"],
-                    "carbonFootprint": 12.5,
-                    "declaredUnit": "kg",
+                    "carbonFootprint": 1.8,
+                    "declaredUnit": "KGM",
                     "operationalScope": "CradleToGate",
-                    "primarySourcedRatio": 75,
+                    "primarySourcedRatio": 0.3,
                     "reportingStandard": {
                       "type": ["Standard"],
-                      "id": "https://www.ifrs.org/standards/issb/s2",
-                      "name": "WBSCD Pathfinder framework - V.2.0",
+                      "id": "https://www.globalbattery.org/media/publications/gba-rulebook-v2.0-master.pdf",
+                      "name": "GBA Battery Passport Greenhouse Gas Rulebook - V.2.0",
                       "issuingParty": {
-                        "type": ["Identifier"],
-                        "id": "https://id.ifrs.org/issuing-party/123",
-                        "name": "International Financial Reporting Standards Foundation",
+                        "id": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                        "name": "Example Company Pty Ltd.",
                         "registeredId": "90664869327",
                         "idScheme": {
                           "type": ["IdentifierScheme"],
-                          "id": "https://id.ifrs.org/issuing-party/",
-                          "name": "IFRS Issuing Party"
+                          "id": "https://id.gs1.org/01/",
+                          "name": "Global Trade Identification Number (GTIN)"
                         }
                       },
-                      "issueDate": "2024-04-25"
+                      "issueDate": "2023-12-05"
                     }
                   },
-                  "traceabilityInformation": {
-                    "valueChainProcess": "Spinning",
-                    "verifiedRatio": 0.5,
-                    "traceabilityEvent": [
-                      {
-                        "linkURL": "https://files.example-certifier.com/1234567.json",
-                        "linkName": "Object Event",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "hashDigest": "6239119",
-                        "hashMethod": "SHA-256",
-                        "encryptionMethod": "AES"
-                      },
-                      {
-                        "linkURL": "https://files.example-certifier.com/1234567.json",
-                        "linkName": "Transformation Event",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "hashDigest": "6239119",
-                        "hashMethod": "SHA-256",
-                        "encryptionMethod": "AES"
-                      },
-                      {
-                        "linkURL": "https://files.example-certifier.com/1234567.json",
-                        "linkName": "Transaction Event",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "hashDigest": "6239119",
-                        "hashMethod": "SHA-256",
-                        "encryptionMethod": "AES"
-                      },
-                      {
-                        "linkURL": "https://files.example-certifier.com/1234567.json",
-                        "linkName": "Aggregation Event",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "hashDigest": "6239119",
-                        "hashMethod": "SHA-256",
-                        "encryptionMethod": "AES"
-                      },
-                      {
-                        "linkURL": "https://files.example-certifier.com/1234567.json",
-                        "linkName": "Association Event",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "hashDigest": "6239119",
-                        "hashMethod": "SHA-256",
-                        "encryptionMethod": "AES"
-                      },
-                      {
-                        "linkURL": "https://files.example-certifier.com/1234567.json",
-                        "linkName": "Object Event",
-                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
-                        "hashDigest": "6239119",
-                        "hashMethod": "SHA-256",
-                        "encryptionMethod": "AES"
-                      }
-                    ]
-                  }
-                },
-                "constructData": {
-                  "mappingFields": [],
-                  "dummyFields": [],
-                  "generationFields": [
+                  "traceabilityInformation": [
                     {
-                      "path": "/eventID",
-                      "handler": "generateIdWithSerialNumber"
+                      "valueChainProcess": "Spinning",
+                      "verifiedRatio": 0.5,
+                      "traceabilityEvent": [
+                        {
+                          "linkURL": "https://files.example-certifier.com/1234567.json",
+                          "linkName": "GBA rule book conformity certificate",
+                          "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc",
+                          "hashDigest": "6239119dda5bd4c8a6ffb832fe16feaa5c27b7dba154d24c53d4470a2c69adc2",
+                          "hashMethod": "SHA-256",
+                          "encryptionMethod": "AES"
+                        }
+                      ]
+                    }
+                  ],
+                  "circularityScorecard": {
+                    "recyclingInformation": {
+                      "linkURL": "https://files.example-certifier.com/1234567.json",
+                      "linkName": "GBA rule book conformity certificate",
+                      "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+                    },
+                    "repairInformation": {
+                      "linkURL": "https://files.example-certifier.com/1234567.json",
+                      "linkName": "GBA rule book conformity certificate",
+                      "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+                    },
+                    "recyclableContent": 0.5,
+                    "recycledContent": 0.3,
+                    "utilityFactor": 1.2,
+                    "materialCircularityIndicator": 0.67
+                  },
+                  "dueDiligenceDeclaration": {
+                    "linkURL": "https://files.example-certifier.com/1234567.json",
+                    "linkName": "GBA rule book conformity certificate",
+                    "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+                  },
+                  "materialsProvenance": [
+                    {
+                      "name": "Lithium Spodumene",
+                      "originCountry": "AU",
+                      "materialType": {
+                        "type": ["Classification"],
+                        "id": "https://unstats.un.org/unsd/classifications/Econ/cpc/46410",
+                        "code": "46410",
+                        "name": "Primary cells and primary batteries",
+                        "schemeID": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+                        "schemeName": "UN Central Product Classification (CPC)"
+                      },
+                      "massFraction": 0.2,
+                      "mass": {
+                        "value": 10,
+                        "unit": "KGM"
+                      },
+                      "recycledMassFraction": 0.5,
+                      "hazardous": false,
+                      "symbol": "undefined",
+                      "materialSafetyInformation": {
+                        "linkURL": "https://files.example-certifier.com/1234567.json",
+                        "linkName": "GBA rule book conformity certificate",
+                        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+                      }
                     }
                   ]
-                },
-                "className": "json-form",
-                "style": {
-                  "margin": "40px auto",
-                  "paddingTop": "40px",
-                  "width": "80%"
                 }
               }
             },
@@ -2418,24 +3246,37 @@
                   "vckit": {
                     "vckitAPIUrl": "http://localhost:3332/v2",
                     "issuer": {
+                      "type": ["CredentialIssuer"],
                       "id": "did:web:uncefact.github.io:project-vckit:test-and-development",
-                      "name": "Orchard Facility"
+                      "name": "Example Company Pty Ltd",
+                      "issuerAlsoKnownAs": [
+                        {
+                          "id": "https://abr.business.gov.au/ABN/View?abn=90664869327",
+                          "name": "Example Company Pty Ltd.",
+                          "registeredId": "90664869327",
+                          "idScheme": {
+                            "type": ["IdentifierScheme"],
+                            "id": "https://abr.business.gov.au/ABN/",
+                            "name": "Australian Business Number (ABN)"
+                          }
+                        }
+                      ]
                     },
                     "headers": {
                       "Authorization": "Bearer test123"
                     }
                   },
                   "dpp": {
-                    "validUntil": "2025-11-28T04:47:15.136Z",
-                    "context": ["https://test.uncefact.org/vocabulary/untp/dpp/0.6.0-beta7/"],
+                    "validUntil": "2026-11-28T04:47:15.136Z",
+                    "context": ["https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/"],
                     "renderTemplate": [
                       {
-                        "template": "<!DOCTYPE html> <html lang=\"en\"> <head> <meta charset=\"UTF-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> <link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap\" rel=\"stylesheet\"> <title>Digital Product Passport</title> <style> :root { --image-src: url('{{credentialSubject.productImage.linkURL}}'); --highlight: rgba(0, 99, 83, 1); --primary-colorsblue-400: rgba(79, 149, 221, 1); --primary-colorsblue-50: rgba(210, 229, 249, 1); --primary-colorsblue-10: rgba(247, 250, 253, 1); --white: rgba(255, 255, 255, 1); --black: rgba(0, 0, 0, 1); --primary-colorsgray-400: rgba(212, 214, 216, 1); --primary-colorsgray-600: rgba(85, 96, 110, 1); --primary-colorsblue-700: rgba(31, 90, 149, 1); --primary-colorsgray-700: rgba(35, 46, 61, 1); --accent-colorslight-green: rgba(184, 236, 182, 1); --text-color-green: rgba(8, 50, 0, 1); --accent-colorslight-red: rgba(255, 188, 183, 1); --text-color-red: rgba(50, 0, 0, 1); } * { margin: 0; padding: 0; box-sizing: border-box; } body { font-family: 'Lato', sans-serif; } section { padding: 0 16px 0 16px; } .section-title { font-size: 18px; font-weight: 700; line-height: 19.62px; color: #000000; } .section-description { margin-top: 12px; font-size: 16px; line-height: 18.88px; color: #000000; font-weight: 400; } .table { display: flex; flex-direction: column; justify-content: center; gap: 10px; } .table-item { display: grid; grid-template-columns: 1fr 2fr; column-gap: 16px; align-items: center; padding-bottom: 10px; border-bottom: 1px solid #d4d6d8; } .table-item span { font-size: 16px; font-weight: 400; line-height: 22px; color: var(--primary-colorsgray-600); } .table-item p, .table-item a, .table-item a:link { font-size: 16px; font-weight: 500; line-height: 22px; color: var(--primary-colorsgray-700); } .table-line { border-bottom: 1px solid #d4d6d8; } .item-title { display: flex; font-size: 16px; font-weight: 400; line-height: 17.44px; color: #55606E; } .item-value { display: flex; flex-direction: column; font-size: 16px; font-weight: 500; line-height: 17.44px; color: #232E3D; } .item-value a, .item-value span { color: #232E3D; } .annotation { display: flex; gap: 4px; font-size: 14px; font-weight: 400; line-height: 15.26px; color: #55606E; } .annotation span { padding-top: 2px; } .mobile { min-width: 150px; width: 100%; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; word-break: break-word; } .header { min-height: 320px; } .header-image { background: linear-gradient(248.36deg, rgba(0, 0, 0, 0.18) 7.6%, rgba(0, 0, 0, 0.6) 70.52%); background-image: var(--image-src); background-size: cover; background-position: center; height: 232px; position: relative; } .header-image-top-left { position: absolute; top: 25px; left: 15px; font-weight: 500; font-size: 16px; line-height: 22px; color: #ffffff; } .header-image-bottom-left { position: absolute; bottom: 18px; left: 15px; color: #ffffff; } .header-image-bottom-left h1 { font-size: 30px; font-weight: 900; line-height: 32.5px; } .header-batch { padding: 12px 16px 16px 16px; background-color: #F7FAFD; display: grid; grid-template-columns: 1.2fr 1fr; grid-auto-flow: row; row-gap: 12px; } .header-batch-item { display: flex; align-items: center; gap: 6px; } .header-batch-item a { color: #232E3D; font-size: 14px; line-height: 15.25px; font-weight: 500; } .header-batch a { padding: 0 2px; font-size: 14px; font-weight: 400; line-height: 19.25px; text-decoration: none; color: #000000; } .information { display: flex; flex-direction: column; gap: 8px; } .information-text { font-size: 19px; font-weight: 300; line-height: 22.42px; } .information-show-more { display: flex; flex-direction: column; gap: 10px; font-size: 14px; font-weight: 500; line-height: 22px; } .information-show-more a { color: var(--primary-colorsgray-700); } .passport { display: flex; flex-direction: column; gap: 24px; } .passport-header { display: flex; justify-content: space-between; align-items: center; } .passport-box { display: grid; grid-template-columns: 1fr 1fr; border: #D4D6D8 1px dotted; border-radius: 5px; overflow: hidden; } .passport-box-item { display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 12px 16px 12px 16px; border: #D4D6D8 1px dotted; outline-offset: -1px; min-height: 94px; color: #1F5A95; } .passport-box-item h3 { font-size: 40px; font-weight: 900; line-height: 43.33px; letter-spacing: 2px; } .passport-box-item p { margin-top: 8px; font-size: 15px; font-weight: 600; line-height: 18.88px; } .passport-box-item:last-child { background-color: #F7FAFD; } .passport-issued-by-header { display: flex; flex-direction: column; gap: 12px; } .passport-issued-by-header h3 { margin-top: 2px; font-size: 20px; font-weight: 700; line-height: 21.8px; } .passport-issued-by-header p { font-size: 16px; font-weight: 400; line-height: 19.25px; color: #55606E; } .passport-annotation { font-size: 14px; font-weight: 400; line-height: 15.26px; color: #55606E; } .traceability-cards { display: flex; flex-direction: column; gap: 12px; } .traceability-card { display: grid; grid-template-columns: 3fr 1fr; justify-content: space-between; align-items: center; min-height: 40px; text-decoration: none; } .traceability-card-text { display: flex; align-items: center; gap: 8px; font-size: 16px; font-weight: 400; line-height: 17.44px; color: #000000; } .traceability-card-view-details, .traceability-card-view-details:link { display: flex; justify-content: flex-end; align-items: center; gap: 8px; } .emission-score-card { display: flex; flex-direction: column; gap: 12px; } .mission-score-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .mission-score-description { font-size: 16px; font-weight: 400; line-height: 18.88px; color: #000000; } .score { display: flex; flex-direction: column; gap: 6px; } .score-unit { font-size: 40px; font-weight: 900; line-height: 43.33px; color: #1F5A95; letter-spacing: 2px; } .score-name { font-size: 16px; font-weight: 400; line-height: 17.44px; color: #55606E; } .declarations { display: flex; flex-direction: column; gap: 12px; } .declaration-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .cards-conformities { display: flex; flex-direction: column; gap: 8px; } .cards-conformity { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; min-width: 100%; padding: 16px 18px 16px 16px; position: relative; background-color: var(--white); border-radius: 4px; border: 1px solid; border-color: var(--primary-colorsgray-400); } .frame { display: flex; align-items: center; justify-content: space-between; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .div { display: inline-flex; align-items: center; gap: 4px; position: relative; flex: 0 0 auto; } .company-name { position: relative; width: fit-content; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .tags-VC-badge-red { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-red); color: var(--text-color-red); border-radius: 8px; overflow: hidden; } .tags-VC-badge-green { display: inline-flex; align-items: center; justify-content: center; gap: 10px; padding: 4px 8px; flex: 0 0 auto; background-color: var(--accent-colorslight-green); color: var(--text-color-green); border-radius: 8px; overflow: hidden; } .verifiable { width: fit-content; font-weight: 600; font-size: 14px; line-height: 15.3px; } .mobile .frame-2 { display: flex; flex-direction: column; align-items: center; gap: 4px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .text-wrapper { position: relative; align-self: stretch; margin-top: -1px; font-weight: 400; color: var(--primary-colorsblue-700); font-size: 18px; line-height: 21.2px; } .p { color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; align-self: stretch; font-weight: 400; color: #55606e; } .span { font-weight: 400; font-size: 14px; line-height: 19.2px; } .text-wrapper-2 { color: #55606e; } .frame-3 { display: inline-flex; flex-direction: column; align-items: flex-start; position: relative; flex: 0 0 auto; margin-right: -2px; border-bottom-width: 1px; border-bottom-style: solid; border-color: var(--white); } .frame-4 { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 4px; padding: 4px 0px; position: relative; flex: 0 0 auto; border-top-width: 1px; border-top-style: solid; border-color: var(--white); } .typography-heading { display: flex; align-items: center; justify-content: center; gap: 10px; } .heading { position: relative; flex: 1; font-weight: 400; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 17.4px; } .heading-2 { position: relative; flex: 1; margin-top: -0.5px; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; } .cards-traceability { display: grid; grid-template-columns: 1fr auto; align-items: center; justify-content: space-between; padding: 8px 0px; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; border-radius: 4px; text-decoration: none; } .history-information { display: flex; flex-direction: column; gap: 12px; } .history-value-chain-item { display: flex; flex-direction: column; gap: 8px; } .history-value-chain { display: flex; flex-direction: column; gap: 4px; } .history-value-chain p { font-size: 18px; font-weight: 400; line-height: 21.24px; color: #1F5A95; } .verified-ratio { background-color: #D2E5F9; width: fit-content; padding: 2px 4px; } .verified-ratio p { font-size: 14px; font-weight: 400; line-height: 19.25px; color: var(--black); } .frame-5 { display: inline-flex; align-items: center; gap: 8px; position: relative; flex: 0 0 auto; } .company-name-wrapper { display: flex; flex-direction: column; width: 100%; align-items: flex-start; gap: 4px; position: relative; } .company-name-2 { color: var(--black); font-size: 16px; line-height: 17.4px; position: relative; align-self: stretch; font-weight: 400; } .img { position: relative; flex: 0 0 auto; margin-right: -1px; } .production { display: none; flex-direction: column; gap: 12px; } .production:has(.table-item) { display: flex; } .production-title { font-size: 20px; font-weight: 700; line-height: 21.8px; } .product-table, .product-table:link, .product-table:visited, .product-table:active { color: #232E3D; } .composition-box { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; } .composition-box-item { display: grid; grid-template-columns: 1fr auto; justify-content: space-between; border: 1px solid #d4d6d8; border-radius: 4px; padding: 16px; } .composition-percent { font-size: 16px; font-weight: 500; line-height: 21.92px; color: #000000; } .composition-title { font-size: 16px; font-weight: 600; line-height: 17.44px; color: #000000; } .composition-tag { display: flex; } .composition-tag-item { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #000000; background-color: #D2E5F9; padding: 2px 4px 2px 4px; margin-right: 4px; } .composition-box-first-column { display: grid; grid-template-columns: 40px 1fr; gap: 12px; } .composition-box-second-column { display: flex; flex-direction: column; gap: 6px; } .composition-box-second-column a { color: #232E3D; line-height: 22px; } .composition-box-third-column { display: flex; justify-content: end; gap: 12px; } .composition-box-third-column svg { margin: 1px 10px 0 0; } .passport-issued-by { display: flex; flex-direction: column; gap: 12px; } .history { display: flex; flex-direction: column; gap: 12px; } .history-event { display: flex; flex-direction: column; } .history-item { border-bottom: 1px solid #d4d6d8; padding: 10px 0 12px 0; display: grid; grid-template-columns: 1fr auto; gap: 16px; justify-content: space-between; } .history-item span { font-size: 16px; font-weight: 400; line-height: 17.44px; color: #000000; } .history-item a { font-size: 16px; font-weight: 500; line-height: 17.44px; color: var(--primary-colorsgray-700); text-decoration-color: #4f95dd; text-decoration-thickness: 2px; } .country-code { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #55606e; } .blue-bottom-line-thin, .blue-bottom-line-thin:link { border-bottom: 1px #4F95DD solid; width: fit-content; justify-content: flex-start; align-items: flex-start; gap: 10px; display: inline-flex; cursor: pointer; text-decoration: none; } .blue-bottom-line-thick, .blue-bottom-line-thick:link { width: fit-content; justify-content: flex-start; align-items: flex-start; gap: 10px; display: inline-flex; text-decoration-line: underline; text-decoration-thickness: 2px; text-decoration-color: #4F95DD; text-underline-offset: 3px; } .gray-bottom-line { border-bottom: 1px #55606E solid; width: fit-content; text-decoration: none; } .view-more-button { display: flex; justify-content: center; align-items: center; color: var(--primary-colorsblue-700); cursor: pointer; } footer { padding: 16px 16px 32px 16px; min-height: 60px; background-color: #F7FAFD; } footer p, footer a, footer a:link { font-size: 14px; font-weight: 400; line-height: 19.25px; color: #232E3D; } /* Media Queries for Mobiles */ @media (min-width: 50px) { .container { min-width: 100%; } .contents { display: none; } } /* Media Queries for Desktops */ @media (min-width: 1440px) { .container { min-width: 100%; display: flex; align-items: flex-start; gap: 10px; background-color: #ffffff; } .mobile { display: none; } html, body { margin: 0px; height: 100%; } /* a blue color as a generic focus style */ button:focus-visible { outline: 2px solid #4a90e2 !important; outline: -webkit-focus-ring-color auto 5px !important; } a { text-decoration: none; } .container { display: flex; align-items: flex-start; gap: 10px; background-color: #ffffff; } .container .contents { display: flex; flex-direction: column; align-items: center; gap: 40px; flex: 1; flex-grow: 1; } .container .frame { display: flex; flex-direction: column; align-items: flex-start; gap: 16px; padding: 56px 200px 0px; align-self: stretch; width: 100%; } .container .cards-conformity-header { display: flex; align-items: center; justify-content: space-between; position: relative; align-self: stretch; width: 100%; flex: 0 0 auto; } .container .conformance { font-size: 14px; font-weight: 400; line-height: 19.25px; color: var(--primary-colorsgray-600); } .container .cards-conformity-conformance { display: inline-flex; align-items: center; gap: 4px; flex: 0 0 auto; } .container .cards-conformity-body { display: flex; flex-direction: column; gap: 4px; } .container .cards-conformity-title { font-size: 20px; font-weight: 400; line-height: 23.6px; color: var(--primary-colorsblue-700); } .container .cards-conformity-description { color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; align-self: stretch; font-weight: 400; } .container .cards-conformity-description a { color: var(--primary-colorsgray-600); } .container .declared-values { display: flex; flex-direction: column; gap: 12px; } .container .declared-value { display: flex; flex-direction: column; gap: 4px; } .container .declared-value h3 { font-size: 16px; font-weight: 400; line-height: 17.44px; } .container .declared-value p { font-size: 14px; font-weight: 400; line-height: 19.25px; } .container .PP-title { width: 300px; margin-top: -1px; font-weight: 500; color: var(--primary-colorsgray-600); font-size: 24px; line-height: 33px; } .container .text-wrapper { align-self: stretch; font-weight: 900; color: var(--black); font-size: 72px; letter-spacing: 4.32px; line-height: 78px; } .container .product-ID-ALT { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 12px 12px; padding: 12px 12px 16px; align-self: stretch; width: 100%; background-color: var(--primary-colorsblue-10); } .container .div { display: inline-flex; align-items: center; gap: 6px; } .container .line { gap: 10px; display: inline-flex; align-items: flex-start; text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: var(--primary-colorsblue-400); text-underline-offset: 3px; } .container .text-wrapper-2 { width: fit-content; font-weight: 500; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 22px; } .container .div-wrapper { display: inline-flex; align-items: flex-start; gap: 10px; padding: 0px 0px 3px; } .container .text-wrapper-3 { width: fit-content; margin-top: -2px; font-weight: 500; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 17.4px; } .container .frame-2 { display: flex; align-items: flex-start; gap: 16px; align-self: stretch; width: 100%; } .container .PP-header { min-width: 320px; min-height: 200px; background: linear-gradient(180deg, rgba(0, 0, 0, 0.18) 0%, rgba(0, 0, 0, 0.6) 79.5%); background-image: var(--image-src); background-size: cover; background-position: 50% 50%; } .container .frame-3 { display: flex; flex-direction: column; align-items: flex-start; justify-content: flex-end; gap: 8px; align-self: stretch; width: 100%; } .container .frame-4 { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; flex: 1; flex-grow: 1; } .container .p { align-self: stretch; margin-top: -1px; font-weight: 300; color: var(--black); font-size: 19px; line-height: 22.4px; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; } .container .div-2 { display: flex; flex-direction: column; align-items: flex-start; gap: 16px; padding: 0px 200px; align-self: stretch; width: 100%; } .container .typography-heading { display: inline-flex; align-items: center; justify-content: center; gap: 10px; } .container .text-wrapper-4 { width: fit-content; font-weight: 700; color: var(--primary-colorsgray-700); font-size: 40px; line-height: 43.6px; } .container .text-wrapper-5 { align-self: stretch; font-weight: 400; color: var(--black); font-size: 16px; line-height: 18.9px; } .container .div-3 { display: grid; grid-template-columns: 1fr 1.3fr; gap: 32px; width: 100%; } .container .div-7 { display: grid; grid-template-columns: 1fr 3fr; gap: 32px; justify-items: center; } .container .frame-5 { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 12px; } .container .frame-6 { display: flex; flex-wrap: wrap; width: 510px; align-items: flex-start; gap: 0px 0px; margin-top: -1px; margin-left: -1px; margin-right: -1px; border-radius: 5px; border: 1px solid; border-color: var(--primary-colorsgray-400); } .container .frame-7 { display: flex; flex-direction: column; min-width: 170px; align-items: center; gap: 8px; padding: 12px 16px; flex: 1; flex-grow: 1; } .container .text-wrapper-6 { align-self: stretch; margin-top: -1px; font-weight: 900; color: var(--primary-colorsblue-700); font-size: 56px; text-align: center; letter-spacing: 3.36px; line-height: 60.7px; } .container .text-wrapper-7 { width: fit-content; font-weight: 700; color: var(--primary-colorsblue-700); font-size: 16px; line-height: 18.9px; } .container .frame-8 { display: flex; flex-direction: column; min-width: 170px; align-items: center; gap: 8px; padding: 12px 16px; flex: 1; flex-grow: 1; background-color: var(--primary-colorsblue-10); } .container .text-wrapper-8 { align-self: stretch; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 15.3px; } .container .frame-9 { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; flex: 1; flex-grow: 1; } .container .div-4 { display: inline-flex; align-items: center; gap: 12px; } .container .frame-10 { display: flex; flex-direction: column; width: 260px; align-items: flex-start; gap: 4px; } .container .text-wrapper-9 { align-self: stretch; font-weight: 600; color: var(--black); font-size: 16px; line-height: 17.4px; } .container .frame-11 { display: inline-flex; flex-direction: column; align-items: flex-start; } .container .text-wrapper-10 { width: fit-content; margin-top: -1px; font-weight: 900; color: var(--primary-colorsblue-700); font-size: 56px; letter-spacing: 3.36px; line-height: 60.7px; } .container .co-eq { width: 130px; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 16px; line-height: 17.4px; } .container .span { font-weight: 400; color: #55606e; font-size: 16px; line-height: 17.4px; } .container .text-wrapper-11 { font-size: 20px; line-height: 21.8px; } .container .div-5 { display: flex; flex-direction: column; align-items: flex-start; align-self: stretch; width: 100%; } .container .data-two-columns { display: grid; grid-template-columns: 1fr 8fr; align-items: flex-start; gap: 16px; padding: 10px 0px 12px; align-self: stretch; width: 100%; border-bottom-width: 1px; border-bottom-style: solid; border-color: var(--primary-colorsgray-400); } .container .data-two-columns-2 { display: flex; align-items: flex-start; gap: 16px; padding: 10px 0px 12px; align-self: stretch; width: 100%; border-bottom-width: 1px; border-bottom-style: solid; border-color: var(--primary-colorsgray-400); } .container .data-two-columns-3 { display: grid; grid-template-columns: 1.1fr 2fr; gap: 16px; padding: 10px 0px 12px; width: 100%; border-bottom-width: 1px; border-bottom-style: solid; border-color: var(--primary-colorsgray-400); } .container .data-two-columns .list { display: flex; flex-direction: column; } .container .text-wrapper-12 { font-weight: 400; color: var(--primary-colorsgray-600); font-size: 16px; line-height: 22px; } .container .data-data { display: flex; align-items: center; justify-content: center; gap: 10px; align-self: stretch; flex-grow: 1; flex: 1; } .container .data { flex: 1; font-weight: 500; color: var(--primary-colorsgray-700); font-size: 16px; } .container .data-2 { font-weight: 500; color: var(--primary-colorsgray-700); font-size: 16px; line-height: 17.4px; flex: 1; } .container .frame-12 { display: flex; flex-direction: column; align-items: flex-start; flex: 1; flex-grow: 1; } .container .line-wrapper { flex-wrap: wrap; gap: 10px 10px; display: inline-flex; align-items: flex-start; padding: 0px 0px 3px; border-bottom-width: 2px; border-bottom-style: solid; border-color: var(--primary-colorsblue-400); } .container .frame-13 { display: flex; align-items: flex-start; gap: 4px; align-self: stretch; width: 100%; } .container .text-wrapper-13 { width: fit-content; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 15.3px; margin-top: -1px; } .container .text-wrapper-14 { width: 358px; margin-top: -1px; font-weight: 700; color: var(--primary-colorsgray-700); font-size: 40px; line-height: 43.6px; } .container .frame-14 { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; padding: 0px 32px 32px; align-self: stretch; width: 100%; background-color: var(--primary-colorsblue-10); border-radius: 4px; overflow: hidden; } .container .frame-15 { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 16px 0px 0px; align-self: stretch; width: 100%; } .container .environment { align-self: stretch; margin-top: -1px; font-weight: 400; color: var(--primary-colorsgray-600); font-size: 14px; line-height: 19.2px; text-transform: uppercase; } .container .text-wrapper-15 { align-self: stretch; font-weight: 400; color: var(--primary-colorsblue-700); font-size: 18px; line-height: 21.2px; } .container .frame-16 { display: grid; grid-template-columns: 1fr 1fr 1fr; row-gap: 24px; column-gap: 32px; align-self: stretch; } .container .frame-17 { display: flex; flex-direction: column; min-width: 400px; align-items: flex-start; gap: 4px; flex: 1; flex-grow: 1; } .container .data-wrapper { align-items: center; justify-content: center; gap: 10px; display: flex; flex: 1; flex-grow: 1; } .container .text-wrapper-16 { font-weight: 500; color: var(--primary-colorsgray-700); font-size: 14px; } .container .cards-conformities { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; width: 100%; } .container .history-due-diligence { display: flex; align-items: center; gap: 8px; color: var(--black); } .container .history-due-diligence div { font-size: 16px; font-weight: 400; line-height: 17.44px; } .container .contents .history-information { width: 100%; display: flex; flex-direction: column; gap: 16px; } .container .contents .history-value-chain-item { margin-top: 8px; display: flex; flex-direction: column; gap: 16px; } .container .contents .history-value-chain { display: flex; flex-direction: row; gap: 16px; } .container .contents .verified-ratio {} .container .contents .history-event {} .container .contents .history-item {} .container .contents .view-more-button { align-self: baseline; } .container .frame-18 { display: flex; flex-direction: column; min-width: 400px; align-items: flex-start; flex: 1; flex-grow: 1; } .container .frame-19 { display: flex; flex-direction: column; align-items: flex-start; } .container .frame-20 { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; align-self: stretch; width: 100%; } .container .cards-traceability-2 { display: flex; align-items: center; justify-content: space-between; padding: 8px 0px; align-self: stretch; width: 100%; border-radius: 4px; } .container .frame-21 { display: inline-flex; align-items: center; gap: 8px; } .container .company-name { align-self: stretch; font-weight: 400; color: var(--black); font-size: 16px; line-height: 17.4px; } .container .frame-22 { display: flex; flex-direction: column; align-items: center; gap: 8px; align-self: stretch; width: 100%; } .container .rectangle-3 { align-self: stretch; width: 100%; height: 1px; background-color: var(--primary-colorsgray-400); } .container .frame-23 { display: flex; align-items: flex-start; gap: 8px; align-self: stretch; width: 100%; } .container .div-6 { width: fit-content; margin-top: -1px; font-weight: 400; color: var(--primary-colorsgray-700); font-size: 14px; line-height: 19.2px; } .container .text-wrapper-17 { font-weight: 400; color: #232e3d; font-size: 14px; line-height: 19.2px; } .container .text-wrapper-18 { font-size: 16px; font-weight: 500; line-height: 17.44px; color: #232E3D; } .container .black-line { text-decoration: none; color: #232e3d; border-bottom: 1px solid; } .container .frame-24 { display: none; flex-direction: column; align-items: flex-start; gap: 12px; padding: 0px 200px; align-self: stretch; width: 100%; } .container .frame-24:has(.data-two-columns) { display: flex; } .container .heading-wrapper { display: flex; align-items: center; justify-content: center; gap: 10px; align-self: stretch; width: 100%; } .container .heading { flex: 1; margin-top: -1px; font-weight: 700; color: var(--primary-colorsgray-700); font-size: 40px; line-height: 43.6px; } .container .cards { display: grid; grid-template-columns: 1fr 1fr; align-items: flex-start; gap: 20px 20px; align-self: stretch; } .container .cards-composition { display: flex; min-width: 400px; align-items: flex-start; justify-content: space-between; padding: 20px; background-color: var(--white); border-radius: 4px; border: 1px solid; border-color: var(--primary-colorsgray-400); } .container .first-column { display: flex; width: 260px; align-items: flex-start; gap: 12px; } .container .percentage { width: 40px; margin-top: -1px; font-weight: 500; color: var(--black); font-size: 15px; line-height: 20.6px; } .container .details { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; flex: 1; flex-grow: 1; } .container .frame-25 { display: inline-flex; align-items: flex-start; gap: 6px; } .container .frame-26 { display: inline-flex; align-items: flex-start; gap: 4px; padding: 2px 4px; background-color: #d2e5f8; } .container .text-wrapper-19 { width: fit-content; margin-top: -1px; font-weight: 400; color: var(--black); font-size: 14px; text-align: right; line-height: 19.2px; } .container .frame-27 { display: inline-flex; align-items: flex-start; gap: 4px; padding: 2px 4px; background-color: var(--primary-colorsblue-50); } .container .data-data-link-2 { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 6px; } .container .frame-28 { display: flex; flex-direction: column; align-items: center; gap: 12px; align-self: stretch; width: 100%; } .container .frame-29 { display: flex; flex-direction: column; gap: 8px; } .container .type-of-event { flex: 1; margin-top: -1px; font-weight: 400; color: var(--black); font-size: 16px; line-height: 17.4px; } .container .text-wrapper-20 { align-self: stretch; font-weight: 400; color: var(--primary-colorsblue-700); font-size: 16px; line-height: 17.4px; cursor: pointer; } .container .this-digital-product-wrapper { display: flex; align-items: center; justify-content: center; gap: 10px; padding: 24px 200px 76px; align-self: stretch; width: 100%; background-color: var(--primary-colorsblue-10); } .container .this-digital-product { flex: 1; margin-top: -1px; font-weight: 400; color: var(--primary-colorsgray-700); font-size: 14px; line-height: 19.2px; } } /* Mobile adjustments */ div:has(.container) .mobile section{ padding: 0px; } /* Desktop adjustments */ div:has(.container) .contents .frame { padding: 56px 0px 0px; } div:has(.container) .contents .div-2, div:has(.container) .contents .frame-24, div:has(.container) .contents .this-digital-product-wrapper { padding: 0px; } </style> </head> <body> <div class=\"container\"> <!-- Mobile width 390px--> <div class=\"mobile\"> <header class=\"header\"> <div class=\"header-image\"> <p class=\"header-image-top-left\">PRODUCT PASSPORT</p> <div class=\"header-image-bottom-left\"> <h1>{{credentialSubject.name}}</h1> </div> </div> <div> <div class=\"header-batch\"> <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a href=\"{{credentialSubject.idScheme.id}}\" class=\"blue-bottom-line-thick\">ID: {{credentialSubject.registeredId}}</a> </div> <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a>Batch: {{credentialSubject.batchNumber}}</a> </div> <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a>Serial: {{credentialSubject.serialNumber}}</a> </div> </div> </div> </header> <section class=\"information\"> <div class=\"information-text\"> {{credentialSubject.description}} </div> <div class=\"information-show-more\"> {{#each credentialSubject.furtherInformation}} <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\">{{linkName}}</a> {{/each}} </div> </section> {{#if credentialSubject.characteristic}} <section class=\"production\"> <div class=\"production-title\">Characteristics</div> <div class=\"product-table table\"> {{#each credentialSubject.characteristic}} <div class=\"table-item\"> <span class=\"item-title\">{{@key}}</span> <p class=\"item-value\">{{this}}</p> </div> {{/each}} </div> </section> {{/if}} <section class=\"production\"> <div class=\"production-title\">Production</div> <div class=\"product-table table\"> <div class=\"table-item\"> <span class=\"item-title\">Product category</span> <p class=\"item-value\">{{#each credentialSubject.productCategory}}{{name}}{{#unless @last}},{{/unless}} {{/each}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Produced by</span> <a href=\"{{credentialSubject.producedByParty.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.producedByParty.name}}</a> </div> <div class=\"table-item\"> <span class=\"item-title\">Produced at</span> <div class=\"item-value\"> <a href=\"{{credentialSubject.producedAtFacility.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.producedAtFacility.name}}</a> </div> </div> <div class=\"table-item\"> <span class=\"item-title\">Date produced</span> <p class=\"item-value\">{{credentialSubject.productionDate}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Country</span> <p class=\"item-value\">{{credentialSubject.countryOfProduction}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Dimensions</span> <p class=\"item-value\"> <span>Weight: {{credentialSubject.dimensions.weight.value}}{{credentialSubject.dimensions.weight.unit}}</span> <span>Length: {{credentialSubject.dimensions.length.value}}{{credentialSubject.dimensions.length.unit}}</span> <span>Width: {{credentialSubject.dimensions.width.value}}{{credentialSubject.dimensions.width.unit}}</span> <span>Height: {{credentialSubject.dimensions.height.value}}{{credentialSubject.dimensions.height.unit}}</span> <span>Volume: {{credentialSubject.dimensions.volume.value}}{{credentialSubject.dimensions.volume.unit}}</span> </p> </div> </div> </section> <section class=\"passport\"> <div class=\"passport-issued-by-header\"> <h3>Circularity Scorecard</h3> <p>The circularity Scorecard provides a simple high level summary of circularity performance of the product. </p> </div> <div class=\"passport-box\"> <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.recyclableContent}}%</h3> <p>Recyclable content</p> </div> <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.recycledContent}}%</h3> <p>Recycled content</p> </div> <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.utilityFactor}}</h3> <p>Utility factor</p> </div> <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.materialCircularityIndicator}}</h3> <p>Material circularity*</p> </div> </div> <div class=\"passport-annotation\"> <p>*The Material Circularity Indicator provides an overall circularity score which is a function of all three of the earlier measures.</p> </div> <div class=\"traceability-cards\"> <a href=\"{{credentialSubject.circularityScorecard.recyclingInformation.linkURL}}\" class=\"traceability-card\"> <div class=\"traceability-card-text\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M21.82 15.42L19.32 19.75C18.83 20.61 17.92 21.06 17 21H15V23L12.5 18.5L15 14V16H17.82L15.6 12.15L19.93 9.65L21.73 12.77C22.25 13.54 22.32 14.57 21.82 15.42ZM9.21003 3.06H14.21C15.19 3.06 16.04 3.63 16.45 4.45L17.45 6.19L19.18 5.19L16.54 9.6L11.39 9.69L13.12 8.69L11.71 6.24L9.50003 10.09L5.16003 7.59L6.96003 4.47C7.37003 3.64 8.22003 3.06 9.21003 3.06ZM5.05003 19.76L2.55003 15.43C2.06003 14.58 2.13003 13.56 2.64003 12.79L3.64003 11.06L1.91003 10.06L7.05003 10.14L9.70003 14.56L7.97003 13.56L6.56003 16H11V21H7.40003C6.93154 21.0339 6.46293 20.9357 6.0475 20.7165C5.63206 20.4973 5.28648 20.1659 5.05003 19.76Z\" fill=\"#1F5A95\" /> </svg> <p>Recycling instructions</p> </div> <div class=\"traceability-card-view-details\"> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> <a href=\"{{credentialSubject.circularityScorecard.repairInformation.linkURL}}\" class=\"traceability-card\"> <div class=\"traceability-card-text\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M18.85 21.975C18.7167 21.975 18.5917 21.9543 18.475 21.913C18.3583 21.8717 18.25 21.8007 18.15 21.7L13.05 16.6C12.95 16.5 12.879 16.3917 12.837 16.275C12.795 16.1583 12.7743 16.0333 12.775 15.9C12.7757 15.7667 12.7967 15.6417 12.838 15.525C12.8793 15.4083 12.95 15.3 13.05 15.2L15.175 13.075C15.275 12.975 15.3833 12.9043 15.5 12.863C15.6167 12.8217 15.7417 12.8007 15.875 12.8C16.0083 12.7993 16.1333 12.8203 16.25 12.863C16.3667 12.9057 16.475 12.9763 16.575 13.075L21.675 18.175C21.775 18.275 21.846 18.3833 21.888 18.5C21.93 18.6167 21.9507 18.7417 21.95 18.875C21.9493 19.0083 21.9287 19.1333 21.888 19.25C21.8473 19.3667 21.7763 19.475 21.675 19.575L19.55 21.7C19.45 21.8 19.3417 21.871 19.225 21.913C19.1083 21.955 18.9833 21.9757 18.85 21.975ZM18.85 19.6L19.575 18.875L15.9 15.2L15.175 15.925L18.85 19.6ZM5.125 22C4.99167 22 4.86267 21.975 4.738 21.925C4.61333 21.875 4.50067 21.8 4.4 21.7L2.3 19.6C2.2 19.5 2.125 19.3873 2.075 19.262C2.025 19.1367 2 19.008 2 18.876C2 18.744 2.025 18.619 2.075 18.501C2.125 18.383 2.2 18.2747 2.3 18.176L7.6 12.876H9.725L10.575 12.026L6.45 7.9H5.025L2 4.875L4.825 2.05L7.85 5.075V6.5L11.975 10.625L14.875 7.725L13.8 6.65L15.2 5.25H12.375L11.675 4.55L15.225 1L15.925 1.7V4.525L17.325 3.125L20.875 6.675C21.1583 6.95833 21.375 7.27933 21.525 7.638C21.675 7.99667 21.75 8.37567 21.75 8.775C21.75 9.17433 21.675 9.55767 21.525 9.925C21.375 10.2923 21.1583 10.6173 20.875 10.9L18.75 8.775L17.35 10.175L16.3 9.125L11.125 14.3V16.4L5.825 21.7C5.725 21.8 5.61667 21.875 5.5 21.925C5.38333 21.975 5.25833 22 5.125 22ZM5.125 19.6L9.375 15.35V14.625H8.65L4.4 18.875L5.125 19.6ZM5.125 19.6L4.4 18.875L4.775 19.225L5.125 19.6Z\" fill=\"#1F5A95\" /> </svg> <p>Repair instructions</p> </div> <div class=\"traceability-card-view-details\"> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> </div> </section> <section class=\"emission-score-card\"> <h3 class=\"mission-score-title\">Emissions Scorecard</h3> <p class=\"mission-score-description\">The Emissions Scorecard gives a clear snapshot of the product's greenhouse gas (GHG) emissions performance, providing a single indicator to assess its overall environmental impact.</p> <div class=\"score\"> <p class=\"score-unit\"> {{credentialSubject.emissionsScorecard.carbonFootprint}}{{credentialSubject.emissionsScorecard.declaredUnit}} </p> <p class=\"score-name\">Co2Eq</p> </div> <div class=\"table\"> <div class=\"table-item\"> <span class=\"item-title\">Scope includes</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.operationalScope}}</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Primary sourced ratio*</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.primarySourcedRatio}}% primary sources</p> </div> <div class=\"table-item\"> <span class=\"item-title\">Reporting standard</span> <div class=\"item-value\"> <a href=\"{{credentialSubject.emissionsScorecard.reportingStandard.id}}\" class=\"blue-bottom-line-thick\">{{credentialSubject.emissionsScorecard.reportingStandard.name}}</a> </div> </div> <div class=\"table-item\"> <span class=\"item-title\">Issue date</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.reportingStandard.issueDate}}</p> </div> </div> <div class=\"annotation\"> <span>*</span> <p>The Primary Sourced Ratio shows the percentage of scope 3 emissions data that is directly collected from actual sources, rather than being based on estimates.</p> </div> </section> <section class=\"declarations\"> <div class=\"declaration-title\">Declarations</div> <div class=\"cards-conformities\"> {{#each credentialSubject.conformityClaim}} <div class=\"cards-conformity\"> <div class=\"frame\"> <div class=\"div\"> <div class=\"company-name\">Conformance:</div> <div class=\"{{#if conformance}}tags-VC-badge-green{{else}}tags-VC-badge-red{{/if}}\"> <div class=\"verifiable\">{{#if conformance}}Yes{{else}}No{{/if}}</div> </div> </div> <div class=\"company-name\">Assessed: {{assessmentDate}}</div> </div> <div class=\"frame-2\"> <div class=\"text-wrapper\">{{conformityEvidence.linkName}}</div> <p class=\"p\"> <span class=\"span\">{{referenceRegulation.name}} administered in {{referenceRegulation.jurisdictionCountry}} by </span> <a href=\"{{referenceRegulation.administeredBy.id}}\" class=\"text-wrapper-2 gray-bottom-line\">{{referenceRegulation.administeredBy.name}}</a> </p> <p class=\"p\"> <span class=\"span\">{{referenceStandard.name}} issued by </span> <a href=\"{{referenceStandard.issuingParty.id}}\" class=\"text-wrapper-2 gray-bottom-line\">{{referenceStandard.issuingParty.name}}</a> </p> </div> <div class=\"frame-3\"> {{#each declaredValue}} <div class=\"frame-4\"> <div class=\"typography-heading\"> <p class=\"heading\">{{metricName}} is {{metricValue.value}}{{metricValue.unit}}</p> </div> <div class=\"typography-heading\"> <p class=\"heading-2\">Score: {{score}} | Accuracy {{accuracy}}</p> </div> </div> {{/each}} </div> <a href=\"{{conformityEvidence.linkURL}}\" class=\"cards-traceability\"> <div class=\"frame-5\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"#1F5A95\"></path> </svg> <div class=\"company-name-wrapper\"> <div class=\"company-name-2\">Evidence</div> </div> </div> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"> </path> </svg> </a> </div> {{/each}} </div> </section> <section class=\"composition\"> <div> <p class=\"section-title\">Product composition</p> <p class=\"section-description\"> A complete list of materials that make up the composition of this product. </p> </div> <div class=\"composition-box\"> {{#each credentialSubject.materialsProvenance}} <div class=\"composition-box-item\"> <div class=\"composition-box-first-column\"> <p class=\"composition-percent\">{{massFraction}}%</p> <div class=\"composition-box-second-column\"> <p class=\"composition-title\">{{massAmount.value}}{{massAmount.unit}} {{name}}</p> <div class=\"composition-tag\"> <p class=\"composition-tag-item\">Recycled {{recycledAmount}}%</p> <p class=\"composition-tag-item\">Hazard {{#if hazardous}}Yes{{else}}No{{/if}}</p> </div> <a href=\"{{materialSafetyInformation.linkURL}}\" class=\"blue-bottom-line-thick\">{{materialSafetyInformation.linkName}}</a> </div> </div> <div class=\"composition-box-third-column\"> <div class=\"country-code\">{{originCountry}}</div> </div> </div> {{/each}} </div> </section> <section class=\"history\"> <div> <p class=\"section-title\">History</p> </div> {{!-- start: Supply chain due diligence report --}} <a href=\"{{credentialSubject.dueDiligenceDeclaration.linkURL}}\" class=\"cards-traceability\"> <div class=\"frame-5\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"#1F5A95\"></path> </svg> <div class=\"company-name-wrapper\"> <div class=\"company-name-2\">Supply chain due diligence report</div> </div> </div> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"> </path> </svg> </a> {{!-- end: Supply chain due diligence report --}} <div class=\"history-information\"> <div class=\"history-value-chain-item\"> <div class=\"history-value-chain\"> <p>{{credentialSubject.traceabilityInformation.valueChainProcess}}</p> <div class=\"verified-ratio\"> <p>Verified ratio {{credentialSubject.traceabilityInformation.verifiedRatio}}</p> </div> </div> <div id=\"history-items-390px\" class=\"history-event\"> {{#each credentialSubject.traceabilityInformation.traceabilityEvent}} <div class=\"history-item\"> <span>{{linkName}}</span> <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\">View</a> </div> {{/each}} </div> </div> </div> </section> <section class=\"passport-issued-by\"> <div> <h2 class=\"section-title\">Passport issued by</h2> </div> <div class=\"table\"> <div class=\"table-item\"> <span>Organisation</span> <p>{{issuer.name}}</p> </div> <div class=\"table-item\"> <span>Registered ID</span> <a href=\"{{issuer.id}}\" class=\"blue-bottom-line-thick\">{{issuer.id}}</a> </div> <div class=\"table-item\"> <span>Valid from</span> <p>{{validFrom}}</p> </div> <div class=\"table-item\"> <span>Valid to</span> <p>{{validUntil}}</p> </div> </div> </section> <footer> <p>This Digital Product Passport (DPP) is a digital record of the product's sustainability and environmental performance, ensuring transparency and accountability in line with UNTP standards. For more information visit <a href=\"https://uncefact.github.io/spec-untp/\" class=\"gray-bottom-line\">uncefact.github.io/spec-untp/</a>. </p> </footer> </div> <!-- End mobile --> <!-- Desktop width 1440px --> <div class=\"contents\"> <div class=\"frame\"> <div class=\"PP-title\">PRODUCT PASSPORT</div> <div class=\"text-wrapper\">{{credentialSubject.name}}</div> <div class=\"product-ID-ALT\"> <div class=\"div\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <a href=\"{{credentialSubject.id}}\" class=\"line\"> <div class=\"text-wrapper-2\">ID: {{credentialSubject.id}}</div> </a> </div> <div class=\"div\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <div class=\"div-wrapper\"> <div class=\"text-wrapper-2\">Batch: {{credentialSubject.batchNumber}}</div> </div> </div> <div class=\"div\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"#1F5A95\" /> </svg> <div class=\"div-wrapper\"> <div class=\"text-wrapper-2\">Serial: {{credentialSubject.serialNumber}}</div> </div> </div> </div> <div class=\"frame-2\"> <div class=\"PP-header\"> <div class=\"frame-3\"></div> </div> <div class=\"frame-4\"> <p class=\"p\"> {{credentialSubject.description}} </p> {{#each credentialSubject.furtherInformation}} <a href=\"{{linkURL}}\" class=\"line\"> <div class=\"text-wrapper-16\">{{linkName}}</div> </a> {{/each}} </div> </div> </div> {{#if credentialSubject.characteristic}} <div class=\"frame-24\"> <div class=\"heading-wrapper\"> <div class=\"heading\">Characteristics</div> </div> <div class=\"div-5\"> {{#each credentialSubject.characteristic}} <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">{{@key}}</div> <div class=\"data-wrapper\"> <div class=\"data\">{{this}}</div> </div> </div> {{/each}} </div> </div> {{/if}} <div class=\"div-2\"> <div class=\"typography-heading\"> <div class=\"text-wrapper-4\">Production</div> </div> <div class=\"div-5\"> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Product category</div> <div class=\"data-data\"> <div class=\"data-2\">{{#each credentialSubject.productCategory}}{{name}}{{#unless @last}},{{/unless}} {{/each}}</div> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Produced by</div> <div class=\"data-data-link\"> <a href=\"{{credentialSubject.producedByParty.id}}\" class=\"line\"> <p class=\"text-wrapper-2\">{{credentialSubject.producedByParty.name}}</p> </a> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Produced at</div> <div class=\"data-data-link\"> <a href=\"{{credentialSubject.producedAtFacility.id}}\" class=\"line\"> <p class=\"text-wrapper-2\">{{credentialSubject.producedAtFacility.name}}</p> </a> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Date produced</div> <div class=\"data-wrapper\"> <div class=\"data\">{{credentialSubject.productionDate}}</div> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Country</div> <div class=\"data-data\"> <div class=\"data\">{{credentialSubject.countryOfProduction}}</div> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Dimensions</div> <div class=\"list\"> <span>Weight: {{credentialSubject.dimensions.weight.value}}{{credentialSubject.dimensions.weight.unit}}</span> <span>Length: {{credentialSubject.dimensions.length.value}}{{credentialSubject.dimensions.length.unit}}</span> <span>Width: {{credentialSubject.dimensions.width.value}}{{credentialSubject.dimensions.width.unit}}</span> <span>Height: {{credentialSubject.dimensions.height.value}}{{credentialSubject.dimensions.height.unit}}</span> <span>Volume: {{credentialSubject.dimensions.volume.value}}{{credentialSubject.dimensions.volume.unit}}</span> </div> </div> </div> </div> <div class=\"div-2\"> <div class=\"typography-heading\"> <div class=\"text-wrapper-4\">Circularity Scorecard</div> </div> <p class=\"text-wrapper-5\"> The circularity Scorecard provides a simple high level summary of circularity performance of the product. </p> <div class=\"div-3\"> <div class=\"frame-5\"> <div class=\"frame-6\"> <div class=\"frame-7\"> <div class=\"text-wrapper-6\">{{credentialSubject.circularityScorecard.recyclableContent}}%</div> <div class=\"text-wrapper-7\">Recyclable content</div> </div> <div class=\"frame-7\"> <div class=\"text-wrapper-6\">{{credentialSubject.circularityScorecard.recycledContent}}%</div> <div class=\"text-wrapper-7\">Recycled content</div> </div> <div class=\"frame-7\"> <div class=\"text-wrapper-6\">{{credentialSubject.circularityScorecard.utilityFactor}}</div> <div class=\"text-wrapper-7\">Utility factor</div> </div> <div class=\"frame-8\"> <div class=\"text-wrapper-6\">{{credentialSubject.circularityScorecard.materialCircularityIndicator}} </div> <div class=\"text-wrapper-7\">Material circularity*</div> </div> </div> <p class=\"text-wrapper-8\"> *The Material Circularity Indicator provides an overall circularity score which is a function of all three of the earlier measures. </p> </div> <div class=\"frame-9\"> <a href=\"{{credentialSubject.circularityScorecard.recyclingInformation.linkURL}}\" class=\"cards-traceability\"> <div class=\"div-4\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M21.82 15.42L19.32 19.75C18.83 20.61 17.92 21.06 17 21H15V23L12.5 18.5L15 14V16H17.82L15.6 12.15L19.93 9.65L21.73 12.77C22.25 13.54 22.32 14.57 21.82 15.42ZM9.21003 3.06H14.21C15.19 3.06 16.04 3.63 16.45 4.45L17.45 6.19L19.18 5.19L16.54 9.6L11.39 9.69L13.12 8.69L11.71 6.24L9.50003 10.09L5.16003 7.59L6.96003 4.47C7.37003 3.64 8.22003 3.06 9.21003 3.06ZM5.05003 19.76L2.55003 15.43C2.06003 14.58 2.13003 13.56 2.64003 12.79L3.64003 11.06L1.91003 10.06L7.05003 10.14L9.70003 14.56L7.97003 13.56L6.56003 16H11V21H7.40003C6.93154 21.0339 6.46293 20.9357 6.0475 20.7165C5.63206 20.4973 5.28648 20.1659 5.05003 19.76Z\" fill=\"#1F5A95\" /> </svg> <div class=\"frame-10\"> <div class=\"text-wrapper-9\">Recycling instructions</div> </div> </div> <div class=\"div-4\"> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> <a href=\"{{credentialSubject.circularityScorecard.repairInformation.linkURL}}\" class=\"cards-traceability\"> <div class=\"div-4\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M18.85 21.975C18.7167 21.975 18.5917 21.9543 18.475 21.913C18.3583 21.8717 18.25 21.8007 18.15 21.7L13.05 16.6C12.95 16.5 12.879 16.3917 12.837 16.275C12.795 16.1583 12.7743 16.0333 12.775 15.9C12.7757 15.7667 12.7967 15.6417 12.838 15.525C12.8793 15.4083 12.95 15.3 13.05 15.2L15.175 13.075C15.275 12.975 15.3833 12.9043 15.5 12.863C15.6167 12.8217 15.7417 12.8007 15.875 12.8C16.0083 12.7993 16.1333 12.8203 16.25 12.863C16.3667 12.9057 16.475 12.9763 16.575 13.075L21.675 18.175C21.775 18.275 21.846 18.3833 21.888 18.5C21.93 18.6167 21.9507 18.7417 21.95 18.875C21.9493 19.0083 21.9287 19.1333 21.888 19.25C21.8473 19.3667 21.7763 19.475 21.675 19.575L19.55 21.7C19.45 21.8 19.3417 21.871 19.225 21.913C19.1083 21.955 18.9833 21.9757 18.85 21.975ZM18.85 19.6L19.575 18.875L15.9 15.2L15.175 15.925L18.85 19.6ZM5.125 22C4.99167 22 4.86267 21.975 4.738 21.925C4.61333 21.875 4.50067 21.8 4.4 21.7L2.3 19.6C2.2 19.5 2.125 19.3873 2.075 19.262C2.025 19.1367 2 19.008 2 18.876C2 18.744 2.025 18.619 2.075 18.501C2.125 18.383 2.2 18.2747 2.3 18.176L7.6 12.876H9.725L10.575 12.026L6.45 7.9H5.025L2 4.875L4.825 2.05L7.85 5.075V6.5L11.975 10.625L14.875 7.725L13.8 6.65L15.2 5.25H12.375L11.675 4.55L15.225 1L15.925 1.7V4.525L17.325 3.125L20.875 6.675C21.1583 6.95833 21.375 7.27933 21.525 7.638C21.675 7.99667 21.75 8.37567 21.75 8.775C21.75 9.17433 21.675 9.55767 21.525 9.925C21.375 10.2923 21.1583 10.6173 20.875 10.9L18.75 8.775L17.35 10.175L16.3 9.125L11.125 14.3V16.4L5.825 21.7C5.725 21.8 5.61667 21.875 5.5 21.925C5.38333 21.975 5.25833 22 5.125 22ZM5.125 19.6L9.375 15.35V14.625H8.65L4.4 18.875L5.125 19.6ZM5.125 19.6L4.4 18.875L4.775 19.225L5.125 19.6Z\" fill=\"#1F5A95\" /> </svg> <div class=\"frame-10\"> <div class=\"text-wrapper-9\">Repair instructions</div> </div> </div> <div class=\"div-4\"> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> </div> </div> </div> <div class=\"div-2\"> <div class=\"typography-heading\"> <div class=\"text-wrapper-4\">Emissions Scorecard</div> </div> <p class=\"text-wrapper-5\"> The Emissions Scorecard gives a clear snapshot of the product's greenhouse gas (GHG) emissions performance, providing a single indicator to assess its overall environmental impact. </p> <div class=\"div-7\"> <div class=\"frame-11\"> <div class=\"text-wrapper-10\"> {{credentialSubject.emissionsScorecard.carbonFootprint}}{{credentialSubject.emissionsScorecard.declaredUnit}} </div> <p class=\"co-eq\"> <span class=\"span\">Co2Eq</span> </p> </div> <div class=\"frame-9\"> <div class=\"div-3\"> <div class=\"frame-9\"> <div class=\"div-5\"> <div class=\"data-two-columns-3\"> <div class=\"text-wrapper-12\">Scope includes</div> <div class=\"data-data\"> <div class=\"data\">{{credentialSubject.emissionsScorecard.operationalScope}}</div> </div> </div> <div class=\"data-two-columns-3\"> <div class=\"text-wrapper-12\">Primary sourced ratio*</div> <div class=\"data-data\"> <div class=\"data-2\">{{credentialSubject.emissionsScorecard.primarySourcedRatio}}% primary sources </div> </div> </div> </div> <p class=\"text-wrapper-8\"> The Primary Sourced Ratio shows the percentage of scope 3 emissions data that is directly collected from actual sources, rather than being based on estimates. </p> </div> <div class=\"frame-12\"> <div class=\"data-two-columns-3\"> <div class=\"text-wrapper-12\">Reporting standard</div> <a href=\"{{credentialSubject.emissionsScorecard.reportingStandard.id}}\" class=\"line\"> <div class=\"text-wrapper-2\">{{credentialSubject.emissionsScorecard.reportingStandard.name}}</div> </a> </div> <div class=\"data-two-columns-3\"> <div class=\"text-wrapper-12\">Issue date</div> <div class=\"data-data\"> <div class=\"data\">{{credentialSubject.emissionsScorecard.reportingStandard.issueDate}}</div> </div> </div> </div> </div> <div class=\"frame-13\"> <div class=\"text-wrapper-13\">*</div> </div> </div> </div> </div> <section class=\"div-2\"> <div class=\"text-wrapper-14\">Declarations</div> <div class=\"cards-conformities\"> {{#each credentialSubject.conformityClaim}} <div class=\"cards-conformity\"> <div class=\"cards-conformity-header\"> <div class=\"cards-conformity-conformance\"> <div class=\"conformance\">Conformance:</div> <div class=\"{{#if conformance}}tags-VC-badge-green{{else}}tags-VC-badge-red{{/if}}\"> <div class=\"verifiable\">{{#if conformance}}Yes{{else}}No{{/if}}</div> </div> </div> <div class=\"conformance\">Assessed: {{assessmentDate}}</div> </div> <div class=\"cards-conformity-body\"> <div class=\"cards-conformity-title\">{{conformityEvidence.linkName}}</div> <p class=\"cards-conformity-description\"> <span>{{referenceRegulation.name}} administered in {{referenceRegulation.jurisdictionCountry}} by </span> <a href=\"{{referenceRegulation.administeredBy.id}}\" class=\"gray-bottom-line\">{{referenceRegulation.administeredBy.name}}</a> </p> <p class=\"cards-conformity-description\"> <span>{{referenceStandard.name}} issued by </span> <a href=\"{{referenceStandard.issuingParty.id}}\" class=\"gray-bottom-line\">{{referenceStandard.issuingParty.name}}</a> </p> </div> <div class=\"declared-values\"> {{#each declaredValue}} <div class=\"declared-value\"> <h3>{{metricName}} is {{metricValue.value}}{{metricValue.unit}}</h3> <p class=\"heading-2\">Score: {{score}} | Accuracy {{accuracy}}</p> </div> {{/each}} </div> <a href=\"{{conformityEvidence.linkURL}}\" class=\"cards-traceability-2\"> <div class=\"frame-21\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"#1F5A95\"></path> </svg> <div class=\"company-name-wrapper\"> <div class=\"company-name-2\">Evidence</div> </div> </div> <div class=\"div-4\"> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"> </path> </svg> </div> </a> </div> {{/each}} </div> </section> <div class=\"div-2\"> <div class=\"typography-heading\"> <div class=\"text-wrapper-4\">Composition</div> </div> <p class=\"text-wrapper-5\"> The Product Composition List details the materials and components used in the product, providing transparency on the origin and nature of each element. </p> <div class=\"cards\"> {{#each credentialSubject.materialsProvenance}} <div class=\"cards-composition\"> <div class=\"first-column\"> <div class=\"percentage\">{{massFraction}}%</div> <div class=\"details\"> <div class=\"text-wrapper-9\">{{massAmount.value}}{{massAmount.unit}} {{name}}</div> <div class=\"frame-25\"> <div class=\"frame-26\"> <div class=\"text-wrapper-19\">Recycled {{#if recycledAmount}}{{recycledAmount}}{{else}}0{{/if}}% </div> </div> <div class=\"frame-27\"> <div class=\"text-wrapper-19\">Hazard {{#if hazardous}}Yes{{else}}No{{/if}}</div> </div> </div> <div class=\"data-data-link-2\"> <a href=\"{{materialSafetyInformation.linkURL}}\" class=\"line\"> <div class=\"text-wrapper-2\">{{materialSafetyInformation.linkName}}</div> </a> </div> </div> </div> <div class=\"div-4\"> <div class=\"text-wrapper-19\">{{originCountry}}</div> </div> </div> {{/each}} </div> </div> <div class=\"div-2\"> <div class=\"typography-heading\"> <div class=\"text-wrapper-4\">History</div> </div> {{!-- start: Supply chain due diligence report --}} <a href=\"{{credentialSubject.dueDiligenceDeclaration.linkURL}}\" class=\"cards-traceability\"> <div class=\"history-due-diligence\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"#1F5A95\"></path> </svg> <div>Supply chain due diligence report</div> </div> <svg width=\"10\" height=\"15\" viewBox=\"0 0 10 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"> <path d=\"M1 1L8 8L1 15\" stroke=\"#1F5A95\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"> </path> </svg> </a> {{!-- end: Supply chain due diligence report --}} <div class=\"history-information\"> <div class=\"history-value-chain-item\"> <div class=\"history-value-chain\"> <p>{{credentialSubject.traceabilityInformation.valueChainProcess}}</p> <div class=\"verified-ratio\"> <p>Verified ratio {{credentialSubject.traceabilityInformation.verifiedRatio}}</p> </div> </div> <div id=\"history-items-1440px\" class=\"history-event\"> {{#each credentialSubject.traceabilityInformation.traceabilityEvent}} <div class=\"history-item\"> <span>{{linkName}}</span> <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\">View</a> </div> {{/each}} </div> </div> </div> </div> <div class=\"div-2\"> <div class=\"text-wrapper-4\">Passport issued by</div> <div class=\"div-5\"> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Organisation</div> <div class=\"data-data\"> <div class=\"data\">{{issuer.name}}</div> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Registered ID</div> <div class=\"data-data-link\"> <a href=\"{{issuer.id}}\" class=\"line\"> <div class=\"text-wrapper-2\">{{issuer.id}}</div> </a> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Valid from</div> <div class=\"data-data\"> <div class=\"data\">{{validFrom}}</div> </div> </div> <div class=\"data-two-columns\"> <div class=\"text-wrapper-12\">Valid to</div> <div class=\"data-data\"> <div class=\"data\">{{validUntil}}</div> </div> </div> </div> </div> <div class=\"this-digital-product-wrapper\"> <p class=\"this-digital-product\"> <span class=\"text-wrapper-17\">This Digital Product Passport (DPP) is a digital record of the product's sustainability and environmental performance, ensuring transparency and accountability in line with UNTP standards. For more information visit <a href=\"https://uncefact.github.io/spec-untp/\" class=\"gray-bottom-line\">uncefact.github.io/spec-untp/</a>.</span> </p> </div> </div> <!-- End desktop --> </div> </body> </html>",
-                        "type": "WebRenderingTemplate2022"
+                        "type": "WebRenderingTemplate2022",
+                        "template": "<!DOCTYPE html><html lang=\"en\"> <head> <meta charset=\"UTF-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /> <link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap\" rel=\"stylesheet\" /> <title>Digital Product Passport</title> <style> :root { /* Brand Colors */ --color-primary: rgba(31, 90, 149, 1); /* Color for passport box item text, emission scorecard unit, conformity details, and history value chain process text; Default: rgba(31, 90, 149, 1) */ /* Neutrals */ --color-white: rgba(255, 255, 255, 1); /* Background color for main container, conformity cards, and issuing details section; Default: rgba(255, 255, 255, 1) */ --color-black: rgba(0, 0, 0, 1); /* Text color for section descriptions, information text, composition title, composition percent, composition tag item, history item span, and traceability card text; Default: rgba(0, 0, 0, 1) */ --color-gray-700: rgba(35, 46, 61, 1); /* Text color for links, section titles, table item values, declared value text, and header batch item links; Default: rgba(35, 46, 61, 1) */ --color-gray-600: rgba(85, 96, 110, 1); /* Text color for table item spans, conformity labels, score name, passport annotation, conformity info, declared value span, country code, footer text, and header image background; Default: rgba(85, 96, 110, 1) */ --color-gray-400: rgba(212, 214, 216, 1); /* Border color for table items, conformity cards, composition box items, history items, and passport box; Default: rgba(212, 214, 216, 1) */ --color-gray-100: rgba(247, 250, 253, 1); /* Background color for footer, verified ratio, composition tag item, header batch, and one passport box item; Default: rgba(247, 250, 253, 1) */ /* Semantic (Functional) Colors */ --color-link-underline-dark: rgba(79, 149, 221, 1); /* Underline color for blue-bottom-line-thick links; Default: rgba(79, 149, 221, 1) */ --color-accent-success: rgba(184, 236, 182, 1); /* Background color for green conformance badge; Default: rgba(184, 236, 182, 1) */ --color-accent-error: rgba(255, 188, 183, 1); /* Background color for red conformance badge; Default: rgba(255, 188, 183, 1) */ --color-icon: rgba(31, 90, 149, 1); /* Fill and stroke color for all SVG icons; Default: rgba(31, 90, 149, 1) */ /* Font Variables */ --font-family: \"Lato\", sans-serif; /* Font family for all text; Default: Lato, sans-serif */ /* Font Weight Variables */ --font-weight-light: 300; /* Font weight for information text; Default: 300 */ --font-weight-regular: 400; /* Font weight for section descriptions, conformity labels, table item spans, declared value text, passport annotation, conformity info, score name, composition tag item, country code, footer text, history item span, traceability card text, and header image top-left text; Default: 400 */ --font-weight-medium: 500; /* Font weight for links, table item paragraphs, composition percent, and header image top-left text; Default: 500 */ --font-weight-bold: 600; /* Font weight for section titles, composition title, and conformance badge text; Default: 600 */ --font-weight-black: 900; /* Font weight for header image bottom left h1, passport box item h3, and emission score unit; Default: 900 */ /* Other Variables */ --image-src: url(\"{{credentialSubject.product.productImage.linkURL}}\"); /* Background image for header image; Default: url(\"{{credentialSubject.product.productImage.linkURL}}\") */ } * { margin: 0; padding: 0; box-sizing: border-box; } body { font-family: var(--font-family); color: var(--color-gray-600); font-weight: var(--font-weight-regular); } .container { min-width: 150px; width: 100%; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; word-break: break-word; background-color: var(--color-white); } section, header, footer { padding: 0 16px; } /* Neutralise default margins on header elements within sections */ section header { margin: 0; } .header-image { background-color: var(--color-gray-600); background-image: var(--image-src, none), linear-gradient( 248.36deg, rgba(0, 0, 0, 0.18) 7.6%, rgba(0, 0, 0, 0.6) 70.52% ); background-size: cover; background-position: center; background-repeat: no-repeat; height: 232px; position: relative; } .header-image-top-left { position: absolute; top: 25px; left: 15px; font-weight: var(--font-weight-medium); font-size: 16px; line-height: 22px; color: var(--color-white); } .header-image-bottom-left { position: absolute; bottom: 18px; left: 15px; color: var(--color-white); } .header-image-bottom-left h1 { font-size: 30px; font-weight: var(--font-weight-black); line-height: 32.5px; } .header-batch { padding: 12px 16px; background-color: var(--color-gray-100); display: flex; flex-wrap: wrap; justify-content: space-between; gap: 12px; } .header-batch-item { display: flex; align-items: center; gap: 6px; flex-grow: 1; min-width: 0; } .header-batch-item a { color: var(--color-gray-700); font-size: 14px; font-weight: var(--font-weight-medium); } .header-batch-item svg { fill: var(--color-icon); stroke: var(--color-icon); } /* General Section Styles */ .section-title { font-size: 18px; font-weight: var(--font-weight-bold); line-height: 19.62px; color: var(--color-gray-700); } .section-description { margin-top: 12px; font-size: 16px; line-height: 18.88px; color: var(--color-black); font-weight: var(--font-weight-regular); } /* Table Styles */ .table { display: flex; flex-direction: column; gap: 10px; } .table-item { display: grid; grid-template-columns: 1fr 2fr; column-gap: 16px; align-items: center; padding-bottom: 10px; border-bottom: 1px solid var(--color-gray-400); } .table-item span { font-size: 16px; font-weight: var(--font-weight-regular); color: var(--color-gray-600); } .table-item p, .table-item a { font-size: 16px; font-weight: var(--font-weight-medium); color: var(--color-gray-700); } .item-value { display: flex; flex-direction: column; font-size: 16px; font-weight: var(--font-weight-medium); color: var(--color-gray-600); } .item-value span { color: var(--color-gray-700); } .information-text { font-size: 19px; padding-bottom: 8px; font-weight: var(--font-weight-light); color: var(--color-black); line-height: 22.42px; } .information-show-more { display: flex; flex-direction: column; gap: 10px; font-size: 14px; font-weight: var(--font-weight-medium); } /* Production Section */ .production { display: flex; flex-direction: column; gap: 12px; } /* Passport Section */ .passport { display: flex; flex-direction: column; gap: 24px; } .passport-box { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--color-gray-400); border-radius: 5px; } .passport-box-item { display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 12px 16px; border: 1px solid var(--color-gray-400); min-height: 94px; color: var(--color-primary); } .passport-box-item h3 { font-size: 40px; font-weight: var(--font-weight-black); line-height: 43.33px; letter-spacing: 2px; } .passport-box-item p { margin-top: 8px; font-size: 15px; font-weight: var(--font-weight-bold); } .passport-box-item:nth-child(4) { background-color: var(--color-gray-100); } .passport-annotation { font-size: 14px; font-weight: var(--font-weight-regular); line-height: 15.26px; color: var(--color-gray-600); } .traceability-cards { display: flex; flex-direction: column; gap: 12px; } .traceability-card { display: grid; grid-template-columns: 3fr 1fr; align-items: center; text-decoration: none; } .traceability-card-text { display: flex; align-items: center; gap: 8px; font-size: 16px; font-weight: var(--font-weight-regular); color: var(--color-black); } .traceability-card-text svg { fill: var(--color-icon); stroke: var(--color-icon); } .traceability-card-view-details { display: flex; justify-content: flex-end; gap: 8px; } /* Emission Scorecard */ .emission-score-card { display: flex; flex-direction: column; gap: 12px; } .score { display: flex; flex-direction: column; gap: 6px; } .score-unit { font-size: 40px; font-weight: var(--font-weight-black); line-height: 43.33px; color: var(--color-primary); letter-spacing: 2px; } .score-name { font-size: 16px; font-weight: var(--font-weight-regular); color: var(--color-gray-600); } /* Declarations */ .declarations { display: flex; flex-direction: column; gap: 12px; } .cards-conformities { display: flex; flex-direction: column; gap: 8px; } .cards-conformity { display: flex; flex-direction: column; gap: 8px; padding: 16px; background-color: var(--color-white); border: 1px solid var(--color-gray-400); border-radius: 4px; } .cards-conformity header { margin: 0; } .conformance-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 5px; } .conformance-status { display: flex; align-items: center; gap: 4px; } .conformance-label { font-size: 14px; font-weight: var(--font-weight-regular); color: var(--color-gray-600); } .tags-VC-badge-red, .tags-VC-badge-green { padding: 4px 8px; border-radius: 8px; font-size: 14px; font-weight: var(--font-weight-bold); } .tags-VC-badge-red { background-color: var(--color-accent-error); color: var(--color-gray-600); } .tags-VC-badge-green { background-color: var(--color-accent-success); color: var(--color-gray-600); } .conformity-details { font-size: 18px; font-weight: var(--font-weight-regular); color: var(--color-primary); } .conformity-info { display: flex; flex-direction: column; gap: 8px; } .conformity-info p { font-size: 14px; font-weight: var(--font-weight-regular); color: var(--color-gray-600); } .declared-values { display: flex; flex-direction: column; gap: 4px; } .declared-value p { font-size: 16px; font-weight: var(--font-weight-regular); color: var(--color-gray-700); } .declared-value span { font-size: 14px; color: var(--color-gray-600); } /* Composition */ .composition-box { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; } .composition-box-item { display: grid; grid-template-columns: 1fr auto; border: 1px solid var(--color-gray-400); border-radius: 4px; padding: 16px; } .composition-first-column { display: grid; grid-template-columns: 40px 1fr; gap: 12px; } .composition-percent { font-size: 16px; font-weight: var(--font-weight-medium); color: var(--color-black); } .composition-title { font-size: 16px; font-weight: var(--font-weight-bold); color: var(--color-black); } .composition-tag { display: flex; gap: 4px; } .composition-tag-item { font-size: 14px; font-weight: var(--font-weight-regular); color: var(--color-black); background-color: var(--color-gray-100); padding: 2px 4px; } .country-code { font-size: 14px; font-weight: var(--font-weight-regular); color: var(--color-gray-600); } /* History */ .history { display: flex; flex-direction: column; gap: 12px; } .history-value-chain { display: flex; flex-direction: column; gap: 4px; } .history-value-chain p { font-size: 18px; font-weight: var(--font-weight-regular); color: var(--color-primary); } .verified-ratio { background-color: var(--color-gray-100); padding: 2px 4px; width: fit-content; } .history-item { display: grid; grid-template-columns: 1fr auto; padding: 10px 0; border-bottom: 1px solid var(--color-gray-400); } .history-item span { font-size: 16px; font-weight: var(--font-weight-regular); color: var(--color-black); } .history-item a { font-size: 16px; font-weight: var(--font-weight-medium); color: var(--color-gray-700); } /* Issued By */ .issued-by { display: flex; flex-direction: column; gap: 12px; } /* Footer */ footer { padding: 16px 16px 32px; background-color: var(--color-gray-100); } footer p { font-size: 14px; font-weight: var(--font-weight-regular); color: var(--color-gray-600); } /* Links */ .blue-bottom-line-thick { text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: var(--color-link-underline-dark); text-underline-offset: 3px; color: var(--color-gray-700); } .blue-bottom-line-thick.disabled { pointer-events: none; cursor: not-allowed; text-decoration: none; } .blue-bottom-line-thick.disabled:focus { outline: none; } .gray-bottom-line { border-bottom: 1px solid var(--color-gray-600); text-decoration: none; color: var(--color-gray-600); } /* Desktop Adjustments */ @media (min-width: 1200px) { .container { max-width: 1200px; } } </style> </head> <body> <div class=\"container\"> <header class=\"header\"> <div class=\"header-image\"> <p class=\"header-image-top-left\">PRODUCT PASSPORT</p> <div class=\"header-image-bottom-left\"> <h1>{{credentialSubject.product.name}}</h1> </div> </div> <div class=\"header-batch\"> {{#if credentialSubject.product.registeredId}} <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"var(--color-icon)\" stroke=\"var(--color-icon)\" /> </svg> <a href=\"{{credentialSubject.product.id}}\" class=\"blue-bottom-line-thick\" target=\"_blank\" >ID: {{credentialSubject.product.registeredId}}</a > </div> {{/if}} {{#if credentialSubject.product.batchNumber}} <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"var(--color-icon)\" stroke=\"var(--color-icon)\" /> </svg> <a>Batch: {{credentialSubject.product.batchNumber}}</a> </div> {{/if}} {{#if credentialSubject.product.serialNumber}} <div class=\"header-batch-item\"> <svg width=\"14\" height=\"14\" viewBox=\"0 0 14 14\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z\" fill=\"var(--color-icon)\" stroke=\"var(--color-icon)\" /> </svg> <a>Serial: {{credentialSubject.product.serialNumber}}</a> </div> {{/if}} </div> </header> <section> {{#if credentialSubject.product.description}} <div class=\"information-text\"> {{credentialSubject.product.description}} </div> {{/if}} {{#if credentialSubject.product.furtherInformation}} <div class=\"information-show-more\"> {{#each credentialSubject.product.furtherInformation}} {{#if linkURL}} {{#if linkName}} <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\" target=\"_blank\"> {{linkName}} </a> {{/if}} {{/if}} {{/each}} </div> {{/if}} </section> {{#if credentialSubject.product.characteristics}} <section class=\"production\"> <div class=\"section-title\">Characteristics</div> <div class=\"table\"> {{#each credentialSubject.product.characteristics}} <div class=\"table-item\"> <span>{{@key}}</span> <p class=\"item-value\">{{this}}</p> </div> {{/each}} </div> </section> {{/if}} <section class=\"production\"> <div class=\"section-title\">Production</div> <div class=\"table\"> {{#if credentialSubject.product.productCategory}} <div class=\"table-item\"> <span>Product category</span> <p class=\"item-value\"> {{#each credentialSubject.product.productCategory}}{{name}}{{#unless @last}}, {{/unless}}{{/each}} </p> </div> {{/if}} {{#if credentialSubject.product.producedByParty}} <div class=\"table-item\"> <span>Produced by</span> <a href=\"{{credentialSubject.product.producedByParty.id}}\" class=\"blue-bottom-line-thick\" target=\"_blank\" >{{credentialSubject.product.producedByParty.name}}</a > </div> {{/if}} {{#if credentialSubject.product.producedAtFacility}} {{#with credentialSubject.product.producedAtFacility}} <div class=\"table-item\"> <span>Produced at</span> <p class=\"item-value\"> <a href=\"{{id}}\" class=\"blue-bottom-line-thick\" target=\"_blank\">{{name}}</a> </p> </div> <!-- TODO: Add locationInformation and address back to the DPP data model --> {{#if address}} <div class=\"table-item\"> <span>Location</span> <p class=\"item-value\"> <a href=\"{{locationInformation.plusCode}}\" class=\"blue-bottom-line-thick {{#unless locationInformation.plusCode}}disabled{{/unless}}\" {{#unless locationInformation.plusCode}}aria-disabled=\"true\" tabindex=\"-1\"{{/unless}} aria-label=\"View location on map\" target=\"_blank\" > {{#if address.streetAddress}}{{address.streetAddress}}{{/if}} {{#if address.addressLocality}}{{address.addressLocality}}{{/if}} {{#if address.addressRegion}}{{address.addressRegion}}{{/if}} {{#if address.postalCode}}{{address.postalCode}}{{/if}} </a> </p> </div> {{/if}} {{/with}} {{/if}} {{#if credentialSubject.product.productionDate}} <div class=\"table-item\"> <span>Date produced</span> <p class=\"item-value\">{{credentialSubject.product.productionDate}}</p> </div> {{/if}} {{#if credentialSubject.product.countryOfProduction}} <div class=\"table-item\"> <span>Country</span> <p class=\"item-value\">{{credentialSubject.product.countryOfProduction}}</p> </div> {{/if}} {{#if credentialSubject.product.dimensions}} <div class=\"table-item\"> <span>Dimensions</span> <p class=\"item-value\"> {{#if credentialSubject.product.dimensions.weight}} <span>Weight: {{credentialSubject.product.dimensions.weight.value}}{{credentialSubject.product.dimensions.weight.unit}}</span> {{/if}} {{#if credentialSubject.product.dimensions.length}} <span>Length: {{credentialSubject.product.dimensions.length.value}}{{credentialSubject.product.dimensions.length.unit}}</span> {{/if}} {{#if credentialSubject.product.dimensions.width}} <span>Width: {{credentialSubject.product.dimensions.width.value}}{{credentialSubject.product.dimensions.width.unit}}</span> {{/if}} {{#if credentialSubject.product.dimensions.height}} <span>Height: {{credentialSubject.product.dimensions.height.value}}{{credentialSubject.product.dimensions.height.unit}}</span> {{/if}} {{#if credentialSubject.product.dimensions.volume}} <span>Volume: {{credentialSubject.product.dimensions.volume.value}}{{credentialSubject.product.dimensions.volume.unit}}</span> {{/if}} </p> </div> {{/if}} </div> </section> {{#if credentialSubject.circularityScorecard}} <section class=\"passport\"> <div> <h3 class=\"section-title\">Circularity Scorecard</h3> <p class=\"section-description\"> The circularity Scorecard provides a simple high level summary of circularity performance of the product. </p> </div> <div class=\"passport-box\"> {{#if credentialSubject.circularityScorecard.recyclableContent}} <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.recyclableContent}}%</h3> <p>Recyclable content</p> </div> {{/if}} {{#if credentialSubject.circularityScorecard.recycledContent}} <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.recycledContent}}%</h3> <p>Recycled content</p> </div> {{/if}} {{#if credentialSubject.circularityScorecard.utilityFactor}} <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.utilityFactor}}</h3> <p>Utility factor</p> </div> {{/if}} {{#if credentialSubject.circularityScorecard.materialCircularityIndicator}} <div class=\"passport-box-item\"> <h3>{{credentialSubject.circularityScorecard.materialCircularityIndicator}}</h3> <p>Material circularity*</p> </div> {{/if}} </div> {{#if credentialSubject.circularityScorecard.materialCircularityIndicator}} <div class=\"passport-annotation\"> <p>*The Material Circularity Indicator provides an overall circularity score which is a function of all three of the earlier measures.</p> </div> {{/if}} <div class=\"traceability-cards\"> {{#if credentialSubject.circularityScorecard.recyclingInformation.linkURL}} <a href=\"{{credentialSubject.circularityScorecard.recyclingInformation.linkURL}}\" class=\"traceability-card\" target=\"_blank\"> <div class=\"traceability-card-text\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M21.82 15.42L19.32 19.75C18.83 20.61 17.92 21.06 17 21H15V23L12.5 18.5L15 14V16H17.82L15.6 12.15L19.93 9.65L21.73 12.77C22.25 13.54 22.32 14.57 21.82 15.42ZM9.21003 3.06H14.21C15.19 3.06 16.04 3.63 16.45 4.45L17.45 6.19L19.18 5.19L16.54 9.6L11.39 9.69L13.12 8.69L11.71 6.24L9.50003 10.09L5.16003 7.59L6.96003 4.47C7.37003 3.64 8.22003 3.06 9.21003 3.06ZM5.05003 19.76L2.55003 15.43C2.06003 14.58 2.13003 13.56 2.64003 12.79L3.64003 11.06L1.91003 10.06L7.05003 10.14L9.70003 14.56L7.97003 13.56L6.56003 16H11V21H7.40003C6.93154 21.0339 6.46293 20.9357 6.0475 20.7165C5.63206 20.4973 5.28648 20.1659 5.05003 19.76Z\" fill=\"var(--color-icon)\" stroke=\"var(--color-icon)\" /> </svg> <p>Recycling instructions</p> </div> <div class=\"traceability-card-view-details\"> <svg width=\"9\" height=\"16\" viewBox=\"0 0 9 16\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M1 1L8 8L1 15\" stroke=\"var(--color-icon)\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> {{/if}} {{#if credentialSubject.circularityScorecard.repairInformation.linkURL}} <a href=\"{{credentialSubject.circularityScorecard.repairInformation.linkURL}}\" class=\"traceability-card\" target=\"_blank\"> <div class=\"traceability-card-text\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M18.85 21.975C18.7167 21.975 18.5917 21.9543 18.475 21.913C18.3583 21.8717 18.25 21.8007 18.15 21.7L13.05 16.6C12.95 16.5 12.879 16.3917 12.837 16.275C12.795 16.1583 12.7743 16.0333 12.775 15.9C12.7757 15.7667 12.7967 15.6417 12.838 15.525C12.8793 15.4083 12.95 15.3 13.05 15.2L15.175 13.075C15.275 12.975 15.3833 12.9043 15.5 12.863C15.6167 12.8217 15.7417 12.8007 15.875 12.8C16.0083 12.7993 16.1333 12.8203 16.25 12.863C16.3667 12.9057 16.475 12.9763 16.575 13.075L21.675 18.175C21.775 18.275 21.846 18.3833 21.888 18.5C21.93 18.6167 21.9507 18.7417 21.95 18.875C21.9493 19.0083 21.9287 19.1333 21.888 19.25C21.8473 19.3667 21.7763 19.475 21.675 19.575L19.55 21.7C19.45 21.8 19.3417 21.871 19.225 21.913C19.1083 21.955 18.9833 21.9757 18.85 21.975ZM18.85 19.6L19.575 18.875L15.9 15.2L15.175 15.925L18.85 19.6ZM5.125 22C4.99167 22 4.86267 21.975 4.738 21.925C4.61333 21.875 4.50067 21.8 4.4 21.7L2.3 19.6C2.2 19.5 2.125 19.3873 2.075 19.262C2.025 19.1367 2 19.008 2 18.876C2 18.744 2.025 18.619 2.075 18.501C2.125 18.383 2.2 18.2747 2.3 18.176L7.6 12.876H9.725L10.575 12.026L6.45 7.9H5.025L2 4.875L4.825 2.05L7.85 5.075V6.5L11.975 10.625L14.875 7.725L13.8 6.65L15.2 5.25H12.375L11.675 4.55L15.225 1L15.925 1.7V4.525L17.325 3.125L20.875 6.675C21.1583 6.95833 21.375 7.27933 21.525 7.638C21.675 7.99667 21.75 8.37567 21.75 8.775C21.75 9.17433 21.675 9.55767 21.525 9.925C21.375 10.2923 21.1583 10.6173 20.875 10.9L18.75 8.775L17.35 10.175L16.3 9.125L11.125 14.3V16.4L5.825 21.7C5.725 21.8 5.61667 21.875 5.5 21.925C5.38333 21.975 5.25833 22 5.125 22ZM5.125 19.6L9.375 15.35V14.625H8.65L4.4 18.875L5.125 19.6ZM5.125 19.6L4.4 18.875L4.775 19.225L5.125 19.6Z\" fill=\"var(--color-icon)\" stroke=\"var(--color-icon)\" /> </svg> <p>Repair instructions</p> </div> <div class=\"traceability-card-view-details\"> <svg width=\"9\" height=\"16\" viewBox=\"0 0 9 16\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M1 1L8 8L1 15\" stroke=\"var(--color-icon)\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> {{/if}} </div> </section> {{/if}} {{#if credentialSubject.emissionsScorecard}} <section class=\"emission-score-card\"> <div> <h3 class=\"section-title\">Emissions Scorecard</h3> <p class=\"section-description\"> The Emissions Scorecard gives a clear snapshot of the product's greenhouse gas (GHG) emissions performance, providing a single indicator to assess its overall environmental impact. </p> </div> <div class=\"score\"> <p class=\"score-unit\"> {{credentialSubject.emissionsScorecard.carbonFootprint}}{{credentialSubject.emissionsScorecard.declaredUnit}} </p> <p class=\"score-name\">Co2Eq</p> </div> <div class=\"table\"> <div class=\"table-item\"> <span>Scope includes</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.operationalScope}}</p> </div> <div class=\"table-item\"> <span>Primary sourced ratio*</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.primarySourcedRatio}}% primary sources</p> </div> {{#if credentialSubject.emissionsScorecard.reportingStandard}} {{#if credentialSubject.emissionsScorecard.reportingStandard.name}} <div class=\"table-item\"> <span>Reporting standard</span> {{#if credentialSubject.emissionsScorecard.reportingStandard.id}} <a href=\"{{credentialSubject.emissionsScorecard.reportingStandard.id}}\" class=\"blue-bottom-line-thick\" target=\"_blank\"> {{credentialSubject.emissionsScorecard.reportingStandard.name}} </a> {{else}} <p class=\"item-value\"> {{credentialSubject.emissionsScorecard.reportingStandard.name}} </p> {{/if}} </div> {{/if}} {{#if credentialSubject.emissionsScorecard.reportingStandard.issueDate}} <div class=\"table-item\"> <span>Issue date</span> <p class=\"item-value\">{{credentialSubject.emissionsScorecard.reportingStandard.issueDate}}</p> </div> {{/if}} {{/if}} </div> <div class=\"passport-annotation\"> <p>*The Primary Sourced Ratio shows the percentage of scope 3 emissions data that is directly collected from actual sources, rather than being based on estimates.</p> </div> </section> {{/if}} {{#if credentialSubject.conformityClaim}} <section class=\"declarations\"> <div> <h3 class=\"section-title\">Declarations</h3> </div> <div class=\"cards-conformities\"> {{#each credentialSubject.conformityClaim}} <article class=\"cards-conformity\"> <div class=\"conformance-header\"> <div class=\"conformance-status\"> <span class=\"conformance-label\">Conformance:</span> <div class=\"{{#if conformance}}tags-VC-badge-green{{else}}tags-VC-badge-red{{/if}}\"> {{#if conformance}}Yes{{else}}No{{/if}} </div> </div> {{#if assessmentDate}} <span class=\"conformance-label\">Assessed: {{assessmentDate}}</span> {{/if}} </div> {{#if conformityEvidence.linkName}} <div class=\"conformity-details\">{{conformityEvidence.linkName}}</div> {{/if}} <div class=\"conformity-info\"> {{#if referenceRegulation}} <p> {{#if referenceRegulation.name}} {{referenceRegulation.name}} {{#if referenceRegulation.jurisdictionCountry}} administered in {{referenceRegulation.jurisdictionCountry}} {{/if}} {{#if referenceRegulation.administeredBy}} administered by <a href=\"{{referenceRegulation.administeredBy.id}}\" class=\"gray-bottom-line\" target=\"_blank\" > {{referenceRegulation.administeredBy.name}} </a> {{/if}} {{else if referenceRegulation.jurisdictionCountry}} Administered in {{referenceRegulation.jurisdictionCountry}} {{#if referenceRegulation.administeredBy}} by <a href=\"{{referenceRegulation.administeredBy.id}}\" class=\"gray-bottom-line\" target=\"_blank\" > {{referenceRegulation.administeredBy.name}} </a> {{/if}} {{else if referenceRegulation.administeredBy}} Administered by <a href=\"{{referenceRegulation.administeredBy.id}}\" class=\"gray-bottom-line\" target=\"_blank\" > {{referenceRegulation.administeredBy.name}} </a> {{/if}} </p> {{/if}} {{#if referenceStandard}} {{#if referenceStandard.name}} <p> {{referenceStandard.name}} {{#if referenceStandard.issuingParty}} issued by <a href=\"{{referenceStandard.issuingParty.id}}\" class=\"gray-bottom-line\" target=\"_blank\" > {{referenceStandard.issuingParty.name}} </a> {{/if}} </p> {{/if}} {{/if}} </div> {{#if declaredValue}} <div class=\"declared-values\"> {{#each declaredValue}} <div class=\"declared-value\"> <p>{{metricName}} is {{metricValue.value}}{{metricValue.unit}}</p> {{#if score}} <span> Score: {{score}}{{#if accuracy}} | Accuracy: {{accuracy}}{{/if}} </span> {{else if accuracy}} <span> Accuracy: {{accuracy}} </span> {{/if}} </div> {{/each}} </div> {{/if}} {{#if conformityEvidence.linkURL}} <a href=\"{{conformityEvidence.linkURL}}\" class=\"traceability-card\" target=\"_blank\"> <div class=\"traceability-card-text\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"var(--color-icon)\" ></path> </svg> <p>Evidence</p> </div> <div class=\"traceability-card-view-details\"> <svg width=\"9\" height=\"16\" viewBox=\"0 0 9 16\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M1 1L8 8L1 15\" stroke=\"var(--color-icon)\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> {{/if}} </article> {{/each}} </div> </section> {{/if}} {{#if credentialSubject.materialsProvenance}} {{#if credentialSubject.materialsProvenance.0.massFraction}} {{#if credentialSubject.materialsProvenance.0.name}} <section class=\"composition\"> <div> <h3 class=\"section-title\">Product Composition</h3> <p class=\"section-description\"> A complete list of materials that make up the composition of this product. </p> </div> <div class=\"composition-box\"> {{#each credentialSubject.materialsProvenance}} <article class=\"composition-box-item\"> <div class=\"composition-first-column\"> <p class=\"composition-percent\">{{massFraction}}%</p> <div> <p class=\"composition-title\"> {{#if mass}}{{mass.value}}{{mass.unit}} {{/if}}{{name}} </p> <div class=\"composition-tag\"> {{#if recycledMassFraction}} <p class=\"composition-tag-item\">Recycled {{recycledMassFraction}}%</p> {{/if}} <!-- TODO: If hazardous is not present it will display the tag \"Hazard No\" which may not be true. --> <p class=\"composition-tag-item\">Hazard {{#if hazardous}}Yes{{else}}No{{/if}}</p> </div> {{#if materialSafetyInformation.linkURL}} <a href=\"{{materialSafetyInformation.linkURL}}\" class=\"blue-bottom-line-thick\" target=\"_blank\">{{materialSafetyInformation.linkName}}</a> {{/if}} </div> </div> {{#if originCountry}} <div class=\"country-code\">{{originCountry}}</div> {{/if}} </article> {{/each}} </div> </section> {{/if}} {{/if}} {{/if}} {{#if credentialSubject.traceabilityInformation}} <section class=\"history\"> <div> <h3 class=\"section-title\">History</h3> </div> {{#if credentialSubject.dueDiligenceDeclaration.linkURL}} <a href=\"{{credentialSubject.dueDiligenceDeclaration.linkURL}}\" class=\"traceability-card\" target=\"_blank\"> <div class=\"traceability-card-text\"> <svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M5 21C4.45 21 3.97933 20.8043 3.588 20.413C3.19667 20.0217 3.00067 19.5507 3 19V5C3 4.45 3.196 3.97933 3.588 3.588C3.98 3.19667 4.45067 3.00067 5 3H19C19.55 3 20.021 3.196 20.413 3.588C20.805 3.98 21.0007 4.45067 21 5V19C21 19.55 20.8043 20.021 20.413 20.413C20.0217 20.805 19.5507 21.0007 19 21H5ZM5 5V19H19V5H17V12L14.5 10.5L12 12V5H5Z\" fill=\"var(--color-icon)\" ></path> </svg> <p>Supply chain due diligence report</p> </div> <div class=\"traceability-card-view-details\"> <svg width=\"9\" height=\"16\" viewBox=\"0 0 9 16\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" > <path d=\"M1 1L8 8L1 15\" stroke=\"var(--color-icon)\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" /> </svg> </div> </a> {{/if}} {{#each credentialSubject.traceabilityInformation}} <div class=\"history-value-chain\"> {{#if valueChainProcess}} <p>{{valueChainProcess}}</p> {{#if verifiedRatio}} <div class=\"verified-ratio\"> <p>Verified ratio {{verifiedRatio}}</p> </div> {{/if}} {{/if}} </div> {{#if traceabilityEvent}} <div> {{#each traceabilityEvent}} {{#if linkName}} {{#if linkURL}} <div class=\"history-item\"> <span>{{linkName}}</span> <a href=\"{{linkURL}}\" class=\"blue-bottom-line-thick\" target=\"_blank\">View</a> </div> {{/if}} {{/if}} {{/each}} </div> {{/if}} {{/each}} </section> {{/if}} <section class=\"issued-by\"> <div> <h3 class=\"section-title\">Passport Issued By</h3> </div> <div class=\"table\"> <div class=\"table-item\"> <span>Organisation</span> <p class=\"item-value\">{{issuer.name}}</p> </div> <div class=\"table-item\"> <span>Registered ID</span> <a href=\"{{issuer.id}}\" class=\"blue-bottom-line-thick\" target=\"_blank\">{{issuer.id}}</a> </div> {{#if validFrom}} <div class=\"table-item\"> <span>Valid from</span> <p class=\"item-value\">{{validFrom}}</p> </div> {{/if}} {{#if validUntil}} <div class=\"table-item\"> <span>Valid to</span> <p class=\"item-value\">{{validUntil}}</p> </div> {{/if}} </div> </section> <footer> <p> This Digital Product Passport (DPP) is a digital record of the product's sustainability and environmental performance, ensuring transparency and accountability in line with UNTP standards. For more information visit <a href=\"https://uncefact.github.io/spec-untp/\" class=\"gray-bottom-line\" target=\"_blank\">uncefact.github.io/spec-untp/</a>. </p> </footer> </div> </body></html>"
                       }
                     ],
                     "type": ["DigitalProductPassport"],
-                    "dlrLinkTitle": "Cherries Product Passport",
+                    "dlrLinkTitle": "Product Passport",
                     "dlrVerificationPage": "http://localhost:3003/verify"
                   },
                   "dlr": {
@@ -2456,35 +3297,7 @@
                       }
                     }
                   },
-                  "identifierKeyPath": {
-                    "primary": {
-                      "ai": "01",
-                      "path": "/registeredId"
-                    },
-                    "qualifiers": [
-                      {
-                        "ai": "10",
-                        "path": "/batchNumber"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "name": "mergeToLocalStorage",
-              "parameters": [
-                {
-                  "storageKey": "orchard_facility_dpps",
-                  "objectKeyPath": "/decodedEnvelopedVC/credentialSubject/id"
-                }
-              ]
-            },
-            {
-              "name": "getValueFromLocalStorage",
-              "parameters": [
-                {
-                  "storageKey": "orchard_facility_dpps"
+                  "identifierKeyPath": "/product/id"
                 }
               ]
             }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR updates the existing e2e tests for the Digital Product Passport, specifically:
- Update the app configuration to use the latest v0.6.0 DPP data model/render template
- Update the schema validation configuration to use the v0.6.0 schema

**NOTE**: 
- This PR has a dependency on PR #226 being merged.

- While making the updates, I've identified a false positive within the ["Render DPP end-to-end testing flow"](https://github.com/uncefact/tests-untp/blob/next/e2e/cypress/e2e/vc_render/render_dpp.cy.ts) test cases, specifically the ["should render template when content is exist"](https://github.com/uncefact/tests-untp/blob/bf7b7c627007227bce3538e0e3b807599674bac1/e2e/cypress/e2e/vc_render/render_dpp.cy.ts#L43) test case where it's passing even though the credential isn't rendering due to the issue PR [#279](https://github.com/uncefact/project-vckit/pull/279) addresses. A subsequent PR will be raised to address this [issue](https://github.com/uncefact/tests-untp/issues/272).

## Mobile & Desktop Screenshots/Recordings
<img width="1689" alt="Screenshot 2025-06-11 at 11 33 53 pm" src="https://github.com/user-attachments/assets/bb135243-acc4-4063-ba29-b54c61639df9" />
<img width="1689" alt="Screenshot 2025-06-11 at 11 34 06 pm" src="https://github.com/user-attachments/assets/de827eb8-e02e-4c25-af1e-94afa9281c42" />


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed