### PR TITLE
test: fix false positive render test cases

### DIFF
--- a/e2e/cypress/page/renderPage.ts
+++ b/e2e/cypress/page/renderPage.ts
@@ -28,11 +28,15 @@ class RenderPage {
 
   verifyTemplateRenderingWhenContentExists() {
     cy.contains('button', 'Rendered').click();
+
     cy.get('div[role="tabpanel"]#tabpanel-0')
-      .should('be.visible')
-      .within(() => {
-        cy.get('div').should('exist');
-      });
+    .should('be.visible');
+    
+    cy.get('[data-testid="loading-indicator"]')
+    .should('not.exist');
+
+    cy.get('[data-testid="rendered-template"]')
+    .should('be.visible');
   }
 
   verifyNoContentRenderingWhenTemplateIsEmpty() {

--- a/packages/mock-app/src/components/CredentialRender/CredentialRender.tsx
+++ b/packages/mock-app/src/components/CredentialRender/CredentialRender.tsx
@@ -45,9 +45,9 @@ const CredentialRender = ({ credential }: { credential: VerifiableCredential | U
 
   return (
     <>
-      {isLoading && <CircularProgress sx={{ margin: 'auto' }} />}
+      {isLoading && <CircularProgress sx={{ margin: 'auto' }} data-testid="loading-indicator" />}
       <Box
-        data-testid='loading-indicator'
+        data-testid='rendered-template-container'
         sx={{
           overflowY: 'scroll',
           margin: '0 auto',
@@ -69,6 +69,7 @@ const CredentialRender = ({ credential }: { credential: VerifiableCredential | U
                   }}
                   key={i}
                   dangerouslySetInnerHTML={{ __html: doc }}
+                  data-testid={"rendered-template"}
                 ></div>
               </>
             ))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR addresses the false positive render test cases as described in ticket #272.

I've attempted to integrate a "robust" test case where we take a snapshot of the screen once the credential is rendered, but after a few runs, I'm unable to get consistent results even with a failure threshold of 5%.

For now, I've instead taken a more straightforward approach by adding two test IDs, one for the loading spinner (loading-indicator) and the other for the element that is only rendered if a template is present (rendered-template).

## Related Tickets & Documents
Fixes #272

## Mobile & Desktop Screenshots/Recordings

<img width="1744" alt="Screenshot 2025-06-16 at 7 40 12 pm" src="https://github.com/user-attachments/assets/9dd9a3b1-5a74-42fd-8012-d1dcf79b4708" />

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed