### PR TITLE
feat(services): rename package to @uncefact/untp-ri-services

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn cache clean && yarn install --immutable
+          yarn cache clean && yarn install --frozen-lockfile
 
       - name: Check linting
         run: yarn build && yarn lint

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -16,6 +16,7 @@ const jestConfig = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^react($|/.+)': '<rootDir>/../../node_modules/react$1',
     '^react-dom($|/.+)': '<rootDir>/../../node_modules/react-dom$1',
+    '^@uncefact/untp-ri-services$': '<rootDir>/../services/src/index.ts',
   },
   transform: {
     '^.+\\.m?tsx?$': [

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -16,7 +16,10 @@ const jestConfig = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^react($|/.+)': '<rootDir>/../../node_modules/react$1',
     '^react-dom($|/.+)': '<rootDir>/../../node_modules/react-dom$1',
-    '^@uncefact/untp-ri-services$': '<rootDir>/../services/src/index.ts',
+    '^@uncefact/untp-ri-services/server$': '<rootDir>/../services/build/server.js',
+    '^@uncefact/untp-ri-services/encryption$': '<rootDir>/../services/build/encryption/index.js',
+    '^@uncefact/untp-ri-services/key-provider$': '<rootDir>/../services/build/key-provider/index.js',
+    '^@uncefact/untp-ri-services$': '<rootDir>/../services/build/index.js',
   },
   transform: {
     '^.+\\.m?tsx?$': [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
     "@jsonforms/core": "^3.2.0",
     "@jsonforms/material-renderers": "^3.2.0",
     "@jsonforms/react": "^3.2.0",
-    "@mock-app/services": "0.2.0",
+    "@uncefact/untp-ri-services": "0.1.0-dev.8",
     "@mui/icons-material": "^5.15.5",
     "@mui/lab": "5.0.0-alpha.161",
     "@mui/material": "^5.15.5",

--- a/packages/components/src/__tests__/ConformityCredential.test.tsx
+++ b/packages/components/src/__tests__/ConformityCredential.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConformityCredential } from '../components';
 import { FetchOptions } from '../types/conformityCredential.types';
-import { getJsonDataFromConformityAPI, uploadData, getValueByPath } from '@mock-app/services';
+import { getJsonDataFromConformityAPI, uploadData, getValueByPath } from '@uncefact/untp-ri-services';
 import { checkStoredCredentialsConfig } from '../components/ConformityCredential/utils';
 
-jest.mock('@mock-app/services', () => ({
+jest.mock('@uncefact/untp-ri-services', () => ({
   uploadData: jest.fn(),
   generateUUID: jest.fn(),
   getJsonDataFromConformityAPI: jest.fn(),

--- a/packages/components/src/__tests__/QRCodeScannerDialogButton.test.tsx
+++ b/packages/components/src/__tests__/QRCodeScannerDialogButton.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { publicAPI } from '@mock-app/services';
+import { publicAPI } from '@uncefact/untp-ri-services';
 import { render, screen, getByText, fireEvent, waitFor } from '@testing-library/react';
 import { processVerifiableCredentialData } from '../utils/importDataHelpers.js';
 import { QRCodeScannerDialogButton } from '../components/QRCodeScannerDialogButton/QRCodeScannerDialogButton';
 import { ScannerDialog } from '../components/QRCodeScannerDialogButton/ScannerDialog';
 import { ImportDataType } from '../types/common.types';
 
-jest.mock('@mock-app/services', () => ({
+jest.mock('@uncefact/untp-ri-services', () => ({
   publicAPI: {
     get: jest.fn(),
   },

--- a/packages/components/src/__tests__/RenderCheckList.test.tsx
+++ b/packages/components/src/__tests__/RenderCheckList.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { RenderCheckList } from '../components/RenderCheckList/RenderCheckList';
 import { IDynamicComponentRendererProps } from '../components/DynamicComponentRenderer/DynamicComponentRenderer';
 import { processVerifiableCredentialData } from '../utils/importDataHelpers.js';
-import { publicAPI } from '@mock-app/services';
+import { publicAPI } from '@uncefact/untp-ri-services';
 import { ScannerDialog } from '../components/QRCodeScannerDialogButton/ScannerDialog';
 
 jest.mock('../components/ConformityCredential/index.ts', () => ({}));
@@ -12,7 +12,7 @@ jest.mock('../utils/importDataHelpers.js', () => ({
   processVerifiableCredentialData: jest.fn(),
 }));
 
-jest.mock('@mock-app/services', () => ({
+jest.mock('@uncefact/untp-ri-services', () => ({
   publicAPI: {
     get: jest.fn(),
   },

--- a/packages/components/src/__tests__/utils/importDataHelpers.test.tsx
+++ b/packages/components/src/__tests__/utils/importDataHelpers.test.tsx
@@ -1,7 +1,7 @@
 import { processVerifiableCredentialData } from '../../utils';
-import { verifyVC, decodeEnvelopedVC } from '@mock-app/services';
+import { verifyVC, decodeEnvelopedVC } from '@uncefact/untp-ri-services';
 
-jest.mock('@mock-app/services', () => ({
+jest.mock('@uncefact/untp-ri-services', () => ({
   verifyVC: jest.fn(),
   decodeEnvelopedVC: jest.fn(),
 }));

--- a/packages/components/src/components/BarcodeGenerator/BarcodeGenerator.tsx
+++ b/packages/components/src/components/BarcodeGenerator/BarcodeGenerator.tsx
@@ -1,4 +1,4 @@
-import { extractFromElementString, constructIdentifierData, constructElementString } from '@mock-app/services';
+import { extractFromElementString, constructIdentifierData, constructElementString } from '@uncefact/untp-ri-services';
 import { Box } from '@mui/material';
 import { useEffect, useState } from 'react';
 import Barcode from 'react-barcode';

--- a/packages/components/src/components/ConformityCredential/ConformityCredential.tsx
+++ b/packages/components/src/components/ConformityCredential/ConformityCredential.tsx
@@ -9,7 +9,7 @@ import {
   getJsonDataFromConformityAPI,
   uploadData,
   getValueByPath,
-} from '@mock-app/services';
+} from '@uncefact/untp-ri-services';
 
 import { checkStoredCredentialsConfig } from './utils.js';
 import { Status, ToastMessage, toastMessage } from '../ToastMessage/ToastMessage.js';

--- a/packages/components/src/components/ConformityCredential/utils.ts
+++ b/packages/components/src/components/ConformityCredential/utils.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { StorageServiceConfig } from '@mock-app/services';
+import { StorageServiceConfig } from '@uncefact/untp-ri-services';
 
 export type Result<T> = { ok: true; value: T } | { ok: false; value: string };
 

--- a/packages/components/src/components/LocalStorageLoader/LocalStorageLoader.tsx
+++ b/packages/components/src/components/LocalStorageLoader/LocalStorageLoader.tsx
@@ -4,7 +4,7 @@ import {
   IDynamicComponentRendererProps,
 } from '../DynamicComponentRenderer/DynamicComponentRenderer.js';
 import { Box } from '@mui/material';
-import { IConstructObjectParameters, constructObject, genericHandlerFunctions } from '@mock-app/services';
+import { IConstructObjectParameters, constructObject, genericHandlerFunctions } from '@uncefact/untp-ri-services';
 
 export interface ILocalStorageLoaderProps {
   onChange: (data: any) => void;

--- a/packages/components/src/components/QRCodeScannerDialogButton/QRCodeScannerDialogButton.tsx
+++ b/packages/components/src/components/QRCodeScannerDialogButton/QRCodeScannerDialogButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from '@mui/material';
 import { CredentialPayload } from '@vckit/core-types';
-import { publicAPI } from '@mock-app/services';
+import { publicAPI } from '@uncefact/untp-ri-services';
 import { ScannerDialog } from './ScannerDialog.js';
 import { Status, ToastMessage, toastMessage } from '../ToastMessage/ToastMessage.js';
 import { ImportDataType } from '../../types/common.types.js';

--- a/packages/components/src/types/conformityCredential.types.ts
+++ b/packages/components/src/types/conformityCredential.types.ts
@@ -1,4 +1,4 @@
-import { StorageServiceConfig } from '@mock-app/services';
+import { StorageServiceConfig } from '@uncefact/untp-ri-services';
 
 export type FetchOptions = {
   method: 'POST' | 'GET';

--- a/packages/components/src/utils/importDataHelpers.ts
+++ b/packages/components/src/utils/importDataHelpers.ts
@@ -1,4 +1,4 @@
-import { verifyVC, decodeEnvelopedVC } from '@mock-app/services';
+import { verifyVC, decodeEnvelopedVC } from '@uncefact/untp-ri-services';
 import { VerifiableCredential } from '@vckit/core-types';
 import JSONPointer from 'jsonpointer';
 import { IVCContext } from '../types/common.types';

--- a/packages/mock-app/jest.config.mjs
+++ b/packages/mock-app/jest.config.mjs
@@ -21,6 +21,10 @@ const jestConfig = {
     '^next-auth/react$': '<rootDir>/src/__mocks__/next-auth/react.ts',
     '^react($|/.+)': '<rootDir>/../../node_modules/react$1',
     '^react-dom($|/.+)': '<rootDir>/../../node_modules/react-dom$1',
+    '^@uncefact/untp-ri-services/server$': '<rootDir>/../services/build/server.js',
+    '^@uncefact/untp-ri-services/encryption$': '<rootDir>/../services/build/encryption/index.js',
+    '^@uncefact/untp-ri-services/key-provider$': '<rootDir>/../services/build/key-provider/index.js',
+    '^@uncefact/untp-ri-services$': '<rootDir>/../services/build/index.js',
   },
   transform: {
     '^.+\\.m?[tj]sx?$': [

--- a/packages/mock-app/package.json
+++ b/packages/mock-app/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
     "@mock-app/components": "0.2.0",
-    "@mock-app/services": "0.2.0",
+    "@uncefact/untp-ri-services": "0.1.0-dev.8",
     "@mui/icons-material": "^7.3.4",
     "@mui/material": "^7.3.4",
     "@prisma/client": "^6.18.0",

--- a/packages/mock-app/prisma/seed.ts
+++ b/packages/mock-app/prisma/seed.ts
@@ -1,8 +1,8 @@
 import dotenv from "dotenv";
 import path from "path";
 import { DidMethod, DidStatus, DidType, PrismaClient, ServiceType as PrismaServiceType, AdapterType as PrismaAdapterType } from "../src/lib/prisma/generated";
-import { AesGcmEncryptionAdapter } from "@mock-app/services/server";
-import { EncryptionAlgorithm } from "@mock-app/services";
+import { AesGcmEncryptionAdapter } from "@uncefact/untp-ri-services/server";
+import { EncryptionAlgorithm } from "@uncefact/untp-ri-services";
 import { getDidConfig } from "../src/lib/config/did.config";
 
 // Load .env before accessing config (seed runs outside Next.js)

--- a/packages/mock-app/src/__tests__/GenericFeature.test.tsx
+++ b/packages/mock-app/src/__tests__/GenericFeature.test.tsx
@@ -18,7 +18,7 @@ jest.mock('@mock-app/components', () => ({
   },
 }));
 
-jest.mock('@mock-app/services', () => ({
+jest.mock('@uncefact/untp-ri-services', () => ({
   logService: jest.fn().mockImplementation(() => 'logService'),
 }));
 

--- a/packages/mock-app/src/__tests__/Scanning.test.tsx
+++ b/packages/mock-app/src/__tests__/Scanning.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
-import { publicAPI } from '@mock-app/services';
+import { publicAPI } from '@uncefact/untp-ri-services';
 import { Scanner } from '../components/Scanner';
 import Scanning from '../app/(public)/scanning/page';
 
@@ -63,7 +63,7 @@ jest.mock('../components/CustomDialog', () => ({
   CustomDialog: jest.fn(),
 }));
 
-jest.mock('@mock-app/services', () => ({
+jest.mock('@uncefact/untp-ri-services', () => ({
   publicAPI: jest.fn(),
 }));
 

--- a/packages/mock-app/src/__tests__/Verify.test.tsx
+++ b/packages/mock-app/src/__tests__/Verify.test.tsx
@@ -1,7 +1,7 @@
 import * as jose from 'jose';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { UnsignedCredential, VerifiableCredential } from '@uncefact/vckit-core-types';
-import { computeHash, decryptCredential, publicAPI, verifyVC } from '@mock-app/services';
+import { computeHash, decryptCredential, publicAPI, verifyVC } from '@uncefact/untp-ri-services';
 import Verify from '../app/(public)/verify/page';
 
 console.error = jest.fn();
@@ -59,7 +59,7 @@ jest.mock('@mock-app/components', () => ({
   toastMessage: jest.fn(),
   ToastMessage: jest.fn(),
 }));
-jest.mock('@mock-app/services', () => ({
+jest.mock('@uncefact/untp-ri-services', () => ({
   getDlrPassport: jest.fn(),
   IdentityProvider: jest.fn(),
   getProviderByType: jest.fn(),

--- a/packages/mock-app/src/app/(public)/scanning/page.tsx
+++ b/packages/mock-app/src/app/(public)/scanning/page.tsx
@@ -7,7 +7,7 @@ import { VerifiableCredential } from '@vckit/core-types';
 import { Html5QrcodeResult } from 'html5-qrcode';
 import { useRouter } from 'next/navigation';
 import { toastMessage, Status, ToastMessage } from '@mock-app/components';
-import { getDlrPassport, IdentityProvider, getProviderByType } from '@mock-app/services';
+import { getDlrPassport, IdentityProvider, getProviderByType } from '@uncefact/untp-ri-services';
 import { IScannerRef } from '@/types/scanner.types';
 import { CustomDialog } from '@/components/CustomDialog';
 import appConfig from '@/constants/app-config.json';

--- a/packages/mock-app/src/app/(public)/verify/page.tsx
+++ b/packages/mock-app/src/app/(public)/verify/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Status } from '@mock-app/components';
-import { computeHash, decryptCredential, publicAPI, verifyVC } from '@mock-app/services';
+import { computeHash, decryptCredential, publicAPI, verifyVC } from '@uncefact/untp-ri-services';
 import { IVerifyResult, VerifiableCredential } from '@vckit/core-types';
 import * as jose from 'jose';
 import _ from 'lodash';

--- a/packages/mock-app/src/app/api/v1/credentials/route.ts
+++ b/packages/mock-app/src/app/api/v1/credentials/route.ts
@@ -8,7 +8,7 @@ import {
   issueCredentialStatus,
   PROOF_FORMAT,
   StorageRecord,
-} from "@mock-app/services";
+} from "@uncefact/untp-ri-services";
 import { createCredential } from "@/lib/prisma/repositories";
 
 type JSONPrimitive = string | number | boolean | null;

--- a/packages/mock-app/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/mock-app/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -17,7 +17,7 @@ const mockResolveDidService = jest.fn();
 const mockGetDidById = jest.fn();
 const mockUpdateDidStatus = jest.fn();
 
-jest.mock("@mock-app/services", () => ({
+jest.mock("@uncefact/untp-ri-services", () => ({
   DidStatus: {
     ACTIVE: "ACTIVE",
     INACTIVE: "INACTIVE",

--- a/packages/mock-app/src/app/api/v1/dids/[id]/verify/route.ts
+++ b/packages/mock-app/src/app/api/v1/dids/[id]/verify/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { resolveDidService } from "@/lib/services/resolve-did-service";
 import { NotFoundError, ServiceRegistryError, errorMessage } from "@/lib/api/errors";
-import { DidStatus } from "@mock-app/services";
+import { DidStatus } from "@uncefact/untp-ri-services";
 import { withOrgAuth } from "@/lib/api/with-org-auth";
 import { getDidById, updateDidStatus } from "@/lib/prisma/repositories";
 

--- a/packages/mock-app/src/app/api/v1/dids/route.test.ts
+++ b/packages/mock-app/src/app/api/v1/dids/route.test.ts
@@ -27,7 +27,7 @@ jest.mock("@/lib/prisma/repositories", () => ({
 }));
 
 import { ServiceResolutionError } from "@/lib/api/errors";
-import { DidType, DidMethod, DidStatus } from "@mock-app/services";
+import { DidType, DidMethod, DidStatus } from "@uncefact/untp-ri-services";
 import { POST, GET } from "./route";
 
 function createFakeRequest(options: {

--- a/packages/mock-app/src/app/api/v1/dids/route.ts
+++ b/packages/mock-app/src/app/api/v1/dids/route.ts
@@ -4,7 +4,7 @@ import { ServiceRegistryError, errorMessage } from "@/lib/api/errors";
 import { ValidationError, validateEnum, parsePositiveInt, parseNonNegativeInt } from "@/lib/api/validation";
 import { withOrgAuth } from "@/lib/api/with-org-auth";
 import { createDid, listDids } from "@/lib/prisma/repositories";
-import { CREATABLE_DID_TYPES, DidType, DidMethod, DidStatus } from "@mock-app/services";
+import { CREATABLE_DID_TYPES, DidType, DidMethod, DidStatus } from "@uncefact/untp-ri-services";
 
 export const POST = withOrgAuth(async (req, { organizationId }) => {
   let body: {

--- a/packages/mock-app/src/components/GenericFeature/GenericFeature.tsx
+++ b/packages/mock-app/src/components/GenericFeature/GenericFeature.tsx
@@ -80,7 +80,7 @@
 */
 
 import React from 'react';
-import * as services from '@mock-app/services';
+import * as services from '@uncefact/untp-ri-services';
 // import * as events from '@mock-app/events';
 import {
   toastMessage,

--- a/packages/mock-app/src/lib/encryption/encryption.test.ts
+++ b/packages/mock-app/src/lib/encryption/encryption.test.ts
@@ -70,7 +70,7 @@ describe("getEncryptionService", () => {
   it("service can encrypt and decrypt content", async () => {
     process.env.SERVICE_ENCRYPTION_KEY = VALID_KEY;
     const { getEncryptionService } = await import("./encryption");
-    const { EncryptionAlgorithm } = await import("@mock-app/services");
+    const { EncryptionAlgorithm } = await import("@uncefact/untp-ri-services/encryption");
 
     const service = getEncryptionService();
     const plaintext = '{"apiUrl":"https://example.com"}';

--- a/packages/mock-app/src/lib/encryption/encryption.ts
+++ b/packages/mock-app/src/lib/encryption/encryption.ts
@@ -1,4 +1,4 @@
-import { AesGcmEncryptionAdapter } from "@mock-app/services/server";
+import { AesGcmEncryptionAdapter } from "@uncefact/untp-ri-services/server";
 
 let cached: AesGcmEncryptionAdapter | null = null;
 

--- a/packages/mock-app/src/lib/services/resolve-did-service.test.ts
+++ b/packages/mock-app/src/lib/services/resolve-did-service.test.ts
@@ -25,7 +25,7 @@ jest.mock("@/lib/prisma/repositories", () => ({
 }));
 
 // Mock the services package (types only from main barrel)
-jest.mock("@mock-app/services", () => ({
+jest.mock("@uncefact/untp-ri-services", () => ({
   ServiceType: { DID: "DID" },
   AdapterType: { VCKIT: "VCKIT" },
 }));
@@ -35,7 +35,7 @@ const mockFactory = jest.fn();
 const mockConfigSchema = {
   safeParse: jest.fn(),
 };
-jest.mock("@mock-app/services/server", () => ({
+jest.mock("@uncefact/untp-ri-services/server", () => ({
   adapterRegistry: {
     DID: {
       VCKIT: {

--- a/packages/mock-app/src/lib/services/resolve-did-service.ts
+++ b/packages/mock-app/src/lib/services/resolve-did-service.ts
@@ -1,6 +1,6 @@
-import { ServiceType, AdapterType } from "@mock-app/services";
-import { adapterRegistry } from "@mock-app/services/server";
-import type { IDidService } from "@mock-app/services";
+import { ServiceType, AdapterType } from "@uncefact/untp-ri-services";
+import { adapterRegistry } from "@uncefact/untp-ri-services/server";
+import type { IDidService } from "@uncefact/untp-ri-services";
 import { getEncryptionService } from "@/lib/encryption/encryption";
 import { getInstanceByResolution } from "@/lib/prisma/repositories";
 import {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,19 +1,61 @@
 {
-  "name": "@mock-app/services",
-  "version": "0.2.0",
-  "description": "",
+  "name": "@uncefact/untp-ri-services",
+  "version": "0.1.0-dev.8",
+  "description": "Services for the UNTP reference implementation",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
     ".": {
-      "types": "./build/index.d.ts",
-      "default": "./build/index.js"
+      "import": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      },
+      "require": {
+        "types": "./build/index.d.cts",
+        "default": "./build/index.cjs"
+      }
     },
     "./server": {
-      "types": "./build/server.d.ts",
-      "default": "./build/server.js"
+      "import": {
+        "types": "./build/server.d.ts",
+        "default": "./build/server.js"
+      },
+      "require": {
+        "types": "./build/server.d.cts",
+        "default": "./build/server.cjs"
+      }
+    },
+    "./encryption": {
+      "import": {
+        "types": "./build/encryption/index.d.ts",
+        "default": "./build/encryption/index.js"
+      },
+      "require": {
+        "types": "./build/encryption/index.d.cts",
+        "default": "./build/encryption/index.cjs"
+      }
+    },
+    "./key-provider": {
+      "import": {
+        "types": "./build/key-provider/index.d.ts",
+        "default": "./build/key-provider/index.js"
+      },
+      "require": {
+        "types": "./build/key-provider/index.d.cts",
+        "default": "./build/key-provider/index.cjs"
+      }
     }
   },
+  "typesVersions": {
+    "*": {
+      "server": ["./build/server.d.ts"],
+      "encryption": ["./build/encryption/index.d.ts"],
+      "key-provider": ["./build/key-provider/index.d.ts"]
+    }
+  },
+  "files": [
+    "build"
+  ],
   "scripts": {
     "build": "tsc --build --clean && tsc",
     "watch": "tsc -b --watch",
@@ -29,10 +71,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@babel/preset-typescript": "^7.23.3",
     "@vckit/core-types": "1.0.0-beta.7",
     "axios": "^1.6.7",
-    "babel-jest": "^29.7.0",
     "digitallink_toolkit_server": "file:../../digitallink_toolkit_server",
     "jsonpointer": "^5.0.1",
     "jose": "^5.9.3",
@@ -43,8 +83,10 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.23.3",
     "@types/jsonld": "^1.5.15",
     "axios-mock-adapter": "^1.19.0",
+    "babel-jest": "^29.7.0",
     "typescript": "^5.3.3"
   }
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -4,46 +4,23 @@
   "description": "Services for the UNTP reference implementation",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "_exports_note": "Exports use flat types/default conditions, not nested import/require. The require conditions (.cjs/.d.cts) are only built during npm publish and do not exist in the workspace. The Next.js standalone tracer (@vercel/nft) fails when exports reference non-existent files. A publish pipeline should add import/require conditions before publishing.",
   "exports": {
     ".": {
-      "import": {
-        "types": "./build/index.d.ts",
-        "default": "./build/index.js"
-      },
-      "require": {
-        "types": "./build/index.d.cts",
-        "default": "./build/index.cjs"
-      }
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
     },
     "./server": {
-      "import": {
-        "types": "./build/server.d.ts",
-        "default": "./build/server.js"
-      },
-      "require": {
-        "types": "./build/server.d.cts",
-        "default": "./build/server.cjs"
-      }
+      "types": "./build/server.d.ts",
+      "default": "./build/server.js"
     },
     "./encryption": {
-      "import": {
-        "types": "./build/encryption/index.d.ts",
-        "default": "./build/encryption/index.js"
-      },
-      "require": {
-        "types": "./build/encryption/index.d.cts",
-        "default": "./build/encryption/index.cjs"
-      }
+      "types": "./build/encryption/index.d.ts",
+      "default": "./build/encryption/index.js"
     },
     "./key-provider": {
-      "import": {
-        "types": "./build/key-provider/index.d.ts",
-        "default": "./build/key-provider/index.js"
-      },
-      "require": {
-        "types": "./build/key-provider/index.d.cts",
-        "default": "./build/key-provider/index.cjs"
-      }
+      "types": "./build/key-provider/index.d.ts",
+      "default": "./build/key-provider/index.js"
     }
   },
   "typesVersions": {

--- a/packages/services/src/encryption/index.ts
+++ b/packages/services/src/encryption/index.ts
@@ -1,0 +1,16 @@
+// Subpath barrel: the main entry re-exports linkResolver.service which depends
+// on digitallink_toolkit_server (a local-only package not published to npm).
+// This barrel lets consumers import encryption without hitting that dependency.
+// Remove once digitallink_toolkit_server is eliminated (https://github.com/uncefact/tests-untp/issues/401).
+export { AesGcmEncryptionAdapter } from './adapters/aes-gcm/aes-gcm.adapter.js';
+export {
+  EncryptionAlgorithm,
+  assertPermittedAlgorithm,
+} from './encryption.interface.js';
+export type {
+  EncryptedEnvelope,
+  IEncryptionService,
+} from './encryption.interface.js';
+export { computeHash, HashAlgorithm } from './compute-hash.js';
+export { decryptCredential } from './decrypt-credential.js';
+export type { DecryptionParams } from './decrypt-credential.js';

--- a/packages/services/src/key-provider/index.ts
+++ b/packages/services/src/key-provider/index.ts
@@ -1,0 +1,6 @@
+// Subpath barrel: the main entry re-exports linkResolver.service which depends
+// on digitallink_toolkit_server (a local-only package not published to npm).
+// This barrel lets consumers import key-provider without hitting that dependency.
+// Remove once digitallink_toolkit_server is eliminated (https://github.com/uncefact/tests-untp/issues/401).
+export type { IKeyGenerator, IKeyStore } from './key-provider.interface.js';
+export { LocalKeyGenerator } from './adapters/local/local.adapter.js';

--- a/packages/services/src/linkResolver.service.ts
+++ b/packages/services/src/linkResolver.service.ts
@@ -1,3 +1,4 @@
+// TODO: Replace with a published npm package (https://github.com/uncefact/tests-untp/issues/401)
 import GS1DigitalLinkToolkit from 'digitallink_toolkit_server/src/GS1DigitalLinkToolkit.js';
 import { IDLRAI, MimeTypeEnum } from './types/index.js';
 import { GS1ServiceEnum } from './identityProviders/GS1Provider.js';

--- a/packages/services/src/server.ts
+++ b/packages/services/src/server.ts
@@ -3,7 +3,7 @@
  *
  * These modules depend on Node.js built-ins (node:crypto) or native-optional
  * packages (jsonld/rdf-canonize) that break Next.js client-side webpack.
- * Import from '@mock-app/services/server' in server components, API routes,
+ * Import from '@uncefact/untp-ri-services/server' in server components, API routes,
  * and scripts — never in client components.
  */
 

--- a/packages/vc-test-suite/package.json
+++ b/packages/vc-test-suite/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@digitalbazaar/mocha-w3c-interop-reporter": "1.6.0",
-    "@mock-app/services": "0.2.0",
+    "@uncefact/untp-ri-services": "0.1.0-dev.8",
     "axios": "^1.7.2",
     "chai": "^4.3.6",
     "jsonwebtoken": "^9.0.2",

--- a/packages/vc-test-suite/tests/QrLinkVerification/qrlink-verification.test.ts
+++ b/packages/vc-test-suite/tests/QrLinkVerification/qrlink-verification.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 
-import { computeHash, HashAlgorithm, decryptCredential } from '@mock-app/services';
+import { computeHash, HashAlgorithm, decryptCredential } from '@uncefact/untp-ri-services';
 
 import { reportRow, setupMatrix } from '../../helpers';
 import { request } from '../../httpService';


### PR DESCRIPTION
This PR renames the services package from `@mock-app/services` to `@uncefact/untp-ri-services` and adds subpath exports for external consumption. The package is already published to npm as `@uncefact/untp-ri-services@0.1.0-dev.8` and consumed by the [project-identity-resolver](https://github.com/uncefact/project-identity-resolver).

## Changes

- **Package rename**: `@mock-app/services` to `@uncefact/untp-ri-services` across all 36 files in the monorepo (imports, package.json dependencies, jest mocks)
- **Subpath exports**: `./encryption` and `./key-provider` entry points that bypass the main entry's `digitallink_toolkit_server` dependency (#401)
- **Dual CJS/ESM**: Conditional `import`/`require` exports for Jest compatibility without transform workarounds
- **`typesVersions`**: Backwards-compatible type resolution for consumers using `"moduleResolution": "node"`
- **Dependency cleanup**: `babel-jest` and `@babel/preset-typescript` moved to `devDependencies` (test/build tools, not runtime)

## Test plan

- [x] Services tests pass (418/418)
- [x] Mock-app tests pass (31/31 suites, 242 tests)
- [x] Full workspace build succeeds
- [x] Lint passes (0 errors)
- [x] Package published and verified in downstream consumer