### PR TITLE
fix(ci): disable eslint during next build to fix eslint 9 incompatibility

### DIFF
--- a/packages/reference-implementation/next.config.ts
+++ b/packages/reference-implementation/next.config.ts
@@ -63,6 +63,7 @@ const nextConfig = (phase: string): NextConfig => {
   return {
     output: 'standalone',
     reactStrictMode: false,
+    eslint: { ignoreDuringBuilds: true },
     transpilePackages: ['@reference-implementation/components'],
     env: {
       NEXT_PUBLIC_AUTH_KEYCLOAK_ISSUER: AUTH_KEYCLOAK_ISSUER || '',


### PR DESCRIPTION
This PR fixes the RI Docker image build failure caused by Next.js 15 passing removed ESLint 8 options (`useEslintrc`, `extensions`) to ESLint 9 during `next build`. Adding `eslint: { ignoreDuringBuilds: true }` to the Next config skips the broken internal ESLint step. Linting still runs separately via `yarn lint` in CI, so no coverage is lost.

## Test plan
- [x] `next build` completes without ESLint errors
- [x] `yarn lint` still runs ESLint 9 independently via `eslint.config.mjs`
- [x] Pre-commit hooks (prettier + eslint) pass