### PR TITLE
feat(ri): add master data entity management for organisations, facilities, and products

### DIFF
--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -147,6 +147,39 @@ export default defineConfig({
             await client.connect();
 
             // Delete in dependency order (children first)
+
+            // Master data secondary identifier join tables
+            await client.query(
+              `DELETE FROM "ProductSecondaryIdentifier" WHERE "productId" IN (SELECT id FROM "Product" WHERE "tenantId" = $1)`,
+              [tenantId],
+            );
+            await client.query(
+              `DELETE FROM "FacilitySecondaryIdentifier" WHERE "facilityId" IN (SELECT id FROM "Facility" WHERE "tenantId" = $1)`,
+              [tenantId],
+            );
+            await client.query(
+              `DELETE FROM "OrganisationSecondaryIdentifier" WHERE "organisationId" IN (SELECT id FROM "OrganisationEntity" WHERE "tenantId" = $1)`,
+              [tenantId],
+            );
+
+            // Master data entities (products have hierarchy — children first)
+            await client.query(
+              `DELETE FROM "Product" WHERE "tenantId" = $1 AND "parentId" IS NOT NULL`,
+              [tenantId],
+            );
+            await client.query(
+              `DELETE FROM "Product" WHERE "tenantId" = $1`,
+              [tenantId],
+            );
+            await client.query(
+              `DELETE FROM "Facility" WHERE "tenantId" = $1`,
+              [tenantId],
+            );
+            await client.query(
+              `DELETE FROM "OrganisationEntity" WHERE "tenantId" = $1`,
+              [tenantId],
+            );
+
             await client.query(
               `DELETE FROM "LinkRegistration" WHERE "tenantId" = $1`,
               [tenantId],

--- a/e2e/cypress/e2e/facility_api/facility-management.cy.ts
+++ b/e2e/cypress/e2e/facility_api/facility-management.cy.ts
@@ -1,0 +1,303 @@
+describe('Facility API', { testIsolation: false }, () => {
+  const RUN_ID = Date.now();
+  let registrarId: string;
+  let schemeId: string;
+  let identifierId: string;
+  let secondaryIdentifierId: string;
+  let organisationId: string;
+  let createdFacilityId: string;
+
+  before(() => {
+    cy.apiLogin();
+    cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+
+    // Create prerequisite chain:
+    // 1. registrar -> scheme -> 2 identifiers (primary + secondary)
+    // 2. organisation (for operatingOrganisationId)
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/registrars',
+      body: {
+        name: `Fac Test Registrar ${RUN_ID}`,
+        namespace: `fac-reg-${RUN_ID}`,
+        url: `https://fac-reg-${RUN_ID}.example.com`,
+      },
+    }).then((regResponse) => {
+      registrarId = regResponse.body.registrar.id;
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId,
+          name: `Fac Test Scheme ${RUN_ID}`,
+          primaryKey: `fac-pk-${RUN_ID}`,
+          validationPattern: '^\\d{11}$',
+        },
+      }).then((schemeResponse) => {
+        schemeId = schemeResponse.body.scheme.id;
+
+        // Create primary identifier
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/identifiers',
+          body: {
+            schemeId,
+            value: '11111111111',
+          },
+        }).then((identResponse) => {
+          identifierId = identResponse.body.identifier.id;
+        });
+
+        // Create secondary identifier
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/identifiers',
+          body: {
+            schemeId,
+            value: '22222222222',
+          },
+        }).then((secIdentResponse) => {
+          secondaryIdentifierId = secIdentResponse.body.identifier.id;
+        });
+      });
+    });
+
+    // Create prerequisite organisation
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/organisations',
+      body: [{ name: `Fac Test Organisation ${RUN_ID}` }],
+    }).then((orgResponse) => {
+      organisationId = orgResponse.body.organisations[0].id;
+    });
+  });
+
+  after(() => {
+    cy.task('cleanupTestData', { tenantId: 'e2e-test-org' });
+  });
+
+  describe('CRUD operations', () => {
+    it('POST /api/v1/facilities — creates facilities', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/facilities',
+        body: [
+          {
+            name: `E2E Facility ${RUN_ID}`,
+            operatingOrganisationId: organisationId,
+          },
+        ],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.facilities).to.be.an('array');
+        expect(response.body.facilities).to.have.length(1);
+        expect(response.body.facilities[0].name).to.eq(`E2E Facility ${RUN_ID}`);
+        expect(response.body.facilities[0].operatingOrganisationId).to.eq(organisationId);
+
+        createdFacilityId = response.body.facilities[0].id;
+      });
+    });
+
+    it('GET /api/v1/facilities — lists facilities', () => {
+      cy.request('/api/v1/facilities').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facilities).to.be.an('array');
+
+        const created = response.body.facilities.find(
+          (f: any) => f.id === createdFacilityId,
+        );
+        expect(created).to.exist;
+      });
+    });
+
+    it('GET /api/v1/facilities — filters by search', () => {
+      cy.request(`/api/v1/facilities?search=E2E Facility ${RUN_ID}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facilities).to.be.an('array');
+        expect(response.body.facilities.length).to.be.greaterThan(0);
+
+        response.body.facilities.forEach((f: any) => {
+          expect(f.name).to.include('E2E Facility');
+        });
+      });
+    });
+
+    it('GET /api/v1/facilities — filters by organisationId', () => {
+      cy.request(`/api/v1/facilities?organisationId=${organisationId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facilities).to.be.an('array');
+        expect(response.body.facilities.length).to.be.greaterThan(0);
+
+        response.body.facilities.forEach((f: any) => {
+          expect(f.operatingOrganisationId).to.eq(organisationId);
+        });
+      });
+    });
+
+    it('GET /api/v1/facilities/:id — retrieves specific facility', () => {
+      cy.request(`/api/v1/facilities/${createdFacilityId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facility).to.exist;
+        expect(response.body.facility.id).to.eq(createdFacilityId);
+        expect(response.body.facility.name).to.eq(`E2E Facility ${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/facilities/:id — updates name', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/facilities/${createdFacilityId}`,
+        body: { name: `Updated Facility ${RUN_ID}` },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facility.name).to.eq(`Updated Facility ${RUN_ID}`);
+      });
+    });
+
+    it('GET /api/v1/facilities/:id — confirms update persisted', () => {
+      cy.request(`/api/v1/facilities/${createdFacilityId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facility.name).to.eq(`Updated Facility ${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/facilities/:id — assigns primary identifier', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/facilities/${createdFacilityId}`,
+        body: { primaryIdentifierId: identifierId },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facility.primaryIdentifierId).to.eq(identifierId);
+      });
+    });
+
+    it('PATCH /api/v1/facilities/:id — assigns secondary identifiers', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/facilities/${createdFacilityId}`,
+        body: { secondaryIdentifierIds: [secondaryIdentifierId] },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facility.secondaryIdentifiers).to.be.an('array');
+        expect(response.body.facility.secondaryIdentifiers).to.have.length(1);
+      });
+    });
+
+    it('GET /api/v1/facilities/:id — confirms identifiers assigned', () => {
+      cy.request(`/api/v1/facilities/${createdFacilityId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facility.primaryIdentifierId).to.eq(identifierId);
+        expect(response.body.facility.secondaryIdentifiers).to.be.an('array');
+        expect(response.body.facility.secondaryIdentifiers).to.have.length(1);
+      });
+    });
+
+    it('PATCH /api/v1/facilities/:id — clears secondary identifiers', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/facilities/${createdFacilityId}`,
+        body: { secondaryIdentifierIds: [] },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facility.secondaryIdentifiers).to.be.an('array');
+        expect(response.body.facility.secondaryIdentifiers).to.have.length(0);
+      });
+    });
+
+    it('DELETE /api/v1/facilities/:id — deletes the facility', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/facilities/${createdFacilityId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.deep.eq({});
+      });
+    });
+
+    it('GET /api/v1/facilities/:id — returns 404 after deletion', () => {
+      cy.request({
+        method: 'GET',
+        url: `/api/v1/facilities/${createdFacilityId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+
+  describe('Validation', () => {
+    it('returns 400 when name is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/facilities',
+        body: [{}],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when body is not an array', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/facilities',
+        body: { name: `Not Array ${RUN_ID}` },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when body is an empty array', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/facilities',
+        body: [],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 404 for nonexistent facility', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/facilities/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+
+    it('returns 400 for non-numeric limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/facilities?limit=abc',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for negative offset', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/facilities?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+  });
+
+  describe('Pagination', () => {
+    it('supports limit and offset parameters', () => {
+      cy.request('/api/v1/facilities?limit=1&offset=0').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.facilities.length).to.be.at.most(1);
+      });
+    });
+  });
+});

--- a/e2e/cypress/e2e/organisation_api/organisation-management.cy.ts
+++ b/e2e/cypress/e2e/organisation_api/organisation-management.cy.ts
@@ -1,0 +1,291 @@
+describe('Organisation API', { testIsolation: false }, () => {
+  const RUN_ID = Date.now();
+  let registrarId: string;
+  let schemeId: string;
+  let identifierId: string;
+  let secondaryIdentifierId: string;
+  let createdOrgId: string;
+
+  before(() => {
+    cy.apiLogin();
+    cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+
+    // Create prerequisite registrar → scheme → 2 identifiers chain
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/registrars',
+      body: {
+        name: `Org Test Registrar ${RUN_ID}`,
+        namespace: `org-reg-${RUN_ID}`,
+        url: `https://org-reg-${RUN_ID}.example.com`,
+      },
+    }).then((regResponse) => {
+      registrarId = regResponse.body.registrar.id;
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId,
+          name: `Org Test ABN Scheme ${RUN_ID}`,
+          primaryKey: `abn-${RUN_ID}`,
+          validationPattern: '^\\d{11}$',
+        },
+      }).then((schemeResponse) => {
+        schemeId = schemeResponse.body.scheme.id;
+
+        // Create primary identifier
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/identifiers',
+          body: {
+            schemeId,
+            value: '11111111111',
+          },
+        }).then((identResponse) => {
+          identifierId = identResponse.body.identifier.id;
+
+          // Create secondary identifier
+          cy.request({
+            method: 'POST',
+            url: '/api/v1/identifiers',
+            body: {
+              schemeId,
+              value: '22222222222',
+            },
+          }).then((secIdentResponse) => {
+            secondaryIdentifierId = secIdentResponse.body.identifier.id;
+          });
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.task('cleanupTestData', { tenantId: 'e2e-test-org' });
+  });
+
+  describe('CRUD operations', () => {
+    it('POST /api/v1/organisations — creates organisations', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/organisations',
+        body: [
+          {
+            name: `Test Organisation ${RUN_ID}`,
+          },
+        ],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.organisations).to.be.an('array');
+        expect(response.body.organisations).to.have.length(1);
+        expect(response.body.organisations[0].name).to.eq(
+          `Test Organisation ${RUN_ID}`,
+        );
+
+        createdOrgId = response.body.organisations[0].id;
+      });
+    });
+
+    it('GET /api/v1/organisations — lists organisations', () => {
+      cy.request('/api/v1/organisations').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisations).to.be.an('array');
+
+        const created = response.body.organisations.find(
+          (o: any) => o.id === createdOrgId,
+        );
+        expect(created).to.exist;
+      });
+    });
+
+    it('GET /api/v1/organisations — filters by search', () => {
+      cy.request(
+        `/api/v1/organisations?search=Test Organisation ${RUN_ID}`,
+      ).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisations).to.be.an('array');
+        expect(response.body.organisations.length).to.be.greaterThan(0);
+
+        response.body.organisations.forEach((o: any) => {
+          expect(o.name).to.include(`${RUN_ID}`);
+        });
+      });
+    });
+
+    it('GET /api/v1/organisations/:id — retrieves specific organisation', () => {
+      cy.request(`/api/v1/organisations/${createdOrgId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisation).to.exist;
+        expect(response.body.organisation.id).to.eq(createdOrgId);
+        expect(response.body.organisation.name).to.eq(
+          `Test Organisation ${RUN_ID}`,
+        );
+      });
+    });
+
+    it('PATCH /api/v1/organisations/:id — updates name', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/organisations/${createdOrgId}`,
+        body: { name: `Updated Organisation ${RUN_ID}` },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisation.name).to.eq(
+          `Updated Organisation ${RUN_ID}`,
+        );
+      });
+    });
+
+    it('GET /api/v1/organisations/:id — confirms update persisted', () => {
+      cy.request(`/api/v1/organisations/${createdOrgId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisation.name).to.eq(
+          `Updated Organisation ${RUN_ID}`,
+        );
+      });
+    });
+
+    it('PATCH /api/v1/organisations/:id — assigns primary identifier', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/organisations/${createdOrgId}`,
+        body: { primaryIdentifierId: identifierId },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisation.primaryIdentifierId).to.eq(
+          identifierId,
+        );
+      });
+    });
+
+    it('PATCH /api/v1/organisations/:id — assigns secondary identifiers', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/organisations/${createdOrgId}`,
+        body: { secondaryIdentifierIds: [secondaryIdentifierId] },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisation).to.exist;
+      });
+    });
+
+    it('GET /api/v1/organisations/:id — confirms identifiers assigned', () => {
+      cy.request(`/api/v1/organisations/${createdOrgId}`).then((response) => {
+        expect(response.status).to.eq(200);
+
+        const org = response.body.organisation;
+        expect(org.primaryIdentifier).to.exist;
+        expect(org.primaryIdentifier.id).to.eq(identifierId);
+        expect(org.secondaryIdentifiers).to.be.an('array');
+        expect(org.secondaryIdentifiers).to.have.length(1);
+        expect(org.secondaryIdentifiers[0].id).to.eq(secondaryIdentifierId);
+      });
+    });
+
+    it('PATCH /api/v1/organisations/:id — clears secondary identifiers', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/organisations/${createdOrgId}`,
+        body: { secondaryIdentifierIds: [] },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisation).to.exist;
+      });
+    });
+
+    it('DELETE /api/v1/organisations/:id — deletes the organisation', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/organisations/${createdOrgId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.deep.eq({});
+      });
+    });
+
+    it('GET /api/v1/organisations/:id — returns 404 after deletion', () => {
+      cy.request({
+        method: 'GET',
+        url: `/api/v1/organisations/${createdOrgId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+
+  describe('Validation', () => {
+    it('returns 400 when name is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/organisations',
+        body: [{}],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when body is not an array', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/organisations',
+        body: { name: `Invalid Organisation ${RUN_ID}` },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when body is an empty array', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/organisations',
+        body: [],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 404 for nonexistent organisation', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/organisations/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+
+    it('returns 400 for non-numeric limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/organisations?limit=abc',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for negative offset', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/organisations?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+  });
+
+  describe('Pagination', () => {
+    it('supports limit and offset parameters', () => {
+      cy.request('/api/v1/organisations?limit=1&offset=0').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.organisations.length).to.be.at.most(1);
+      });
+    });
+  });
+});

--- a/e2e/cypress/e2e/organisation_api/organisation-management.cy.ts
+++ b/e2e/cypress/e2e/organisation_api/organisation-management.cy.ts
@@ -44,18 +44,18 @@ describe('Organisation API', { testIsolation: false }, () => {
           },
         }).then((identResponse) => {
           identifierId = identResponse.body.identifier.id;
+        });
 
-          // Create secondary identifier
-          cy.request({
-            method: 'POST',
-            url: '/api/v1/identifiers',
-            body: {
-              schemeId,
-              value: '22222222222',
-            },
-          }).then((secIdentResponse) => {
-            secondaryIdentifierId = secIdentResponse.body.identifier.id;
-          });
+        // Create secondary identifier
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/identifiers',
+          body: {
+            schemeId,
+            value: '22222222222',
+          },
+        }).then((secIdentResponse) => {
+          secondaryIdentifierId = secIdentResponse.body.identifier.id;
         });
       });
     });
@@ -179,7 +179,7 @@ describe('Organisation API', { testIsolation: false }, () => {
         expect(org.primaryIdentifier.id).to.eq(identifierId);
         expect(org.secondaryIdentifiers).to.be.an('array');
         expect(org.secondaryIdentifiers).to.have.length(1);
-        expect(org.secondaryIdentifiers[0].id).to.eq(secondaryIdentifierId);
+        expect(org.secondaryIdentifiers[0].identifier.id).to.eq(secondaryIdentifierId);
       });
     });
 

--- a/e2e/cypress/e2e/product_api/product-management.cy.ts
+++ b/e2e/cypress/e2e/product_api/product-management.cy.ts
@@ -49,18 +49,18 @@ describe('Product API', { testIsolation: false }, () => {
           },
         }).then((identResponse) => {
           identifierId = identResponse.body.identifier.id;
+        });
 
-          // Create secondary identifier
-          cy.request({
-            method: 'POST',
-            url: '/api/v1/identifiers',
-            body: {
-              schemeId,
-              value: '22222222222',
-            },
-          }).then((secIdentResponse) => {
-            secondaryIdentifierId = secIdentResponse.body.identifier.id;
-          });
+        // Create secondary identifier
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/identifiers',
+          body: {
+            schemeId,
+            value: '22222222222',
+          },
+        }).then((secIdentResponse) => {
+          secondaryIdentifierId = secIdentResponse.body.identifier.id;
         });
       });
     });
@@ -322,7 +322,7 @@ describe('Product API', { testIsolation: false }, () => {
         expect(product.primaryIdentifier.id).to.eq(identifierId);
         expect(product.secondaryIdentifiers).to.be.an('array');
         expect(product.secondaryIdentifiers).to.have.length(1);
-        expect(product.secondaryIdentifiers[0].id).to.eq(
+        expect(product.secondaryIdentifiers[0].identifier.id).to.eq(
           secondaryIdentifierId,
         );
       });

--- a/e2e/cypress/e2e/product_api/product-management.cy.ts
+++ b/e2e/cypress/e2e/product_api/product-management.cy.ts
@@ -1,0 +1,548 @@
+describe('Product API', { testIsolation: false }, () => {
+  const RUN_ID = Date.now();
+  let registrarId: string;
+  let schemeId: string;
+  let identifierId: string;
+  let secondaryIdentifierId: string;
+  let organisationId: string;
+  let facilityId: string;
+  let modelProductId: string;
+  let batchProductId: string;
+  let itemProductId: string;
+  let standaloneItemId: string;
+
+  before(() => {
+    cy.apiLogin();
+    cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+
+    // Create prerequisite registrar -> scheme -> 2 identifiers chain
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/registrars',
+      body: {
+        name: `Prod Test Registrar ${RUN_ID}`,
+        namespace: `prod-reg-${RUN_ID}`,
+        url: `https://prod-reg-${RUN_ID}.example.com`,
+      },
+    }).then((regResponse) => {
+      registrarId = regResponse.body.registrar.id;
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId,
+          name: `Prod Test Scheme ${RUN_ID}`,
+          primaryKey: `prod-key-${RUN_ID}`,
+          validationPattern: '^\\d{11}$',
+        },
+      }).then((schemeResponse) => {
+        schemeId = schemeResponse.body.scheme.id;
+
+        // Create primary identifier
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/identifiers',
+          body: {
+            schemeId,
+            value: '11111111111',
+          },
+        }).then((identResponse) => {
+          identifierId = identResponse.body.identifier.id;
+
+          // Create secondary identifier
+          cy.request({
+            method: 'POST',
+            url: '/api/v1/identifiers',
+            body: {
+              schemeId,
+              value: '22222222222',
+            },
+          }).then((secIdentResponse) => {
+            secondaryIdentifierId = secIdentResponse.body.identifier.id;
+          });
+        });
+      });
+    });
+
+    // Create prerequisite organisation
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/organisations',
+      body: [{ name: `Prod Test Org ${RUN_ID}` }],
+    }).then((orgResponse) => {
+      organisationId = orgResponse.body.organisations[0].id;
+    });
+
+    // Create prerequisite facility
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/facilities',
+      body: [{ name: `Prod Test Facility ${RUN_ID}` }],
+    }).then((facResponse) => {
+      facilityId = facResponse.body.facilities[0].id;
+    });
+  });
+
+  after(() => {
+    cy.task('cleanupTestData', { tenantId: 'e2e-test-org' });
+  });
+
+  describe('CRUD operations', () => {
+    it('POST /api/v1/products — creates a MODEL product', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Model Product ${RUN_ID}`,
+            level: 'MODEL',
+            producedByOrganisationId: organisationId,
+            manufacturingFacilityId: facilityId,
+          },
+        ],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.products).to.be.an('array');
+        expect(response.body.products).to.have.length(1);
+        expect(response.body.products[0].name).to.eq(
+          `Model Product ${RUN_ID}`,
+        );
+        expect(response.body.products[0].level).to.eq('MODEL');
+        expect(response.body.products[0].parentId).to.be.null;
+
+        modelProductId = response.body.products[0].id;
+      });
+    });
+
+    it('POST /api/v1/products — creates a BATCH product with MODEL parent', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Batch Product ${RUN_ID}`,
+            level: 'BATCH',
+            parentId: modelProductId,
+          },
+        ],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.products).to.be.an('array');
+        expect(response.body.products).to.have.length(1);
+        expect(response.body.products[0].name).to.eq(
+          `Batch Product ${RUN_ID}`,
+        );
+        expect(response.body.products[0].level).to.eq('BATCH');
+        expect(response.body.products[0].parentId).to.eq(modelProductId);
+
+        batchProductId = response.body.products[0].id;
+      });
+    });
+
+    it('POST /api/v1/products — creates an ITEM product with BATCH parent', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Item Product ${RUN_ID}`,
+            level: 'ITEM',
+            parentId: batchProductId,
+          },
+        ],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.products).to.be.an('array');
+        expect(response.body.products).to.have.length(1);
+        expect(response.body.products[0].name).to.eq(
+          `Item Product ${RUN_ID}`,
+        );
+        expect(response.body.products[0].level).to.eq('ITEM');
+        expect(response.body.products[0].parentId).to.eq(batchProductId);
+
+        itemProductId = response.body.products[0].id;
+      });
+    });
+
+    it('POST /api/v1/products — creates an ITEM product with no parent', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Standalone Item ${RUN_ID}`,
+            level: 'ITEM',
+          },
+        ],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.products).to.be.an('array');
+        expect(response.body.products).to.have.length(1);
+        expect(response.body.products[0].name).to.eq(
+          `Standalone Item ${RUN_ID}`,
+        );
+        expect(response.body.products[0].level).to.eq('ITEM');
+        expect(response.body.products[0].parentId).to.be.null;
+
+        standaloneItemId = response.body.products[0].id;
+      });
+    });
+
+    it('GET /api/v1/products — lists products', () => {
+      cy.request('/api/v1/products').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.products).to.be.an('array');
+
+        const created = response.body.products.find(
+          (p: any) => p.id === modelProductId,
+        );
+        expect(created).to.exist;
+      });
+    });
+
+    it('GET /api/v1/products — filters by level', () => {
+      cy.request('/api/v1/products?level=MODEL').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.products).to.be.an('array');
+        expect(response.body.products.length).to.be.greaterThan(0);
+
+        response.body.products.forEach((p: any) => {
+          expect(p.level).to.eq('MODEL');
+        });
+      });
+    });
+
+    it('GET /api/v1/products — filters by parentId', () => {
+      cy.request(`/api/v1/products?parentId=${modelProductId}`).then(
+        (response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.products).to.be.an('array');
+          expect(response.body.products.length).to.be.greaterThan(0);
+
+          response.body.products.forEach((p: any) => {
+            expect(p.parentId).to.eq(modelProductId);
+          });
+
+          const batch = response.body.products.find(
+            (p: any) => p.id === batchProductId,
+          );
+          expect(batch).to.exist;
+        },
+      );
+    });
+
+    it('GET /api/v1/products — filters by organisationId', () => {
+      cy.request(`/api/v1/products?organisationId=${organisationId}`).then(
+        (response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.products).to.be.an('array');
+
+          response.body.products.forEach((p: any) => {
+            expect(p.producedByOrganisationId).to.eq(organisationId);
+          });
+        },
+      );
+    });
+
+    it('GET /api/v1/products — filters by facilityId', () => {
+      cy.request(`/api/v1/products?facilityId=${facilityId}`).then(
+        (response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.products).to.be.an('array');
+
+          response.body.products.forEach((p: any) => {
+            expect(p.manufacturingFacilityId).to.eq(facilityId);
+          });
+        },
+      );
+    });
+
+    it('GET /api/v1/products/:id — retrieves specific product', () => {
+      cy.request(`/api/v1/products/${modelProductId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.product).to.exist;
+        expect(response.body.product.id).to.eq(modelProductId);
+        expect(response.body.product.name).to.eq(`Model Product ${RUN_ID}`);
+        expect(response.body.product.level).to.eq('MODEL');
+      });
+    });
+
+    it('PATCH /api/v1/products/:id — updates name', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/products/${modelProductId}`,
+        body: { name: `Updated Model ${RUN_ID}` },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.product.name).to.eq(`Updated Model ${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/products/:id — level is stripped (immutable)', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/products/${modelProductId}`,
+        body: { name: `Still Model ${RUN_ID}`, level: 'BATCH' },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.product.name).to.eq(`Still Model ${RUN_ID}`);
+        expect(response.body.product.level).to.eq('MODEL');
+      });
+    });
+
+    it('GET /api/v1/products/:id — confirms update persisted', () => {
+      cy.request(`/api/v1/products/${modelProductId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.product.name).to.eq(`Still Model ${RUN_ID}`);
+        expect(response.body.product.level).to.eq('MODEL');
+      });
+    });
+
+    it('PATCH /api/v1/products/:id — assigns identifiers', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/products/${modelProductId}`,
+        body: {
+          primaryIdentifierId: identifierId,
+          secondaryIdentifierIds: [secondaryIdentifierId],
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.product).to.exist;
+      });
+    });
+
+    it('GET /api/v1/products/:id — confirms identifiers assigned', () => {
+      cy.request(`/api/v1/products/${modelProductId}`).then((response) => {
+        expect(response.status).to.eq(200);
+
+        const product = response.body.product;
+        expect(product.primaryIdentifier).to.exist;
+        expect(product.primaryIdentifier.id).to.eq(identifierId);
+        expect(product.secondaryIdentifiers).to.be.an('array');
+        expect(product.secondaryIdentifiers).to.have.length(1);
+        expect(product.secondaryIdentifiers[0].id).to.eq(
+          secondaryIdentifierId,
+        );
+      });
+    });
+  });
+
+  describe('Hierarchy validation', () => {
+    it('returns 400 for MODEL with parent', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Invalid Model ${RUN_ID}`,
+            level: 'MODEL',
+            parentId: modelProductId,
+          },
+        ],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for BATCH without parent', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Invalid Batch ${RUN_ID}`,
+            level: 'BATCH',
+          },
+        ],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for ITEM with MODEL parent', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Invalid Item ${RUN_ID}`,
+            level: 'ITEM',
+            parentId: modelProductId,
+          },
+        ],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+  });
+
+  describe('Delete behaviour', () => {
+    it('returns 400 when deleting MODEL with BATCH children', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/products/${modelProductId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('deletes BATCH — detaches ITEM children', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/products/${batchProductId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.deep.eq({});
+      });
+    });
+
+    it('confirms ITEM is now parentless after BATCH deletion', () => {
+      cy.request(`/api/v1/products/${itemProductId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.product.id).to.eq(itemProductId);
+        expect(response.body.product.parentId).to.be.null;
+      });
+    });
+
+    it('deletes remaining products', () => {
+      // Delete standalone item
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/products/${standaloneItemId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.deep.eq({});
+      });
+
+      // Delete the detached item
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/products/${itemProductId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.deep.eq({});
+      });
+
+      // Delete model (now has no BATCH children)
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/products/${modelProductId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.deep.eq({});
+      });
+    });
+
+    it('GET /api/v1/products/:id — returns 404 after deletion', () => {
+      cy.request({
+        method: 'GET',
+        url: `/api/v1/products/${modelProductId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+
+  describe('Validation', () => {
+    it('returns 400 when name is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [{ level: 'MODEL' }],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when level is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [{ name: `No Level Product ${RUN_ID}` }],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when level is invalid', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [{ name: `Invalid Level Product ${RUN_ID}`, level: 'INVALID' }],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when body is not an array', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: { name: `Not Array Product ${RUN_ID}`, level: 'MODEL' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when body is an empty array', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 404 for nonexistent product', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/products/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+
+    it('returns 400 for non-numeric limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/products?limit=abc',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for negative offset', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/products?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+  });
+
+  describe('Pagination', () => {
+    it('supports limit and offset parameters', () => {
+      cy.request('/api/v1/products?limit=1&offset=0').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.products.length).to.be.at.most(1);
+      });
+    });
+  });
+});

--- a/packages/reference-implementation/prisma/migrations/20260216102855_add_master_data_entities/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260216102855_add_master_data_entities/migration.sql
@@ -1,0 +1,168 @@
+/*
+  Warnings:
+
+  - Made the column `validationPattern` on table `SchemeQualifier` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- CreateEnum
+CREATE TYPE "ProductLevel" AS ENUM ('MODEL', 'BATCH', 'ITEM');
+
+-- AlterEnum
+ALTER TYPE "AdapterType" ADD VALUE 'UNCEFACT_STORAGE';
+
+-- AlterEnum
+ALTER TYPE "ServiceType" ADD VALUE 'STORAGE';
+
+-- AlterTable
+ALTER TABLE "SchemeQualifier" ALTER COLUMN "validationPattern" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Tenant" RENAME CONSTRAINT "Organization_pkey" TO "Tenant_pkey";
+
+-- CreateTable
+CREATE TABLE "OrganisationEntity" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "location" JSONB,
+    "primaryIdentifierId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrganisationEntity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Facility" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "location" JSONB,
+    "operatingOrganisationId" TEXT,
+    "primaryIdentifierId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Facility_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "level" "ProductLevel" NOT NULL,
+    "parentId" TEXT,
+    "brandOrganisationId" TEXT,
+    "manufacturingFacilityId" TEXT,
+    "primaryIdentifierId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrganisationSecondaryIdentifier" (
+    "organisationId" TEXT NOT NULL,
+    "identifierId" TEXT NOT NULL,
+
+    CONSTRAINT "OrganisationSecondaryIdentifier_pkey" PRIMARY KEY ("organisationId","identifierId")
+);
+
+-- CreateTable
+CREATE TABLE "FacilitySecondaryIdentifier" (
+    "facilityId" TEXT NOT NULL,
+    "identifierId" TEXT NOT NULL,
+
+    CONSTRAINT "FacilitySecondaryIdentifier_pkey" PRIMARY KEY ("facilityId","identifierId")
+);
+
+-- CreateTable
+CREATE TABLE "ProductSecondaryIdentifier" (
+    "productId" TEXT NOT NULL,
+    "identifierId" TEXT NOT NULL,
+
+    CONSTRAINT "ProductSecondaryIdentifier_pkey" PRIMARY KEY ("productId","identifierId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganisationEntity_primaryIdentifierId_key" ON "OrganisationEntity"("primaryIdentifierId");
+
+-- CreateIndex
+CREATE INDEX "OrganisationEntity_tenantId_idx" ON "OrganisationEntity"("tenantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Facility_primaryIdentifierId_key" ON "Facility"("primaryIdentifierId");
+
+-- CreateIndex
+CREATE INDEX "Facility_tenantId_idx" ON "Facility"("tenantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Product_primaryIdentifierId_key" ON "Product"("primaryIdentifierId");
+
+-- CreateIndex
+CREATE INDEX "Product_tenantId_idx" ON "Product"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "Product_parentId_idx" ON "Product"("parentId");
+
+-- RenameForeignKey
+ALTER TABLE "Did" RENAME CONSTRAINT "Did_organizationId_fkey" TO "Did_tenantId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "ServiceInstance" RENAME CONSTRAINT "ServiceInstance_organizationId_fkey" TO "ServiceInstance_tenantId_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "User" RENAME CONSTRAINT "User_organizationId_fkey" TO "User_tenantId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "OrganisationEntity" ADD CONSTRAINT "OrganisationEntity_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganisationEntity" ADD CONSTRAINT "OrganisationEntity_primaryIdentifierId_fkey" FOREIGN KEY ("primaryIdentifierId") REFERENCES "Identifier"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Facility" ADD CONSTRAINT "Facility_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Facility" ADD CONSTRAINT "Facility_operatingOrganisationId_fkey" FOREIGN KEY ("operatingOrganisationId") REFERENCES "OrganisationEntity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Facility" ADD CONSTRAINT "Facility_primaryIdentifierId_fkey" FOREIGN KEY ("primaryIdentifierId") REFERENCES "Identifier"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_brandOrganisationId_fkey" FOREIGN KEY ("brandOrganisationId") REFERENCES "OrganisationEntity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_manufacturingFacilityId_fkey" FOREIGN KEY ("manufacturingFacilityId") REFERENCES "Facility"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_primaryIdentifierId_fkey" FOREIGN KEY ("primaryIdentifierId") REFERENCES "Identifier"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganisationSecondaryIdentifier" ADD CONSTRAINT "OrganisationSecondaryIdentifier_organisationId_fkey" FOREIGN KEY ("organisationId") REFERENCES "OrganisationEntity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganisationSecondaryIdentifier" ADD CONSTRAINT "OrganisationSecondaryIdentifier_identifierId_fkey" FOREIGN KEY ("identifierId") REFERENCES "Identifier"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FacilitySecondaryIdentifier" ADD CONSTRAINT "FacilitySecondaryIdentifier_facilityId_fkey" FOREIGN KEY ("facilityId") REFERENCES "Facility"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FacilitySecondaryIdentifier" ADD CONSTRAINT "FacilitySecondaryIdentifier_identifierId_fkey" FOREIGN KEY ("identifierId") REFERENCES "Identifier"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductSecondaryIdentifier" ADD CONSTRAINT "ProductSecondaryIdentifier_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductSecondaryIdentifier" ADD CONSTRAINT "ProductSecondaryIdentifier_identifierId_fkey" FOREIGN KEY ("identifierId") REFERENCES "Identifier"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/reference-implementation/prisma/migrations/20260216183438_rename_brand_to_produced_by_organisation/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260216183438_rename_brand_to_produced_by_organisation/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Product" DROP CONSTRAINT "Product_brandOrganisationId_fkey";
+
+-- RenameColumn (data-preserving)
+ALTER TABLE "Product" RENAME COLUMN "brandOrganisationId" TO "producedByOrganisationId";
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_producedByOrganisationId_fkey" FOREIGN KEY ("producedByOrganisationId") REFERENCES "OrganisationEntity"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -40,6 +40,12 @@ enum AdapterType {
   UNCEFACT_STORAGE
 }
 
+enum ProductLevel {
+  MODEL
+  BATCH
+  ITEM
+}
+
 /**
  * Auth.js + Prisma adapter tables for OAuth + JWT sessions
  */
@@ -93,6 +99,9 @@ model Tenant {
   schemes            IdentifierScheme[]
   identifiers        Identifier[]
   linkRegistrations  LinkRegistration[]
+  organisations      OrganisationEntity[]
+  facilities         Facility[]
+  products           Product[]
 
   @@map("Tenant")
 }
@@ -246,6 +255,13 @@ model Identifier {
   scheme            IdentifierScheme   @relation(fields: [schemeId], references: [id], onDelete: Restrict)
   linkRegistrations LinkRegistration[]
 
+  organisationPrimary     OrganisationEntity?              @relation("OrganisationPrimaryIdentifier")
+  facilityPrimary         Facility?                        @relation("FacilityPrimaryIdentifier")
+  productPrimary          Product?                         @relation("ProductPrimaryIdentifier")
+  organisationSecondaries OrganisationSecondaryIdentifier[] @relation("OrganisationSecondaryIdentifiers")
+  facilitySecondaries     FacilitySecondaryIdentifier[]     @relation("FacilitySecondaryIdentifiers")
+  productSecondaries      ProductSecondaryIdentifier[]      @relation("ProductSecondaryIdentifiers")
+
   @@unique([schemeId, value])
   @@index([tenantId])
 }
@@ -271,4 +287,111 @@ model LinkRegistration {
 
   @@index([tenantId])
   @@index([identifierId])
+}
+
+/**
+ * Organisation entities representing trading partners, suppliers, or self.
+ * Distinct from the Tenant model which represents auth tenants.
+ */
+model OrganisationEntity {
+  id                    String   @id @default(cuid())
+  tenantId              String
+  name                  String
+  description           String?
+  location              Json?
+  primaryIdentifierId   String?  @unique
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  tenant                Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  primaryIdentifier     Identifier? @relation("OrganisationPrimaryIdentifier", fields: [primaryIdentifierId], references: [id], onDelete: SetNull)
+
+  secondaryIdentifiers  OrganisationSecondaryIdentifier[]
+  facilities            Facility[]
+  products              Product[]
+
+  @@index([tenantId])
+}
+
+/**
+ * Physical locations (factories, farms, warehouses) operated by organisations.
+ */
+model Facility {
+  id                        String   @id @default(cuid())
+  tenantId                  String
+  name                      String
+  description               String?
+  location                  Json?
+  operatingOrganisationId   String?
+  primaryIdentifierId       String?  @unique
+  createdAt                 DateTime @default(now())
+  updatedAt                 DateTime @updatedAt
+
+  tenant                    Tenant              @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  operatingOrganisation     OrganisationEntity? @relation(fields: [operatingOrganisationId], references: [id], onDelete: SetNull)
+  primaryIdentifier         Identifier?         @relation("FacilityPrimaryIdentifier", fields: [primaryIdentifierId], references: [id], onDelete: SetNull)
+
+  secondaryIdentifiers      FacilitySecondaryIdentifier[]
+  products                  Product[]
+
+  @@index([tenantId])
+}
+
+/**
+ * Products at three levels per UNTP spec: Model, Batch, Serialised Item.
+ */
+model Product {
+  id                        String       @id @default(cuid())
+  tenantId                  String
+  name                      String
+  description               String?
+  level                     ProductLevel
+  parentId                  String?
+  producedByOrganisationId       String?
+  manufacturingFacilityId   String?
+  primaryIdentifierId       String?      @unique
+  createdAt                 DateTime     @default(now())
+  updatedAt                 DateTime     @updatedAt
+
+  tenant                    Tenant              @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  parent                    Product?            @relation("ProductHierarchy", fields: [parentId], references: [id], onDelete: Restrict)
+  children                  Product[]           @relation("ProductHierarchy")
+  producedByOrganisation         OrganisationEntity? @relation(fields: [producedByOrganisationId], references: [id], onDelete: SetNull)
+  manufacturingFacility     Facility?           @relation(fields: [manufacturingFacilityId], references: [id], onDelete: SetNull)
+  primaryIdentifier         Identifier?         @relation("ProductPrimaryIdentifier", fields: [primaryIdentifierId], references: [id], onDelete: SetNull)
+
+  secondaryIdentifiers      ProductSecondaryIdentifier[]
+
+  @@index([tenantId])
+  @@index([parentId])
+}
+
+model OrganisationSecondaryIdentifier {
+  organisationId  String
+  identifierId    String
+
+  organisation    OrganisationEntity @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  identifier      Identifier         @relation("OrganisationSecondaryIdentifiers", fields: [identifierId], references: [id], onDelete: Cascade)
+
+  @@id([organisationId, identifierId])
+}
+
+model FacilitySecondaryIdentifier {
+  facilityId    String
+  identifierId  String
+
+  facility      Facility   @relation(fields: [facilityId], references: [id], onDelete: Cascade)
+  identifier    Identifier @relation("FacilitySecondaryIdentifiers", fields: [identifierId], references: [id], onDelete: Cascade)
+
+  @@id([facilityId, identifierId])
+}
+
+model ProductSecondaryIdentifier {
+  productId     String
+  identifierId  String
+
+  product       Product    @relation(fields: [productId], references: [id], onDelete: Cascade)
+  identifier    Identifier @relation("ProductSecondaryIdentifiers", fields: [identifierId], references: [id], onDelete: Cascade)
+
+  @@id([productId, identifierId])
 }

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
@@ -1,0 +1,213 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockGetFacilityById = jest.fn();
+const mockUpdateFacility = jest.fn();
+const mockDeleteFacility = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getFacilityById: (id: string, tenantId: string) => mockGetFacilityById(id, tenantId),
+  updateFacility: (id: string, tenantId: string, input: unknown) => mockUpdateFacility(id, tenantId, input),
+  deleteFacility: (id: string, tenantId: string) => mockDeleteFacility(id, tenantId),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { GET, PATCH, DELETE } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'GET', body, url = 'http://localhost/api/v1/facilities/fac-1' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createContext(id: string) {
+  return { tenantId: 'org-1', params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/v1/facilities/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the facility record', async () => {
+    const facility = { id: 'fac-1', name: 'Warehouse Alpha' };
+    mockGetFacilityById.mockResolvedValue(facility);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('fac-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.facility).toEqual(facility);
+    expect(json).not.toHaveProperty('ok');
+  });
+
+  it('returns 404 when facility not found', async () => {
+    mockGetFacilityById.mockResolvedValue(null);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('nonexistent') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Facility not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetFacilityById.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('fac-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('PATCH /api/v1/facilities/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates facility fields', async () => {
+    const updated = { id: 'fac-1', name: 'Updated Warehouse' };
+    mockUpdateFacility.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Warehouse' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.facility).toEqual(updated);
+    expect(json).not.toHaveProperty('ok');
+  });
+
+  it('returns 400 when no updatable fields are provided', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: {} });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one updatable field is required');
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name must be a non-empty string');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      method: 'PATCH',
+      url: 'http://localhost/api/v1/facilities/fac-1',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Request;
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 404 when facility not found', async () => {
+    mockUpdateFacility.mockRejectedValue(new NotFoundError('Facility not found or access denied'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Facility not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockUpdateFacility.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('DELETE /api/v1/facilities/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the facility and returns empty object', async () => {
+    mockDeleteFacility.mockResolvedValue({ id: 'fac-1' });
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('fac-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({});
+  });
+
+  it('returns 404 when facility not found', async () => {
+    mockDeleteFacility.mockRejectedValue(new NotFoundError('Facility not found or access denied'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('nonexistent') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Facility not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockDeleteFacility.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('fac-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -1,0 +1,232 @@
+import { NextResponse } from 'next/server';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { getFacilityById, updateFacility, deleteFacility } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/facilities/[id]' });
+
+/** Fields that may be updated on a facility. */
+const UPDATABLE_FIELDS = [
+  'name',
+  'description',
+  'location',
+  'operatingOrganisationId',
+  'primaryIdentifierId',
+  'secondaryIdentifierIds',
+] as const;
+
+/**
+ * @swagger
+ * /facilities/{id}:
+ *   get:
+ *     summary: Get a facility by ID
+ *     description: Retrieves a specific facility by its database ID
+ *     tags:
+ *       - Facilities
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the facility
+ *     responses:
+ *       200:
+ *         description: Facility retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 facility:
+ *                   $ref: '#/components/schemas/Facility'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Facility not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+  logger.info({ tenantId, facilityId: id }, 'Looking up facility');
+  const facility = await getFacilityById(id, tenantId);
+  if (!facility) {
+    throw new NotFoundError('Facility not found');
+  }
+  return NextResponse.json({ facility });
+});
+
+/**
+ * @swagger
+ * /facilities/{id}:
+ *   patch:
+ *     summary: Update a facility
+ *     description: Updates one or more fields of a specific facility
+ *     tags:
+ *       - Facilities
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the facility
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Updated facility name
+ *               description:
+ *                 type: string
+ *                 description: Updated description
+ *               location:
+ *                 type: object
+ *                 description: Updated UNTP location object
+ *               operatingOrganisationId:
+ *                 type: string
+ *                 nullable: true
+ *                 description: ID of the operating organisation (null to clear)
+ *               primaryIdentifierId:
+ *                 type: string
+ *                 nullable: true
+ *                 description: ID of the primary identifier (null to clear)
+ *               secondaryIdentifierIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: IDs of secondary identifiers (replaces existing)
+ *             minProperties: 1
+ *     responses:
+ *       200:
+ *         description: Facility updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 facility:
+ *                   $ref: '#/components/schemas/Facility'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Facility not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
+  const { id } = await params;
+
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  // Ensure at least one updatable field is present
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
+  if (!hasUpdatableField) {
+    throw new ValidationError(`At least one updatable field is required: ${UPDATABLE_FIELDS.join(', ')}`);
+  }
+
+  // Validate name if provided — must be a non-empty string
+  if ('name' in body && !isNonEmptyString(body.name)) {
+    throw new ValidationError('name must be a non-empty string');
+  }
+
+  logger.info({ tenantId, facilityId: id }, 'Updating facility');
+  const facility = await updateFacility(id, tenantId, body);
+
+  logger.info({ tenantId, facilityId: id }, 'Facility updated');
+  return NextResponse.json({ facility });
+});
+
+/**
+ * @swagger
+ * /facilities/{id}:
+ *   delete:
+ *     summary: Delete a facility
+ *     description: Deletes a specific facility by its database ID
+ *     tags:
+ *       - Facilities
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the facility
+ *     responses:
+ *       200:
+ *         description: Facility deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Facility not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+
+  logger.info({ tenantId, facilityId: id }, 'Deleting facility');
+  await deleteFacility(id, tenantId);
+
+  logger.info({ tenantId, facilityId: id }, 'Facility deleted');
+  return NextResponse.json({});
+});

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
@@ -1,0 +1,259 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockCreateFacilities = jest.fn();
+const mockListFacilities = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  createFacilities: (tenantId: string, inputs: unknown) => mockCreateFacilities(tenantId, inputs),
+  listFacilities: (tenantId: string, opts: unknown) => mockListFacilities(tenantId, opts),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { POST, GET } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'POST', body, url = 'http://localhost/api/v1/facilities' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createBadJsonRequest(): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/facilities',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => {
+      throw new SyntaxError('Unexpected token n in JSON at position 0');
+    },
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
+
+describe('POST /api/v1/facilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates facilities and returns 201', async () => {
+    const facilities = [
+      { id: 'fac-1', name: 'Warehouse Alpha' },
+      { id: 'fac-2', name: 'Warehouse Beta' },
+    ];
+    mockCreateFacilities.mockResolvedValue(facilities);
+
+    const req = createFakeRequest({
+      body: [{ name: 'Warehouse Alpha' }, { name: 'Warehouse Beta' }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.facilities).toEqual(facilities);
+    expect(json).not.toHaveProperty('ok');
+  });
+
+  it('passes correct inputs to createFacilities', async () => {
+    mockCreateFacilities.mockResolvedValue([{ id: 'fac-1' }]);
+
+    const input = [{ name: 'Warehouse Alpha', description: 'Main warehouse' }];
+    const req = createFakeRequest({ body: input });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateFacilities).toHaveBeenCalledWith('org-1', input);
+  });
+
+  it('returns 400 when body is not an array', async () => {
+    const req = createFakeRequest({ body: { name: 'Not an array' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Request body must be an array');
+  });
+
+  it('returns 400 when body is an empty array', async () => {
+    const req = createFakeRequest({ body: [] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Request body must not be empty');
+  });
+
+  it('returns 400 when name is missing from an item', async () => {
+    const req = createFakeRequest({ body: [{ description: 'No name here' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name is required');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = createBadJsonRequest();
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockCreateFacilities.mockRejectedValue(new NotFoundError('Organisation not found: org-999'));
+
+    const req = createFakeRequest({ body: [{ name: 'Facility', operatingOrganisationId: 'org-999' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Organisation not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockCreateFacilities.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ body: [{ name: 'Facility' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('GET /api/v1/facilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists facilities for the tenant', async () => {
+    const facilities = [{ id: 'fac-1', name: 'Warehouse Alpha' }];
+    mockListFacilities.mockResolvedValue(facilities);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/facilities' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.facilities).toEqual(facilities);
+    expect(json).not.toHaveProperty('ok');
+  });
+
+  it('passes search and organisationId filters', async () => {
+    mockListFacilities.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/facilities?search=alpha&organisationId=org-42',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListFacilities).toHaveBeenCalledWith('org-1', {
+      search: 'alpha',
+      organisationId: 'org-42',
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('passes pagination parameters', async () => {
+    mockListFacilities.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/facilities?limit=10&offset=5',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListFacilities).toHaveBeenCalledWith('org-1', {
+      search: undefined,
+      organisationId: undefined,
+      limit: 10,
+      offset: 5,
+    });
+  });
+
+  it('handles no query parameters', async () => {
+    mockListFacilities.mockResolvedValue([]);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/facilities' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListFacilities).toHaveBeenCalledWith('org-1', {
+      search: undefined,
+      organisationId: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('returns 400 for non-numeric limit', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/facilities?limit=abc',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for negative offset', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/facilities?offset=-1',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset must be a non-negative integer');
+  });
+
+  it('returns 500 when listFacilities throws', async () => {
+    mockListFacilities.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/facilities' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from 'next/server';
+import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { createFacilities, listFacilities } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/facilities' });
+
+/**
+ * @swagger
+ * /facilities:
+ *   post:
+ *     summary: Create one or more facilities
+ *     description: Creates one or more facilities from an array of inputs. Each item must include a name.
+ *     tags:
+ *       - Facilities
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               type: object
+ *               required:
+ *                 - name
+ *               properties:
+ *                 name:
+ *                   type: string
+ *                   description: Name of the facility
+ *                 description:
+ *                   type: string
+ *                   description: Optional description
+ *                 location:
+ *                   type: object
+ *                   description: Optional UNTP location object
+ *                 operatingOrganisationId:
+ *                   type: string
+ *                   description: ID of the operating organisation
+ *                 primaryIdentifierId:
+ *                   type: string
+ *                   description: ID of the primary identifier
+ *                 secondaryIdentifierIds:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   description: IDs of secondary identifiers
+ *     responses:
+ *       201:
+ *         description: Facilities created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 facilities:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Facility'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Referenced entity not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const POST = withTenantAuth(async (req, { tenantId }) => {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  if (!Array.isArray(body)) {
+    throw new ValidationError('Request body must be an array');
+  }
+
+  if (body.length === 0) {
+    throw new ValidationError('Request body must not be empty');
+  }
+
+  for (const item of body) {
+    if (!isNonEmptyString(item.name)) {
+      throw new ValidationError('name is required for each facility');
+    }
+  }
+
+  logger.info({ tenantId, count: body.length }, 'Creating facilities');
+  const facilities = await createFacilities(tenantId, body);
+
+  logger.info({ tenantId, count: facilities.length }, 'Facilities created');
+  return NextResponse.json({ facilities }, { status: 201 });
+});
+
+/**
+ * @swagger
+ * /facilities:
+ *   get:
+ *     summary: List facilities
+ *     description: Retrieves a list of facilities for the authenticated tenant with optional filtering
+ *     tags:
+ *       - Facilities
+ *     parameters:
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Search by facility name or identifier value
+ *       - in: query
+ *         name: organisationId
+ *         schema:
+ *           type: string
+ *         description: Filter by operating organisation ID
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Maximum number of facilities to return
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *         description: Number of facilities to skip for pagination
+ *     responses:
+ *       200:
+ *         description: List of facilities retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 facilities:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Facility'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (req, { tenantId }) => {
+  const url = new URL(req.url);
+  const search = url.searchParams.get('search') ?? undefined;
+  const organisationId = url.searchParams.get('organisationId') ?? undefined;
+  const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+
+  logger.info({ tenantId, search, organisationId, limit, offset }, 'Listing facilities');
+  const facilities = await listFacilities(tenantId, { search, organisationId, limit, offset });
+
+  logger.info({ tenantId, count: facilities.length }, 'Facilities listed');
+  return NextResponse.json({ facilities });
+});

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
@@ -1,0 +1,211 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockGetOrganisationById = jest.fn();
+const mockUpdateOrganisation = jest.fn();
+const mockDeleteOrganisation = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getOrganisationById: (id: string, tenantId: string) => mockGetOrganisationById(id, tenantId),
+  updateOrganisation: (id: string, tenantId: string, input: unknown) => mockUpdateOrganisation(id, tenantId, input),
+  deleteOrganisation: (id: string, tenantId: string) => mockDeleteOrganisation(id, tenantId),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { GET, PATCH, DELETE } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'GET', body, url = 'http://localhost/api/v1/organisations/org-a' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createContext(id: string) {
+  return { tenantId: 'org-1', params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/v1/organisations/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the organisation record', async () => {
+    const organisation = { id: 'org-a', name: 'Acme Corp' };
+    mockGetOrganisationById.mockResolvedValue(organisation);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('org-a') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.organisation).toEqual(organisation);
+  });
+
+  it('returns 404 when organisation not found', async () => {
+    mockGetOrganisationById.mockResolvedValue(null);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('nonexistent') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Organisation not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetOrganisationById.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('org-a') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('PATCH /api/v1/organisations/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates the organisation', async () => {
+    const updated = { id: 'org-a', name: 'Updated Corp' };
+    mockUpdateOrganisation.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Corp' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.organisation).toEqual(updated);
+  });
+
+  it('returns 400 when no updatable fields are provided', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: {} });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one updatable field must be provided');
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name must be a non-empty string');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      method: 'PATCH',
+      url: 'http://localhost/api/v1/organisations/org-a',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Request;
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 404 when organisation not found', async () => {
+    mockUpdateOrganisation.mockRejectedValue(new NotFoundError('Organisation not found or access denied'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Corp' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Organisation not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockUpdateOrganisation.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Corp' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('DELETE /api/v1/organisations/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the organisation and returns empty body', async () => {
+    mockDeleteOrganisation.mockResolvedValue({ id: 'org-a' });
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('org-a') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({});
+  });
+
+  it('returns 404 when organisation not found', async () => {
+    mockDeleteOrganisation.mockRejectedValue(new NotFoundError('Organisation not found or access denied'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('nonexistent') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Organisation not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockDeleteOrganisation.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('org-a') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -154,7 +154,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => body[field] !== undefined);
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
   if (!hasUpdatableField) {
     throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
   }

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -1,0 +1,222 @@
+import { NextResponse } from 'next/server';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import {
+  getOrganisationById,
+  updateOrganisation,
+  deleteOrganisation,
+  UpdateOrganisationInput,
+} from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/organisations/[id]' });
+
+const UPDATABLE_FIELDS = ['name', 'description', 'location', 'primaryIdentifierId', 'secondaryIdentifierIds'] as const;
+
+/**
+ * @swagger
+ * /organisations/{id}:
+ *   get:
+ *     summary: Get an organisation by ID
+ *     description: Retrieves a specific organisation by its database ID
+ *     tags:
+ *       - Organisations
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the organisation
+ *     responses:
+ *       200:
+ *         description: Organisation retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 organisation:
+ *                   $ref: '#/components/schemas/Organisation'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Organisation not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+  logger.info({ tenantId, organisationId: id }, 'Looking up organisation');
+  const organisation = await getOrganisationById(id, tenantId);
+  if (!organisation) {
+    throw new NotFoundError('Organisation not found');
+  }
+  return NextResponse.json({ organisation });
+});
+
+/**
+ * @swagger
+ * /organisations/{id}:
+ *   patch:
+ *     summary: Update an organisation
+ *     description: Updates one or more fields of a specific organisation
+ *     tags:
+ *       - Organisations
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the organisation
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Updated name of the organisation
+ *               description:
+ *                 type: string
+ *                 description: Updated description
+ *               location:
+ *                 type: string
+ *                 description: Updated location
+ *               primaryIdentifierId:
+ *                 type: string
+ *                 description: ID of the primary identifier
+ *               secondaryIdentifierIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: IDs of secondary identifiers
+ *             minProperties: 1
+ *     responses:
+ *       200:
+ *         description: Organisation updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 organisation:
+ *                   $ref: '#/components/schemas/Organisation'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Organisation not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
+  const { id } = await params;
+
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => body[field] !== undefined);
+  if (!hasUpdatableField) {
+    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
+  }
+
+  if (body.name !== undefined && !isNonEmptyString(body.name)) {
+    throw new ValidationError('name must be a non-empty string');
+  }
+
+  logger.info({ tenantId, organisationId: id }, 'Updating organisation');
+  const organisation = await updateOrganisation(id, tenantId, body as UpdateOrganisationInput);
+
+  logger.info({ tenantId, organisationId: id }, 'Organisation updated');
+  return NextResponse.json({ organisation });
+});
+
+/**
+ * @swagger
+ * /organisations/{id}:
+ *   delete:
+ *     summary: Delete an organisation
+ *     description: Deletes a specific organisation by its database ID
+ *     tags:
+ *       - Organisations
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the organisation
+ *     responses:
+ *       200:
+ *         description: Organisation deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Organisation not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+
+  logger.info({ tenantId, organisationId: id }, 'Deleting organisation');
+  await deleteOrganisation(id, tenantId);
+
+  logger.info({ tenantId, organisationId: id }, 'Organisation deleted');
+  return NextResponse.json({});
+});

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
@@ -1,0 +1,228 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockCreateOrganisations = jest.fn();
+const mockListOrganisations = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  createOrganisations: (tenantId: string, inputs: unknown) => mockCreateOrganisations(tenantId, inputs),
+  listOrganisations: (tenantId: string, opts: unknown) => mockListOrganisations(tenantId, opts),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { POST, GET } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'POST', body, url = 'http://localhost/api/v1/organisations' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createBadJsonRequest(): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/organisations',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => {
+      throw new SyntaxError('Unexpected token n in JSON at position 0');
+    },
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
+
+describe('POST /api/v1/organisations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates organisations and returns 201', async () => {
+    const organisations = [
+      { id: 'org-a', name: 'Acme Corp' },
+      { id: 'org-b', name: 'Widget Co' },
+    ];
+    mockCreateOrganisations.mockResolvedValue(organisations);
+
+    const req = createFakeRequest({
+      body: [{ name: 'Acme Corp' }, { name: 'Widget Co' }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.organisations).toEqual(organisations);
+  });
+
+  it('returns 400 when body is not an array', async () => {
+    const req = createFakeRequest({ body: { name: 'Acme Corp' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Request body must be an array');
+  });
+
+  it('returns 400 when body is an empty array', async () => {
+    const req = createFakeRequest({ body: [] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Request body must not be empty');
+  });
+
+  it('returns 400 when name is missing on an item', async () => {
+    const req = createFakeRequest({ body: [{ description: 'No name here' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name is required for each organisation');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = createBadJsonRequest();
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockCreateOrganisations.mockRejectedValue(new NotFoundError('Tenant not found'));
+
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Tenant not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockCreateOrganisations.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('GET /api/v1/organisations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists organisations for the tenant', async () => {
+    const organisations = [{ id: 'org-a', name: 'Acme Corp' }];
+    mockListOrganisations.mockResolvedValue(organisations);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/organisations' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.organisations).toEqual(organisations);
+  });
+
+  it('passes search and pagination params to listOrganisations', async () => {
+    mockListOrganisations.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/organisations?search=acme&limit=10&offset=5',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListOrganisations).toHaveBeenCalledWith('org-1', {
+      search: 'acme',
+      limit: 10,
+      offset: 5,
+    });
+  });
+
+  it('handles no query parameters', async () => {
+    mockListOrganisations.mockResolvedValue([]);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/organisations' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListOrganisations).toHaveBeenCalledWith('org-1', {
+      search: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('returns 400 for non-numeric limit', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/organisations?limit=abc',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for negative offset', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/organisations?offset=-1',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset must be a non-negative integer');
+  });
+
+  it('returns 500 when listOrganisations throws', async () => {
+    mockListOrganisations.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/organisations' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from 'next/server';
+import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { createOrganisations, listOrganisations } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/organisations' });
+
+/**
+ * @swagger
+ * /organisations:
+ *   post:
+ *     summary: Create organisations
+ *     description: Creates one or more organisations from an array of input objects
+ *     tags:
+ *       - Organisations
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               type: object
+ *               required:
+ *                 - name
+ *               properties:
+ *                 name:
+ *                   type: string
+ *                   description: The name of the organisation
+ *                 description:
+ *                   type: string
+ *                   description: Optional description
+ *                 location:
+ *                   type: string
+ *                   description: Optional location
+ *     responses:
+ *       201:
+ *         description: Organisations created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 organisations:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Organisation'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const POST = withTenantAuth(async (req, { tenantId }) => {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  if (!Array.isArray(body)) {
+    throw new ValidationError('Request body must be an array');
+  }
+
+  if (body.length === 0) {
+    throw new ValidationError('Request body must not be empty');
+  }
+
+  for (const item of body) {
+    if (!isNonEmptyString(item.name)) {
+      throw new ValidationError('name is required for each organisation');
+    }
+  }
+
+  logger.info({ tenantId, count: body.length }, 'Creating organisations');
+  const organisations = await createOrganisations(tenantId, body);
+
+  logger.info({ tenantId, count: organisations.length }, 'Organisations created');
+  return NextResponse.json({ organisations }, { status: 201 });
+});
+
+/**
+ * @swagger
+ * /organisations:
+ *   get:
+ *     summary: List organisations
+ *     description: Retrieves a list of organisations for the authenticated tenant with optional filtering
+ *     tags:
+ *       - Organisations
+ *     parameters:
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Search term to filter organisations
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Maximum number of organisations to return
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *         description: Number of organisations to skip for pagination
+ *     responses:
+ *       200:
+ *         description: List of organisations retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 organisations:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Organisation'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (req, { tenantId }) => {
+  const url = new URL(req.url);
+  const search = url.searchParams.get('search') ?? undefined;
+  const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+
+  logger.info({ tenantId, search, limit, offset }, 'Listing organisations');
+  const organisations = await listOrganisations(tenantId, { search, limit, offset });
+
+  logger.info({ tenantId, count: organisations.length }, 'Organisations listed');
+  return NextResponse.json({ organisations });
+});

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
@@ -1,0 +1,237 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockGetProductById = jest.fn();
+const mockUpdateProduct = jest.fn();
+const mockDeleteProduct = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getProductById: (id: string, tenantId: string) => mockGetProductById(id, tenantId),
+  updateProduct: (id: string, tenantId: string, input: unknown) => mockUpdateProduct(id, tenantId, input),
+  deleteProduct: (id: string, tenantId: string) => mockDeleteProduct(id, tenantId),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+import { GET, PATCH, DELETE } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'GET', body, url = 'http://localhost/api/v1/products/p-1' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createContext(id: string) {
+  return { tenantId: 'org-1', params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/v1/products/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the product record', async () => {
+    const product = { id: 'p-1', name: 'Widget A', level: 'MODEL' };
+    mockGetProductById.mockResolvedValue(product);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('p-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.product).toEqual(product);
+  });
+
+  it('returns 404 when product not found', async () => {
+    mockGetProductById.mockResolvedValue(null);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('nonexistent') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Product not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetProductById.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('p-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('PATCH /api/v1/products/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates product fields', async () => {
+    const updated = { id: 'p-1', name: 'Updated Widget', level: 'MODEL' };
+    mockUpdateProduct.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Widget' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.product).toEqual(updated);
+  });
+
+  it('returns 400 when no updatable fields provided', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: {} });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one updatable field must be provided');
+  });
+
+  it('returns 404 when product not found', async () => {
+    mockUpdateProduct.mockRejectedValue(new NotFoundError('Product not found or access denied'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Widget' } });
+    const res = await PATCH(req, createContext('nonexistent') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Product not found');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      method: 'PATCH',
+      url: 'http://localhost/api/v1/products/p-1',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Request;
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('strips level from body before updating', async () => {
+    const updated = { id: 'p-1', name: 'Updated Widget', level: 'MODEL' };
+    mockUpdateProduct.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Widget', level: 'BATCH' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.product).toEqual(updated);
+    // Verify level was stripped from the update call
+    expect(mockUpdateProduct).toHaveBeenCalledWith('p-1', 'org-1', { name: 'Updated Widget' });
+  });
+
+  it('returns 400 when name is provided but empty', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name must be a non-empty string');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockUpdateProduct.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Widget' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('DELETE /api/v1/products/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the product and returns empty object', async () => {
+    mockDeleteProduct.mockResolvedValue({ id: 'p-1' });
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('p-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({});
+  });
+
+  it('returns 404 when product not found', async () => {
+    mockDeleteProduct.mockRejectedValue(new NotFoundError('Product not found or access denied'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('nonexistent') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Product not found');
+  });
+
+  it('returns 400 when deletion is blocked by ValidationError', async () => {
+    mockDeleteProduct.mockRejectedValue(new ValidationError('Cannot delete product with BATCH children'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('p-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Cannot delete product with BATCH children');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockDeleteProduct.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('p-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -169,7 +169,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   // Strip the immutable level field if provided
   const { level: _level, ...updateFields } = body;
 
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => updateFields[field] !== undefined);
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in updateFields);
   if (!hasUpdatableField) {
     throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
   }

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -1,0 +1,237 @@
+import { NextResponse } from 'next/server';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { getProductById, updateProduct, deleteProduct } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/products/[id]' });
+
+/** Fields that may be updated via PATCH. Level is immutable. */
+const UPDATABLE_FIELDS = [
+  'name',
+  'description',
+  'parentId',
+  'producedByOrganisationId',
+  'manufacturingFacilityId',
+  'primaryIdentifierId',
+  'secondaryIdentifierIds',
+] as const;
+
+/**
+ * @swagger
+ * /products/{id}:
+ *   get:
+ *     summary: Get a product by ID
+ *     description: Retrieves a specific product by its database ID
+ *     tags:
+ *       - Products
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the product
+ *     responses:
+ *       200:
+ *         description: Product retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 product:
+ *                   $ref: '#/components/schemas/Product'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Product not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+  logger.info({ tenantId, productId: id }, 'Looking up product');
+  const product = await getProductById(id, tenantId);
+  if (!product) {
+    throw new NotFoundError('Product not found');
+  }
+  return NextResponse.json({ product });
+});
+
+/**
+ * @swagger
+ * /products/{id}:
+ *   patch:
+ *     summary: Update a product
+ *     description: >
+ *       Updates an existing product. The product level is immutable and cannot be changed.
+ *       At least one updatable field must be provided.
+ *     tags:
+ *       - Products
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the product
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Updated product name
+ *               description:
+ *                 type: string
+ *                 description: Updated product description
+ *               parentId:
+ *                 type: string
+ *                 description: Updated parent product ID
+ *               producedByOrganisationId:
+ *                 type: string
+ *                 description: Updated brand organisation ID
+ *               manufacturingFacilityId:
+ *                 type: string
+ *                 description: Updated manufacturing facility ID
+ *               primaryIdentifierId:
+ *                 type: string
+ *                 description: Updated primary identifier ID
+ *               secondaryIdentifierIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Updated secondary identifier IDs
+ *             minProperties: 1
+ *     responses:
+ *       200:
+ *         description: Product updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 product:
+ *                   $ref: '#/components/schemas/Product'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Product not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
+  const { id } = await params;
+
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  // Strip the immutable level field if provided
+  const { level: _level, ...updateFields } = body;
+
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => updateFields[field] !== undefined);
+  if (!hasUpdatableField) {
+    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
+  }
+
+  if (updateFields.name !== undefined && !isNonEmptyString(updateFields.name)) {
+    throw new ValidationError('name must be a non-empty string');
+  }
+
+  logger.info({ tenantId, productId: id }, 'Updating product');
+  const product = await updateProduct(id, tenantId, updateFields);
+
+  logger.info({ tenantId, productId: id }, 'Product updated');
+  return NextResponse.json({ product });
+});
+
+/**
+ * @swagger
+ * /products/{id}:
+ *   delete:
+ *     summary: Delete a product
+ *     description: Deletes a specific product by its database ID
+ *     tags:
+ *       - Products
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the product
+ *     responses:
+ *       200:
+ *         description: Product deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Product not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+
+  logger.info({ tenantId, productId: id }, 'Deleting product');
+  await deleteProduct(id, tenantId);
+
+  logger.info({ tenantId, productId: id }, 'Product deleted');
+  return NextResponse.json({});
+});

--- a/packages/reference-implementation/src/app/api/v1/products/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.test.ts
@@ -1,0 +1,269 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockCreateProducts = jest.fn();
+const mockListProducts = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  createProducts: (tenantId: string, inputs: unknown) => mockCreateProducts(tenantId, inputs),
+  listProducts: (tenantId: string, opts: unknown) => mockListProducts(tenantId, opts),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { POST, GET } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'POST', body, url = 'http://localhost/api/v1/products' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createBadJsonRequest(): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/products',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => {
+      throw new SyntaxError('Unexpected token n in JSON at position 0');
+    },
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
+
+describe('POST /api/v1/products', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates products and returns 201', async () => {
+    const products = [
+      { id: 'p-1', name: 'Widget A', level: 'MODEL' },
+      { id: 'p-2', name: 'Widget B', level: 'BATCH' },
+    ];
+    mockCreateProducts.mockResolvedValue(products);
+
+    const req = createFakeRequest({
+      body: [
+        { name: 'Widget A', level: 'MODEL' },
+        { name: 'Widget B', level: 'BATCH' },
+      ],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.products).toEqual(products);
+  });
+
+  it('returns 400 when body is not an array', async () => {
+    const req = createFakeRequest({ body: { name: 'Widget A', level: 'MODEL' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Request body must be an array');
+  });
+
+  it('returns 400 when body is an empty array', async () => {
+    const req = createFakeRequest({ body: [] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Request body must not be empty');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const req = createFakeRequest({ body: [{ level: 'MODEL' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name is required for all items');
+  });
+
+  it('returns 400 when level is missing', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget A' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('level is required for all items');
+  });
+
+  it('returns 400 when level is not a valid enum value', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget A', level: 'INVALID' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('level must be one of: MODEL, BATCH, ITEM');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = createBadJsonRequest();
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockCreateProducts.mockRejectedValue(new NotFoundError('Parent product not found'));
+
+    const req = createFakeRequest({ body: [{ name: 'Widget A', level: 'BATCH' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Parent product not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockCreateProducts.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ body: [{ name: 'Widget A', level: 'MODEL' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('GET /api/v1/products', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists products for the tenant', async () => {
+    const products = [{ id: 'p-1', name: 'Widget A', level: 'MODEL' }];
+    mockListProducts.mockResolvedValue(products);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/products' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.products).toEqual(products);
+  });
+
+  it('passes all filter parameters to listProducts', async () => {
+    mockListProducts.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/products?search=widget&level=MODEL&parentId=p-0&organisationId=org-2&facilityId=fac-1&limit=10&offset=5',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListProducts).toHaveBeenCalledWith('org-1', {
+      search: 'widget',
+      level: 'MODEL',
+      parentId: 'p-0',
+      organisationId: 'org-2',
+      facilityId: 'fac-1',
+      limit: 10,
+      offset: 5,
+    });
+  });
+
+  it('handles no query parameters', async () => {
+    mockListProducts.mockResolvedValue([]);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/products' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListProducts).toHaveBeenCalledWith('org-1', {
+      search: undefined,
+      level: undefined,
+      parentId: undefined,
+      organisationId: undefined,
+      facilityId: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('returns 400 for invalid level enum', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/products?level=INVALID',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('level must be one of: MODEL, BATCH, ITEM');
+  });
+
+  it('returns 400 for non-numeric limit', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/products?limit=abc',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for negative offset', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/products?offset=-1',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset must be a non-negative integer');
+  });
+
+  it('returns 500 when listProducts throws', async () => {
+    mockListProducts.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/products' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/products/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.ts
@@ -1,0 +1,219 @@
+import { NextResponse } from 'next/server';
+import {
+  ValidationError,
+  isNonEmptyString,
+  parsePositiveInt,
+  parseNonNegativeInt,
+  validateEnum,
+} from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { createProducts, listProducts, CreateProductInput } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/products' });
+
+const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
+
+/**
+ * @swagger
+ * /products:
+ *   post:
+ *     summary: Create one or more products
+ *     description: Creates products in bulk. Each item must include a name and a valid product level.
+ *     tags:
+ *       - Products
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               type: object
+ *               required:
+ *                 - name
+ *                 - level
+ *               properties:
+ *                 name:
+ *                   type: string
+ *                   description: The product name
+ *                 level:
+ *                   type: string
+ *                   enum: [MODEL, BATCH, ITEM]
+ *                   description: The product level
+ *                 description:
+ *                   type: string
+ *                   description: Optional product description
+ *                 parentId:
+ *                   type: string
+ *                   description: Optional parent product ID
+ *     responses:
+ *       201:
+ *         description: Products created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 products:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Product'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Referenced entity not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const POST = withTenantAuth(async (req, { tenantId }) => {
+  let body: Array<{
+    name?: string;
+    level?: string;
+    description?: string;
+    parentId?: string;
+  }>;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  if (!Array.isArray(body)) {
+    throw new ValidationError('Request body must be an array');
+  }
+
+  if (body.length === 0) {
+    throw new ValidationError('Request body must not be empty');
+  }
+
+  for (const item of body) {
+    if (!isNonEmptyString(item.name)) {
+      throw new ValidationError('name is required for all items');
+    }
+    if (!isNonEmptyString(item.level)) {
+      throw new ValidationError('level is required for all items');
+    }
+    validateEnum(item.level, PRODUCT_LEVELS, 'level');
+  }
+
+  logger.info({ tenantId, count: body.length }, 'Creating products');
+  const products = await createProducts(tenantId, body as CreateProductInput[]);
+
+  logger.info({ tenantId, count: products.length }, 'Products created');
+  return NextResponse.json({ products }, { status: 201 });
+});
+
+/**
+ * @swagger
+ * /products:
+ *   get:
+ *     summary: List products
+ *     description: Retrieves a list of products for the authenticated tenant with optional filtering
+ *     tags:
+ *       - Products
+ *     parameters:
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Search products by name
+ *       - in: query
+ *         name: level
+ *         schema:
+ *           type: string
+ *           enum: [MODEL, BATCH, ITEM]
+ *         description: Filter by product level
+ *       - in: query
+ *         name: parentId
+ *         schema:
+ *           type: string
+ *         description: Filter by parent product ID
+ *       - in: query
+ *         name: organisationId
+ *         schema:
+ *           type: string
+ *         description: Filter by brand organisation ID
+ *       - in: query
+ *         name: facilityId
+ *         schema:
+ *           type: string
+ *         description: Filter by manufacturing facility ID
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Maximum number of products to return
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *         description: Number of products to skip for pagination
+ *     responses:
+ *       200:
+ *         description: List of products retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 products:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Product'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (req, { tenantId }) => {
+  const url = new URL(req.url);
+  const search = url.searchParams.get('search') ?? undefined;
+  const level = validateEnum(url.searchParams.get('level') ?? undefined, PRODUCT_LEVELS, 'level');
+  const parentId = url.searchParams.get('parentId') ?? undefined;
+  const organisationId = url.searchParams.get('organisationId') ?? undefined;
+  const facilityId = url.searchParams.get('facilityId') ?? undefined;
+  const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+
+  logger.info({ tenantId, search, level, parentId, organisationId, facilityId, limit, offset }, 'Listing products');
+  const products = await listProducts(tenantId, { search, level, parentId, organisationId, facilityId, limit, offset });
+
+  logger.info({ tenantId, count: products.length }, 'Products listed');
+  return NextResponse.json({ products });
+});

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
@@ -45,7 +45,6 @@ import { prisma } from '../prisma';
 const mockFacility = prisma.facility as unknown as {
   findFirst: jest.Mock;
   findMany: jest.Mock;
-  delete: jest.Mock;
 };
 
 describe('facility.repository', () => {
@@ -376,22 +375,22 @@ describe('facility.repository', () => {
 
   describe('deleteFacility', () => {
     it('deletes a facility owned by the tenant', async () => {
-      mockFacility.findFirst.mockResolvedValue(FACILITY_RECORD);
-      mockFacility.delete.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.delete.mockResolvedValue(FACILITY_RECORD);
 
       const result = await deleteFacility('facility-1', TENANT_ID);
 
-      expect(mockFacility.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.facility.findFirst).toHaveBeenCalledWith({
         where: { id: 'facility-1', tenantId: TENANT_ID },
       });
-      expect(mockFacility.delete).toHaveBeenCalledWith({
+      expect(mockTx.facility.delete).toHaveBeenCalledWith({
         where: { id: 'facility-1' },
       });
       expect(result).toEqual(FACILITY_RECORD);
     });
 
     it('throws NotFoundError for a facility from another tenant', async () => {
-      mockFacility.findFirst.mockResolvedValue(null);
+      mockTx.facility.findFirst.mockResolvedValue(null);
 
       await expect(deleteFacility('facility-1', OTHER_TENANT)).rejects.toThrow('Facility not found or access denied');
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
@@ -1,0 +1,399 @@
+import {
+  createFacilities,
+  getFacilityById,
+  listFacilities,
+  updateFacility,
+  deleteFacility,
+} from './facility.repository';
+
+// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+const mockTx = {
+  identifier: {
+    findFirst: jest.fn(),
+  },
+  organisationEntity: {
+    findFirst: jest.fn(),
+  },
+  facility: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  facilitySecondaryIdentifier: {
+    deleteMany: jest.fn(),
+    createMany: jest.fn(),
+  },
+};
+
+const mockTransaction = jest.fn().mockImplementation((cb) => cb(mockTx));
+
+jest.mock('../prisma', () => ({
+  prisma: {
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
+    facility: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+// Import the mocked prisma after jest.mock
+import { prisma } from '../prisma';
+
+const mockFacility = prisma.facility as unknown as {
+  findFirst: jest.Mock;
+  findMany: jest.Mock;
+  delete: jest.Mock;
+};
+
+describe('facility.repository', () => {
+  const TENANT_ID = 'tenant-1';
+  const OTHER_TENANT = 'other-tenant';
+  const ORG_ID = 'org-1';
+  const PRIMARY_ID = 'ident-1';
+  const SECONDARY_ID_A = 'ident-2';
+  const SECONDARY_ID_B = 'ident-3';
+
+  const FACILITY_RECORD = {
+    id: 'facility-1',
+    tenantId: TENANT_ID,
+    name: 'Main Warehouse',
+    description: 'Central distribution warehouse',
+    location: { address: { streetAddress: '123 High Street' } },
+    operatingOrganisationId: ORG_ID,
+    primaryIdentifierId: PRIMARY_ID,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    primaryIdentifier: {
+      id: PRIMARY_ID,
+      tenantId: TENANT_ID,
+      schemeId: 'scheme-1',
+      value: '1234567890123',
+      scheme: { id: 'scheme-1', name: 'GLN' },
+    },
+    secondaryIdentifiers: [
+      {
+        facilityId: 'facility-1',
+        identifierId: SECONDARY_ID_A,
+        identifier: {
+          id: SECONDARY_ID_A,
+          tenantId: TENANT_ID,
+          schemeId: 'scheme-2',
+          value: 'SEC-001',
+          scheme: { id: 'scheme-2', name: 'Internal' },
+        },
+      },
+    ],
+    operatingOrganisation: {
+      id: ORG_ID,
+      tenantId: TENANT_ID,
+      name: 'Acme Corp',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createFacilities', () => {
+    it('creates a single facility', async () => {
+      mockTx.organisationEntity.findFirst.mockResolvedValue({ id: ORG_ID, tenantId: TENANT_ID });
+      mockTx.identifier.findFirst.mockResolvedValue({ id: PRIMARY_ID, tenantId: TENANT_ID });
+      mockTx.facility.create.mockResolvedValue(FACILITY_RECORD);
+
+      const result = await createFacilities(TENANT_ID, [
+        {
+          name: 'Main Warehouse',
+          description: 'Central distribution warehouse',
+          location: { address: { streetAddress: '123 High Street' } },
+          operatingOrganisationId: ORG_ID,
+          primaryIdentifierId: PRIMARY_ID,
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(FACILITY_RECORD);
+      expect(mockTx.organisationEntity.findFirst).toHaveBeenCalledWith({
+        where: { id: ORG_ID, tenantId: TENANT_ID },
+      });
+      expect(mockTx.facility.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId: TENANT_ID,
+            name: 'Main Warehouse',
+          }),
+          include: expect.objectContaining({
+            primaryIdentifier: expect.any(Object),
+            secondaryIdentifiers: expect.any(Object),
+            operatingOrganisation: true,
+          }),
+        }),
+      );
+    });
+
+    it('creates multiple facilities', async () => {
+      mockTx.facility.create.mockResolvedValue(FACILITY_RECORD);
+
+      const result = await createFacilities(TENANT_ID, [{ name: 'Warehouse A' }, { name: 'Warehouse B' }]);
+
+      expect(result).toHaveLength(2);
+      expect(mockTx.facility.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('validates primary identifier belongs to tenant', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createFacilities(TENANT_ID, [{ name: 'Warehouse', primaryIdentifierId: 'nonexistent' }]),
+      ).rejects.toThrow('Primary identifier not found: nonexistent');
+    });
+
+    it('validates secondary identifiers belong to tenant', async () => {
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce({ id: PRIMARY_ID, tenantId: TENANT_ID }) // primary passes
+        .mockResolvedValueOnce(null); // secondary fails
+
+      await expect(
+        createFacilities(TENANT_ID, [
+          {
+            name: 'Warehouse',
+            primaryIdentifierId: PRIMARY_ID,
+            secondaryIdentifierIds: ['nonexistent-sec'],
+          },
+        ]),
+      ).rejects.toThrow('Secondary identifier not found: nonexistent-sec');
+    });
+
+    it('validates operatingOrganisationId belongs to tenant', async () => {
+      mockTx.organisationEntity.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createFacilities(TENANT_ID, [{ name: 'Warehouse', operatingOrganisationId: 'bad-org' }]),
+      ).rejects.toThrow('Organisation not found: bad-org');
+    });
+
+    it('rejects primary and secondary identifier overlap', async () => {
+      mockTx.organisationEntity.findFirst.mockResolvedValue({ id: ORG_ID, tenantId: TENANT_ID });
+      mockTx.identifier.findFirst.mockResolvedValue({ id: PRIMARY_ID, tenantId: TENANT_ID });
+
+      await expect(
+        createFacilities(TENANT_ID, [
+          {
+            name: 'Warehouse',
+            primaryIdentifierId: PRIMARY_ID,
+            secondaryIdentifierIds: [PRIMARY_ID],
+          },
+        ]),
+      ).rejects.toThrow('Primary identifier must not also appear in secondary identifiers');
+    });
+  });
+
+  describe('getFacilityById', () => {
+    it('returns the facility with includes if it belongs to the tenant', async () => {
+      mockFacility.findFirst.mockResolvedValue(FACILITY_RECORD);
+
+      const result = await getFacilityById('facility-1', TENANT_ID);
+
+      expect(mockFacility.findFirst).toHaveBeenCalledWith({
+        where: { id: 'facility-1', tenantId: TENANT_ID },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          operatingOrganisation: true,
+        },
+      });
+      expect(result).toEqual(FACILITY_RECORD);
+    });
+
+    it('returns null for a facility from another tenant', async () => {
+      mockFacility.findFirst.mockResolvedValue(null);
+
+      const result = await getFacilityById('facility-1', OTHER_TENANT);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listFacilities', () => {
+    it('lists facilities with default pagination', async () => {
+      mockFacility.findMany.mockResolvedValue([FACILITY_RECORD]);
+
+      const result = await listFacilities(TENANT_ID);
+
+      expect(mockFacility.findMany).toHaveBeenCalledWith({
+        where: { tenantId: TENANT_ID },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          operatingOrganisation: true,
+        },
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toEqual([FACILITY_RECORD]);
+    });
+
+    it('applies custom pagination', async () => {
+      mockFacility.findMany.mockResolvedValue([]);
+
+      await listFacilities(TENANT_ID, { limit: 10, offset: 20 });
+
+      expect(mockFacility.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+          skip: 20,
+        }),
+      );
+    });
+
+    it('searches by name', async () => {
+      mockFacility.findMany.mockResolvedValue([]);
+
+      await listFacilities(TENANT_ID, { search: 'warehouse' });
+
+      expect(mockFacility.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: TENANT_ID,
+            OR: [
+              { name: { contains: 'warehouse', mode: 'insensitive' } },
+              { primaryIdentifier: { value: { contains: 'warehouse', mode: 'insensitive' } } },
+              {
+                secondaryIdentifiers: {
+                  some: {
+                    identifier: { value: { contains: 'warehouse', mode: 'insensitive' } },
+                  },
+                },
+              },
+            ],
+          }),
+        }),
+      );
+    });
+
+    it('filters by organisationId', async () => {
+      mockFacility.findMany.mockResolvedValue([]);
+
+      await listFacilities(TENANT_ID, { organisationId: ORG_ID });
+
+      expect(mockFacility.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: TENANT_ID,
+            operatingOrganisationId: ORG_ID,
+          }),
+        }),
+      );
+    });
+
+    it('returns empty array when no facilities match', async () => {
+      mockFacility.findMany.mockResolvedValue([]);
+
+      const result = await listFacilities(TENANT_ID, { search: 'nonexistent' });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('updateFacility', () => {
+    it('performs a partial update (name only)', async () => {
+      const updatedRecord = { ...FACILITY_RECORD, name: 'Renamed Warehouse' };
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.update.mockResolvedValue(updatedRecord);
+
+      const result = await updateFacility('facility-1', TENANT_ID, { name: 'Renamed Warehouse' });
+
+      expect(mockTx.facility.findFirst).toHaveBeenCalledWith({
+        where: { id: 'facility-1', tenantId: TENANT_ID },
+      });
+      expect(mockTx.facility.update).toHaveBeenCalledWith({
+        where: { id: 'facility-1' },
+        data: { name: 'Renamed Warehouse' },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          operatingOrganisation: true,
+        },
+      });
+      expect(result.name).toBe('Renamed Warehouse');
+    });
+
+    it('validates operatingOrganisationId FK', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.organisationEntity.findFirst.mockResolvedValue(null);
+
+      await expect(updateFacility('facility-1', TENANT_ID, { operatingOrganisationId: 'bad-org' })).rejects.toThrow(
+        'Organisation not found: bad-org',
+      );
+    });
+
+    it('replaces secondary identifiers', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce({ id: SECONDARY_ID_A, tenantId: TENANT_ID })
+        .mockResolvedValueOnce({ id: SECONDARY_ID_B, tenantId: TENANT_ID });
+      mockTx.facilitySecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.facilitySecondaryIdentifier.createMany.mockResolvedValue({ count: 2 });
+      mockTx.facility.update.mockResolvedValue(FACILITY_RECORD);
+
+      await updateFacility('facility-1', TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_A, SECONDARY_ID_B],
+      });
+
+      expect(mockTx.facilitySecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { facilityId: 'facility-1' },
+      });
+      expect(mockTx.facilitySecondaryIdentifier.createMany).toHaveBeenCalledWith({
+        data: [
+          { facilityId: 'facility-1', identifierId: SECONDARY_ID_A },
+          { facilityId: 'facility-1', identifierId: SECONDARY_ID_B },
+        ],
+      });
+    });
+
+    it('clears secondary identifiers with empty array', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facilitySecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.facility.update.mockResolvedValue({ ...FACILITY_RECORD, secondaryIdentifiers: [] });
+
+      await updateFacility('facility-1', TENANT_ID, { secondaryIdentifierIds: [] });
+
+      expect(mockTx.facilitySecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { facilityId: 'facility-1' },
+      });
+      expect(mockTx.facilitySecondaryIdentifier.createMany).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundError for ownership check failure', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(null);
+
+      await expect(updateFacility('facility-1', OTHER_TENANT, { name: 'Nope' })).rejects.toThrow(
+        'Facility not found or access denied',
+      );
+    });
+  });
+
+  describe('deleteFacility', () => {
+    it('deletes a facility owned by the tenant', async () => {
+      mockFacility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockFacility.delete.mockResolvedValue(FACILITY_RECORD);
+
+      const result = await deleteFacility('facility-1', TENANT_ID);
+
+      expect(mockFacility.findFirst).toHaveBeenCalledWith({
+        where: { id: 'facility-1', tenantId: TENANT_ID },
+      });
+      expect(mockFacility.delete).toHaveBeenCalledWith({
+        where: { id: 'facility-1' },
+      });
+      expect(result).toEqual(FACILITY_RECORD);
+    });
+
+    it('throws NotFoundError for a facility from another tenant', async () => {
+      mockFacility.findFirst.mockResolvedValue(null);
+
+      await expect(deleteFacility('facility-1', OTHER_TENANT)).rejects.toThrow('Facility not found or access denied');
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
@@ -1,0 +1,296 @@
+import { Facility, Prisma } from '../generated';
+import { prisma } from '../prisma';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+import { UntpLocation } from '@/lib/types';
+
+/**
+ * Include shape for facility queries — eagerly loads primary and secondary
+ * identifiers (with their schemes) and the operating organisation.
+ */
+const FACILITY_INCLUDE = {
+  primaryIdentifier: { include: { scheme: true } },
+  secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+  operatingOrganisation: true,
+} as const;
+
+/**
+ * A facility with all eagerly-loaded relations matching `FACILITY_INCLUDE`.
+ */
+export type FacilityWithRelations = Prisma.FacilityGetPayload<{ include: typeof FACILITY_INCLUDE }>;
+
+/**
+ * Input for creating a new facility.
+ */
+export type CreateFacilityInput = {
+  name: string;
+  description?: string;
+  location?: UntpLocation;
+  operatingOrganisationId?: string;
+  primaryIdentifierId?: string;
+  secondaryIdentifierIds?: string[];
+};
+
+/**
+ * Input for updating an existing facility.
+ */
+export type UpdateFacilityInput = {
+  name?: string;
+  description?: string;
+  location?: UntpLocation;
+  operatingOrganisationId?: string | null;
+  primaryIdentifierId?: string | null;
+  secondaryIdentifierIds?: string[];
+};
+
+/**
+ * Options for listing facilities with optional filtering and pagination.
+ */
+export type ListFacilitiesOptions = {
+  search?: string;
+  organisationId?: string;
+  limit?: number;
+  offset?: number;
+};
+
+/**
+ * Validates that an identifier exists and belongs to the given tenant.
+ * Throws NotFoundError if the identifier is not found or belongs to another tenant.
+ */
+async function validateIdentifierOwnership(
+  tx: Prisma.TransactionClient,
+  identifierId: string,
+  tenantId: string,
+  label: string,
+): Promise<void> {
+  const identifier = await tx.identifier.findFirst({
+    where: { id: identifierId, tenantId },
+  });
+  if (!identifier) {
+    throw new NotFoundError(`${label} not found: ${identifierId}`);
+  }
+}
+
+/**
+ * Creates one or more facilities within a transaction.
+ * Validates identifier ownership, organisation FK, and primary/secondary overlap.
+ * Returns the created facilities with all includes.
+ */
+export async function createFacilities(
+  tenantId: string,
+  inputs: CreateFacilityInput[],
+): Promise<FacilityWithRelations[]> {
+  return prisma.$transaction(async (tx) => {
+    const results: FacilityWithRelations[] = [];
+
+    for (const input of inputs) {
+      const { name, description, location, operatingOrganisationId, primaryIdentifierId, secondaryIdentifierIds } =
+        input;
+
+      // Validate operating organisation FK if provided
+      if (operatingOrganisationId) {
+        const org = await tx.organisationEntity.findFirst({
+          where: { id: operatingOrganisationId, tenantId },
+        });
+        if (!org) {
+          throw new NotFoundError(`Organisation not found: ${operatingOrganisationId}`);
+        }
+      }
+
+      // Validate primary identifier ownership
+      if (primaryIdentifierId) {
+        await validateIdentifierOwnership(tx, primaryIdentifierId, tenantId, 'Primary identifier');
+      }
+
+      // Validate secondary identifier ownership and check for overlap with primary
+      if (secondaryIdentifierIds?.length) {
+        if (primaryIdentifierId && secondaryIdentifierIds.includes(primaryIdentifierId)) {
+          throw new ValidationError('Primary identifier must not also appear in secondary identifiers');
+        }
+        for (const secId of secondaryIdentifierIds) {
+          await validateIdentifierOwnership(tx, secId, tenantId, 'Secondary identifier');
+        }
+      }
+
+      // Create the facility entity
+      const facility = await tx.facility.create({
+        data: {
+          tenantId,
+          name,
+          description,
+          location: location ? (location as Prisma.InputJsonValue) : undefined,
+          operatingOrganisationId,
+          primaryIdentifierId,
+          ...(secondaryIdentifierIds?.length && {
+            secondaryIdentifiers: {
+              createMany: {
+                data: secondaryIdentifierIds.map((identifierId) => ({ identifierId })),
+              },
+            },
+          }),
+        },
+        include: FACILITY_INCLUDE,
+      });
+
+      results.push(facility);
+    }
+
+    return results;
+  });
+}
+
+/**
+ * Retrieves a facility by ID, scoped to a tenant.
+ * Returns null if the facility does not exist or belongs to another tenant.
+ */
+export async function getFacilityById(id: string, tenantId: string): Promise<FacilityWithRelations | null> {
+  return prisma.facility.findFirst({
+    where: { id, tenantId },
+    include: FACILITY_INCLUDE,
+  });
+}
+
+/**
+ * Lists facilities for a tenant with optional search, organisation filter, and pagination.
+ * Search matches against facility name or any associated identifier value.
+ */
+export async function listFacilities(
+  tenantId: string,
+  options: ListFacilitiesOptions = {},
+): Promise<FacilityWithRelations[]> {
+  const { search, organisationId, limit, offset } = options;
+
+  const where: Prisma.FacilityWhereInput = {
+    tenantId,
+  };
+
+  if (organisationId !== undefined) {
+    where.operatingOrganisationId = organisationId;
+  }
+
+  if (search !== undefined) {
+    where.OR = [
+      { name: { contains: search, mode: 'insensitive' } },
+      { primaryIdentifier: { value: { contains: search, mode: 'insensitive' } } },
+      {
+        secondaryIdentifiers: {
+          some: {
+            identifier: { value: { contains: search, mode: 'insensitive' } },
+          },
+        },
+      },
+    ];
+  }
+
+  return prisma.facility.findMany({
+    where,
+    include: FACILITY_INCLUDE,
+    take: limit ?? 100,
+    skip: offset,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+/**
+ * Updates a facility's fields. Validates tenant ownership, organisation FK,
+ * and identifier ownership. Replaces secondary identifiers when provided.
+ */
+export async function updateFacility(
+  id: string,
+  tenantId: string,
+  input: UpdateFacilityInput,
+): Promise<FacilityWithRelations> {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.facility.findFirst({
+      where: { id, tenantId },
+    });
+
+    if (!existing) {
+      throw new NotFoundError('Facility not found or access denied');
+    }
+
+    const { name, description, location, operatingOrganisationId, primaryIdentifierId, secondaryIdentifierIds } = input;
+
+    // Validate operating organisation FK if provided and not clearing
+    if (operatingOrganisationId !== undefined && operatingOrganisationId !== null) {
+      const org = await tx.organisationEntity.findFirst({
+        where: { id: operatingOrganisationId, tenantId },
+      });
+      if (!org) {
+        throw new NotFoundError(`Organisation not found: ${operatingOrganisationId}`);
+      }
+    }
+
+    // Validate primary identifier ownership if provided and not clearing
+    if (primaryIdentifierId !== undefined && primaryIdentifierId !== null) {
+      await validateIdentifierOwnership(tx, primaryIdentifierId, tenantId, 'Primary identifier');
+    }
+
+    // Validate secondary identifiers and check for overlap with primary
+    if (secondaryIdentifierIds !== undefined) {
+      const effectivePrimaryId = primaryIdentifierId === undefined ? existing.primaryIdentifierId : primaryIdentifierId;
+      if (effectivePrimaryId && secondaryIdentifierIds.includes(effectivePrimaryId)) {
+        throw new ValidationError('Primary identifier must not also appear in secondary identifiers');
+      }
+      for (const secId of secondaryIdentifierIds) {
+        await validateIdentifierOwnership(tx, secId, tenantId, 'Secondary identifier');
+      }
+
+      // Replace secondary identifiers: delete existing, create new
+      await tx.facilitySecondaryIdentifier.deleteMany({
+        where: { facilityId: id },
+      });
+      if (secondaryIdentifierIds.length > 0) {
+        await tx.facilitySecondaryIdentifier.createMany({
+          data: secondaryIdentifierIds.map((identifierId) => ({
+            facilityId: id,
+            identifierId,
+          })),
+        });
+      }
+    }
+
+    // Build the update data, only including fields that were provided
+    const data: Prisma.FacilityUpdateInput = {};
+    if (name !== undefined) data.name = name;
+    if (description !== undefined) data.description = description;
+    if (location !== undefined) data.location = location as Prisma.InputJsonValue;
+
+    // operatingOrganisationId: null = clear, string = set, undefined = no change
+    if (operatingOrganisationId === null) {
+      data.operatingOrganisation = { disconnect: true };
+    } else if (operatingOrganisationId !== undefined) {
+      data.operatingOrganisation = { connect: { id: operatingOrganisationId } };
+    }
+
+    // primaryIdentifierId: null = clear, string = set, undefined = no change
+    if (primaryIdentifierId === null) {
+      data.primaryIdentifier = { disconnect: true };
+    } else if (primaryIdentifierId !== undefined) {
+      data.primaryIdentifier = { connect: { id: primaryIdentifierId } };
+    }
+
+    return tx.facility.update({
+      where: { id },
+      data,
+      include: FACILITY_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Deletes a facility. Validates tenant ownership before deletion.
+ */
+export async function deleteFacility(id: string, tenantId: string): Promise<Facility> {
+  const existing = await prisma.facility.findFirst({
+    where: { id, tenantId },
+  });
+
+  if (!existing) {
+    throw new NotFoundError('Facility not found or access denied');
+  }
+
+  return prisma.facility.delete({
+    where: { id },
+  });
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
@@ -282,15 +282,17 @@ export async function updateFacility(
  * Deletes a facility. Validates tenant ownership before deletion.
  */
 export async function deleteFacility(id: string, tenantId: string): Promise<Facility> {
-  const existing = await prisma.facility.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.facility.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('Facility not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('Facility not found or access denied');
+    }
 
-  return prisma.facility.delete({
-    where: { id },
+    return tx.facility.delete({
+      where: { id },
+    });
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/index.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/index.ts
@@ -5,3 +5,6 @@ export * from './registrar.repository';
 export * from './identifier-scheme.repository';
 export * from './identifier.repository';
 export * from './link-registration.repository';
+export * from './organisation.repository';
+export * from './facility.repository';
+export * from './product.repository';

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
@@ -32,15 +32,9 @@ jest.mock('../prisma', () => ({
 import { prisma } from '../prisma';
 
 const mockOrganisationEntity = prisma.organisationEntity as unknown as {
-  create: jest.Mock;
   findFirst: jest.Mock;
-  findUniqueOrThrow: jest.Mock;
   findMany: jest.Mock;
-  update: jest.Mock;
-  delete: jest.Mock;
 };
-
-const mockIdentifier = (prisma as unknown as { identifier: { findFirst: jest.Mock } }).identifier;
 
 const mockTransaction = prisma.$transaction as unknown as jest.Mock;
 
@@ -396,15 +390,26 @@ describe('organisation.repository', () => {
   describe('updateOrganisation', () => {
     it('performs a partial update (name only)', async () => {
       const updatedOrg = { ...ORG_RECORD, name: 'Acme Industries' };
-      mockOrganisationEntity.findFirst.mockResolvedValue(ORG_RECORD);
-      mockOrganisationEntity.update.mockResolvedValue(updatedOrg);
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn().mockResolvedValue(updatedOrg),
+        },
+        identifier: { findFirst: jest.fn() },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
 
       const result = await updateOrganisation('org-1', TENANT_ID, { name: 'Acme Industries' });
 
-      expect(mockOrganisationEntity.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.organisationEntity.findFirst).toHaveBeenCalledWith({
         where: { id: 'org-1', tenantId: TENANT_ID },
       });
-      expect(mockOrganisationEntity.update).toHaveBeenCalledWith({
+      expect(mockTx.organisationEntity.update).toHaveBeenCalledWith({
         where: { id: 'org-1' },
         data: { name: 'Acme Industries' },
         include: {
@@ -416,21 +421,22 @@ describe('organisation.repository', () => {
     });
 
     it('replaces secondary identifiers via deleteMany + createMany in transaction', async () => {
-      mockOrganisationEntity.findFirst.mockResolvedValue(ORG_RECORD);
-      mockIdentifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD_2);
-
       const updatedOrg = {
         ...ORG_RECORD,
         secondaryIdentifiers: [{ organisationId: 'org-1', identifierId: 'ident-2', identifier: IDENTIFIER_RECORD_2 }],
       };
 
       const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn().mockResolvedValue(updatedOrg),
+        },
+        identifier: {
+          findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2),
+        },
         organisationSecondaryIdentifier: {
           deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
           createMany: jest.fn().mockResolvedValue({ count: 1 }),
-        },
-        organisationEntity: {
-          update: jest.fn().mockResolvedValue(updatedOrg),
         },
       };
 
@@ -455,16 +461,16 @@ describe('organisation.repository', () => {
         ...ORG_RECORD,
         secondaryIdentifiers: [{ organisationId: 'org-1', identifierId: 'ident-2', identifier: IDENTIFIER_RECORD_2 }],
       };
-      mockOrganisationEntity.findFirst.mockResolvedValue(orgWithSecondaries);
-
       const clearedOrg = { ...ORG_RECORD, secondaryIdentifiers: [] };
       const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(orgWithSecondaries),
+          update: jest.fn().mockResolvedValue(clearedOrg),
+        },
+        identifier: { findFirst: jest.fn() },
         organisationSecondaryIdentifier: {
           deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
           createMany: jest.fn(),
-        },
-        organisationEntity: {
-          update: jest.fn().mockResolvedValue(clearedOrg),
         },
       };
 
@@ -477,13 +483,24 @@ describe('organisation.repository', () => {
       expect(mockTx.organisationSecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
         where: { organisationId: 'org-1' },
       });
-      // createMany should not be called with empty array
       expect(mockTx.organisationSecondaryIdentifier.createMany).not.toHaveBeenCalled();
       expect(result.secondaryIdentifiers).toHaveLength(0);
     });
 
     it('throws NotFoundError if organisation does not belong to tenant', async () => {
-      mockOrganisationEntity.findFirst.mockResolvedValue(null);
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(null),
+          update: jest.fn(),
+        },
+        identifier: { findFirst: jest.fn() },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
 
       await expect(updateOrganisation('org-1', OTHER_TENANT_ID, { name: 'Updated' })).rejects.toThrow(
         'Organisation not found or access denied',
@@ -493,15 +510,21 @@ describe('organisation.repository', () => {
 
   describe('deleteOrganisation', () => {
     it('deletes an organisation owned by the tenant', async () => {
-      mockOrganisationEntity.findFirst.mockResolvedValue(ORG_RECORD);
-      mockOrganisationEntity.delete.mockResolvedValue(ORG_RECORD);
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          delete: jest.fn().mockResolvedValue(ORG_RECORD),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
 
       const result = await deleteOrganisation('org-1', TENANT_ID);
 
-      expect(mockOrganisationEntity.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.organisationEntity.findFirst).toHaveBeenCalledWith({
         where: { id: 'org-1', tenantId: TENANT_ID },
       });
-      expect(mockOrganisationEntity.delete).toHaveBeenCalledWith({
+      expect(mockTx.organisationEntity.delete).toHaveBeenCalledWith({
         where: { id: 'org-1' },
         include: {
           primaryIdentifier: { include: { scheme: true } },
@@ -512,7 +535,14 @@ describe('organisation.repository', () => {
     });
 
     it('throws NotFoundError if organisation does not belong to tenant', async () => {
-      mockOrganisationEntity.findFirst.mockResolvedValue(null);
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(null),
+          delete: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
 
       await expect(deleteOrganisation('org-1', OTHER_TENANT_ID)).rejects.toThrow(
         'Organisation not found or access denied',

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
@@ -1,0 +1,522 @@
+import {
+  createOrganisations,
+  getOrganisationById,
+  listOrganisations,
+  updateOrganisation,
+  deleteOrganisation,
+} from './organisation.repository';
+
+// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+jest.mock('../prisma', () => ({
+  prisma: {
+    organisationEntity: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    organisationSecondaryIdentifier: {
+      createMany: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    identifier: {
+      findFirst: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+// Import the mocked prisma after jest.mock
+import { prisma } from '../prisma';
+
+const mockOrganisationEntity = prisma.organisationEntity as unknown as {
+  create: jest.Mock;
+  findFirst: jest.Mock;
+  findUniqueOrThrow: jest.Mock;
+  findMany: jest.Mock;
+  update: jest.Mock;
+  delete: jest.Mock;
+};
+
+const mockIdentifier = (prisma as unknown as { identifier: { findFirst: jest.Mock } }).identifier;
+
+const mockTransaction = prisma.$transaction as unknown as jest.Mock;
+
+describe('organisation.repository', () => {
+  const TENANT_ID = 'tenant-1';
+  const OTHER_TENANT_ID = 'other-tenant';
+  const SCHEME_RECORD = {
+    id: 'scheme-1',
+    tenantId: TENANT_ID,
+    registrarId: 'reg-1',
+    name: 'GTIN',
+    primaryKey: 'gtin',
+    validationPattern: '^\\d{13,14}$',
+    namespace: 'gs1',
+    idrServiceInstanceId: null,
+    isDefault: false,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+  const IDENTIFIER_RECORD = {
+    id: 'ident-1',
+    tenantId: TENANT_ID,
+    schemeId: 'scheme-1',
+    value: '1234567890123',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    scheme: SCHEME_RECORD,
+  };
+  const IDENTIFIER_RECORD_2 = {
+    id: 'ident-2',
+    tenantId: TENANT_ID,
+    schemeId: 'scheme-1',
+    value: '9876543210123',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    scheme: SCHEME_RECORD,
+  };
+  const ORG_RECORD = {
+    id: 'org-1',
+    tenantId: TENANT_ID,
+    name: 'Acme Corp',
+    description: 'A test organisation',
+    location: { address: { streetAddress: '123 Main St' } },
+    primaryIdentifierId: 'ident-1',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    primaryIdentifier: IDENTIFIER_RECORD,
+    secondaryIdentifiers: [],
+  };
+  const ORG_RECORD_2 = {
+    id: 'org-2',
+    tenantId: TENANT_ID,
+    name: 'Beta Ltd',
+    description: null,
+    location: null,
+    primaryIdentifierId: null,
+    createdAt: new Date('2024-01-02'),
+    updatedAt: new Date('2024-01-02'),
+    primaryIdentifier: null,
+    secondaryIdentifiers: [],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createOrganisations', () => {
+    it('creates a single organisation with primary and secondary identifiers', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn(),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      // Primary identifier ownership check
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce(IDENTIFIER_RECORD) // primary
+        .mockResolvedValueOnce(IDENTIFIER_RECORD_2); // secondary
+
+      const createdOrg = { ...ORG_RECORD, secondaryIdentifiers: [] };
+      mockTx.organisationEntity.create.mockResolvedValue(createdOrg);
+      mockTx.organisationSecondaryIdentifier.createMany.mockResolvedValue({ count: 1 });
+
+      const refetchedOrg = {
+        ...ORG_RECORD,
+        secondaryIdentifiers: [{ organisationId: 'org-1', identifierId: 'ident-2', identifier: IDENTIFIER_RECORD_2 }],
+      };
+      mockTx.organisationEntity.findUniqueOrThrow.mockResolvedValue(refetchedOrg);
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = await createOrganisations(TENANT_ID, [
+        {
+          name: 'Acme Corp',
+          description: 'A test organisation',
+          location: { address: { streetAddress: '123 Main St' } },
+          primaryIdentifierId: 'ident-1',
+          secondaryIdentifierIds: ['ident-2'],
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(refetchedOrg);
+      expect(mockTx.identifier.findFirst).toHaveBeenCalledTimes(2);
+      expect(mockTx.organisationEntity.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          tenantId: TENANT_ID,
+          name: 'Acme Corp',
+          description: 'A test organisation',
+          primaryIdentifierId: 'ident-1',
+        }),
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+        },
+      });
+      expect(mockTx.organisationSecondaryIdentifier.createMany).toHaveBeenCalledWith({
+        data: [{ organisationId: 'org-1', identifierId: 'ident-2' }],
+      });
+    });
+
+    it('creates multiple organisations', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn(),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      // No identifiers to validate
+      mockTx.organisationEntity.create.mockResolvedValueOnce(ORG_RECORD).mockResolvedValueOnce(ORG_RECORD_2);
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = await createOrganisations(TENANT_ID, [{ name: 'Acme Corp' }, { name: 'Beta Ltd' }]);
+
+      expect(result).toHaveLength(2);
+      expect(mockTx.organisationEntity.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws NotFoundError if primary identifier does not belong to tenant', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn(),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      mockTx.identifier.findFirst.mockResolvedValue(null);
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      await expect(
+        createOrganisations(TENANT_ID, [{ name: 'Acme Corp', primaryIdentifierId: 'nonexistent' }]),
+      ).rejects.toThrow('Identifier not found: nonexistent');
+    });
+
+    it('throws NotFoundError if secondary identifier does not belong to tenant', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn(),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      // Primary passes but secondary fails
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce(IDENTIFIER_RECORD) // primary valid
+        .mockResolvedValueOnce(null); // secondary invalid
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      await expect(
+        createOrganisations(TENANT_ID, [
+          {
+            name: 'Acme Corp',
+            primaryIdentifierId: 'ident-1',
+            secondaryIdentifierIds: ['nonexistent'],
+          },
+        ]),
+      ).rejects.toThrow('Identifier not found: nonexistent');
+    });
+
+    it('throws ValidationError when primary identifier is also a secondary identifier', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn(),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      // Both ownership checks pass
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce(IDENTIFIER_RECORD) // primary
+        .mockResolvedValueOnce(IDENTIFIER_RECORD); // secondary (same id)
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      await expect(
+        createOrganisations(TENANT_ID, [
+          {
+            name: 'Acme Corp',
+            primaryIdentifierId: 'ident-1',
+            secondaryIdentifierIds: ['ident-1'],
+          },
+        ]),
+      ).rejects.toThrow('Primary identifier cannot also be a secondary identifier');
+    });
+
+    it('rolls back the entire batch on validation failure', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn(),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      // First org succeeds
+      mockTx.organisationEntity.create.mockResolvedValueOnce(ORG_RECORD);
+      // Second org fails validation — primary identifier not found
+      mockTx.identifier.findFirst.mockResolvedValue(null);
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      await expect(
+        createOrganisations(TENANT_ID, [
+          { name: 'Acme Corp' }, // no identifiers, passes
+          { name: 'Beta Ltd', primaryIdentifierId: 'nonexistent' }, // fails
+        ]),
+      ).rejects.toThrow('Identifier not found: nonexistent');
+
+      // The transaction callback threw, so Prisma would roll back.
+      // First org was created inside the transaction but will be rolled back.
+      expect(mockTx.organisationEntity.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getOrganisationById', () => {
+    it('returns the organisation with includes if it belongs to the tenant', async () => {
+      mockOrganisationEntity.findFirst.mockResolvedValue(ORG_RECORD);
+
+      const result = await getOrganisationById('org-1', TENANT_ID);
+
+      expect(mockOrganisationEntity.findFirst).toHaveBeenCalledWith({
+        where: { id: 'org-1', tenantId: TENANT_ID },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+        },
+      });
+      expect(result).toEqual(ORG_RECORD);
+    });
+
+    it('returns null for an organisation from another tenant', async () => {
+      mockOrganisationEntity.findFirst.mockResolvedValue(null);
+
+      const result = await getOrganisationById('org-1', OTHER_TENANT_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listOrganisations', () => {
+    it('lists organisations with default pagination', async () => {
+      mockOrganisationEntity.findMany.mockResolvedValue([ORG_RECORD]);
+
+      const result = await listOrganisations(TENANT_ID);
+
+      expect(mockOrganisationEntity.findMany).toHaveBeenCalledWith({
+        where: { tenantId: TENANT_ID },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+        },
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toEqual([ORG_RECORD]);
+    });
+
+    it('applies custom pagination', async () => {
+      mockOrganisationEntity.findMany.mockResolvedValue([]);
+
+      await listOrganisations(TENANT_ID, { limit: 10, offset: 20 });
+
+      expect(mockOrganisationEntity.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+          skip: 20,
+        }),
+      );
+    });
+
+    it('searches by name', async () => {
+      mockOrganisationEntity.findMany.mockResolvedValue([ORG_RECORD]);
+
+      await listOrganisations(TENANT_ID, { search: 'Acme' });
+
+      expect(mockOrganisationEntity.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: TENANT_ID,
+            OR: expect.arrayContaining([{ name: { contains: 'Acme', mode: 'insensitive' } }]),
+          }),
+        }),
+      );
+    });
+
+    it('searches by identifier value with OR clause', async () => {
+      mockOrganisationEntity.findMany.mockResolvedValue([]);
+
+      await listOrganisations(TENANT_ID, { search: '12345' });
+
+      expect(mockOrganisationEntity.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            OR: [
+              { name: { contains: '12345', mode: 'insensitive' } },
+              { primaryIdentifier: { value: { contains: '12345', mode: 'insensitive' } } },
+              {
+                secondaryIdentifiers: {
+                  some: {
+                    identifier: { value: { contains: '12345', mode: 'insensitive' } },
+                  },
+                },
+              },
+            ],
+          }),
+        }),
+      );
+    });
+
+    it('returns empty array when no matches', async () => {
+      mockOrganisationEntity.findMany.mockResolvedValue([]);
+
+      const result = await listOrganisations(TENANT_ID, { search: 'nonexistent' });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('updateOrganisation', () => {
+    it('performs a partial update (name only)', async () => {
+      const updatedOrg = { ...ORG_RECORD, name: 'Acme Industries' };
+      mockOrganisationEntity.findFirst.mockResolvedValue(ORG_RECORD);
+      mockOrganisationEntity.update.mockResolvedValue(updatedOrg);
+
+      const result = await updateOrganisation('org-1', TENANT_ID, { name: 'Acme Industries' });
+
+      expect(mockOrganisationEntity.findFirst).toHaveBeenCalledWith({
+        where: { id: 'org-1', tenantId: TENANT_ID },
+      });
+      expect(mockOrganisationEntity.update).toHaveBeenCalledWith({
+        where: { id: 'org-1' },
+        data: { name: 'Acme Industries' },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+        },
+      });
+      expect(result.name).toBe('Acme Industries');
+    });
+
+    it('replaces secondary identifiers via deleteMany + createMany in transaction', async () => {
+      mockOrganisationEntity.findFirst.mockResolvedValue(ORG_RECORD);
+      mockIdentifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD_2);
+
+      const updatedOrg = {
+        ...ORG_RECORD,
+        secondaryIdentifiers: [{ organisationId: 'org-1', identifierId: 'ident-2', identifier: IDENTIFIER_RECORD_2 }],
+      };
+
+      const mockTx = {
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+          createMany: jest.fn().mockResolvedValue({ count: 1 }),
+        },
+        organisationEntity: {
+          update: jest.fn().mockResolvedValue(updatedOrg),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = await updateOrganisation('org-1', TENANT_ID, {
+        secondaryIdentifierIds: ['ident-2'],
+      });
+
+      expect(mockTx.organisationSecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { organisationId: 'org-1' },
+      });
+      expect(mockTx.organisationSecondaryIdentifier.createMany).toHaveBeenCalledWith({
+        data: [{ organisationId: 'org-1', identifierId: 'ident-2' }],
+      });
+      expect(mockTx.organisationEntity.update).toHaveBeenCalled();
+      expect(result.secondaryIdentifiers).toHaveLength(1);
+    });
+
+    it('clears all secondary identifiers with empty array', async () => {
+      const orgWithSecondaries = {
+        ...ORG_RECORD,
+        secondaryIdentifiers: [{ organisationId: 'org-1', identifierId: 'ident-2', identifier: IDENTIFIER_RECORD_2 }],
+      };
+      mockOrganisationEntity.findFirst.mockResolvedValue(orgWithSecondaries);
+
+      const clearedOrg = { ...ORG_RECORD, secondaryIdentifiers: [] };
+      const mockTx = {
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+          createMany: jest.fn(),
+        },
+        organisationEntity: {
+          update: jest.fn().mockResolvedValue(clearedOrg),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = await updateOrganisation('org-1', TENANT_ID, {
+        secondaryIdentifierIds: [],
+      });
+
+      expect(mockTx.organisationSecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { organisationId: 'org-1' },
+      });
+      // createMany should not be called with empty array
+      expect(mockTx.organisationSecondaryIdentifier.createMany).not.toHaveBeenCalled();
+      expect(result.secondaryIdentifiers).toHaveLength(0);
+    });
+
+    it('throws NotFoundError if organisation does not belong to tenant', async () => {
+      mockOrganisationEntity.findFirst.mockResolvedValue(null);
+
+      await expect(updateOrganisation('org-1', OTHER_TENANT_ID, { name: 'Updated' })).rejects.toThrow(
+        'Organisation not found or access denied',
+      );
+    });
+  });
+
+  describe('deleteOrganisation', () => {
+    it('deletes an organisation owned by the tenant', async () => {
+      mockOrganisationEntity.findFirst.mockResolvedValue(ORG_RECORD);
+      mockOrganisationEntity.delete.mockResolvedValue(ORG_RECORD);
+
+      const result = await deleteOrganisation('org-1', TENANT_ID);
+
+      expect(mockOrganisationEntity.findFirst).toHaveBeenCalledWith({
+        where: { id: 'org-1', tenantId: TENANT_ID },
+      });
+      expect(mockOrganisationEntity.delete).toHaveBeenCalledWith({
+        where: { id: 'org-1' },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+        },
+      });
+      expect(result).toEqual(ORG_RECORD);
+    });
+
+    it('throws NotFoundError if organisation does not belong to tenant', async () => {
+      mockOrganisationEntity.findFirst.mockResolvedValue(null);
+
+      await expect(deleteOrganisation('org-1', OTHER_TENANT_ID)).rejects.toThrow(
+        'Organisation not found or access denied',
+      );
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
@@ -1,0 +1,309 @@
+import { Prisma } from '../generated';
+import { prisma } from '../prisma';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+import { UntpLocation } from '@/lib/types';
+
+/**
+ * Include shape used by all organisation queries.
+ * Includes the primary identifier (with scheme) and all secondary identifiers
+ * (via the join table, each with its identifier and scheme).
+ */
+const ORGANISATION_INCLUDE = {
+  primaryIdentifier: { include: { scheme: true } },
+  secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+} as const;
+
+/**
+ * An organisation entity with its full identifier relations.
+ * Matches the include shape defined by ORGANISATION_INCLUDE.
+ */
+export type OrganisationEntityWithRelations = Prisma.OrganisationEntityGetPayload<{
+  include: typeof ORGANISATION_INCLUDE;
+}>;
+
+/**
+ * Input for creating a new organisation entity.
+ */
+export type CreateOrganisationInput = {
+  name: string;
+  description?: string;
+  location?: UntpLocation;
+  primaryIdentifierId?: string;
+  secondaryIdentifierIds?: string[];
+};
+
+/**
+ * Input for updating an existing organisation entity.
+ * Fields set to undefined are left unchanged.
+ * primaryIdentifierId set to null clears the primary identifier.
+ * secondaryIdentifierIds set to [] clears all secondary identifiers.
+ */
+export type UpdateOrganisationInput = {
+  name?: string;
+  description?: string;
+  location?: UntpLocation;
+  primaryIdentifierId?: string | null;
+  secondaryIdentifierIds?: string[];
+};
+
+/**
+ * Options for listing organisation entities.
+ */
+export type ListOrganisationsOptions = {
+  search?: string;
+  limit?: number;
+  offset?: number;
+};
+
+/**
+ * Validates that an identifier belongs to the given tenant.
+ * Runs within a transaction client.
+ */
+async function validateIdentifierOwnership(
+  tx: Prisma.TransactionClient,
+  identifierId: string,
+  tenantId: string,
+): Promise<void> {
+  const ident = await tx.identifier.findFirst({ where: { id: identifierId, tenantId } });
+  if (!ident) {
+    throw new NotFoundError(`Identifier not found: ${identifierId}`);
+  }
+}
+
+/**
+ * Validates that the primary identifier is not also listed as a secondary identifier.
+ */
+function validateNoPrimarySecondaryOverlap(
+  primaryIdentifierId: string | undefined | null,
+  secondaryIdentifierIds: string[] | undefined,
+): void {
+  if (primaryIdentifierId && secondaryIdentifierIds?.includes(primaryIdentifierId)) {
+    throw new ValidationError('Primary identifier cannot also be a secondary identifier');
+  }
+}
+
+/**
+ * Creates one or more organisation entities in a single transaction.
+ * Validates all identifier references belong to the tenant before creating.
+ */
+export async function createOrganisations(
+  tenantId: string,
+  inputs: CreateOrganisationInput[],
+): Promise<OrganisationEntityWithRelations[]> {
+  return prisma.$transaction(async (tx) => {
+    const results: OrganisationEntityWithRelations[] = [];
+
+    for (const input of inputs) {
+      // Validate primary identifier belongs to tenant
+      if (input.primaryIdentifierId) {
+        await validateIdentifierOwnership(tx, input.primaryIdentifierId, tenantId);
+      }
+
+      // Validate secondary identifiers belong to tenant
+      if (input.secondaryIdentifierIds?.length) {
+        for (const secId of input.secondaryIdentifierIds) {
+          await validateIdentifierOwnership(tx, secId, tenantId);
+        }
+      }
+
+      // Validate no overlap between primary and secondary
+      validateNoPrimarySecondaryOverlap(input.primaryIdentifierId, input.secondaryIdentifierIds);
+
+      // Create the organisation entity
+      const organisation = await tx.organisationEntity.create({
+        data: {
+          tenantId,
+          name: input.name,
+          ...(input.description !== undefined && { description: input.description }),
+          ...(input.location !== undefined && { location: input.location as Prisma.InputJsonValue }),
+          ...(input.primaryIdentifierId !== undefined && { primaryIdentifierId: input.primaryIdentifierId }),
+        },
+        include: ORGANISATION_INCLUDE,
+      });
+
+      // Create join rows for secondary identifiers
+      if (input.secondaryIdentifierIds?.length) {
+        await tx.organisationSecondaryIdentifier.createMany({
+          data: input.secondaryIdentifierIds.map((identifierId) => ({
+            organisationId: organisation.id,
+            identifierId,
+          })),
+        });
+
+        // Re-fetch to include the newly created secondary identifier relations
+        const refetched = await tx.organisationEntity.findUniqueOrThrow({
+          where: { id: organisation.id },
+          include: ORGANISATION_INCLUDE,
+        });
+        results.push(refetched);
+      } else {
+        results.push(organisation);
+      }
+    }
+
+    return results;
+  });
+}
+
+/**
+ * Retrieves an organisation entity by ID, scoped to the tenant.
+ * Returns null if not found or belongs to a different tenant.
+ */
+export async function getOrganisationById(
+  id: string,
+  tenantId: string,
+): Promise<OrganisationEntityWithRelations | null> {
+  return prisma.organisationEntity.findFirst({
+    where: { id, tenantId },
+    include: ORGANISATION_INCLUDE,
+  });
+}
+
+/**
+ * Lists organisation entities for a tenant.
+ * Supports optional search across name and identifier values.
+ */
+export async function listOrganisations(
+  tenantId: string,
+  options: ListOrganisationsOptions = {},
+): Promise<OrganisationEntityWithRelations[]> {
+  const { search, limit, offset } = options;
+
+  const where: Prisma.OrganisationEntityWhereInput = {
+    tenantId,
+  };
+
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: 'insensitive' } },
+      { primaryIdentifier: { value: { contains: search, mode: 'insensitive' } } },
+      {
+        secondaryIdentifiers: {
+          some: {
+            identifier: { value: { contains: search, mode: 'insensitive' } },
+          },
+        },
+      },
+    ];
+  }
+
+  return prisma.organisationEntity.findMany({
+    where,
+    include: ORGANISATION_INCLUDE,
+    take: limit ?? 100,
+    skip: offset,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+/**
+ * Updates an organisation entity.
+ * Validates ownership and identifier references before updating.
+ */
+export async function updateOrganisation(
+  id: string,
+  tenantId: string,
+  input: UpdateOrganisationInput,
+): Promise<OrganisationEntityWithRelations> {
+  // Ownership check
+  const existing = await prisma.organisationEntity.findFirst({
+    where: { id, tenantId },
+  });
+
+  if (!existing) {
+    throw new NotFoundError('Organisation not found or access denied');
+  }
+
+  // Validate primary identifier belongs to tenant (if provided and not null)
+  if (input.primaryIdentifierId !== undefined && input.primaryIdentifierId !== null) {
+    const ident = await prisma.identifier.findFirst({
+      where: { id: input.primaryIdentifierId, tenantId },
+    });
+    if (!ident) {
+      throw new NotFoundError(`Identifier not found: ${input.primaryIdentifierId}`);
+    }
+  }
+
+  // Build the data object with only explicitly provided fields
+  const data: Prisma.OrganisationEntityUpdateInput = {
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.location !== undefined && { location: input.location as Prisma.InputJsonValue }),
+  };
+
+  // Handle primaryIdentifierId: null = clear, string = set, undefined = no change
+  if (input.primaryIdentifierId === null) {
+    data.primaryIdentifier = { disconnect: true };
+  } else if (input.primaryIdentifierId !== undefined) {
+    data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
+  }
+
+  // Determine the effective primary identifier ID for overlap validation
+  const effectivePrimaryId =
+    input.primaryIdentifierId !== undefined ? input.primaryIdentifierId : existing.primaryIdentifierId;
+
+  if (input.secondaryIdentifierIds !== undefined) {
+    // Validate all secondary identifiers belong to tenant
+    for (const secId of input.secondaryIdentifierIds) {
+      const ident = await prisma.identifier.findFirst({ where: { id: secId, tenantId } });
+      if (!ident) {
+        throw new NotFoundError(`Identifier not found: ${secId}`);
+      }
+    }
+
+    // Validate no overlap with effective primary
+    validateNoPrimarySecondaryOverlap(effectivePrimaryId, input.secondaryIdentifierIds);
+
+    // Use transaction to replace secondary identifiers atomically
+    return prisma.$transaction(async (tx) => {
+      // Remove existing secondary identifier join rows
+      await tx.organisationSecondaryIdentifier.deleteMany({
+        where: { organisationId: id },
+      });
+
+      // Create new join rows
+      if (input.secondaryIdentifierIds!.length > 0) {
+        await tx.organisationSecondaryIdentifier.createMany({
+          data: input.secondaryIdentifierIds!.map((identifierId) => ({
+            organisationId: id,
+            identifierId,
+          })),
+        });
+      }
+
+      // Update the entity
+      return tx.organisationEntity.update({
+        where: { id },
+        data,
+        include: ORGANISATION_INCLUDE,
+      });
+    });
+  }
+
+  // No secondary identifier changes — simple update
+  return prisma.organisationEntity.update({
+    where: { id },
+    data,
+    include: ORGANISATION_INCLUDE,
+  });
+}
+
+/**
+ * Deletes an organisation entity.
+ * Join table rows (secondary identifiers) cascade automatically.
+ */
+export async function deleteOrganisation(id: string, tenantId: string): Promise<OrganisationEntityWithRelations> {
+  const existing = await prisma.organisationEntity.findFirst({
+    where: { id, tenantId },
+  });
+
+  if (!existing) {
+    throw new NotFoundError('Organisation not found or access denied');
+  }
+
+  return prisma.organisationEntity.delete({
+    where: { id },
+    include: ORGANISATION_INCLUDE,
+  });
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
@@ -206,86 +206,64 @@ export async function updateOrganisation(
   tenantId: string,
   input: UpdateOrganisationInput,
 ): Promise<OrganisationEntityWithRelations> {
-  // Ownership check
-  const existing = await prisma.organisationEntity.findFirst({
-    where: { id, tenantId },
-  });
-
-  if (!existing) {
-    throw new NotFoundError('Organisation not found or access denied');
-  }
-
-  // Validate primary identifier belongs to tenant (if provided and not null)
-  if (input.primaryIdentifierId !== undefined && input.primaryIdentifierId !== null) {
-    const ident = await prisma.identifier.findFirst({
-      where: { id: input.primaryIdentifierId, tenantId },
+  return prisma.$transaction(async (tx) => {
+    // Ownership check
+    const existing = await tx.organisationEntity.findFirst({
+      where: { id, tenantId },
     });
-    if (!ident) {
-      throw new NotFoundError(`Identifier not found: ${input.primaryIdentifierId}`);
+
+    if (!existing) {
+      throw new NotFoundError('Organisation not found or access denied');
     }
-  }
 
-  // Build the data object with only explicitly provided fields
-  const data: Prisma.OrganisationEntityUpdateInput = {
-    ...(input.name !== undefined && { name: input.name }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.location !== undefined && { location: input.location as Prisma.InputJsonValue }),
-  };
+    // Validate primary identifier belongs to tenant (if provided and not null)
+    if (input.primaryIdentifierId !== undefined && input.primaryIdentifierId !== null) {
+      await validateIdentifierOwnership(tx, input.primaryIdentifierId, tenantId);
+    }
 
-  // Handle primaryIdentifierId: null = clear, string = set, undefined = no change
-  if (input.primaryIdentifierId === null) {
-    data.primaryIdentifier = { disconnect: true };
-  } else if (input.primaryIdentifierId !== undefined) {
-    data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
-  }
+    // Validate secondary identifiers and check for overlap with primary
+    if (input.secondaryIdentifierIds !== undefined) {
+      const effectivePrimaryId =
+        input.primaryIdentifierId !== undefined ? input.primaryIdentifierId : existing.primaryIdentifierId;
+      validateNoPrimarySecondaryOverlap(effectivePrimaryId, input.secondaryIdentifierIds);
 
-  // Determine the effective primary identifier ID for overlap validation
-  const effectivePrimaryId =
-    input.primaryIdentifierId !== undefined ? input.primaryIdentifierId : existing.primaryIdentifierId;
-
-  if (input.secondaryIdentifierIds !== undefined) {
-    // Validate all secondary identifiers belong to tenant
-    for (const secId of input.secondaryIdentifierIds) {
-      const ident = await prisma.identifier.findFirst({ where: { id: secId, tenantId } });
-      if (!ident) {
-        throw new NotFoundError(`Identifier not found: ${secId}`);
+      for (const secId of input.secondaryIdentifierIds) {
+        await validateIdentifierOwnership(tx, secId, tenantId);
       }
-    }
 
-    // Validate no overlap with effective primary
-    validateNoPrimarySecondaryOverlap(effectivePrimaryId, input.secondaryIdentifierIds);
-
-    // Use transaction to replace secondary identifiers atomically
-    return prisma.$transaction(async (tx) => {
-      // Remove existing secondary identifier join rows
+      // Replace secondary identifiers: delete existing, create new
       await tx.organisationSecondaryIdentifier.deleteMany({
         where: { organisationId: id },
       });
-
-      // Create new join rows
-      if (input.secondaryIdentifierIds!.length > 0) {
+      if (input.secondaryIdentifierIds.length > 0) {
         await tx.organisationSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds!.map((identifierId) => ({
+          data: input.secondaryIdentifierIds.map((identifierId) => ({
             organisationId: id,
             identifierId,
           })),
         });
       }
+    }
 
-      // Update the entity
-      return tx.organisationEntity.update({
-        where: { id },
-        data,
-        include: ORGANISATION_INCLUDE,
-      });
+    // Build the data object with only explicitly provided fields
+    const data: Prisma.OrganisationEntityUpdateInput = {
+      ...(input.name !== undefined && { name: input.name }),
+      ...(input.description !== undefined && { description: input.description }),
+      ...(input.location !== undefined && { location: input.location as Prisma.InputJsonValue }),
+    };
+
+    // Handle primaryIdentifierId: null = clear, string = set, undefined = no change
+    if (input.primaryIdentifierId === null) {
+      data.primaryIdentifier = { disconnect: true };
+    } else if (input.primaryIdentifierId !== undefined) {
+      data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
+    }
+
+    return tx.organisationEntity.update({
+      where: { id },
+      data,
+      include: ORGANISATION_INCLUDE,
     });
-  }
-
-  // No secondary identifier changes — simple update
-  return prisma.organisationEntity.update({
-    where: { id },
-    data,
-    include: ORGANISATION_INCLUDE,
   });
 }
 
@@ -294,16 +272,18 @@ export async function updateOrganisation(
  * Join table rows (secondary identifiers) cascade automatically.
  */
 export async function deleteOrganisation(id: string, tenantId: string): Promise<OrganisationEntityWithRelations> {
-  const existing = await prisma.organisationEntity.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.organisationEntity.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('Organisation not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('Organisation not found or access denied');
+    }
 
-  return prisma.organisationEntity.delete({
-    where: { id },
-    include: ORGANISATION_INCLUDE,
+    return tx.organisationEntity.delete({
+      where: { id },
+      include: ORGANISATION_INCLUDE,
+    });
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
@@ -57,14 +57,7 @@ import { prisma } from '../prisma';
 const mockProduct = prisma.product as unknown as {
   findFirst: jest.Mock;
   findMany: jest.Mock;
-  update: jest.Mock;
-  delete: jest.Mock;
 };
-
-const mockIdentifier = (prisma as unknown as { identifier: { findFirst: jest.Mock } }).identifier;
-const mockOrganisationEntity = (prisma as unknown as { organisationEntity: { findFirst: jest.Mock } })
-  .organisationEntity;
-const mockFacility = (prisma as unknown as { facility: { findFirst: jest.Mock } }).facility;
 
 describe('product.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -430,15 +423,15 @@ describe('product.repository', () => {
 
   describe('updateProduct', () => {
     it('performs a partial update (name only)', async () => {
-      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
-      mockProduct.update.mockResolvedValue({ ...PRODUCT_WITH_RELATIONS, name: 'Updated Name' });
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.product.update.mockResolvedValue({ ...PRODUCT_WITH_RELATIONS, name: 'Updated Name' });
 
       const result = await updateProduct(PRODUCT_ID, TENANT_ID, { name: 'Updated Name' });
 
-      expect(mockProduct.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.product.findFirst).toHaveBeenCalledWith({
         where: { id: PRODUCT_ID, tenantId: TENANT_ID },
       });
-      expect(mockProduct.update).toHaveBeenCalledWith({
+      expect(mockTx.product.update).toHaveBeenCalledWith({
         where: { id: PRODUCT_ID },
         data: { name: 'Updated Name' },
         include: {
@@ -453,8 +446,8 @@ describe('product.repository', () => {
     });
 
     it('validates producedByOrganisationId FK on update', async () => {
-      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
-      mockOrganisationEntity.findFirst.mockResolvedValue(null);
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.organisationEntity.findFirst.mockResolvedValue(null);
 
       await expect(
         updateProduct(PRODUCT_ID, TENANT_ID, { producedByOrganisationId: 'nonexistent-org' }),
@@ -462,8 +455,8 @@ describe('product.repository', () => {
     });
 
     it('validates manufacturingFacilityId FK on update', async () => {
-      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
-      mockFacility.findFirst.mockResolvedValue(null);
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.facility.findFirst.mockResolvedValue(null);
 
       await expect(
         updateProduct(PRODUCT_ID, TENANT_ID, { manufacturingFacilityId: 'nonexistent-facility' }),
@@ -471,8 +464,8 @@ describe('product.repository', () => {
     });
 
     it('replaces secondary identifiers', async () => {
-      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
-      mockIdentifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
       mockTx.productSecondaryIdentifier.deleteMany.mockResolvedValue({ count: 0 });
       mockTx.productSecondaryIdentifier.createMany.mockResolvedValue({ count: 1 });
       mockTx.product.update.mockResolvedValue({
@@ -494,7 +487,7 @@ describe('product.repository', () => {
     });
 
     it('clears secondary identifiers with empty array', async () => {
-      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
       mockTx.productSecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
       mockTx.product.update.mockResolvedValue({
         ...PRODUCT_WITH_RELATIONS,
@@ -513,7 +506,7 @@ describe('product.repository', () => {
     });
 
     it('validates hierarchy when setting parentId on a MODEL product', async () => {
-      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS); // existing is MODEL
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS); // existing is MODEL
 
       await expect(updateProduct(PRODUCT_ID, TENANT_ID, { parentId: PARENT_ID })).rejects.toThrow(
         'MODEL products cannot have a parent',
@@ -522,7 +515,7 @@ describe('product.repository', () => {
 
     it('validates hierarchy when clearing parentId on a BATCH product', async () => {
       const batchProduct = { ...PRODUCT_WITH_RELATIONS, level: 'BATCH', parentId: PARENT_ID };
-      mockProduct.findFirst.mockResolvedValue(batchProduct);
+      mockTx.product.findFirst.mockResolvedValue(batchProduct);
 
       await expect(updateProduct(PRODUCT_ID, TENANT_ID, { parentId: null })).rejects.toThrow(
         'BATCH products require a MODEL parent',
@@ -531,7 +524,7 @@ describe('product.repository', () => {
 
     it('validates parent level when updating parentId on a BATCH product', async () => {
       const batchProduct = { ...PRODUCT_WITH_RELATIONS, level: 'BATCH', parentId: PARENT_ID };
-      mockProduct.findFirst
+      mockTx.product.findFirst
         .mockResolvedValueOnce(batchProduct) // existing product
         .mockResolvedValueOnce(BATCH_PRODUCT); // parent lookup returns a BATCH (invalid)
 
@@ -541,8 +534,8 @@ describe('product.repository', () => {
     });
 
     it('validates primary identifier ownership on update', async () => {
-      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
-      mockIdentifier.findFirst.mockResolvedValue(null);
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.identifier.findFirst.mockResolvedValue(null);
 
       await expect(updateProduct(PRODUCT_ID, TENANT_ID, { primaryIdentifierId: 'nonexistent-ident' })).rejects.toThrow(
         'Identifier not found: nonexistent-ident',
@@ -550,7 +543,7 @@ describe('product.repository', () => {
     });
 
     it('throws NotFoundError for ownership check failure', async () => {
-      mockProduct.findFirst.mockResolvedValue(null);
+      mockTx.product.findFirst.mockResolvedValue(null);
 
       await expect(updateProduct(PRODUCT_ID, 'other-tenant', { name: 'Updated' })).rejects.toThrow(
         'Product not found or access denied',
@@ -560,16 +553,16 @@ describe('product.repository', () => {
 
   describe('deleteProduct', () => {
     it('deletes a product with no children', async () => {
-      mockProduct.findFirst.mockResolvedValue(MODEL_PRODUCT);
-      mockProduct.findMany.mockResolvedValue([]);
+      mockTx.product.findFirst.mockResolvedValue(MODEL_PRODUCT);
+      mockTx.product.findMany.mockResolvedValue([]);
       mockTx.product.delete.mockResolvedValue(MODEL_PRODUCT);
 
       const result = await deleteProduct(PARENT_ID, TENANT_ID);
 
-      expect(mockProduct.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.product.findFirst).toHaveBeenCalledWith({
         where: { id: PARENT_ID, tenantId: TENANT_ID },
       });
-      expect(mockProduct.findMany).toHaveBeenCalledWith({
+      expect(mockTx.product.findMany).toHaveBeenCalledWith({
         where: { parentId: PARENT_ID, tenantId: TENANT_ID },
       });
       expect(mockTx.product.delete).toHaveBeenCalledWith({
@@ -579,8 +572,8 @@ describe('product.repository', () => {
     });
 
     it('blocks deletion when BATCH children exist', async () => {
-      mockProduct.findFirst.mockResolvedValue(MODEL_PRODUCT);
-      mockProduct.findMany.mockResolvedValue([
+      mockTx.product.findFirst.mockResolvedValue(MODEL_PRODUCT);
+      mockTx.product.findMany.mockResolvedValue([
         { ...BATCH_PRODUCT, id: 'batch-1' },
         { ...BATCH_PRODUCT, id: 'batch-2' },
       ]);
@@ -599,8 +592,8 @@ describe('product.repository', () => {
         parentId: BATCH_PRODUCT.id,
       };
 
-      mockProduct.findFirst.mockResolvedValue(BATCH_PRODUCT);
-      mockProduct.findMany.mockResolvedValue([itemChild]);
+      mockTx.product.findFirst.mockResolvedValue(BATCH_PRODUCT);
+      mockTx.product.findMany.mockResolvedValue([itemChild]);
       mockTx.product.updateMany.mockResolvedValue({ count: 1 });
       mockTx.product.delete.mockResolvedValue(BATCH_PRODUCT);
 
@@ -617,7 +610,7 @@ describe('product.repository', () => {
     });
 
     it('throws NotFoundError for another tenant', async () => {
-      mockProduct.findFirst.mockResolvedValue(null);
+      mockTx.product.findFirst.mockResolvedValue(null);
 
       await expect(deleteProduct(PRODUCT_ID, 'other-tenant')).rejects.toThrow('Product not found or access denied');
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
@@ -1,0 +1,588 @@
+import { createProducts, getProductById, listProducts, updateProduct, deleteProduct } from './product.repository';
+
+// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+const mockTx = {
+  product: {
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    findUniqueOrThrow: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+  },
+  identifier: {
+    findFirst: jest.fn(),
+  },
+  organisationEntity: {
+    findFirst: jest.fn(),
+  },
+  facility: {
+    findFirst: jest.fn(),
+  },
+  productSecondaryIdentifier: {
+    deleteMany: jest.fn(),
+    createMany: jest.fn(),
+  },
+};
+
+jest.mock('../prisma', () => ({
+  prisma: {
+    product: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    identifier: {
+      findFirst: jest.fn(),
+    },
+    organisationEntity: {
+      findFirst: jest.fn(),
+    },
+    facility: {
+      findFirst: jest.fn(),
+    },
+    productSecondaryIdentifier: {
+      deleteMany: jest.fn(),
+      createMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+// Import the mocked prisma after jest.mock
+import { prisma } from '../prisma';
+
+const mockProduct = prisma.product as unknown as {
+  findFirst: jest.Mock;
+  findMany: jest.Mock;
+  update: jest.Mock;
+  delete: jest.Mock;
+};
+
+const mockIdentifier = (prisma as unknown as { identifier: { findFirst: jest.Mock } }).identifier;
+const mockOrganisationEntity = (prisma as unknown as { organisationEntity: { findFirst: jest.Mock } })
+  .organisationEntity;
+const mockFacility = (prisma as unknown as { facility: { findFirst: jest.Mock } }).facility;
+
+describe('product.repository', () => {
+  const TENANT_ID = 'tenant-1';
+  const PRODUCT_ID = 'product-1';
+  const PARENT_ID = 'parent-1';
+  const ORG_ID = 'org-1';
+  const FACILITY_ID = 'facility-1';
+  const IDENTIFIER_ID = 'ident-1';
+  const SECONDARY_ID_1 = 'sec-ident-1';
+
+  const MODEL_PRODUCT = {
+    id: PARENT_ID,
+    tenantId: TENANT_ID,
+    name: 'Widget Model',
+    description: 'A model product',
+    level: 'MODEL',
+    parentId: null,
+    producedByOrganisationId: null,
+    manufacturingFacilityId: null,
+    primaryIdentifierId: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+
+  const BATCH_PRODUCT = {
+    id: 'batch-1',
+    tenantId: TENANT_ID,
+    name: 'Widget Batch 001',
+    description: 'A batch product',
+    level: 'BATCH',
+    parentId: PARENT_ID,
+    producedByOrganisationId: null,
+    manufacturingFacilityId: null,
+    primaryIdentifierId: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+
+  const PRODUCT_WITH_RELATIONS = {
+    id: PRODUCT_ID,
+    tenantId: TENANT_ID,
+    name: 'Test Product',
+    description: 'A test product',
+    level: 'MODEL',
+    parentId: null,
+    producedByOrganisationId: null,
+    manufacturingFacilityId: null,
+    primaryIdentifierId: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    primaryIdentifier: null,
+    secondaryIdentifiers: [],
+    producedByOrganisation: null,
+    manufacturingFacility: null,
+    parent: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.$transaction as jest.Mock).mockImplementation((cb: (tx: typeof mockTx) => unknown) => cb(mockTx));
+  });
+
+  describe('createProducts', () => {
+    it('creates a single MODEL product with no parent', async () => {
+      mockTx.product.create.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+
+      const result = await createProducts(TENANT_ID, [{ name: 'Test Product', level: 'MODEL' }]);
+
+      expect(result).toEqual([PRODUCT_WITH_RELATIONS]);
+      expect(mockTx.product.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId: TENANT_ID,
+            name: 'Test Product',
+            level: 'MODEL',
+          }),
+        }),
+      );
+    });
+
+    it('creates a BATCH product with a MODEL parent', async () => {
+      mockTx.product.findFirst.mockResolvedValue(MODEL_PRODUCT);
+      mockTx.product.create.mockResolvedValue({
+        ...PRODUCT_WITH_RELATIONS,
+        level: 'BATCH',
+        parentId: PARENT_ID,
+        parent: MODEL_PRODUCT,
+      });
+
+      const result = await createProducts(TENANT_ID, [{ name: 'Batch Product', level: 'BATCH', parentId: PARENT_ID }]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].level).toBe('BATCH');
+      expect(mockTx.product.findFirst).toHaveBeenCalledWith({
+        where: { id: PARENT_ID, tenantId: TENANT_ID },
+      });
+    });
+
+    it('creates an ITEM product with no parent', async () => {
+      mockTx.product.create.mockResolvedValue({
+        ...PRODUCT_WITH_RELATIONS,
+        level: 'ITEM',
+      });
+
+      const result = await createProducts(TENANT_ID, [{ name: 'Item Product', level: 'ITEM' }]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].level).toBe('ITEM');
+    });
+
+    it('creates an ITEM product with a BATCH parent', async () => {
+      mockTx.product.findFirst.mockResolvedValue(BATCH_PRODUCT);
+      mockTx.product.create.mockResolvedValue({
+        ...PRODUCT_WITH_RELATIONS,
+        level: 'ITEM',
+        parentId: 'batch-1',
+        parent: BATCH_PRODUCT,
+      });
+
+      const result = await createProducts(TENANT_ID, [{ name: 'Item Product', level: 'ITEM', parentId: 'batch-1' }]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].level).toBe('ITEM');
+    });
+
+    it('rejects MODEL with a parent', async () => {
+      await expect(
+        createProducts(TENANT_ID, [{ name: 'Bad Model', level: 'MODEL', parentId: PARENT_ID }]),
+      ).rejects.toThrow('MODEL products cannot have a parent');
+    });
+
+    it('rejects BATCH without a parent', async () => {
+      await expect(createProducts(TENANT_ID, [{ name: 'Bad Batch', level: 'BATCH' }])).rejects.toThrow(
+        'BATCH products require a MODEL parent',
+      );
+    });
+
+    it('rejects BATCH with a non-MODEL parent', async () => {
+      mockTx.product.findFirst.mockResolvedValue(BATCH_PRODUCT);
+
+      await expect(
+        createProducts(TENANT_ID, [{ name: 'Bad Batch', level: 'BATCH', parentId: 'batch-1' }]),
+      ).rejects.toThrow('BATCH parent must be a MODEL product');
+    });
+
+    it('rejects ITEM with a MODEL parent', async () => {
+      mockTx.product.findFirst.mockResolvedValue(MODEL_PRODUCT);
+
+      await expect(
+        createProducts(TENANT_ID, [{ name: 'Bad Item', level: 'ITEM', parentId: PARENT_ID }]),
+      ).rejects.toThrow('ITEM parent must be a BATCH product');
+    });
+
+    it('validates producedByOrganisationId belongs to tenant', async () => {
+      mockTx.organisationEntity.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createProducts(TENANT_ID, [{ name: 'Product', level: 'MODEL', producedByOrganisationId: 'nonexistent-org' }]),
+      ).rejects.toThrow('Organisation not found: nonexistent-org');
+    });
+
+    it('validates manufacturingFacilityId belongs to tenant', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createProducts(TENANT_ID, [
+          { name: 'Product', level: 'MODEL', manufacturingFacilityId: 'nonexistent-facility' },
+        ]),
+      ).rejects.toThrow('Facility not found: nonexistent-facility');
+    });
+
+    it('validates primary identifier belongs to tenant', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createProducts(TENANT_ID, [{ name: 'Product', level: 'MODEL', primaryIdentifierId: 'nonexistent-ident' }]),
+      ).rejects.toThrow('Identifier not found: nonexistent-ident');
+    });
+
+    it('validates secondary identifiers belong to tenant', async () => {
+      // First call succeeds (primary identifier), second call fails (secondary)
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce({ id: IDENTIFIER_ID, tenantId: TENANT_ID })
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        createProducts(TENANT_ID, [
+          {
+            name: 'Product',
+            level: 'MODEL',
+            primaryIdentifierId: IDENTIFIER_ID,
+            secondaryIdentifierIds: ['nonexistent-sec'],
+          },
+        ]),
+      ).rejects.toThrow('Identifier not found: nonexistent-sec');
+    });
+
+    it('rejects primary identifier that is also a secondary identifier', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue({ id: IDENTIFIER_ID, tenantId: TENANT_ID });
+
+      await expect(
+        createProducts(TENANT_ID, [
+          {
+            name: 'Product',
+            level: 'MODEL',
+            primaryIdentifierId: IDENTIFIER_ID,
+            secondaryIdentifierIds: [IDENTIFIER_ID],
+          },
+        ]),
+      ).rejects.toThrow('Primary identifier cannot also be a secondary identifier');
+    });
+  });
+
+  describe('getProductById', () => {
+    it('returns the product with includes if it belongs to the tenant', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+
+      const result = await getProductById(PRODUCT_ID, TENANT_ID);
+
+      expect(mockProduct.findFirst).toHaveBeenCalledWith({
+        where: { id: PRODUCT_ID, tenantId: TENANT_ID },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          producedByOrganisation: true,
+          manufacturingFacility: true,
+          parent: true,
+        },
+      });
+      expect(result).toEqual(PRODUCT_WITH_RELATIONS);
+    });
+
+    it('returns null for a product from another tenant', async () => {
+      mockProduct.findFirst.mockResolvedValue(null);
+
+      const result = await getProductById(PRODUCT_ID, 'other-tenant');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listProducts', () => {
+    it('lists products with default pagination', async () => {
+      mockProduct.findMany.mockResolvedValue([PRODUCT_WITH_RELATIONS]);
+
+      const result = await listProducts(TENANT_ID);
+
+      expect(mockProduct.findMany).toHaveBeenCalledWith({
+        where: { tenantId: TENANT_ID },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          producedByOrganisation: true,
+          manufacturingFacility: true,
+          parent: true,
+        },
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toEqual([PRODUCT_WITH_RELATIONS]);
+    });
+
+    it('applies custom pagination', async () => {
+      mockProduct.findMany.mockResolvedValue([]);
+
+      await listProducts(TENANT_ID, { limit: 10, offset: 20 });
+
+      expect(mockProduct.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+          skip: 20,
+        }),
+      );
+    });
+
+    it('searches by name', async () => {
+      mockProduct.findMany.mockResolvedValue([]);
+
+      await listProducts(TENANT_ID, { search: 'Widget' });
+
+      expect(mockProduct.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            OR: [
+              { name: { contains: 'Widget', mode: 'insensitive' } },
+              { primaryIdentifier: { value: { contains: 'Widget', mode: 'insensitive' } } },
+              {
+                secondaryIdentifiers: {
+                  some: {
+                    identifier: { value: { contains: 'Widget', mode: 'insensitive' } },
+                  },
+                },
+              },
+            ],
+          }),
+        }),
+      );
+    });
+
+    it('filters by level', async () => {
+      mockProduct.findMany.mockResolvedValue([]);
+
+      await listProducts(TENANT_ID, { level: 'MODEL' });
+
+      expect(mockProduct.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            level: 'MODEL',
+          }),
+        }),
+      );
+    });
+
+    it('filters by parentId', async () => {
+      mockProduct.findMany.mockResolvedValue([]);
+
+      await listProducts(TENANT_ID, { parentId: PARENT_ID });
+
+      expect(mockProduct.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            parentId: PARENT_ID,
+          }),
+        }),
+      );
+    });
+
+    it('filters by organisationId (maps to producedByOrganisationId)', async () => {
+      mockProduct.findMany.mockResolvedValue([]);
+
+      await listProducts(TENANT_ID, { organisationId: ORG_ID });
+
+      expect(mockProduct.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            producedByOrganisationId: ORG_ID,
+          }),
+        }),
+      );
+    });
+
+    it('filters by facilityId (maps to manufacturingFacilityId)', async () => {
+      mockProduct.findMany.mockResolvedValue([]);
+
+      await listProducts(TENANT_ID, { facilityId: FACILITY_ID });
+
+      expect(mockProduct.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            manufacturingFacilityId: FACILITY_ID,
+          }),
+        }),
+      );
+    });
+
+    it('returns empty array for no matches', async () => {
+      mockProduct.findMany.mockResolvedValue([]);
+
+      const result = await listProducts(TENANT_ID, { search: 'nonexistent' });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('updateProduct', () => {
+    it('performs a partial update (name only)', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockProduct.update.mockResolvedValue({ ...PRODUCT_WITH_RELATIONS, name: 'Updated Name' });
+
+      const result = await updateProduct(PRODUCT_ID, TENANT_ID, { name: 'Updated Name' });
+
+      expect(mockProduct.findFirst).toHaveBeenCalledWith({
+        where: { id: PRODUCT_ID, tenantId: TENANT_ID },
+      });
+      expect(mockProduct.update).toHaveBeenCalledWith({
+        where: { id: PRODUCT_ID },
+        data: { name: 'Updated Name' },
+        include: {
+          primaryIdentifier: { include: { scheme: true } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          producedByOrganisation: true,
+          manufacturingFacility: true,
+          parent: true,
+        },
+      });
+      expect(result.name).toBe('Updated Name');
+    });
+
+    it('validates producedByOrganisationId FK on update', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockOrganisationEntity.findFirst.mockResolvedValue(null);
+
+      await expect(
+        updateProduct(PRODUCT_ID, TENANT_ID, { producedByOrganisationId: 'nonexistent-org' }),
+      ).rejects.toThrow('Organisation not found: nonexistent-org');
+    });
+
+    it('validates manufacturingFacilityId FK on update', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockFacility.findFirst.mockResolvedValue(null);
+
+      await expect(
+        updateProduct(PRODUCT_ID, TENANT_ID, { manufacturingFacilityId: 'nonexistent-facility' }),
+      ).rejects.toThrow('Facility not found: nonexistent-facility');
+    });
+
+    it('replaces secondary identifiers', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockIdentifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
+      mockTx.productSecondaryIdentifier.deleteMany.mockResolvedValue({ count: 0 });
+      mockTx.productSecondaryIdentifier.createMany.mockResolvedValue({ count: 1 });
+      mockTx.product.update.mockResolvedValue({
+        ...PRODUCT_WITH_RELATIONS,
+        secondaryIdentifiers: [{ productId: PRODUCT_ID, identifierId: SECONDARY_ID_1 }],
+      });
+
+      const result = await updateProduct(PRODUCT_ID, TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_1],
+      });
+
+      expect(mockTx.productSecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { productId: PRODUCT_ID },
+      });
+      expect(mockTx.productSecondaryIdentifier.createMany).toHaveBeenCalledWith({
+        data: [{ productId: PRODUCT_ID, identifierId: SECONDARY_ID_1 }],
+      });
+      expect(result.secondaryIdentifiers).toHaveLength(1);
+    });
+
+    it('clears secondary identifiers with empty array', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.productSecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.product.update.mockResolvedValue({
+        ...PRODUCT_WITH_RELATIONS,
+        secondaryIdentifiers: [],
+      });
+
+      const result = await updateProduct(PRODUCT_ID, TENANT_ID, {
+        secondaryIdentifierIds: [],
+      });
+
+      expect(mockTx.productSecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { productId: PRODUCT_ID },
+      });
+      expect(mockTx.productSecondaryIdentifier.createMany).not.toHaveBeenCalled();
+      expect(result.secondaryIdentifiers).toEqual([]);
+    });
+
+    it('throws NotFoundError for ownership check failure', async () => {
+      mockProduct.findFirst.mockResolvedValue(null);
+
+      await expect(updateProduct(PRODUCT_ID, 'other-tenant', { name: 'Updated' })).rejects.toThrow(
+        'Product not found or access denied',
+      );
+    });
+  });
+
+  describe('deleteProduct', () => {
+    it('deletes a product with no children', async () => {
+      mockProduct.findFirst.mockResolvedValue(MODEL_PRODUCT);
+      mockProduct.findMany.mockResolvedValue([]);
+      mockTx.product.delete.mockResolvedValue(MODEL_PRODUCT);
+
+      const result = await deleteProduct(PARENT_ID, TENANT_ID);
+
+      expect(mockProduct.findFirst).toHaveBeenCalledWith({
+        where: { id: PARENT_ID, tenantId: TENANT_ID },
+      });
+      expect(mockProduct.findMany).toHaveBeenCalledWith({
+        where: { parentId: PARENT_ID, tenantId: TENANT_ID },
+      });
+      expect(mockTx.product.delete).toHaveBeenCalledWith({
+        where: { id: PARENT_ID },
+      });
+      expect(result).toEqual(MODEL_PRODUCT);
+    });
+
+    it('blocks deletion when BATCH children exist', async () => {
+      mockProduct.findFirst.mockResolvedValue(MODEL_PRODUCT);
+      mockProduct.findMany.mockResolvedValue([
+        { ...BATCH_PRODUCT, id: 'batch-1' },
+        { ...BATCH_PRODUCT, id: 'batch-2' },
+      ]);
+
+      await expect(deleteProduct(PARENT_ID, TENANT_ID)).rejects.toThrow(
+        'Cannot delete: 2 BATCH product(s) depend on this MODEL',
+      );
+    });
+
+    it('detaches ITEM children and deletes the product', async () => {
+      const itemChild = {
+        id: 'item-1',
+        tenantId: TENANT_ID,
+        name: 'Item Child',
+        level: 'ITEM',
+        parentId: BATCH_PRODUCT.id,
+      };
+
+      mockProduct.findFirst.mockResolvedValue(BATCH_PRODUCT);
+      mockProduct.findMany.mockResolvedValue([itemChild]);
+      mockTx.product.updateMany.mockResolvedValue({ count: 1 });
+      mockTx.product.delete.mockResolvedValue(BATCH_PRODUCT);
+
+      const result = await deleteProduct(BATCH_PRODUCT.id, TENANT_ID);
+
+      expect(mockTx.product.updateMany).toHaveBeenCalledWith({
+        where: { parentId: BATCH_PRODUCT.id, level: 'ITEM' },
+        data: { parentId: null },
+      });
+      expect(mockTx.product.delete).toHaveBeenCalledWith({
+        where: { id: BATCH_PRODUCT.id },
+      });
+      expect(result).toEqual(BATCH_PRODUCT);
+    });
+
+    it('throws NotFoundError for another tenant', async () => {
+      mockProduct.findFirst.mockResolvedValue(null);
+
+      await expect(deleteProduct(PRODUCT_ID, 'other-tenant')).rejects.toThrow('Product not found or access denied');
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
@@ -512,6 +512,43 @@ describe('product.repository', () => {
       expect(result.secondaryIdentifiers).toEqual([]);
     });
 
+    it('validates hierarchy when setting parentId on a MODEL product', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS); // existing is MODEL
+
+      await expect(updateProduct(PRODUCT_ID, TENANT_ID, { parentId: PARENT_ID })).rejects.toThrow(
+        'MODEL products cannot have a parent',
+      );
+    });
+
+    it('validates hierarchy when clearing parentId on a BATCH product', async () => {
+      const batchProduct = { ...PRODUCT_WITH_RELATIONS, level: 'BATCH', parentId: PARENT_ID };
+      mockProduct.findFirst.mockResolvedValue(batchProduct);
+
+      await expect(updateProduct(PRODUCT_ID, TENANT_ID, { parentId: null })).rejects.toThrow(
+        'BATCH products require a MODEL parent',
+      );
+    });
+
+    it('validates parent level when updating parentId on a BATCH product', async () => {
+      const batchProduct = { ...PRODUCT_WITH_RELATIONS, level: 'BATCH', parentId: PARENT_ID };
+      mockProduct.findFirst
+        .mockResolvedValueOnce(batchProduct) // existing product
+        .mockResolvedValueOnce(BATCH_PRODUCT); // parent lookup returns a BATCH (invalid)
+
+      await expect(updateProduct(PRODUCT_ID, TENANT_ID, { parentId: 'batch-1' })).rejects.toThrow(
+        'BATCH parent must be a MODEL product',
+      );
+    });
+
+    it('validates primary identifier ownership on update', async () => {
+      mockProduct.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockIdentifier.findFirst.mockResolvedValue(null);
+
+      await expect(updateProduct(PRODUCT_ID, TENANT_ID, { primaryIdentifierId: 'nonexistent-ident' })).rejects.toThrow(
+        'Identifier not found: nonexistent-ident',
+      );
+    });
+
     it('throws NotFoundError for ownership check failure', async () => {
       mockProduct.findFirst.mockResolvedValue(null);
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -1,0 +1,439 @@
+import { Product, Prisma } from '../generated';
+import { prisma } from '../prisma';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+
+/**
+ * Include shape used by all product queries.
+ * Includes the primary identifier (with scheme), secondary identifiers
+ * (via the join table, each with its identifier and scheme),
+ * brand organisation, manufacturing facility, and parent product.
+ */
+const PRODUCT_INCLUDE = {
+  primaryIdentifier: { include: { scheme: true } },
+  secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+  producedByOrganisation: true,
+  manufacturingFacility: true,
+  parent: true,
+} as const;
+
+/**
+ * A product with its full relations.
+ * Matches the include shape defined by PRODUCT_INCLUDE.
+ */
+export type ProductWithRelations = Prisma.ProductGetPayload<{
+  include: typeof PRODUCT_INCLUDE;
+}>;
+
+/**
+ * Input for creating a new product.
+ */
+export type CreateProductInput = {
+  name: string;
+  description?: string;
+  level: 'MODEL' | 'BATCH' | 'ITEM';
+  parentId?: string;
+  producedByOrganisationId?: string;
+  manufacturingFacilityId?: string;
+  primaryIdentifierId?: string;
+  secondaryIdentifierIds?: string[];
+};
+
+/**
+ * Input for updating an existing product.
+ * Level is immutable and cannot be changed after creation.
+ * Fields set to undefined are left unchanged.
+ * Fields set to null clear the relation.
+ */
+export type UpdateProductInput = {
+  name?: string;
+  description?: string;
+  parentId?: string | null;
+  producedByOrganisationId?: string | null;
+  manufacturingFacilityId?: string | null;
+  primaryIdentifierId?: string | null;
+  secondaryIdentifierIds?: string[];
+};
+
+/**
+ * Options for listing products.
+ */
+export type ListProductsOptions = {
+  search?: string;
+  level?: 'MODEL' | 'BATCH' | 'ITEM';
+  parentId?: string;
+  organisationId?: string;
+  facilityId?: string;
+  limit?: number;
+  offset?: number;
+};
+
+/**
+ * Validates the product hierarchy constraints based on level.
+ * MODEL products cannot have a parent.
+ * BATCH products require a MODEL parent.
+ * ITEM products may optionally have a BATCH parent.
+ */
+function validateProductHierarchy(level: string, parentId: string | undefined, parent: Product | null): void {
+  switch (level) {
+    case 'MODEL':
+      if (parentId) throw new ValidationError('MODEL products cannot have a parent');
+      break;
+    case 'BATCH':
+      if (!parentId) throw new ValidationError('BATCH products require a MODEL parent');
+      if (!parent) throw new NotFoundError('Parent product not found');
+      if (parent.level !== 'MODEL') throw new ValidationError('BATCH parent must be a MODEL product');
+      break;
+    case 'ITEM':
+      if (parentId) {
+        if (!parent) throw new NotFoundError('Parent product not found');
+        if (parent.level !== 'BATCH') throw new ValidationError('ITEM parent must be a BATCH product');
+      }
+      break;
+  }
+}
+
+/**
+ * Validates that an identifier belongs to the given tenant.
+ * Runs within a transaction client.
+ */
+async function validateIdentifierOwnership(
+  tx: Prisma.TransactionClient,
+  identifierId: string,
+  tenantId: string,
+): Promise<void> {
+  const ident = await tx.identifier.findFirst({ where: { id: identifierId, tenantId } });
+  if (!ident) {
+    throw new NotFoundError(`Identifier not found: ${identifierId}`);
+  }
+}
+
+/**
+ * Validates that the primary identifier is not also listed as a secondary identifier.
+ */
+function validateNoPrimarySecondaryOverlap(
+  primaryIdentifierId: string | undefined | null,
+  secondaryIdentifierIds: string[] | undefined,
+): void {
+  if (primaryIdentifierId && secondaryIdentifierIds?.includes(primaryIdentifierId)) {
+    throw new ValidationError('Primary identifier cannot also be a secondary identifier');
+  }
+}
+
+/**
+ * Creates one or more products in a single transaction.
+ * Validates hierarchy constraints, foreign key references, and identifier ownership.
+ */
+export async function createProducts(tenantId: string, inputs: CreateProductInput[]): Promise<ProductWithRelations[]> {
+  return prisma.$transaction(async (tx) => {
+    const results: ProductWithRelations[] = [];
+
+    for (const input of inputs) {
+      // Look up parent if specified
+      let parent: Product | null = null;
+      if (input.parentId) {
+        parent = await tx.product.findFirst({ where: { id: input.parentId, tenantId } });
+      }
+
+      // Validate hierarchy constraints
+      validateProductHierarchy(input.level, input.parentId, parent);
+
+      // Validate brand organisation belongs to tenant
+      if (input.producedByOrganisationId) {
+        const org = await tx.organisationEntity.findFirst({
+          where: { id: input.producedByOrganisationId, tenantId },
+        });
+        if (!org) {
+          throw new NotFoundError(`Organisation not found: ${input.producedByOrganisationId}`);
+        }
+      }
+
+      // Validate manufacturing facility belongs to tenant
+      if (input.manufacturingFacilityId) {
+        const facility = await tx.facility.findFirst({
+          where: { id: input.manufacturingFacilityId, tenantId },
+        });
+        if (!facility) {
+          throw new NotFoundError(`Facility not found: ${input.manufacturingFacilityId}`);
+        }
+      }
+
+      // Validate primary identifier belongs to tenant
+      if (input.primaryIdentifierId) {
+        await validateIdentifierOwnership(tx, input.primaryIdentifierId, tenantId);
+      }
+
+      // Validate secondary identifiers belong to tenant
+      if (input.secondaryIdentifierIds?.length) {
+        for (const secId of input.secondaryIdentifierIds) {
+          await validateIdentifierOwnership(tx, secId, tenantId);
+        }
+      }
+
+      // Validate no overlap between primary and secondary
+      validateNoPrimarySecondaryOverlap(input.primaryIdentifierId, input.secondaryIdentifierIds);
+
+      // Create the product entity
+      const product = await tx.product.create({
+        data: {
+          tenantId,
+          name: input.name,
+          level: input.level,
+          ...(input.description !== undefined && { description: input.description }),
+          ...(input.parentId !== undefined && { parentId: input.parentId }),
+          ...(input.producedByOrganisationId !== undefined && {
+            producedByOrganisationId: input.producedByOrganisationId,
+          }),
+          ...(input.manufacturingFacilityId !== undefined && {
+            manufacturingFacilityId: input.manufacturingFacilityId,
+          }),
+          ...(input.primaryIdentifierId !== undefined && { primaryIdentifierId: input.primaryIdentifierId }),
+        },
+        include: PRODUCT_INCLUDE,
+      });
+
+      // Create join rows for secondary identifiers
+      if (input.secondaryIdentifierIds?.length) {
+        await tx.productSecondaryIdentifier.createMany({
+          data: input.secondaryIdentifierIds.map((identifierId) => ({
+            productId: product.id,
+            identifierId,
+          })),
+        });
+
+        // Re-fetch to include the newly created secondary identifier relations
+        const refetched = await tx.product.findUniqueOrThrow({
+          where: { id: product.id },
+          include: PRODUCT_INCLUDE,
+        });
+        results.push(refetched);
+      } else {
+        results.push(product);
+      }
+    }
+
+    return results;
+  });
+}
+
+/**
+ * Retrieves a product by ID, scoped to the tenant.
+ * Returns null if not found or belongs to a different tenant.
+ */
+export async function getProductById(id: string, tenantId: string): Promise<ProductWithRelations | null> {
+  return prisma.product.findFirst({
+    where: { id, tenantId },
+    include: PRODUCT_INCLUDE,
+  });
+}
+
+/**
+ * Lists products for a tenant.
+ * Supports optional search across name and identifier values,
+ * plus filtering by level, parentId, organisation, and facility.
+ */
+export async function listProducts(
+  tenantId: string,
+  options: ListProductsOptions = {},
+): Promise<ProductWithRelations[]> {
+  const { search, level, parentId, organisationId, facilityId, limit, offset } = options;
+
+  const where: Prisma.ProductWhereInput = {
+    tenantId,
+  };
+
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: 'insensitive' } },
+      { primaryIdentifier: { value: { contains: search, mode: 'insensitive' } } },
+      {
+        secondaryIdentifiers: {
+          some: {
+            identifier: { value: { contains: search, mode: 'insensitive' } },
+          },
+        },
+      },
+    ];
+  }
+
+  if (level !== undefined) {
+    where.level = level;
+  }
+
+  if (parentId !== undefined) {
+    where.parentId = parentId;
+  }
+
+  if (organisationId !== undefined) {
+    where.producedByOrganisationId = organisationId;
+  }
+
+  if (facilityId !== undefined) {
+    where.manufacturingFacilityId = facilityId;
+  }
+
+  return prisma.product.findMany({
+    where,
+    include: PRODUCT_INCLUDE,
+    take: limit ?? 100,
+    skip: offset,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+/**
+ * Updates a product.
+ * Validates ownership and foreign key references before updating.
+ * Level is immutable and cannot be changed.
+ */
+export async function updateProduct(
+  id: string,
+  tenantId: string,
+  input: UpdateProductInput,
+): Promise<ProductWithRelations> {
+  // Ownership check
+  const existing = await prisma.product.findFirst({
+    where: { id, tenantId },
+  });
+
+  if (!existing) {
+    throw new NotFoundError('Product not found or access denied');
+  }
+
+  // Validate brand organisation belongs to tenant (if provided and not null)
+  if (input.producedByOrganisationId !== undefined && input.producedByOrganisationId !== null) {
+    const org = await prisma.organisationEntity.findFirst({
+      where: { id: input.producedByOrganisationId, tenantId },
+    });
+    if (!org) {
+      throw new NotFoundError(`Organisation not found: ${input.producedByOrganisationId}`);
+    }
+  }
+
+  // Validate manufacturing facility belongs to tenant (if provided and not null)
+  if (input.manufacturingFacilityId !== undefined && input.manufacturingFacilityId !== null) {
+    const facility = await prisma.facility.findFirst({
+      where: { id: input.manufacturingFacilityId, tenantId },
+    });
+    if (!facility) {
+      throw new NotFoundError(`Facility not found: ${input.manufacturingFacilityId}`);
+    }
+  }
+
+  // Validate parent belongs to tenant (if provided and not null)
+  if (input.parentId !== undefined && input.parentId !== null) {
+    const parent = await prisma.product.findFirst({
+      where: { id: input.parentId, tenantId },
+    });
+    if (!parent) {
+      throw new NotFoundError(`Parent product not found: ${input.parentId}`);
+    }
+  }
+
+  // Build the data object with only explicitly provided fields
+  const data: Prisma.ProductUpdateInput = {
+    ...(input.name !== undefined && { name: input.name }),
+    ...(input.description !== undefined && { description: input.description }),
+  };
+
+  // Handle parentId: null = clear, string = set, undefined = no change
+  if (input.parentId === null) {
+    data.parent = { disconnect: true };
+  } else if (input.parentId !== undefined) {
+    data.parent = { connect: { id: input.parentId } };
+  }
+
+  // Handle producedByOrganisationId: null = clear, string = set, undefined = no change
+  if (input.producedByOrganisationId === null) {
+    data.producedByOrganisation = { disconnect: true };
+  } else if (input.producedByOrganisationId !== undefined) {
+    data.producedByOrganisation = { connect: { id: input.producedByOrganisationId } };
+  }
+
+  // Handle manufacturingFacilityId: null = clear, string = set, undefined = no change
+  if (input.manufacturingFacilityId === null) {
+    data.manufacturingFacility = { disconnect: true };
+  } else if (input.manufacturingFacilityId !== undefined) {
+    data.manufacturingFacility = { connect: { id: input.manufacturingFacilityId } };
+  }
+
+  // Handle primaryIdentifierId: null = clear, string = set, undefined = no change
+  if (input.primaryIdentifierId === null) {
+    data.primaryIdentifier = { disconnect: true };
+  } else if (input.primaryIdentifierId !== undefined) {
+    data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
+  }
+
+  // Determine the effective primary identifier ID for overlap validation
+  const effectivePrimaryId =
+    input.primaryIdentifierId !== undefined ? input.primaryIdentifierId : existing.primaryIdentifierId;
+
+  if (input.secondaryIdentifierIds !== undefined) {
+    // Validate all secondary identifiers belong to tenant
+    for (const secId of input.secondaryIdentifierIds) {
+      const ident = await prisma.identifier.findFirst({ where: { id: secId, tenantId } });
+      if (!ident) {
+        throw new NotFoundError(`Identifier not found: ${secId}`);
+      }
+    }
+
+    // Validate no overlap with effective primary
+    validateNoPrimarySecondaryOverlap(effectivePrimaryId, input.secondaryIdentifierIds);
+
+    // Use transaction to replace secondary identifiers atomically
+    return prisma.$transaction(async (tx) => {
+      // Remove existing secondary identifier join rows
+      await tx.productSecondaryIdentifier.deleteMany({
+        where: { productId: id },
+      });
+
+      // Create new join rows
+      if (input.secondaryIdentifierIds!.length > 0) {
+        await tx.productSecondaryIdentifier.createMany({
+          data: input.secondaryIdentifierIds!.map((identifierId) => ({
+            productId: id,
+            identifierId,
+          })),
+        });
+      }
+
+      // Update the entity
+      return tx.product.update({
+        where: { id },
+        data,
+        include: PRODUCT_INCLUDE,
+      });
+    });
+  }
+
+  // No secondary identifier changes — simple update
+  return prisma.product.update({
+    where: { id },
+    data,
+    include: PRODUCT_INCLUDE,
+  });
+}
+
+/**
+ * Deletes a product.
+ * Blocks deletion if BATCH children depend on this MODEL.
+ * Detaches ITEM children (sets parentId to null) before deleting.
+ */
+export async function deleteProduct(id: string, tenantId: string): Promise<Product> {
+  const existing = await prisma.product.findFirst({ where: { id, tenantId } });
+  if (!existing) throw new NotFoundError('Product not found or access denied');
+
+  const children = await prisma.product.findMany({ where: { parentId: id, tenantId } });
+  const batches = children.filter((c) => c.level === 'BATCH');
+  if (batches.length > 0) {
+    throw new ValidationError(`Cannot delete: ${batches.length} BATCH product(s) depend on this MODEL`);
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const items = children.filter((c) => c.level === 'ITEM');
+    if (items.length > 0) {
+      await tx.product.updateMany({ where: { parentId: id, level: 'ITEM' }, data: { parentId: null } });
+    }
+    return tx.product.delete({ where: { id } });
+  });
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -291,136 +291,115 @@ export async function updateProduct(
   tenantId: string,
   input: UpdateProductInput,
 ): Promise<ProductWithRelations> {
-  // Ownership check
-  const existing = await prisma.product.findFirst({
-    where: { id, tenantId },
-  });
-
-  if (!existing) {
-    throw new NotFoundError('Product not found or access denied');
-  }
-
-  // Validate brand organisation belongs to tenant (if provided and not null)
-  if (input.producedByOrganisationId !== undefined && input.producedByOrganisationId !== null) {
-    const org = await prisma.organisationEntity.findFirst({
-      where: { id: input.producedByOrganisationId, tenantId },
+  return prisma.$transaction(async (tx) => {
+    // Ownership check
+    const existing = await tx.product.findFirst({
+      where: { id, tenantId },
     });
-    if (!org) {
-      throw new NotFoundError(`Organisation not found: ${input.producedByOrganisationId}`);
-    }
-  }
 
-  // Validate manufacturing facility belongs to tenant (if provided and not null)
-  if (input.manufacturingFacilityId !== undefined && input.manufacturingFacilityId !== null) {
-    const facility = await prisma.facility.findFirst({
-      where: { id: input.manufacturingFacilityId, tenantId },
-    });
-    if (!facility) {
-      throw new NotFoundError(`Facility not found: ${input.manufacturingFacilityId}`);
+    if (!existing) {
+      throw new NotFoundError('Product not found or access denied');
     }
-  }
 
-  // Validate hierarchy when parentId is being changed
-  if (input.parentId !== undefined) {
-    let parent: Product | null = null;
-    if (input.parentId !== null) {
-      parent = await prisma.product.findFirst({
-        where: { id: input.parentId, tenantId },
+    // Validate brand organisation belongs to tenant (if provided and not null)
+    if (input.producedByOrganisationId !== undefined && input.producedByOrganisationId !== null) {
+      const org = await tx.organisationEntity.findFirst({
+        where: { id: input.producedByOrganisationId, tenantId },
       });
-    }
-    // validateProductHierarchy expects undefined for "no parent"
-    validateProductHierarchy(existing.level, input.parentId ?? undefined, parent);
-  }
-
-  // Validate primary identifier belongs to tenant (if provided and not null)
-  if (input.primaryIdentifierId !== undefined && input.primaryIdentifierId !== null) {
-    const ident = await prisma.identifier.findFirst({ where: { id: input.primaryIdentifierId, tenantId } });
-    if (!ident) {
-      throw new NotFoundError(`Identifier not found: ${input.primaryIdentifierId}`);
-    }
-  }
-
-  // Build the data object with only explicitly provided fields
-  const data: Prisma.ProductUpdateInput = {
-    ...(input.name !== undefined && { name: input.name }),
-    ...(input.description !== undefined && { description: input.description }),
-  };
-
-  // Handle parentId: null = clear, string = set, undefined = no change
-  if (input.parentId === null) {
-    data.parent = { disconnect: true };
-  } else if (input.parentId !== undefined) {
-    data.parent = { connect: { id: input.parentId } };
-  }
-
-  // Handle producedByOrganisationId: null = clear, string = set, undefined = no change
-  if (input.producedByOrganisationId === null) {
-    data.producedByOrganisation = { disconnect: true };
-  } else if (input.producedByOrganisationId !== undefined) {
-    data.producedByOrganisation = { connect: { id: input.producedByOrganisationId } };
-  }
-
-  // Handle manufacturingFacilityId: null = clear, string = set, undefined = no change
-  if (input.manufacturingFacilityId === null) {
-    data.manufacturingFacility = { disconnect: true };
-  } else if (input.manufacturingFacilityId !== undefined) {
-    data.manufacturingFacility = { connect: { id: input.manufacturingFacilityId } };
-  }
-
-  // Handle primaryIdentifierId: null = clear, string = set, undefined = no change
-  if (input.primaryIdentifierId === null) {
-    data.primaryIdentifier = { disconnect: true };
-  } else if (input.primaryIdentifierId !== undefined) {
-    data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
-  }
-
-  // Determine the effective primary identifier ID for overlap validation
-  const effectivePrimaryId =
-    input.primaryIdentifierId !== undefined ? input.primaryIdentifierId : existing.primaryIdentifierId;
-
-  if (input.secondaryIdentifierIds !== undefined) {
-    // Validate all secondary identifiers belong to tenant
-    for (const secId of input.secondaryIdentifierIds) {
-      const ident = await prisma.identifier.findFirst({ where: { id: secId, tenantId } });
-      if (!ident) {
-        throw new NotFoundError(`Identifier not found: ${secId}`);
+      if (!org) {
+        throw new NotFoundError(`Organisation not found: ${input.producedByOrganisationId}`);
       }
     }
 
-    // Validate no overlap with effective primary
-    validateNoPrimarySecondaryOverlap(effectivePrimaryId, input.secondaryIdentifierIds);
+    // Validate manufacturing facility belongs to tenant (if provided and not null)
+    if (input.manufacturingFacilityId !== undefined && input.manufacturingFacilityId !== null) {
+      const facility = await tx.facility.findFirst({
+        where: { id: input.manufacturingFacilityId, tenantId },
+      });
+      if (!facility) {
+        throw new NotFoundError(`Facility not found: ${input.manufacturingFacilityId}`);
+      }
+    }
 
-    // Use transaction to replace secondary identifiers atomically
-    return prisma.$transaction(async (tx) => {
-      // Remove existing secondary identifier join rows
+    // Validate hierarchy when parentId is being changed
+    if (input.parentId !== undefined) {
+      let parent: Product | null = null;
+      if (input.parentId !== null) {
+        parent = await tx.product.findFirst({
+          where: { id: input.parentId, tenantId },
+        });
+      }
+      validateProductHierarchy(existing.level, input.parentId ?? undefined, parent);
+    }
+
+    // Validate primary identifier belongs to tenant (if provided and not null)
+    if (input.primaryIdentifierId !== undefined && input.primaryIdentifierId !== null) {
+      await validateIdentifierOwnership(tx, input.primaryIdentifierId, tenantId);
+    }
+
+    // Validate secondary identifiers and check for overlap with primary
+    if (input.secondaryIdentifierIds !== undefined) {
+      const effectivePrimaryId =
+        input.primaryIdentifierId !== undefined ? input.primaryIdentifierId : existing.primaryIdentifierId;
+      validateNoPrimarySecondaryOverlap(effectivePrimaryId, input.secondaryIdentifierIds);
+
+      for (const secId of input.secondaryIdentifierIds) {
+        await validateIdentifierOwnership(tx, secId, tenantId);
+      }
+
+      // Replace secondary identifiers: delete existing, create new
       await tx.productSecondaryIdentifier.deleteMany({
         where: { productId: id },
       });
-
-      // Create new join rows
-      if (input.secondaryIdentifierIds!.length > 0) {
+      if (input.secondaryIdentifierIds.length > 0) {
         await tx.productSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds!.map((identifierId) => ({
+          data: input.secondaryIdentifierIds.map((identifierId) => ({
             productId: id,
             identifierId,
           })),
         });
       }
+    }
 
-      // Update the entity
-      return tx.product.update({
-        where: { id },
-        data,
-        include: PRODUCT_INCLUDE,
-      });
+    // Build the data object with only explicitly provided fields
+    const data: Prisma.ProductUpdateInput = {
+      ...(input.name !== undefined && { name: input.name }),
+      ...(input.description !== undefined && { description: input.description }),
+    };
+
+    // Handle parentId: null = clear, string = set, undefined = no change
+    if (input.parentId === null) {
+      data.parent = { disconnect: true };
+    } else if (input.parentId !== undefined) {
+      data.parent = { connect: { id: input.parentId } };
+    }
+
+    // Handle producedByOrganisationId: null = clear, string = set, undefined = no change
+    if (input.producedByOrganisationId === null) {
+      data.producedByOrganisation = { disconnect: true };
+    } else if (input.producedByOrganisationId !== undefined) {
+      data.producedByOrganisation = { connect: { id: input.producedByOrganisationId } };
+    }
+
+    // Handle manufacturingFacilityId: null = clear, string = set, undefined = no change
+    if (input.manufacturingFacilityId === null) {
+      data.manufacturingFacility = { disconnect: true };
+    } else if (input.manufacturingFacilityId !== undefined) {
+      data.manufacturingFacility = { connect: { id: input.manufacturingFacilityId } };
+    }
+
+    // Handle primaryIdentifierId: null = clear, string = set, undefined = no change
+    if (input.primaryIdentifierId === null) {
+      data.primaryIdentifier = { disconnect: true };
+    } else if (input.primaryIdentifierId !== undefined) {
+      data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
+    }
+
+    return tx.product.update({
+      where: { id },
+      data,
+      include: PRODUCT_INCLUDE,
     });
-  }
-
-  // No secondary identifier changes — simple update
-  return prisma.product.update({
-    where: { id },
-    data,
-    include: PRODUCT_INCLUDE,
   });
 }
 
@@ -430,16 +409,16 @@ export async function updateProduct(
  * Detaches ITEM children (sets parentId to null) before deleting.
  */
 export async function deleteProduct(id: string, tenantId: string): Promise<Product> {
-  const existing = await prisma.product.findFirst({ where: { id, tenantId } });
-  if (!existing) throw new NotFoundError('Product not found or access denied');
-
-  const children = await prisma.product.findMany({ where: { parentId: id, tenantId } });
-  const batches = children.filter((c) => c.level === 'BATCH');
-  if (batches.length > 0) {
-    throw new ValidationError(`Cannot delete: ${batches.length} BATCH product(s) depend on this MODEL`);
-  }
-
   return prisma.$transaction(async (tx) => {
+    const existing = await tx.product.findFirst({ where: { id, tenantId } });
+    if (!existing) throw new NotFoundError('Product not found or access denied');
+
+    const children = await tx.product.findMany({ where: { parentId: id, tenantId } });
+    const batches = children.filter((c) => c.level === 'BATCH');
+    if (batches.length > 0) {
+      throw new ValidationError(`Cannot delete: ${batches.length} BATCH product(s) depend on this MODEL`);
+    }
+
     const items = children.filter((c) => c.level === 'ITEM');
     if (items.length > 0) {
       await tx.product.updateMany({ where: { parentId: id, level: 'ITEM' }, data: { parentId: null } });

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -320,13 +320,23 @@ export async function updateProduct(
     }
   }
 
-  // Validate parent belongs to tenant (if provided and not null)
-  if (input.parentId !== undefined && input.parentId !== null) {
-    const parent = await prisma.product.findFirst({
-      where: { id: input.parentId, tenantId },
-    });
-    if (!parent) {
-      throw new NotFoundError(`Parent product not found: ${input.parentId}`);
+  // Validate hierarchy when parentId is being changed
+  if (input.parentId !== undefined) {
+    let parent: Product | null = null;
+    if (input.parentId !== null) {
+      parent = await prisma.product.findFirst({
+        where: { id: input.parentId, tenantId },
+      });
+    }
+    // validateProductHierarchy expects undefined for "no parent"
+    validateProductHierarchy(existing.level, input.parentId ?? undefined, parent);
+  }
+
+  // Validate primary identifier belongs to tenant (if provided and not null)
+  if (input.primaryIdentifierId !== undefined && input.primaryIdentifierId !== null) {
+    const ident = await prisma.identifier.findFirst({ where: { id: input.primaryIdentifierId, tenantId } });
+    if (!ident) {
+      throw new NotFoundError(`Identifier not found: ${input.primaryIdentifierId}`);
     }
   }
 

--- a/packages/reference-implementation/src/lib/types/index.ts
+++ b/packages/reference-implementation/src/lib/types/index.ts
@@ -1,0 +1,1 @@
+export * from './master-data';

--- a/packages/reference-implementation/src/lib/types/master-data.ts
+++ b/packages/reference-implementation/src/lib/types/master-data.ts
@@ -1,0 +1,17 @@
+/**
+ * Location structure matching the UNTP core vocabulary.
+ * Stored as Json in Prisma, validated at application layer.
+ * All fields optional — users with only a free-text address use address.streetAddress.
+ */
+export interface UntpLocation {
+  address?: {
+    streetAddress?: string;
+    postalCode?: string;
+    addressLocality?: string;
+    addressRegion?: string;
+    addressCountry?: string; // ISO-3166 alpha-2
+  };
+  plusCode?: string;
+  geoLocation?: { type: 'Point'; coordinates: [number, number] };
+  geoBoundary?: { type: 'Polygon'; coordinates: [number, number][][] };
+}


### PR DESCRIPTION
## Summary

This PR adds full CRUD management for the three core master data entities (organisations, facilities, products) to the reference implementation.

- Prisma models, repositories, and REST API routes for organisations, facilities, and products with tenant-scoped access, hierarchy validation (MODEL > BATCH > ITEM), primary/secondary identifier support, and Swagger annotations
- Comprehensive unit tests for all repository and route handler layers
- E2E specs covering the full lifecycle for each entity

## Test plan

- [x] 37 product repository unit tests (including hierarchy and identifier validation on update)
- [x] 20 facility repository unit tests
- [x] 20 organisation repository unit tests
- [x] Route handler tests for all three entities (GET/POST/PATCH/DELETE)
- [x] E2E specs: organisation-management (19 tests), facility-management (19 tests), product-management (32 tests)
- [x] All 563 passing unit tests confirmed