### PR TITLE
Feature: get UNTP Playground version from release tag

### DIFF
--- a/.github/workflows/ci_cd-untp-playground.yml
+++ b/.github/workflows/ci_cd-untp-playground.yml
@@ -60,6 +60,7 @@ jobs:
           NEXT_PUBLIC_ASSET_PREFIX: /test-untp-playground
           NEXT_PUBLIC_IMAGE_PATH: /test-untp-playground/_next/image
           NEXT_PUBLIC_REPORT_NAME:
+          NEXT_PUBLIC_PLAYGROUND_VERSION: ${{ github.sha }}
           STACK_NAME: test
 
   deploy_prod:
@@ -110,4 +111,5 @@ jobs:
           NEXT_PUBLIC_ASSET_PREFIX: /untp-playground
           NEXT_PUBLIC_IMAGE_PATH: /untp-playground/_next/image
           NEXT_PUBLIC_REPORT_NAME:
+          NEXT_PUBLIC_PLAYGROUND_VERSION: ${{ github.ref_name }}
           STACK_NAME: prod

--- a/packages/untp-playground/__tests__/lib/reportService.test.ts
+++ b/packages/untp-playground/__tests__/lib/reportService.test.ts
@@ -103,7 +103,7 @@ describe('generateReport', () => {
       reportName: 'UNTP',
       testSuite: {
         runner: 'untp-playground',
-        version: '0.2.0',
+        version: '0.2.2',
       },
       implementation: {
         name: 'Test Implementation',

--- a/packages/untp-playground/config.ts
+++ b/packages/untp-playground/config.ts
@@ -2,7 +2,7 @@ import packageJson from './package.json' assert { type: 'json' };
 
 // Included within the test report
 const testSuiteRunner = 'untp-playground';
-const testSuiteVersion = packageJson.version || 'unknown';
+const testSuiteVersion = process.env.NEXT_PUBLIC_PLAYGROUND_VERSION || packageJson.version || 'unknown';
 const reportName = process.env.NEXT_PUBLIC_REPORT_NAME || 'UNTP';
 
 // VC Verification Service

--- a/packages/untp-playground/package.json
+++ b/packages/untp-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untp-playground",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR increases the version number of the UNTP Playground to 0.2.2. 
It also changes the way the UI gets the version number. To avoid having to update the version number manually, it is now taken from the release tag.

## Related Tickets & Documents
#390 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Mock App docs site](https://uncefact.github.io/tests-untp/docs/mock-apps/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

