### PR TITLE
feat: add postgres db for ri

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+RI_POSTGRES_USER=ri-postgres
+RI_POSTGRES_PASSWORD=ri-postgres
+RI_POSTGRES_DB=ri

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -156,5 +156,18 @@ services:
     depends_on:
       - untp-playground
 
+  e2e-ri-db:
+    image: postgres:17-alpine
+    ports:
+      - 5433:5432
+    environment:
+      - POSTGRES_USER=${RI_POSTGRES_USER:-ri-postgres}
+      - POSTGRES_PASSWORD=${RI_POSTGRES_PASSWORD:-ri-postgres}
+      - POSTGRES_DB=${RI_POSTGRES_DB:-ri}
+    volumes:
+      - e2e-ri-db-data:/var/lib/postgresql/data
+    restart: always
+
 volumes:
   vckit-data:
+  e2e-ri-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,16 @@
 services:
+  ri-db:
+    image: postgres:17-alpine
+    ports:
+      - 5433:5432
+    environment:
+      - POSTGRES_USER=${RI_POSTGRES_USER:-ri-postgres}
+      - POSTGRES_PASSWORD=${RI_POSTGRES_PASSWORD:-ri-postgres}
+      - POSTGRES_DB=${RI_POSTGRES_DB:-ri}
+    volumes:
+      - ri-db-data:/var/lib/postgresql/data
+    restart: always
+
   documentation:
     build:
       context: ./documentation
@@ -163,5 +175,6 @@ services:
       - mock-global-gs1-resolver
 
 volumes:
+  ri-db-data:
   vckit-data:
   storage_service_data:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR adds a Postgres database service to the Docker Compose configurations for the Reference Implementation (RI), enabling a path forward for data persistence.
A dedicated instance was chosen instead of reusing the VCkit-provisioned Postgres DB to maintain separation of concerns, as this database stores key material.

## Mobile & Desktop Screenshots/Recordings

<img width="1694" height="912" alt="Screenshot 2025-10-27 at 1 59 53 pm" src="https://github.com/user-attachments/assets/572467fc-9607-4cfb-a6d5-021876e52d2b" />
<img width="1690" height="842" alt="Screenshot 2025-10-27 at 2 00 03 pm" src="https://github.com/user-attachments/assets/0073b147-1c1f-4087-b491-fa7d8c6d57c6" />
<img width="1690" height="842" alt="Screenshot 2025-10-27 at 2 02 34 pm" src="https://github.com/user-attachments/assets/7129b871-d5c4-48b1-998c-f2a088b5d37e" />
<img width="1690" height="842" alt="Screenshot 2025-10-27 at 2 27 15 pm" src="https://github.com/user-attachments/assets/8245693b-be68-4e50-8204-0d2537d8a721" />


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

