### PR TITLE
fix: conflicting app ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ yarn build
 yarn start
 ```
 
+Access the Reference Implementation on [http://localhost:3003](http://localhost:3003)
+
 > Note 
 > You only need to run the install command once. Similarly, if you haven’t made any modifications within the `packages` directory, you only need to run the build command once.
 

--- a/documentation/docs/mock-apps/common/verify-link.md
+++ b/documentation/docs/mock-apps/common/verify-link.md
@@ -31,13 +31,13 @@ The general structure of the verify link is as follows:
 
 ### Decoded (Human-readable) Example:
 ```
-http://localhost:3001/verify?q={payload:{uri:'http://localhost:3001/conformity-credentials/steel-mill-1-emissions.json', key:'secret', hash:'595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f'}}
+http://localhost:3003/verify?q={payload:{uri:'http://localhost:3001/conformity-credentials/steel-mill-1-emissions.json', key:'secret', hash:'595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f'}}
 ```
 
 ### Encoded (URL-safe) Example:
 ```
-http://localhost:3001/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D
-http://localhost:3001/verify?q%3D%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%22%2C%22key%22%3A%22secret%22%2C%22hash%22%3A%22595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f%22%7D%7D
+http://localhost:3003/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D
+http://localhost:3003/verify?q%3D%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%22%2C%22key%22%3A%22secret%22%2C%22hash%22%3A%22595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f%22%7D%7D
 ```
 
 ### Production Example:

--- a/documentation/docs/mock-apps/configuration/service-config.md
+++ b/documentation/docs/mock-apps/configuration/service-config.md
@@ -56,7 +56,7 @@ graph TD
             "type": ["VerifiableCredential", " DigitalProductPassport"],
             "dlrLinkTitle": "Steel Passport",
             "dlrIdentificationKeyType": "gtin",
-            "dlrVerificationPage": "http://localhost:3000/verify"
+            "dlrVerificationPage": "http://localhost:3003/verify"
           },
           "dlr": {
             "dlrAPIUrl": "http://localhost:8080",

--- a/documentation/docs/mock-apps/conformity-credential.md
+++ b/documentation/docs/mock-apps/conformity-credential.md
@@ -113,7 +113,7 @@ Steps:
                   "conformityEvidence": {
                     "type": "w3c_vc",
                     "assuranceLevel": "3rdParty",
-                    "reference": "http://localhost:3001/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
+                    "reference": "http://localhost:3003/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
                   }
                 }
               ]

--- a/documentation/docs/mock-apps/services/index.md
+++ b/documentation/docs/mock-apps/services/index.md
@@ -67,7 +67,7 @@ graph TD
             "renderTemplate": [],
             "type": ["VerifiableCredential", " DigitalProductPassport"],
             "dlrLinkTitle": "Steel Passport",
-            "dlrVerificationPage": "http://localhost:3000/verify"
+            "dlrVerificationPage": "http://localhost:3003/verify"
           },
           "dlr": {
             "dlrAPIUrl": "http://localhost:8080",

--- a/documentation/docs/mock-apps/services/process-dpp.md
+++ b/documentation/docs/mock-apps/services/process-dpp.md
@@ -73,7 +73,7 @@ P-->>C: Return VC and resolver URL
         ],
         "type": ["DigitalProductPassport"],
         "dlrLinkTitle": "Steel Passport",
-        "dlrVerificationPage": "http://localhost:3332/verify",
+        "dlrVerificationPage": "http://localhost:3003/verify",
         "validUntil": "2025-11-28T04:47:15.136Z"
       },
       "dlr": {

--- a/documentation/versioned_docs/version-0.1.0/mock-apps/common/verify-link.md
+++ b/documentation/versioned_docs/version-0.1.0/mock-apps/common/verify-link.md
@@ -31,13 +31,13 @@ The general structure of the verify link is as follows:
 
 ### Decoded (Human-readable) Example:
 ```
-http://localhost:3001/verify?q={payload:{uri:'http://localhost:3001/conformity-credentials/steel-mill-1-emissions.json', key:'secret', hash:'595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f'}}
+http://localhost:3003/verify?q={payload:{uri:'http://localhost:3001/conformity-credentials/steel-mill-1-emissions.json', key:'secret', hash:'595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f'}}
 ```
 
 ### Encoded (URL-safe) Example:
 ```
-http://localhost:3001/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D
-http://localhost:3001/verify?q%3D%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%22%2C%22key%22%3A%22secret%22%2C%22hash%22%3A%22595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f%22%7D%7D
+http://localhost:3003/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D
+http://localhost:3003/verify?q%3D%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%22%2C%22key%22%3A%22secret%22%2C%22hash%22%3A%22595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f%22%7D%7D
 ```
 
 ### Production Example:

--- a/documentation/versioned_docs/version-0.1.0/mock-apps/configuration/service-config.md
+++ b/documentation/versioned_docs/version-0.1.0/mock-apps/configuration/service-config.md
@@ -56,7 +56,7 @@ graph TD
             "type": ["VerifiableCredential", " DigitalProductPassport"],
             "dlrLinkTitle": "Steel Passport",
             "dlrIdentificationKeyType": "gtin",
-            "dlrVerificationPage": "http://localhost:3000/verify"
+            "dlrVerificationPage": "http://localhost:3003/verify"
           },
           "dlr": {
             "dlrAPIUrl": "http://localhost:8080",

--- a/documentation/versioned_docs/version-0.1.0/mock-apps/conformity-credential.md
+++ b/documentation/versioned_docs/version-0.1.0/mock-apps/conformity-credential.md
@@ -113,7 +113,7 @@ Steps:
                   "conformityEvidence": {
                     "type": "w3c_vc",
                     "assuranceLevel": "3rdParty",
-                    "reference": "http://localhost:3001/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
+                    "reference": "http://localhost:3003/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
                   }
                 }
               ]

--- a/documentation/versioned_docs/version-0.1.0/mock-apps/services/index.md
+++ b/documentation/versioned_docs/version-0.1.0/mock-apps/services/index.md
@@ -66,7 +66,7 @@ graph TD
             "renderTemplate": [],
             "type": ["VerifiableCredential", " DigitalProductPassport"],
             "dlrLinkTitle": "Steel Passport",
-            "dlrVerificationPage": "http://localhost:3000/verify"
+            "dlrVerificationPage": "http://localhost:3003/verify"
           },
           "dlr": {
             "dlrAPIUrl": "http://localhost:8080",

--- a/documentation/versioned_docs/version-0.1.0/mock-apps/services/process-dpp.md
+++ b/documentation/versioned_docs/version-0.1.0/mock-apps/services/process-dpp.md
@@ -73,7 +73,7 @@ P-->>C: Return VC and resolver URL
         ],
         "type": ["DigitalProductPassport"],
         "dlrLinkTitle": "Steel Passport",
-        "dlrVerificationPage": "http://localhost:3332/verify",
+        "dlrVerificationPage": "http://localhost:3003/verify",
         "validUntil": "2025-11-28T04:47:15.136Z"
       },
       "dlr": {

--- a/documentation/versioned_docs/version-0.2.0/mock-apps/common/verify-link.md
+++ b/documentation/versioned_docs/version-0.2.0/mock-apps/common/verify-link.md
@@ -31,13 +31,13 @@ The general structure of the verify link is as follows:
 
 ### Decoded (Human-readable) Example:
 ```
-http://localhost:3001/verify?q={payload:{uri:'http://localhost:3001/conformity-credentials/steel-mill-1-emissions.json', key:'secret', hash:'595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f'}}
+http://localhost:3003/verify?q={payload:{uri:'http://localhost:3001/conformity-credentials/steel-mill-1-emissions.json', key:'secret', hash:'595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f'}}
 ```
 
 ### Encoded (URL-safe) Example:
 ```
-http://localhost:3001/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D
-http://localhost:3001/verify?q%3D%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%22%2C%22key%22%3A%22secret%22%2C%22hash%22%3A%22595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f%22%7D%7D
+http://localhost:3003/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D
+http://localhost:3003/verify?q%3D%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%22%2C%22key%22%3A%22secret%22%2C%22hash%22%3A%22595d8d20c586c6f55f8a758f294674fa85069db5c518a0f4cbbd3fd61f46522f%22%7D%7D
 ```
 
 ### Production Example:

--- a/documentation/versioned_docs/version-0.2.0/mock-apps/configuration/service-config.md
+++ b/documentation/versioned_docs/version-0.2.0/mock-apps/configuration/service-config.md
@@ -56,7 +56,7 @@ graph TD
             "type": ["VerifiableCredential", " DigitalProductPassport"],
             "dlrLinkTitle": "Steel Passport",
             "dlrIdentificationKeyType": "gtin",
-            "dlrVerificationPage": "http://localhost:3000/verify"
+            "dlrVerificationPage": "http://localhost:3003/verify"
           },
           "dlr": {
             "dlrAPIUrl": "http://localhost:8080",

--- a/documentation/versioned_docs/version-0.2.0/mock-apps/conformity-credential.md
+++ b/documentation/versioned_docs/version-0.2.0/mock-apps/conformity-credential.md
@@ -113,7 +113,7 @@ Steps:
                   "conformityEvidence": {
                     "type": "w3c_vc",
                     "assuranceLevel": "3rdParty",
-                    "reference": "http://localhost:3001/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
+                    "reference": "http://localhost:3003verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
                   }
                 }
               ]

--- a/documentation/versioned_docs/version-0.2.0/mock-apps/conformity-credential.md
+++ b/documentation/versioned_docs/version-0.2.0/mock-apps/conformity-credential.md
@@ -113,7 +113,7 @@ Steps:
                   "conformityEvidence": {
                     "type": "w3c_vc",
                     "assuranceLevel": "3rdParty",
-                    "reference": "http://localhost:3003verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
+                    "reference": "http://localhost:3003/verify?q%3D%7Bpayload%3A%7Buri%3Ahttp%3A%2F%2Flocalhost%3A3001%2Fconformity-credentials%2Fsteel-mill-1-emissions.json%7D%7D"
                   }
                 }
               ]

--- a/documentation/versioned_docs/version-0.2.0/mock-apps/services/index.md
+++ b/documentation/versioned_docs/version-0.2.0/mock-apps/services/index.md
@@ -67,7 +67,7 @@ graph TD
             "renderTemplate": [],
             "type": ["VerifiableCredential", " DigitalProductPassport"],
             "dlrLinkTitle": "Steel Passport",
-            "dlrVerificationPage": "http://localhost:3000/verify"
+            "dlrVerificationPage": "http://localhost:3003/verify"
           },
           "dlr": {
             "dlrAPIUrl": "http://localhost:8080",

--- a/documentation/versioned_docs/version-0.2.0/mock-apps/services/process-dpp.md
+++ b/documentation/versioned_docs/version-0.2.0/mock-apps/services/process-dpp.md
@@ -73,7 +73,7 @@ P-->>C: Return VC and resolver URL
         ],
         "type": ["DigitalProductPassport"],
         "dlrLinkTitle": "Steel Passport",
-        "dlrVerificationPage": "http://localhost:3333/verify",
+        "dlrVerificationPage": "http://localhost:3003/verify",
         "validUntil": "2025-11-28T04:47:15.136Z"
       },
       "dlr": {

--- a/documentation/versioned_docs/version-0.2.0/mock-apps/services/process-dpp.md
+++ b/documentation/versioned_docs/version-0.2.0/mock-apps/services/process-dpp.md
@@ -73,7 +73,7 @@ P-->>C: Return VC and resolver URL
         ],
         "type": ["DigitalProductPassport"],
         "dlrLinkTitle": "Steel Passport",
-        "dlrVerificationPage": "http://localhost:3332/verify",
+        "dlrVerificationPage": "http://localhost:3333/verify",
         "validUntil": "2025-11-28T04:47:15.136Z"
       },
       "dlr": {

--- a/packages/mock-app/documents/configure-document.md
+++ b/packages/mock-app/documents/configure-document.md
@@ -158,7 +158,7 @@ Based on the example, you can define the features of the apps in the configurati
                     ],
                     "type": ["DigitalProductPassport"],
                     "dlrLinkTitle": "Livestock Passport",
-                    "dlrVerificationPage": "http://localhost:3001/verify"
+                    "dlrVerificationPage": "http://localhost:3003/verify"
                   },
 
                   "dlr": {

--- a/packages/mock-app/package.json
+++ b/packages/mock-app/package.json
@@ -25,7 +25,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "PORT=3003 craco start",
     "build": "craco build",
     "storybook": "storybook dev -p 6006",
     "test": "jest",

--- a/packages/mock-app/src/__tests__/Header.test.tsx
+++ b/packages/mock-app/src/__tests__/Header.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../hooks/GlobalContext', () => ({
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
-    pathname: 'localhost:3000/',
+    pathname: 'localhost:3003/',
   }),
 }));
 

--- a/packages/mock-app/src/constants/app-config.dev.example.json
+++ b/packages/mock-app/src/constants/app-config.dev.example.json
@@ -725,7 +725,7 @@
                     ],
                     "type": ["VerifiableCredential", " DigitalProductPassport"],
                     "dlrLinkTitle": "Steel Passport",
-                    "dlrVerificationPage": "http://localhost:3000/verify"
+                    "dlrVerificationPage": "http://localhost:3003/verify"
                   },
                   "dlr": {
                     "dlrAPIUrl": "http://localhost:8080",
@@ -1204,7 +1204,7 @@
                     ],
                     "type": ["TransactionEventCredential"],
                     "dlrLinkTitle": "Transaction Event",
-                    "dlrVerificationPage": "http://localhost:3000/verify"
+                    "dlrVerificationPage": "http://localhost:3003/verify"
                   },
                   "dlr": {
                     "dlrAPIUrl": "http://localhost:8080",
@@ -1938,7 +1938,7 @@
                     ],
                     "type": ["VerifiableCredential", " DigitalProductPassport"],
                     "dlrLinkTitle": "Steel Passport",
-                    "dlrVerificationPage": "http://localhost:3000/verify"
+                    "dlrVerificationPage": "http://localhost:3003/verify"
                   },
 
                   "dlr": {
@@ -2418,7 +2418,7 @@
                     ],
                     "type": ["TransactionEventCredential"],
                     "dlrLinkTitle": "Transaction Event",
-                    "dlrVerificationPage": "http://localhost:3000/verify"
+                    "dlrVerificationPage": "http://localhost:3003/verify"
                   },
                   "dlr": {
                     "dlrAPIUrl": "http://localhost:8080",
@@ -2512,7 +2512,7 @@
                     "type": ["TransformationEventCredential"],
                     "dlrIdentificationKeyType": "gtin",
                     "dlrLinkTitle": "EPCIS transformation event VC",
-                    "dlrVerificationPage": "http://localhost:3000/verify",
+                    "dlrVerificationPage": "http://localhost:3003/verify",
                     "dlrQualifierPath": ""
                   },
                   "dpp": {
@@ -2526,7 +2526,7 @@
                     "type": ["DigitalProductPassport"],
                     "dlrIdentificationKeyType": "gtin",
                     "dlrLinkTitle": "Digital Product Passport",
-                    "dlrVerificationPage": "http://localhost:3000/verify",
+                    "dlrVerificationPage": "http://localhost:3003/verify",
                     "dlrQualifierPath": ""
                   },
                   "vckit": {

--- a/packages/mock-app/src/constants/app-config.example.json
+++ b/packages/mock-app/src/constants/app-config.example.json
@@ -706,7 +706,7 @@
                     ],
                     "type": ["VerifiableCredential", "DigitalProductPassport"],
                     "dlrLinkTitle": "Truffle Product Passport",
-                    "dlrVerificationPage": "http://localhost:3001/verify"
+                    "dlrVerificationPage": "http://localhost:3003/verify"
                   },
                   "dlr": {
                     "dlrAPIUrl": "http://localhost:8080",
@@ -1186,7 +1186,7 @@
                     ],
                     "type": ["TransactionEventCredential"],
                     "dlrLinkTitle": "Transaction Event",
-                    "dlrVerificationPage": "http://localhost:3001/verify"
+                    "dlrVerificationPage": "http://localhost:3003/verify"
                   },
                   "dlr": {
                     "dlrAPIUrl": "http://localhost:8080",

--- a/packages/services/src/__tests__/helpers.test.ts
+++ b/packages/services/src/__tests__/helpers.test.ts
@@ -282,13 +282,13 @@ describe('constructVerifyURL', () => {
   beforeEach(() => {
     // Mock window location for consistent tests
     delete (window as any).location;
-    (window as any).location = new URL('http://localhost:3000');
+    (window as any).location = new URL('http://localhost:3003');
   });
 
   it('should construct the correct verify URL with only URI', () => {
     const uri = 'http://example.com/credential';
     const expectedURL =
-      'http://localhost:3000/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%7D%7D';
+      'http://localhost:3003/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%7D%7D';
     const result = constructVerifyURL({ uri });
 
     expect(result).toBe(expectedURL);
@@ -299,7 +299,7 @@ describe('constructVerifyURL', () => {
     const hash = 'someHash';
     const result = constructVerifyURL({ uri, hash });
     
-    const expectedURL = 'http://localhost:3000/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22hash%22%3A%22someHash%22%7D%7D';
+    const expectedURL = 'http://localhost:3003/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22hash%22%3A%22someHash%22%7D%7D';
     expect(result).toBe(expectedURL);
   });
 
@@ -308,7 +308,7 @@ describe('constructVerifyURL', () => {
     const key = 'someKey';
     const result = constructVerifyURL({ uri, key });
     
-    const expectedURL = 'http://localhost:3000/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22key%22%3A%22someKey%22%7D%7D';
+    const expectedURL = 'http://localhost:3003/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22key%22%3A%22someKey%22%7D%7D';
     expect(result).toBe(expectedURL);
   });
 
@@ -317,7 +317,7 @@ describe('constructVerifyURL', () => {
     const key = 'someKey';
     const hash = 'someHash';
     const expectedURL =
-      'http://localhost:3000/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22key%22%3A%22someKey%22%2C%22hash%22%3A%22someHash%22%7D%7D';
+      'http://localhost:3003/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22key%22%3A%22someKey%22%2C%22hash%22%3A%22someHash%22%7D%7D';
     const result = constructVerifyURL({ uri, key, hash });
 
     expect(result).toBe(expectedURL);
@@ -338,7 +338,7 @@ describe('validateAndConstructVerifyURL', () => {
   it('should return the verify URL when value is a string', () => {
     const value = 'http://example.com/credential';
     const expectedURL =
-      'http://localhost:3000/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%7D%7D';
+      'http://localhost:3003/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%7D%7D';
     const result = validateAndConstructVerifyURL(value);
 
     expect(result).toBe(expectedURL);
@@ -351,7 +351,7 @@ describe('validateAndConstructVerifyURL', () => {
       hash: 'someHash',
     };
     const expectedURL =
-      'http://localhost:3000/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22key%22%3A%22someKey%22%2C%22hash%22%3A%22someHash%22%7D%7D';
+      'http://localhost:3003/verify?q=%7B%22payload%22%3A%7B%22uri%22%3A%22http%3A%2F%2Fexample.com%2Fcredential%22%2C%22key%22%3A%22someKey%22%2C%22hash%22%3A%22someHash%22%7D%7D';
     const result = validateAndConstructVerifyURL(value);
 
     expect(result).toBe(expectedURL);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR resolves the port conflict between the IDR service (provisioned by Docker Compose) and the Reference Implementation by setting the port used by the Reference Implementation to port 3003. This port aligns with the port used by the Reference Implementation within the E2E tests configuration. The documentation has been updated to reflect the change.

## Related Tickets & Documents
Fixes #315

## Mobile & Desktop Screenshots/Recordings
<img width="1904" height="1012" alt="Screenshot 2025-08-08 at 9 54 30 am" src="https://github.com/user-attachments/assets/dceb2238-f666-48ae-8078-d691800e4488" />
<img width="1904" height="1012" alt="Screenshot 2025-08-08 at 9 54 23 am" src="https://github.com/user-attachments/assets/8c56a195-f0d5-4602-8750-3f9d1958ea0b" />

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [x] 📜 README.md
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

