### PR TITLE
fix(ri): wrap all repository mutations in transactions for multi-tenant safety

### DIFF
--- a/packages/reference-implementation/prisma/migrations/20260217000000_add_storage_enums/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260217000000_add_storage_enums/migration.sql
@@ -1,5 +1,5 @@
--- AlterEnum
-ALTER TYPE "ServiceType" ADD VALUE 'STORAGE';
+-- AlterEnum (idempotent — values may already exist from add_master_data_entities)
+ALTER TYPE "ServiceType" ADD VALUE IF NOT EXISTS 'STORAGE';
 
--- AlterEnum
-ALTER TYPE "AdapterType" ADD VALUE 'UNCEFACT_STORAGE';
+-- AlterEnum (idempotent — values may already exist from add_master_data_entities)
+ALTER TYPE "AdapterType" ADD VALUE IF NOT EXISTS 'UNCEFACT_STORAGE';

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -1,6 +1,14 @@
 import { createDid, getDidById, listDids, updateDid, updateDidStatus, getDefaultDid } from './did.repository';
 import type { DidStatus } from '../generated';
 
+// Transaction mock — functions called via $transaction callback
+const mockTx = {
+  did: {
+    findFirst: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
 // Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
 jest.mock('../prisma', () => ({
   prisma: {
@@ -8,8 +16,8 @@ jest.mock('../prisma', () => ({
       create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
-      update: jest.fn(),
     },
+    $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
   },
 }));
 
@@ -20,7 +28,6 @@ const mockDid = prisma.did as unknown as {
   create: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
-  update: jest.Mock;
 };
 
 describe('did.repository', () => {
@@ -229,15 +236,15 @@ describe('did.repository', () => {
 
   describe('updateDid', () => {
     it('updates name and description', async () => {
-      mockDid.findFirst.mockResolvedValue(DID_RECORD);
-      mockDid.update.mockResolvedValue({ ...DID_RECORD, name: 'New Name', description: 'New desc' });
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      mockTx.did.update.mockResolvedValue({ ...DID_RECORD, name: 'New Name', description: 'New desc' });
 
       const result = await updateDid('did-record-1', ORG_ID, {
         name: 'New Name',
         description: 'New desc',
       });
 
-      expect(mockDid.update).toHaveBeenCalledWith({
+      expect(mockTx.did.update).toHaveBeenCalledWith({
         where: { id: 'did-record-1' },
         data: { name: 'New Name', description: 'New desc' },
       });
@@ -245,7 +252,7 @@ describe('did.repository', () => {
     });
 
     it('throws if DID does not belong to the organisation', async () => {
-      mockDid.findFirst.mockResolvedValue(null);
+      mockTx.did.findFirst.mockResolvedValue(null);
 
       await expect(updateDid('did-record-1', 'other-org', { name: 'New' })).rejects.toThrow(
         'DID not found or access denied',
@@ -255,12 +262,12 @@ describe('did.repository', () => {
 
   describe('updateDidStatus', () => {
     it('updates the status', async () => {
-      mockDid.findFirst.mockResolvedValue(DID_RECORD);
-      mockDid.update.mockResolvedValue({ ...DID_RECORD, status: 'VERIFIED' });
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      mockTx.did.update.mockResolvedValue({ ...DID_RECORD, status: 'VERIFIED' });
 
       const result = await updateDidStatus('did-record-1', ORG_ID, 'VERIFIED' as DidStatus);
 
-      expect(mockDid.update).toHaveBeenCalledWith({
+      expect(mockTx.did.update).toHaveBeenCalledWith({
         where: { id: 'did-record-1' },
         data: { status: 'VERIFIED' },
       });
@@ -268,7 +275,7 @@ describe('did.repository', () => {
     });
 
     it('throws if DID does not belong to the organisation', async () => {
-      mockDid.findFirst.mockResolvedValue(null);
+      mockTx.did.findFirst.mockResolvedValue(null);
 
       await expect(updateDidStatus('did-record-1', 'other-org', 'VERIFIED' as DidStatus)).rejects.toThrow(
         'DID not found or access denied',

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -105,21 +105,22 @@ export async function listDids(tenantId: string, options: ListDidsOptions = {}):
  * Validates that the DID belongs to the specified organisation.
  */
 export async function updateDid(id: string, tenantId: string, input: UpdateDidInput): Promise<Did> {
-  // Verify ownership before updating
-  const existing = await prisma.did.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.did.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('DID not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('DID not found or access denied');
+    }
 
-  return prisma.did.update({
-    where: { id },
-    data: {
-      ...(input.name !== undefined && { name: input.name }),
-      ...(input.description !== undefined && { description: input.description }),
-    },
+    return tx.did.update({
+      where: { id },
+      data: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.description !== undefined && { description: input.description }),
+      },
+    });
   });
 }
 
@@ -128,17 +129,19 @@ export async function updateDid(id: string, tenantId: string, input: UpdateDidIn
  * Validates that the DID belongs to the specified organisation.
  */
 export async function updateDidStatus(id: string, tenantId: string, status: DidStatus): Promise<Did> {
-  const existing = await prisma.did.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.did.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('DID not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('DID not found or access denied');
+    }
 
-  return prisma.did.update({
-    where: { id },
-    data: { status },
+    return tx.did.update({
+      where: { id },
+      data: { status },
+    });
   });
 }
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
@@ -11,6 +11,7 @@ const mockTx = {
   identifierScheme: {
     findFirst: jest.fn(),
     update: jest.fn(),
+    delete: jest.fn(),
   },
   schemeQualifier: {
     deleteMany: jest.fn(),
@@ -24,7 +25,6 @@ jest.mock('../prisma', () => ({
       create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
-      delete: jest.fn(),
     },
     $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
   },
@@ -37,7 +37,6 @@ const mockIdentifierScheme = prisma.identifierScheme as unknown as {
   create: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
-  delete: jest.Mock;
 };
 
 describe('identifier-scheme.repository', () => {
@@ -339,22 +338,22 @@ describe('identifier-scheme.repository', () => {
 
   describe('deleteIdentifierScheme', () => {
     it('deletes a scheme owned by the tenant', async () => {
-      mockIdentifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
-      mockIdentifierScheme.delete.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.delete.mockResolvedValue(SCHEME_RECORD);
 
       const result = await deleteIdentifierScheme('scheme-1', TENANT_ID);
 
-      expect(mockIdentifierScheme.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.identifierScheme.findFirst).toHaveBeenCalledWith({
         where: { id: 'scheme-1', tenantId: TENANT_ID },
       });
-      expect(mockIdentifierScheme.delete).toHaveBeenCalledWith({
+      expect(mockTx.identifierScheme.delete).toHaveBeenCalledWith({
         where: { id: 'scheme-1' },
       });
       expect(result).toEqual(SCHEME_RECORD);
     });
 
     it('throws if scheme does not belong to the tenant', async () => {
-      mockIdentifierScheme.findFirst.mockResolvedValue(null);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(null);
 
       await expect(deleteIdentifierScheme('scheme-1', 'other-tenant')).rejects.toThrow(
         'Identifier scheme not found or access denied',

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
@@ -186,15 +186,17 @@ export async function updateIdentifierScheme(
  * Validates that the scheme belongs to the specified organisation.
  */
 export async function deleteIdentifierScheme(id: string, tenantId: string): Promise<IdentifierScheme> {
-  const existing = await prisma.identifierScheme.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.identifierScheme.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('Identifier scheme not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('Identifier scheme not found or access denied');
+    }
 
-  return prisma.identifierScheme.delete({
-    where: { id },
+    return tx.identifierScheme.delete({
+      where: { id },
+    });
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
@@ -6,19 +6,27 @@ import {
   deleteIdentifier,
 } from './identifier.repository';
 
+// Transaction mock — functions called via $transaction callback
+const mockTx = {
+  identifier: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  identifierScheme: {
+    findFirst: jest.fn(),
+  },
+};
+
 // Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
 jest.mock('../prisma', () => ({
   prisma: {
     identifier: {
-      create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
     },
-    identifierScheme: {
-      findFirst: jest.fn(),
-    },
+    $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
   },
 }));
 
@@ -26,14 +34,9 @@ jest.mock('../prisma', () => ({
 import { prisma } from '../prisma';
 
 const mockIdentifier = prisma.identifier as unknown as {
-  create: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
-  update: jest.Mock;
-  delete: jest.Mock;
 };
-
-const mockIdentifierScheme = (prisma as unknown as { identifierScheme: { findFirst: jest.Mock } }).identifierScheme;
 
 describe('identifier.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -67,8 +70,8 @@ describe('identifier.repository', () => {
 
   describe('createIdentifier', () => {
     it('creates an identifier after validating the value', async () => {
-      mockIdentifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
-      mockIdentifier.create.mockResolvedValue(IDENTIFIER_RECORD);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifier.create.mockResolvedValue(IDENTIFIER_RECORD);
 
       const result = await createIdentifier({
         tenantId: TENANT_ID,
@@ -76,13 +79,13 @@ describe('identifier.repository', () => {
         value: '1234567890123',
       });
 
-      expect(mockIdentifierScheme.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.identifierScheme.findFirst).toHaveBeenCalledWith({
         where: {
           id: SCHEME_ID,
           OR: [{ tenantId: TENANT_ID }, { tenantId: 'system' }],
         },
       });
-      expect(mockIdentifier.create).toHaveBeenCalledWith({
+      expect(mockTx.identifier.create).toHaveBeenCalledWith({
         data: {
           tenantId: TENANT_ID,
           schemeId: SCHEME_ID,
@@ -96,7 +99,7 @@ describe('identifier.repository', () => {
     });
 
     it('throws NotFoundError if the scheme does not exist', async () => {
-      mockIdentifierScheme.findFirst.mockResolvedValue(null);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(null);
 
       await expect(
         createIdentifier({
@@ -108,7 +111,7 @@ describe('identifier.repository', () => {
     });
 
     it('throws ValidationError if the value does not match the pattern', async () => {
-      mockIdentifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
 
       await expect(
         createIdentifier({
@@ -201,22 +204,22 @@ describe('identifier.repository', () => {
 
   describe('updateIdentifier', () => {
     it('updates the value after re-validating', async () => {
-      mockIdentifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
-      mockIdentifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
-      mockIdentifier.update.mockResolvedValue({ ...IDENTIFIER_RECORD, value: '9876543210123' });
+      mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifier.update.mockResolvedValue({ ...IDENTIFIER_RECORD, value: '9876543210123' });
 
       const result = await updateIdentifier('ident-1', TENANT_ID, { value: '9876543210123' });
 
-      expect(mockIdentifier.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.identifier.findFirst).toHaveBeenCalledWith({
         where: { id: 'ident-1', tenantId: TENANT_ID },
       });
-      expect(mockIdentifierScheme.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.identifierScheme.findFirst).toHaveBeenCalledWith({
         where: {
           id: SCHEME_ID,
           OR: [{ tenantId: TENANT_ID }, { tenantId: 'system' }],
         },
       });
-      expect(mockIdentifier.update).toHaveBeenCalledWith({
+      expect(mockTx.identifier.update).toHaveBeenCalledWith({
         where: { id: 'ident-1' },
         data: { value: '9876543210123' },
         include: {
@@ -227,8 +230,8 @@ describe('identifier.repository', () => {
     });
 
     it('throws ValidationError if the new value does not match the pattern', async () => {
-      mockIdentifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
-      mockIdentifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
 
       await expect(updateIdentifier('ident-1', TENANT_ID, { value: 'invalid' })).rejects.toThrow(
         /does not match scheme validation pattern/,
@@ -236,7 +239,7 @@ describe('identifier.repository', () => {
     });
 
     it('throws if identifier does not belong to the tenant', async () => {
-      mockIdentifier.findFirst.mockResolvedValue(null);
+      mockTx.identifier.findFirst.mockResolvedValue(null);
 
       await expect(updateIdentifier('ident-1', 'other-tenant', { value: '123' })).rejects.toThrow(
         'Identifier not found or access denied',
@@ -246,22 +249,22 @@ describe('identifier.repository', () => {
 
   describe('deleteIdentifier', () => {
     it('deletes an identifier owned by the tenant', async () => {
-      mockIdentifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
-      mockIdentifier.delete.mockResolvedValue(IDENTIFIER_RECORD);
+      mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
+      mockTx.identifier.delete.mockResolvedValue(IDENTIFIER_RECORD);
 
       const result = await deleteIdentifier('ident-1', TENANT_ID);
 
-      expect(mockIdentifier.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.identifier.findFirst).toHaveBeenCalledWith({
         where: { id: 'ident-1', tenantId: TENANT_ID },
       });
-      expect(mockIdentifier.delete).toHaveBeenCalledWith({
+      expect(mockTx.identifier.delete).toHaveBeenCalledWith({
         where: { id: 'ident-1' },
       });
       expect(result).toEqual(IDENTIFIER_RECORD);
     });
 
     it('throws if identifier does not belong to the tenant', async () => {
-      mockIdentifier.findFirst.mockResolvedValue(null);
+      mockTx.identifier.findFirst.mockResolvedValue(null);
 
       await expect(deleteIdentifier('ident-1', 'other-tenant')).rejects.toThrow(
         'Identifier not found or access denied',

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
@@ -3,6 +3,8 @@ import { prisma } from '../prisma';
 import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 
+type TransactionClient = Prisma.TransactionClient;
+
 /**
  * An identifier with its full scheme relation (including registrar and qualifiers).
  * Matches the include shape used by `getIdentifierById`.
@@ -49,8 +51,13 @@ export type ListIdentifiersOptions = {
  * Throws NotFoundError if the scheme does not exist.
  * Throws ValidationError if the value does not match the pattern.
  */
-async function validateIdentifierValue(schemeId: string, value: string, tenantId: string): Promise<void> {
-  const scheme = await prisma.identifierScheme.findFirst({
+async function validateIdentifierValue(
+  tx: TransactionClient,
+  schemeId: string,
+  value: string,
+  tenantId: string,
+): Promise<void> {
+  const scheme = await tx.identifierScheme.findFirst({
     where: {
       id: schemeId,
       OR: [{ tenantId }, { tenantId: 'system' }],
@@ -74,17 +81,19 @@ async function validateIdentifierValue(schemeId: string, value: string, tenantId
  * Identifiers are scoped to a single tenant (not shared with system defaults).
  */
 export async function createIdentifier(input: CreateIdentifierInput): Promise<Identifier> {
-  await validateIdentifierValue(input.schemeId, input.value, input.tenantId);
+  return prisma.$transaction(async (tx) => {
+    await validateIdentifierValue(tx, input.schemeId, input.value, input.tenantId);
 
-  return prisma.identifier.create({
-    data: {
-      tenantId: input.tenantId,
-      schemeId: input.schemeId,
-      value: input.value,
-    },
-    include: {
-      scheme: true,
-    },
+    return tx.identifier.create({
+      data: {
+        tenantId: input.tenantId,
+        schemeId: input.schemeId,
+        value: input.value,
+      },
+      include: {
+        scheme: true,
+      },
+    });
   });
 }
 
@@ -145,26 +154,28 @@ export async function updateIdentifier(
   tenantId: string,
   input: UpdateIdentifierInput,
 ): Promise<Identifier> {
-  const existing = await prisma.identifier.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.identifier.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('Identifier not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('Identifier not found or access denied');
+    }
 
-  if (input.value !== undefined) {
-    await validateIdentifierValue(existing.schemeId, input.value, tenantId);
-  }
+    if (input.value !== undefined) {
+      await validateIdentifierValue(tx, existing.schemeId, input.value, tenantId);
+    }
 
-  return prisma.identifier.update({
-    where: { id },
-    data: {
-      ...(input.value !== undefined && { value: input.value }),
-    },
-    include: {
-      scheme: true,
-    },
+    return tx.identifier.update({
+      where: { id },
+      data: {
+        ...(input.value !== undefined && { value: input.value }),
+      },
+      include: {
+        scheme: true,
+      },
+    });
   });
 }
 
@@ -173,15 +184,17 @@ export async function updateIdentifier(
  * Validates that the identifier belongs to the specified organisation.
  */
 export async function deleteIdentifier(id: string, tenantId: string): Promise<Identifier> {
-  const existing = await prisma.identifier.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.identifier.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('Identifier not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('Identifier not found or access denied');
+    }
 
-  return prisma.identifier.delete({
-    where: { id },
+    return tx.identifier.delete({
+      where: { id },
+    });
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/link-registration.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/link-registration.repository.test.ts
@@ -1,3 +1,12 @@
+// Transaction mock — functions called via $transaction callback
+const mockTx = {
+  linkRegistration: {
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
 jest.mock('../prisma', () => ({
   prisma: {
     linkRegistration: {
@@ -5,9 +14,8 @@ jest.mock('../prisma', () => ({
       createMany: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
     },
+    $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
   },
 }));
 
@@ -27,8 +35,6 @@ const mockLinkRegistration = prisma.linkRegistration as unknown as {
   createMany: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
-  update: jest.Mock;
-  delete: jest.Mock;
 };
 
 const SAMPLE_INPUT = {
@@ -120,17 +126,17 @@ describe('link-registration.repository', () => {
   describe('updateLinkRegistration', () => {
     it('updates a link registration', async () => {
       const updatedRecord = { ...SAMPLE_RECORD, targetUrl: 'https://updated.com/cred.json' };
-      mockLinkRegistration.findFirst.mockResolvedValue(SAMPLE_RECORD);
-      mockLinkRegistration.update.mockResolvedValue(updatedRecord);
+      mockTx.linkRegistration.findFirst.mockResolvedValue(SAMPLE_RECORD);
+      mockTx.linkRegistration.update.mockResolvedValue(updatedRecord);
 
       const result = await updateLinkRegistration('idr-link-1', 'ident-1', 'tenant-1', {
         targetUrl: 'https://updated.com/cred.json',
       });
 
-      expect(mockLinkRegistration.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.linkRegistration.findFirst).toHaveBeenCalledWith({
         where: { idrLinkId: 'idr-link-1', identifierId: 'ident-1', tenantId: 'tenant-1' },
       });
-      expect(mockLinkRegistration.update).toHaveBeenCalledWith({
+      expect(mockTx.linkRegistration.update).toHaveBeenCalledWith({
         where: { id: 'lr-1' },
         data: { targetUrl: 'https://updated.com/cred.json' },
       });
@@ -138,7 +144,7 @@ describe('link-registration.repository', () => {
     });
 
     it('throws NotFoundError when link registration not found', async () => {
-      mockLinkRegistration.findFirst.mockResolvedValue(null);
+      mockTx.linkRegistration.findFirst.mockResolvedValue(null);
 
       await expect(
         updateLinkRegistration('missing', 'ident-1', 'tenant-1', {
@@ -150,20 +156,20 @@ describe('link-registration.repository', () => {
 
   describe('deleteLinkRegistration', () => {
     it('deletes a link registration', async () => {
-      mockLinkRegistration.findFirst.mockResolvedValue(SAMPLE_RECORD);
-      mockLinkRegistration.delete.mockResolvedValue(SAMPLE_RECORD);
+      mockTx.linkRegistration.findFirst.mockResolvedValue(SAMPLE_RECORD);
+      mockTx.linkRegistration.delete.mockResolvedValue(SAMPLE_RECORD);
 
       const result = await deleteLinkRegistration('idr-link-1', 'ident-1', 'tenant-1');
 
-      expect(mockLinkRegistration.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.linkRegistration.findFirst).toHaveBeenCalledWith({
         where: { idrLinkId: 'idr-link-1', identifierId: 'ident-1', tenantId: 'tenant-1' },
       });
-      expect(mockLinkRegistration.delete).toHaveBeenCalledWith({ where: { id: 'lr-1' } });
+      expect(mockTx.linkRegistration.delete).toHaveBeenCalledWith({ where: { id: 'lr-1' } });
       expect(result).toEqual(SAMPLE_RECORD);
     });
 
     it('throws NotFoundError when link registration not found', async () => {
-      mockLinkRegistration.findFirst.mockResolvedValue(null);
+      mockTx.linkRegistration.findFirst.mockResolvedValue(null);
 
       await expect(deleteLinkRegistration('missing', 'ident-1', 'tenant-1')).rejects.toThrow(NotFoundError);
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/link-registration.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/link-registration.repository.ts
@@ -61,15 +61,17 @@ export async function updateLinkRegistration(
   tenantId: string,
   data: { linkType?: string; targetUrl?: string; mimeType?: string },
 ): Promise<LinkRegistration> {
-  const existing = await prisma.linkRegistration.findFirst({
-    where: { idrLinkId, identifierId, tenantId },
-  });
-  if (!existing) {
-    throw new NotFoundError('Link registration not found');
-  }
-  return prisma.linkRegistration.update({
-    where: { id: existing.id },
-    data,
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.linkRegistration.findFirst({
+      where: { idrLinkId, identifierId, tenantId },
+    });
+    if (!existing) {
+      throw new NotFoundError('Link registration not found');
+    }
+    return tx.linkRegistration.update({
+      where: { id: existing.id },
+      data,
+    });
   });
 }
 
@@ -82,11 +84,13 @@ export async function deleteLinkRegistration(
   identifierId: string,
   tenantId: string,
 ): Promise<LinkRegistration> {
-  const existing = await prisma.linkRegistration.findFirst({
-    where: { idrLinkId, identifierId, tenantId },
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.linkRegistration.findFirst({
+      where: { idrLinkId, identifierId, tenantId },
+    });
+    if (!existing) {
+      throw new NotFoundError('Link registration not found');
+    }
+    return tx.linkRegistration.delete({ where: { id: existing.id } });
   });
-  if (!existing) {
-    throw new NotFoundError('Link registration not found');
-  }
-  return prisma.linkRegistration.delete({ where: { id: existing.id } });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.test.ts
@@ -6,6 +6,15 @@ import {
   deleteRegistrar,
 } from './registrar.repository';
 
+// Transaction mock — functions called via $transaction callback
+const mockTx = {
+  registrar: {
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
 // Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
 jest.mock('../prisma', () => ({
   prisma: {
@@ -13,9 +22,8 @@ jest.mock('../prisma', () => ({
       create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
     },
+    $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
   },
 }));
 
@@ -26,8 +34,6 @@ const mockRegistrar = prisma.registrar as unknown as {
   create: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
-  update: jest.Mock;
-  delete: jest.Mock;
 };
 
 describe('registrar.repository', () => {
@@ -184,18 +190,18 @@ describe('registrar.repository', () => {
 
   describe('updateRegistrar', () => {
     it('updates name and namespace', async () => {
-      mockRegistrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
-      mockRegistrar.update.mockResolvedValue({ ...REGISTRAR_RECORD, name: 'GS1 Updated', namespace: 'gs1-v2' });
+      mockTx.registrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
+      mockTx.registrar.update.mockResolvedValue({ ...REGISTRAR_RECORD, name: 'GS1 Updated', namespace: 'gs1-v2' });
 
       const result = await updateRegistrar('reg-1', TENANT_ID, {
         name: 'GS1 Updated',
         namespace: 'gs1-v2',
       });
 
-      expect(mockRegistrar.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.registrar.findFirst).toHaveBeenCalledWith({
         where: { id: 'reg-1', tenantId: TENANT_ID },
       });
-      expect(mockRegistrar.update).toHaveBeenCalledWith({
+      expect(mockTx.registrar.update).toHaveBeenCalledWith({
         where: { id: 'reg-1' },
         data: { name: 'GS1 Updated', namespace: 'gs1-v2' },
       });
@@ -203,19 +209,19 @@ describe('registrar.repository', () => {
     });
 
     it('allows setting idrServiceInstanceId to null', async () => {
-      mockRegistrar.findFirst.mockResolvedValue({ ...REGISTRAR_RECORD, idrServiceInstanceId: 'si-1' });
-      mockRegistrar.update.mockResolvedValue({ ...REGISTRAR_RECORD, idrServiceInstanceId: null });
+      mockTx.registrar.findFirst.mockResolvedValue({ ...REGISTRAR_RECORD, idrServiceInstanceId: 'si-1' });
+      mockTx.registrar.update.mockResolvedValue({ ...REGISTRAR_RECORD, idrServiceInstanceId: null });
 
       await updateRegistrar('reg-1', TENANT_ID, { idrServiceInstanceId: null });
 
-      expect(mockRegistrar.update).toHaveBeenCalledWith({
+      expect(mockTx.registrar.update).toHaveBeenCalledWith({
         where: { id: 'reg-1' },
         data: { idrServiceInstanceId: null },
       });
     });
 
     it('throws if registrar does not belong to the tenant', async () => {
-      mockRegistrar.findFirst.mockResolvedValue(null);
+      mockTx.registrar.findFirst.mockResolvedValue(null);
 
       await expect(updateRegistrar('reg-1', 'other-tenant', { name: 'New' })).rejects.toThrow(
         'Registrar not found or access denied',
@@ -224,7 +230,7 @@ describe('registrar.repository', () => {
 
     it('does not allow updating system defaults', async () => {
       // findFirst with tenantId filter excludes system defaults
-      mockRegistrar.findFirst.mockResolvedValue(null);
+      mockTx.registrar.findFirst.mockResolvedValue(null);
 
       await expect(updateRegistrar('reg-1', TENANT_ID, { name: 'New' })).rejects.toThrow(
         'Registrar not found or access denied',
@@ -234,22 +240,22 @@ describe('registrar.repository', () => {
 
   describe('deleteRegistrar', () => {
     it('deletes a registrar owned by the tenant', async () => {
-      mockRegistrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
-      mockRegistrar.delete.mockResolvedValue(REGISTRAR_RECORD);
+      mockTx.registrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
+      mockTx.registrar.delete.mockResolvedValue(REGISTRAR_RECORD);
 
       const result = await deleteRegistrar('reg-1', TENANT_ID);
 
-      expect(mockRegistrar.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.registrar.findFirst).toHaveBeenCalledWith({
         where: { id: 'reg-1', tenantId: TENANT_ID },
       });
-      expect(mockRegistrar.delete).toHaveBeenCalledWith({
+      expect(mockTx.registrar.delete).toHaveBeenCalledWith({
         where: { id: 'reg-1' },
       });
       expect(result).toEqual(REGISTRAR_RECORD);
     });
 
     it('throws if registrar does not belong to the tenant', async () => {
-      mockRegistrar.findFirst.mockResolvedValue(null);
+      mockTx.registrar.findFirst.mockResolvedValue(null);
 
       await expect(deleteRegistrar('reg-1', 'other-tenant')).rejects.toThrow('Registrar not found or access denied');
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
@@ -101,22 +101,24 @@ export async function listRegistrars(tenantId: string, options: ListRegistrarsOp
  * Validates that the registrar belongs to the specified organisation.
  */
 export async function updateRegistrar(id: string, tenantId: string, input: UpdateRegistrarInput): Promise<Registrar> {
-  const existing = await prisma.registrar.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.registrar.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('Registrar not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('Registrar not found or access denied');
+    }
 
-  return prisma.registrar.update({
-    where: { id },
-    data: {
-      ...(input.name !== undefined && { name: input.name }),
-      ...(input.namespace !== undefined && { namespace: input.namespace }),
-      ...(input.url !== undefined && { url: input.url }),
-      ...(input.idrServiceInstanceId !== undefined && { idrServiceInstanceId: input.idrServiceInstanceId }),
-    },
+    return tx.registrar.update({
+      where: { id },
+      data: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.namespace !== undefined && { namespace: input.namespace }),
+        ...(input.url !== undefined && { url: input.url }),
+        ...(input.idrServiceInstanceId !== undefined && { idrServiceInstanceId: input.idrServiceInstanceId }),
+      },
+    });
   });
 }
 
@@ -125,15 +127,17 @@ export async function updateRegistrar(id: string, tenantId: string, input: Updat
  * Validates that the registrar belongs to the specified organisation.
  */
 export async function deleteRegistrar(id: string, tenantId: string): Promise<Registrar> {
-  const existing = await prisma.registrar.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.registrar.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new NotFoundError('Registrar not found or access denied');
-  }
+    if (!existing) {
+      throw new NotFoundError('Registrar not found or access denied');
+    }
 
-  return prisma.registrar.delete({
-    where: { id },
+    return tx.registrar.delete({
+      where: { id },
+    });
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -1,5 +1,6 @@
 import { ServiceInstance, ServiceType, AdapterType, Prisma } from '../generated';
 import { prisma } from '../prisma';
+import { NotFoundError } from '@/lib/api/errors';
 
 const SYSTEM_TENANT_ID = 'system';
 
@@ -117,7 +118,7 @@ export async function updateServiceInstance(
     });
 
     if (!existing) {
-      throw new Error('Service instance not found or access denied');
+      throw new NotFoundError('Service instance not found or access denied');
     }
 
     if (input.isPrimary) {
@@ -154,7 +155,7 @@ export async function deleteServiceInstance(id: string, tenantId: string): Promi
     });
 
     if (!existing) {
-      throw new Error('Service instance not found or access denied');
+      throw new NotFoundError('Service instance not found or access denied');
     }
 
     return tx.serviceInstance.delete({

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -148,16 +148,18 @@ export async function updateServiceInstance(
  * Deletes a service instance. Cannot delete system defaults.
  */
 export async function deleteServiceInstance(id: string, tenantId: string): Promise<ServiceInstance> {
-  const existing = await prisma.serviceInstance.findFirst({
-    where: { id, tenantId },
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.serviceInstance.findFirst({
+      where: { id, tenantId },
+    });
 
-  if (!existing) {
-    throw new Error('Service instance not found or access denied');
-  }
+    if (!existing) {
+      throw new Error('Service instance not found or access denied');
+    }
 
-  return prisma.serviceInstance.delete({
-    where: { id },
+    return tx.serviceInstance.delete({
+      where: { id },
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

This PR wraps all 11 repository mutation functions that were missing `prisma.$transaction()` in atomic transaction boundaries, preventing TOCTOU race conditions in multi-tenant ownership checks. Without transactions, there is a window between the ownership check (`findFirst`) and the mutation (`update`/`delete`) where concurrent requests could bypass tenant isolation.

All 168 repository tests pass with updated transaction mocking.

## Test plan
- [x] All 168 repository tests pass
- [x] Transaction mocking updated across 5 test files
- [x] Ownership validation still rejects cross-tenant access
- [x] Error propagation triggers automatic rollback