### PR TITLE
fix: add guard for localStorageParams

### DIFF
--- a/packages/services/src/__tests__/transactionEvent.test.ts
+++ b/packages/services/src/__tests__/transactionEvent.test.ts
@@ -10,6 +10,7 @@ import { publicAPI } from '../utils/httpService';
 import { transactionEventMock } from './mocks/constants';
 import { constructVerifyURL } from '../utils/helpers';
 import { issueVC } from '../vckit.service';
+import { deleteValuesFromLocalStorageByKeyPath } from '../epcisEvents/helpers';
 
 jest.mock('../vckit.service', () => ({
   issueVC: jest.fn(),
@@ -37,40 +38,42 @@ jest.mock('../utils/helpers', () => ({
   constructVerifyURL: jest.fn(),
 }));
 
-describe('processTransactionEvent', () => {
-  const { nlisidMock, transactionEventDLRMock, transactionVCMock } = transactionEventMock;
-  const transactionEvent = {
-    data: [
-      {
-        sourceParty: { partyID: `https://beef-steak-shop.com/info.json`, name: 'Beef Steak Shop' },
-        destinationParty: { partyID: 'https://beef-shop.com/info.json', name: 'Beef Shop' },
-        transaction: {
-          type: 'inv',
-          identifier: 'uuid-123456',
-          documentURL: 'https://transaction-example.com/trans-uuid-1.json',
-        },
-        itemList: [{ itemID: 'https://beef-example.com/info-uuid-1.json', name: 'Beef' }],
-        quantityList: [{ productClass: 'Beef', quantity: '50', uom: 'units' }],
-      },
-    ],
-  };
-  const context = {
-    vckit: { vckitAPIUrl: 'https://example.com', issuer: 'did:web:example.com' },
-    traceabilityEvent: {
-      context: ['https://example.sh/TransactionEvent.jsonld'],
-      type: ['DigitalTraceabilityEvent'],
-      dlrLinkTitle: 'Transaction Event',
-      dlrVerificationPage: 'http://exampleUI.com/verify',
-    },
-    dlr: { dlrAPIUrl: 'http://exampleDLR.com', dlrAPIKey: 'test-key' },
-    storage: {
-      url: 'https://storage.dlr.com',
-      params: {},
-    },
-    identifierKeyPath: '/0/transaction/identifier',
-    localStorageParams: { storageKey: 'transaction', keyPath: '/transaction/type' },
-  };
+const { transactionEventDLRMock, transactionVCMock } = transactionEventMock;
 
+const transactionEvent = {
+  data: [
+    {
+      sourceParty: { partyID: `https://beef-steak-shop.com/info.json`, name: 'Beef Steak Shop' },
+      destinationParty: { partyID: 'https://beef-shop.com/info.json', name: 'Beef Shop' },
+      transaction: {
+        type: 'inv',
+        identifier: 'uuid-123456',
+        documentURL: 'https://transaction-example.com/trans-uuid-1.json',
+      },
+      itemList: [{ itemID: 'https://beef-example.com/info-uuid-1.json', name: 'Beef' }],
+      quantityList: [{ productClass: 'Beef', quantity: '50', uom: 'units' }],
+    },
+  ],
+};
+
+const context = {
+  vckit: { vckitAPIUrl: 'https://example.com', issuer: 'did:web:example.com' },
+  traceabilityEvent: {
+    context: ['https://example.sh/TransactionEvent.jsonld'],
+    type: ['DigitalTraceabilityEvent'],
+    dlrLinkTitle: 'Transaction Event',
+    dlrVerificationPage: 'http://exampleUI.com/verify',
+  },
+  dlr: { dlrAPIUrl: 'http://exampleDLR.com', dlrAPIKey: 'test-key' },
+  storage: {
+    url: 'https://storage.dlr.com',
+    params: {},
+  },
+  identifierKeyPath: '/0/transaction/identifier',
+  localStorageParams: { storageKey: 'transaction', keyPath: '/transaction/type' },
+};
+
+describe('processTransactionEvent', () => {
   it('should process transaction event', async () => {
     (vckitService.issueVC as jest.Mock).mockImplementationOnce(() => transactionVCMock);
     (vckitService.decodeEnvelopedVC as jest.Mock).mockReturnValue(transactionVCMock);
@@ -337,5 +340,99 @@ describe('processTransactionEvent', () => {
     expect(uploadData).toHaveBeenCalled();
     expect(validateContext.validateTraceabilityEventContext).toHaveBeenCalled();
     expect(linkResolverService.registerLinkResolver).toHaveBeenCalled();
+  });
+});
+
+describe('deleteValuesFromLocalStorageByKeyPath functionality', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (vckitService.issueVC as jest.Mock).mockImplementationOnce(() => transactionVCMock);
+    (vckitService.decodeEnvelopedVC as jest.Mock).mockReturnValue(transactionVCMock);
+    (uploadData as jest.Mock).mockResolvedValueOnce({
+      uri: 'https://exampleStorage.com/vc.json',
+      key: '123',
+      hash: 'ABC123',
+    });
+    (constructVerifyURL as jest.Mock).mockReturnValueOnce('http://localhost/event/1234');
+    
+    jest.spyOn(identifierSchemeServices, 'constructIdentifierData').mockReturnValue({
+      primary: { ai: '01', value: '9359502000010' },
+      qualifiers: [{ ai: '10', value: 'ABC123' }],
+    });
+    jest.spyOn(identifierSchemeServices, 'constructQualifierPath').mockReturnValue('/10/ABC123');
+    jest
+      .spyOn(validateContext, 'validateTraceabilityEventContext')
+      .mockReturnValueOnce({ ok: true, value: context } as unknown as Result<ITraceabilityEventContext>);
+    jest.spyOn(linkResolverService, 'registerLinkResolver').mockResolvedValueOnce(transactionEventDLRMock);
+  });
+
+  it('should call deleteValuesFromLocalStorageByKeyPath when both storageKey and keyPath are provided', async () => {
+    const contextWithLocalStorage = {
+      ...context,
+      localStorageParams: { storageKey: 'transaction', keyPath: '/transaction/type' },
+    };
+
+    await processTransactionEvent(transactionEvent, contextWithLocalStorage);
+
+    expect(deleteValuesFromLocalStorageByKeyPath).toHaveBeenCalledWith(
+      'transaction',
+      transactionEvent.data,
+      '/transaction/type',
+    );
+  });
+
+  it('should not call deleteValuesFromLocalStorageByKeyPath when localStorageParams is undefined', async () => {
+    const contextWithoutLocalStorage = {
+      ...context,
+      localStorageParams: undefined,
+    };
+
+    await processTransactionEvent(transactionEvent, contextWithoutLocalStorage);
+
+    expect(deleteValuesFromLocalStorageByKeyPath).not.toHaveBeenCalled();
+  });
+
+  it('should not call deleteValuesFromLocalStorageByKeyPath when storageKey is missing', async () => {
+    const contextWithMissingStorageKey = {
+      ...context,
+      localStorageParams: { keyPath: '/transaction/type' },
+    };
+
+    await processTransactionEvent(transactionEvent, contextWithMissingStorageKey);
+
+    expect(deleteValuesFromLocalStorageByKeyPath).not.toHaveBeenCalled();
+  });
+
+  it('should not call deleteValuesFromLocalStorageByKeyPath when keyPath is missing', async () => {
+    const contextWithMissingKeyPath = {
+      ...context,
+      localStorageParams: { storageKey: 'transaction' },
+    };
+
+    await processTransactionEvent(transactionEvent, contextWithMissingKeyPath);
+
+    expect(deleteValuesFromLocalStorageByKeyPath).not.toHaveBeenCalled();
+  });
+
+  it('should not call deleteValuesFromLocalStorageByKeyPath when both storageKey and keyPath are empty strings', async () => {
+    const contextWithEmptyValues = {
+      ...context,
+      localStorageParams: { storageKey: '', keyPath: '' },
+    };
+
+    await processTransactionEvent(transactionEvent, contextWithEmptyValues);
+
+    expect(deleteValuesFromLocalStorageByKeyPath).not.toHaveBeenCalled();
+  });
+
+  it('should not call deleteValuesFromLocalStorageByKeyPath when storageKey is null', async () => {
+    const contextWithNullStorageKey = {
+      ...context,
+      localStorageParams: { storageKey: null, keyPath: '/transaction/type' },
+    };
+
+    await processTransactionEvent(transactionEvent, contextWithNullStorageKey);
+
+    expect(deleteValuesFromLocalStorageByKeyPath).not.toHaveBeenCalled();
   });
 });

--- a/packages/services/src/epcisEvents/transactionEvent.ts
+++ b/packages/services/src/epcisEvents/transactionEvent.ts
@@ -64,11 +64,13 @@ export const processTransactionEvent: IService = async (
     LinkType.traceability,
   );
 
-  deleteValuesFromLocalStorageByKeyPath(
-    localStorageParams.storageKey,
-    transactionEvent.data,
-    localStorageParams.keyPath,
-  );
+  if (localStorageParams?.storageKey && localStorageParams?.keyPath) {
+    deleteValuesFromLocalStorageByKeyPath(
+      localStorageParams.storageKey,
+      transactionEvent.data,
+      localStorageParams.keyPath,
+    );
+  }
 
   return { vc, decodedEnvelopedVC, linkResolver };
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR adds a guard to the transactionEvent service that ensures storageKey and keyPath are present before attempting to delete the DPP from local storage. The previous implementation assumed that the service would always use a DPP stored within local storage, which is not always the case.

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

