### PR TITLE
test(e2e): add credential API end-to-end tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,6 @@ PYX_IDR_API_KEY=test123
 #
 # VCKit Verifiable Credentials Service
 VCKIT_API_URL=http://localhost:3332/v2
-VCKIT_AUTH_TOKEN=test123
 VCKIT_API_KEY=test123
 
 # Default Issuer Configuration

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -168,7 +168,7 @@ services:
       - DEFAULT_HUMAN_VERIFICATION_URL=http://localhost:3003
       - DEFAULT_MACHINE_VERIFICATION_URL=http://vckit-api:3332/agent/routeVerificationCredential
       - VCKIT_API_URL=http://vckit-api:3332/v2
-      - VCKIT_AUTH_TOKEN=test123
+      - VCKIT_API_KEY=test123
       - DEFAULT_ISSUER_DID=did:web:uncefact.github.io:project-vckit:test-and-development
       - SERVICE_ENCRYPTION_KEY=dd1b7430915155b51c503806031f31f901e85563035f65421d707f042c75f44b
       - AUTH_SECRET=e2e-super-secret-key-for-testing

--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -148,6 +148,10 @@ export default defineConfig({
 
             // Delete in dependency order (children first)
             await client.query(
+              `DELETE FROM "Credential" WHERE "tenantId" = $1`,
+              [tenantId],
+            );
+            await client.query(
               `DELETE FROM "LinkRegistration" WHERE "tenantId" = $1`,
               [tenantId],
             );

--- a/e2e/cypress/e2e/credential_api/credential-management.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-management.cy.ts
@@ -30,6 +30,45 @@ describe('Credential API', { testIsolation: false }, () => {
   before(() => {
     cy.apiLogin();
     cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+
+    // Create VC service instance (required for signing credentials)
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/services',
+      body: {
+        serviceType: 'VC',
+        adapterType: 'VCKIT',
+        name: 'E2E VCKit VC',
+        config: {
+          endpoint: 'http://vckit-api:3332/v2',
+          apiKey: 'test123',
+        },
+        apiVersion: '1.0.0',
+        isPrimary: true,
+      },
+    }).then((res) => {
+      expect(res.status).to.eq(201);
+    });
+
+    // Create STORAGE service instance (required for storing credentials)
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/services',
+      body: {
+        serviceType: 'STORAGE',
+        adapterType: 'UNCEFACT_STORAGE',
+        name: 'E2E Storage',
+        config: {
+          baseUrl: 'http://storage-service:3334',
+          apiKey: 'test123',
+          apiVersion: '3.0.0',
+        },
+        apiVersion: '3.0.0',
+        isPrimary: true,
+      },
+    }).then((res) => {
+      expect(res.status).to.eq(201);
+    });
   });
 
   after(() => {

--- a/e2e/cypress/e2e/credential_api/credential-management.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-management.cy.ts
@@ -1,0 +1,204 @@
+describe('Credential API', { testIsolation: false }, () => {
+  const TEST_ORG_ID = 'e2e-test-org';
+  const RUN_ID = Date.now();
+  let defaultDidValue: string;
+  let encryptedCredentialId: string;
+  let unencryptedCredentialId: string;
+  let publishedCredentialId: string;
+
+  /**
+   * Builds a minimal valid CredentialPayload for the given issuer DID.
+   * Uses the W3C VC v2 context and a simple Product subject.
+   */
+  function buildCredentialPayload(issuerDid: string) {
+    return {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: {
+        type: ['CredentialIssuer'],
+        id: issuerDid,
+        name: `E2E Test Issuer ${RUN_ID}`,
+      },
+      credentialSubject: {
+        type: ['Product'],
+        id: `https://example.com/products/e2e-${RUN_ID}`,
+        name: `E2E Test Product ${RUN_ID}`,
+      },
+    };
+  }
+
+  before(() => {
+    cy.apiLogin();
+    cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+  });
+
+  after(() => {
+    cy.task('cleanupTestData', { tenantId: TEST_ORG_ID });
+  });
+
+  // -----------------------------------------------------------------------
+  // Issue and retrieve
+  // -----------------------------------------------------------------------
+  describe('Issue and retrieve credentials', () => {
+    it('looks up the system default DID to use as issuer', () => {
+      cy.request('/api/v1/dids').then((response) => {
+        expect(response.status).to.eq(200);
+        const defaultDid = response.body.dids.find(
+          (d: any) => d.isDefault === true,
+        );
+        expect(defaultDid).to.exist;
+        defaultDidValue = defaultDid.did;
+      });
+    });
+
+    it('POST /api/v1/credentials — issues an encrypted credential', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.credentialId).to.be.a('string');
+        encryptedCredentialId = response.body.credentialId;
+      });
+    });
+
+    it('GET /api/v1/credentials/:id — retrieves the encrypted credential', () => {
+      cy.request(`/api/v1/credentials/${encryptedCredentialId}`).then(
+        (response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.credential).to.exist;
+
+          const cred = response.body.credential;
+          expect(cred.id).to.eq(encryptedCredentialId);
+          expect(cred.storageUri).to.be.a('string');
+          expect(cred.hash).to.be.a('string');
+          expect(cred.credentialType).to.eq('VerifiableCredential');
+          expect(cred.isPublished).to.be.false;
+          // API defaults encrypt to true, so decryptionKey is present
+          expect(cred.decryptionKey).to.be.a('string');
+        },
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Issuance options
+  // -----------------------------------------------------------------------
+  describe('Issuance options', () => {
+    it('POST /api/v1/credentials — encrypt=false stores without encryption', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+          encrypt: false,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        unencryptedCredentialId = response.body.credentialId;
+      });
+    });
+
+    it('GET /api/v1/credentials/:id — unencrypted credential has null decryptionKey', () => {
+      cy.request(`/api/v1/credentials/${unencryptedCredentialId}`).then(
+        (response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.credential.decryptionKey).to.be.null;
+        },
+      );
+    });
+
+    it('POST /api/v1/credentials — publish=true succeeds (publishing not yet wired up)', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+          publish: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.credentialId).to.be.a('string');
+        publishedCredentialId = response.body.credentialId;
+      });
+    });
+
+    it('GET /api/v1/credentials/:id — published credential has isPublished=false until wired up', () => {
+      cy.request(`/api/v1/credentials/${publishedCredentialId}`).then(
+        (response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.credential.isPublished).to.be.false;
+        },
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Validation errors
+  // -----------------------------------------------------------------------
+  describe('Validation errors', () => {
+    it('returns 400 with error body when credentialPayload is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {},
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.ok).to.be.false;
+        expect(response.body.error).to.be.a('string').and.not.be.empty;
+      });
+    });
+
+    it('returns 400 when credentialPayload is null', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: { credentialPayload: null },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when credentialPayload is a string', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: { credentialPayload: 'not-an-object' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when credentialPayload is a number', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: { credentialPayload: 42 },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+  describe('Error handling', () => {
+    it('GET /api/v1/credentials/:id — returns 404 for nonexistent credential', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/credentials/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+});

--- a/packages/reference-implementation/next.config.ts
+++ b/packages/reference-implementation/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig = (phase: string): NextConfig => {
     DEFAULT_HUMAN_VERIFICATION_URL,
     DEFAULT_MACHINE_VERIFICATION_URL,
     VCKIT_API_URL,
-    VCKIT_AUTH_TOKEN,
+    VCKIT_API_KEY,
     DEFAULT_ISSUER_DID,
     SERVICE_ENCRYPTION_KEY,
   } = process.env;
@@ -38,7 +38,7 @@ const nextConfig = (phase: string): NextConfig => {
       DEFAULT_HUMAN_VERIFICATION_URL,
       DEFAULT_MACHINE_VERIFICATION_URL,
       VCKIT_API_URL,
-      VCKIT_AUTH_TOKEN,
+      VCKIT_API_KEY,
       DEFAULT_ISSUER_DID,
       SERVICE_ENCRYPTION_KEY,
     };

--- a/packages/reference-implementation/prisma/migrations/20260217000000_add_storage_enums/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260217000000_add_storage_enums/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "ServiceType" ADD VALUE 'STORAGE';
+
+-- AlterEnum
+ALTER TYPE "AdapterType" ADD VALUE 'UNCEFACT_STORAGE';

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -74,10 +74,10 @@ async function main() {
   });
 
   // Upsert the system default VCKit DID service instance
-  const { vckitApiUrl, vckitAuthToken } = getDidConfig();
+  const { vckitApiUrl, vckitApiKey: vckitDidApiKey } = getDidConfig();
   const didServiceConfig = JSON.stringify({
     endpoint: new URL(vckitApiUrl).origin,
-    authToken: vckitAuthToken,
+    authToken: vckitDidApiKey,
   });
   const encryptedConfig = JSON.stringify(encryptionService.encrypt(didServiceConfig, EncryptionAlgorithm.AES_256_GCM));
 
@@ -269,8 +269,10 @@ async function main() {
   let storageSeeded = false;
   try {
     const { storageServiceUrl } = getStorageConfig();
+    const storageApiKey = process.env.UNCEFACT_STORAGE_API_KEY;
     const storageServiceConfig = JSON.stringify({
       baseUrl: new URL(storageServiceUrl).origin,
+      ...(storageApiKey && { apiKey: storageApiKey }),
       apiVersion: '3.0.0',
       publicBucket: 'verifiable-credentials',
       privateBucket: 'private-verifiable-credentials',

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -236,6 +236,14 @@ async function main() {
     const idrServiceConfig = JSON.stringify({
       baseUrl: new URL(pyxIdrApiUrl).origin,
       apiKey: pyxIdrApiKey,
+      apiVersion: '2.0.0',
+      ianaLanguage: 'en',
+      context: 'au',
+      defaultLinkType: 'untp:dpp',
+      defaultMimeType: 'text/html',
+      defaultIanaLanguage: 'en',
+      defaultContext: 'au',
+      fwqs: false,
     });
     const encryptedIdrConfig = JSON.stringify(
       encryptionService.encrypt(idrServiceConfig, EncryptionAlgorithm.AES_256_GCM),

--- a/packages/reference-implementation/src/lib/config/did.config.test.ts
+++ b/packages/reference-implementation/src/lib/config/did.config.test.ts
@@ -15,7 +15,7 @@ describe('did.config', () => {
 
   const validEnv = {
     VCKIT_API_URL: 'https://vckit.example.com',
-    VCKIT_AUTH_TOKEN: 'test-token-123',
+    VCKIT_API_KEY: 'test-token-123',
     DEFAULT_ISSUER_DID: 'did:web:example.com:org:123',
   };
 
@@ -26,14 +26,14 @@ describe('did.config', () => {
 
     expect(config).toEqual({
       vckitApiUrl: validEnv.VCKIT_API_URL,
-      vckitAuthToken: validEnv.VCKIT_AUTH_TOKEN,
+      vckitApiKey: validEnv.VCKIT_API_KEY,
       defaultDid: validEnv.DEFAULT_ISSUER_DID,
     });
   });
 
   it('throws listing ALL missing vars when none are set', () => {
     delete process.env.VCKIT_API_URL;
-    delete process.env.VCKIT_AUTH_TOKEN;
+    delete process.env.VCKIT_API_KEY;
     delete process.env.DEFAULT_ISSUER_DID;
 
     expect(() => getDidConfig()).toThrow('Missing required DID configuration');
@@ -43,14 +43,14 @@ describe('did.config', () => {
     } catch (error) {
       const message = (error as Error).message;
       expect(message).toContain('VCKIT_API_URL');
-      expect(message).toContain('VCKIT_AUTH_TOKEN');
+      expect(message).toContain('VCKIT_API_KEY');
       expect(message).toContain('DEFAULT_ISSUER_DID');
     }
   });
 
   it('includes .env guidance text in the error message', () => {
     delete process.env.VCKIT_API_URL;
-    delete process.env.VCKIT_AUTH_TOKEN;
+    delete process.env.VCKIT_API_KEY;
     delete process.env.DEFAULT_ISSUER_DID;
 
     expect(() => getDidConfig()).toThrow('Set these in your .env file or environment.');
@@ -93,11 +93,11 @@ describe('did.config', () => {
     expect(() => getDidConfig()).toThrow('VCKIT_API_URL');
   });
 
-  it('throws when VCKIT_AUTH_TOKEN is missing', () => {
+  it('throws when VCKIT_API_KEY is missing', () => {
     Object.assign(process.env, validEnv);
-    delete process.env.VCKIT_AUTH_TOKEN;
+    delete process.env.VCKIT_API_KEY;
 
-    expect(() => getDidConfig()).toThrow('VCKIT_AUTH_TOKEN');
+    expect(() => getDidConfig()).toThrow('VCKIT_API_KEY');
   });
 
   it('throws when DEFAULT_ISSUER_DID is missing', () => {

--- a/packages/reference-implementation/src/lib/config/did.config.ts
+++ b/packages/reference-implementation/src/lib/config/did.config.ts
@@ -1,6 +1,6 @@
 export interface DidConfig {
   vckitApiUrl: string;
-  vckitAuthToken: string;
+  vckitApiKey: string;
   defaultDid: string;
 }
 
@@ -9,9 +9,9 @@ let cached: DidConfig | null = null;
 export function getDidConfig(): DidConfig {
   if (cached) return cached;
 
-  const { VCKIT_API_URL, VCKIT_AUTH_TOKEN, DEFAULT_ISSUER_DID } = process.env;
+  const { VCKIT_API_URL, VCKIT_API_KEY, DEFAULT_ISSUER_DID } = process.env;
 
-  const required = { VCKIT_API_URL, VCKIT_AUTH_TOKEN, DEFAULT_ISSUER_DID };
+  const required = { VCKIT_API_URL, VCKIT_API_KEY, DEFAULT_ISSUER_DID };
   const missing = Object.entries(required)
     .filter(([, value]) => !value)
     .map(([key]) => key);
@@ -24,7 +24,7 @@ export function getDidConfig(): DidConfig {
 
   cached = {
     vckitApiUrl: VCKIT_API_URL!,
-    vckitAuthToken: VCKIT_AUTH_TOKEN!,
+    vckitApiKey: VCKIT_API_KEY!,
     defaultDid: DEFAULT_ISSUER_DID!,
   };
   return cached;


### PR DESCRIPTION
This PR adds E2E tests for the credential API (`POST /api/v1/credentials` and `GET /api/v1/credentials/:id`), covering the full issuance and retrieval lifecycle. This is the companion to #420 (service API E2E tests).

## Test plan
- [x] Issue encrypted credential (default) and verify all response fields
- [x] Issue unencrypted credential (`encrypt=false`) and verify `decryptionKey` is null
- [x] Issue with `publish=true` and verify `isPublished` remains false (publishing not yet wired up)
- [x] Validation errors: missing, null, string, and number `credentialPayload` all return 400
- [x] Error body structure verified (`ok: false`, `error` message present)
- [x] 404 for nonexistent credential ID
- [x] Test cleanup includes `Credential` table deletion in `cleanupTestData`