### PR TITLE
tests: increase timeout

### DIFF
--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
       runMode: 2, // Retries in headless mode
       openMode: 0, // No retries in interactive mode
     },
-    defaultCommandTimeout: 4000,
+    defaultCommandTimeout: 10000,
     defaultBrowser: 'chrome',
     setupNodeEvents(on) {
       on('task', {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR increases the timeout for Cypress commands from 4 to 10 seconds to address an issue with a VCDM verification test case timing out within `untp-playground/vcdm-validation.cy.ts` in the pipeline.

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed