### PR TITLE
Docker: Rename mock-app to reference-implementation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,13 +101,13 @@ services:
   ri:
     build:
       context: .
-      dockerfile: packages/mock-app/Dockerfile
+      dockerfile: packages/reference-implementation/Dockerfile
       args:
         CONFIG_FILE: ./app-config.json
     ports:
       - '3003:3003'
     volumes:
-      - ./packages/mock-app/src/constants/app-config.issue.json:/app/config/app-config.json:ro
+      - ./packages/reference-implementation/src/constants/app-config.issue.json:/app/config/app-config.json:ro
     environment:
       # Database (using docker internal networking)
       RI_POSTGRES_USER: ${RI_POSTGRES_USER}

--- a/packages/reference-implementation/Dockerfile
+++ b/packages/reference-implementation/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock ./
-COPY packages/mock-app/package.json ./packages/mock-app/
+COPY packages/reference-implementation/package.json ./packages/reference-implementation/
 COPY packages/components/package.json ./packages/components/
 COPY packages/services/package.json ./packages/services/
 COPY digitallink_toolkit_server ./digitallink_toolkit_server/
@@ -20,32 +20,32 @@ RUN yarn install --frozen-lockfile
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/packages/mock-app/node_modules ./packages/mock-app/node_modules
+COPY --from=deps /app/packages/reference-implementation/node_modules ./packages/reference-implementation/node_modules
 COPY --from=deps /app/packages/components/node_modules ./packages/components/node_modules
 COPY --from=deps /app/packages/services/node_modules ./packages/services/node_modules
 COPY package.json ./
-COPY packages/mock-app/. ./packages/mock-app/
+COPY packages/reference-implementation/. ./packages/reference-implementation/
 COPY packages/components/. ./packages/components/
 COPY packages/services/. ./packages/services/
 COPY digitallink_toolkit_server ./digitallink_toolkit_server/
 
 # Copy app-config.json from root to expected locations (excluded by .dockerignore)
 ARG CONFIG_FILE=./app-config.json
-COPY ${CONFIG_FILE} ./packages/mock-app/src/constants/app-config.json
+COPY ${CONFIG_FILE} ./packages/reference-implementation/src/constants/app-config.json
 COPY ${CONFIG_FILE} ./packages/components/src/constants/app-config.json
 
 # Recreate workspace symlinks after copying source files
 WORKDIR /app
 RUN yarn install --frozen-lockfile
 
-# Build workspace dependencies in order: services -> components -> mock-app
+# Build workspace dependencies in order: services -> components -> reference-implementation
 WORKDIR /app/packages/services
 RUN yarn run build
 
 WORKDIR /app/packages/components
 RUN yarn run build
 
-WORKDIR /app/packages/mock-app
+WORKDIR /app/packages/reference-implementation
 RUN yarn run build
 
 # Production image, copy all the files and run next
@@ -59,22 +59,22 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/packages/mock-app/public ./public
+COPY --from=builder /app/packages/reference-implementation/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/packages/mock-app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/packages/mock-app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/.next/static ./.next/static
 
 # Copy prisma files and node_modules for running migrations at runtime
-COPY --from=builder --chown=nextjs:nodejs /app/packages/mock-app/prisma ./prisma
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/prisma ./prisma
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 
 # Copy built-in config files for fallback (when no runtime config is mounted)
-COPY --from=builder --chown=nextjs:nodejs /app/packages/mock-app/src/constants/app-config*.json ./src/constants/
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/constants/app-config*.json ./src/constants/
 
 # Copy and set up entrypoint script
-COPY --chown=nextjs:nodejs packages/mock-app/docker-entrypoint.sh ./docker-entrypoint.sh
+COPY --chown=nextjs:nodejs packages/reference-implementation/docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh
 
 # Create config directory for runtime configuration

--- a/packages/reference-implementation/docker-entrypoint.sh
+++ b/packages/reference-implementation/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-echo "Starting mock-app entrypoint..."
+echo "Starting reference-implementation entrypoint..."
 
 # Construct RI_DATABASE_URL from individual Postgres variables if not already set
 if [ -z "$RI_DATABASE_URL" ] && [ -n "$RI_POSTGRES_HOST" ]; then


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes the `Dockerfile` and `docker-compose.yml` that were referencing `mock-app` package which has been renamed to `reference-implementation`.

## Related Tickets & Documents

Fixes https://github.com/uncefact/tests-untp/pull/370 after https://github.com/uncefact/tests-untp/issues/385

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Reference Implementation docs site](https://uncefact.github.io/tests-untp/docs/reference-implementation/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
