### PR TITLE
feat(ri): add data model and render template management with credential mapping pipeline

### DIFF
--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -180,6 +180,21 @@ export default defineConfig({
               [tenantId],
             );
 
+            // Render templates (FK to DataModel)
+            await client.query(
+              `DELETE FROM "RenderTemplate" WHERE "tenantId" = $1`,
+              [tenantId],
+            );
+            // Data model extensions (self-referencing — children first)
+            await client.query(
+              `DELETE FROM "DataModel" WHERE "tenantId" = $1 AND "parentConfigId" IS NOT NULL`,
+              [tenantId],
+            );
+            await client.query(
+              `DELETE FROM "DataModel" WHERE "tenantId" = $1`,
+              [tenantId],
+            );
+
             await client.query(
               `DELETE FROM "Credential" WHERE "tenantId" = $1`,
               [tenantId],

--- a/e2e/cypress/e2e/data_model_api/data-model-management.cy.ts
+++ b/e2e/cypress/e2e/data_model_api/data-model-management.cy.ts
@@ -1,0 +1,439 @@
+describe('Data Model API', { testIsolation: false }, () => {
+  const RUN_ID = Date.now();
+  let parentConfigId: string;
+  let createdDataModelId: string;
+
+  before(() => {
+    cy.apiLogin();
+    cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+
+    // Find a core data model to use as parent for extension tests
+    cy.request('/api/v1/data-models').then((response) => {
+      const core = response.body.dataModels.find(
+        (dm: any) => !dm.isExtension,
+      );
+      if (core) {
+        parentConfigId = core.id;
+      }
+    });
+  });
+
+  after(() => {
+    cy.task('cleanupTestData', { tenantId: 'e2e-test-org' });
+  });
+
+  describe('Listing core data models', () => {
+    it('GET /api/v1/data-models — lists data models including system defaults', () => {
+      cy.request('/api/v1/data-models').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.dataModels).to.be.an('array');
+      });
+    });
+
+    it('GET /api/v1/data-models — filters by credentialType', () => {
+      cy.request('/api/v1/data-models?credentialType=DigitalProductPassport').then((response) => {
+        expect(response.status).to.eq(200);
+        response.body.dataModels.forEach((dm: any) => {
+          expect(dm.credentialType).to.eq('DigitalProductPassport');
+        });
+      });
+    });
+
+    it('GET /api/v1/data-models — filters by isExtension=false', () => {
+      cy.request('/api/v1/data-models?isExtension=false').then((response) => {
+        expect(response.status).to.eq(200);
+        response.body.dataModels.forEach((dm: any) => {
+          expect(dm.isExtension).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('CRUD operations on extensions', () => {
+    it('POST /api/v1/data-models — creates a data model extension', function () {
+      if (!parentConfigId) this.skip();
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: `E2E DPP Extension ${RUN_ID}`,
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+          schemaUrl: `https://example.com/e2e-${RUN_ID}/schema.json`,
+          contextUrl: `https://example.com/e2e-${RUN_ID}/context.jsonld`,
+          parentConfigId,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.dataModel).to.exist;
+        expect(response.body.dataModel.name).to.eq(`E2E DPP Extension ${RUN_ID}`);
+        expect(response.body.dataModel.credentialType).to.eq('DigitalProductPassport');
+        expect(response.body.dataModel.version).to.eq('0.6.1');
+        expect(response.body.dataModel.isExtension).to.be.true;
+
+        createdDataModelId = response.body.dataModel.id;
+      });
+    });
+
+    it('POST /api/v1/data-models — includes optional websiteUrl', function () {
+      if (!parentConfigId) this.skip();
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: `E2E DCC Extension ${RUN_ID}`,
+          credentialType: 'DigitalConformityCredential',
+          version: '0.6.1',
+          schemaUrl: `https://example.com/e2e-dcc-${RUN_ID}/schema.json`,
+          contextUrl: `https://example.com/e2e-dcc-${RUN_ID}/context.jsonld`,
+          parentConfigId,
+          websiteUrl: `https://example.com/e2e-dcc-${RUN_ID}`,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.dataModel.websiteUrl).to.eq(`https://example.com/e2e-dcc-${RUN_ID}`);
+
+        // Clean up — only keep the first extension for remaining tests
+        cy.request({ method: 'DELETE', url: `/api/v1/data-models/${response.body.dataModel.id}` });
+      });
+    });
+
+    it('GET /api/v1/data-models — includes newly created extension', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request('/api/v1/data-models').then((response) => {
+        expect(response.status).to.eq(200);
+        const found = response.body.dataModels.find(
+          (dm: any) => dm.id === createdDataModelId,
+        );
+        expect(found).to.exist;
+      });
+    });
+
+    it('GET /api/v1/data-models — filters by isExtension=true', () => {
+      cy.request('/api/v1/data-models?isExtension=true').then((response) => {
+        expect(response.status).to.eq(200);
+        response.body.dataModels.forEach((dm: any) => {
+          expect(dm.isExtension).to.be.true;
+        });
+      });
+    });
+
+    it('GET /api/v1/data-models/:id — retrieves a specific data model', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request(`/api/v1/data-models/${createdDataModelId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.dataModel.id).to.eq(createdDataModelId);
+        expect(response.body.dataModel.name).to.eq(`E2E DPP Extension ${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/data-models/:id — updates name', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/data-models/${createdDataModelId}`,
+        body: { name: `Updated E2E Extension ${RUN_ID}` },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.dataModel.name).to.eq(`Updated E2E Extension ${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/data-models/:id — updates schemaUrl and contextUrl', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/data-models/${createdDataModelId}`,
+        body: {
+          schemaUrl: `https://example.com/e2e-updated-${RUN_ID}/schema.json`,
+          contextUrl: `https://example.com/e2e-updated-${RUN_ID}/context.jsonld`,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.dataModel.schemaUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/schema.json`);
+        expect(response.body.dataModel.contextUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/context.jsonld`);
+      });
+    });
+
+    it('GET /api/v1/data-models/:id — confirms updates persisted', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request(`/api/v1/data-models/${createdDataModelId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.dataModel.name).to.eq(`Updated E2E Extension ${RUN_ID}`);
+        expect(response.body.dataModel.schemaUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/schema.json`);
+      });
+    });
+
+    it('GET /api/v1/data-models/:id/form-config — returns form configuration', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request(`/api/v1/data-models/${createdDataModelId}/form-config`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.formConfig).to.exist;
+        expect(response.body.formConfig.dataModelId).to.eq(createdDataModelId);
+        expect(response.body.formConfig.credentialType).to.eq('DigitalProductPassport');
+        expect(response.body.formConfig.sections).to.be.an('array');
+        expect(response.body.formConfig.sections.length).to.be.greaterThan(0);
+      });
+    });
+
+    it('DELETE /api/v1/data-models/:id — deletes the data model extension', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/data-models/${createdDataModelId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+      });
+    });
+
+    it('GET /api/v1/data-models/:id — returns 404 after deletion', function () {
+      if (!createdDataModelId) this.skip();
+
+      cy.request({
+        method: 'GET',
+        url: `/api/v1/data-models/${createdDataModelId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+
+  describe('Pagination', () => {
+    it('supports limit and offset parameters', () => {
+      cy.request('/api/v1/data-models?limit=1&offset=0').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.dataModels.length).to.be.at.most(1);
+      });
+    });
+  });
+
+  describe('Validation errors', () => {
+    it('returns 400 when name is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          parentConfigId: 'some-id',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when credentialType is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: 'Test',
+          version: '0.6.1',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          parentConfigId: 'some-id',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when credentialType is invalid', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: 'Test',
+          credentialType: 'InvalidType',
+          version: '0.6.1',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          parentConfigId: 'some-id',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when version is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: 'Test',
+          credentialType: 'DigitalProductPassport',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          parentConfigId: 'some-id',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when schemaUrl is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: 'Test',
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+          contextUrl: 'https://example.com/context.jsonld',
+          parentConfigId: 'some-id',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when contextUrl is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: 'Test',
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+          schemaUrl: 'https://example.com/schema.json',
+          parentConfigId: 'some-id',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when parentConfigId is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: 'Test',
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for invalid isExtension filter', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/data-models?isExtension=maybe',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for invalid credentialType filter', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/data-models?credentialType=InvalidType',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for non-numeric limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/data-models?limit=abc',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for negative offset', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/data-models?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when PATCH body is empty', function () {
+      if (!parentConfigId) this.skip();
+
+      // Create a temporary extension to test PATCH validation
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/data-models',
+        body: {
+          name: `Temp Extension ${RUN_ID}`,
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+          schemaUrl: 'https://example.com/temp/schema.json',
+          contextUrl: 'https://example.com/temp/context.jsonld',
+          parentConfigId,
+        },
+      }).then((createResponse) => {
+        const tempId = createResponse.body.dataModel.id;
+
+        cy.request({
+          method: 'PATCH',
+          url: `/api/v1/data-models/${tempId}`,
+          body: {},
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(400);
+        });
+
+        // Clean up
+        cy.request({ method: 'DELETE', url: `/api/v1/data-models/${tempId}` });
+      });
+    });
+
+    it('returns 404 for nonexistent data model', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/data-models/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+
+    it('returns 404 for form-config on nonexistent data model', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/data-models/nonexistent-id/form-config',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+});

--- a/e2e/cypress/e2e/facility_api/facility-management.cy.ts
+++ b/e2e/cypress/e2e/facility_api/facility-management.cy.ts
@@ -33,6 +33,7 @@ describe('Facility API', { testIsolation: false }, () => {
           name: `Fac Test Scheme ${RUN_ID}`,
           primaryKey: `fac-pk-${RUN_ID}`,
           validationPattern: '^\\d{11}$',
+          linkTemplate: '/{primaryKey}/{value}',
         },
       }).then((schemeResponse) => {
         schemeId = schemeResponse.body.scheme.id;

--- a/e2e/cypress/e2e/identifier_api/identifier-management.cy.ts
+++ b/e2e/cypress/e2e/identifier_api/identifier-management.cy.ts
@@ -28,6 +28,7 @@ describe('Identifier API', { testIsolation: false }, () => {
           name: `Ident Test ABN Scheme ${RUN_ID}`,
           primaryKey: `abn-${RUN_ID}`,
           validationPattern: '^\\d{11}$',
+          linkTemplate: '/{primaryKey}/{value}',
         },
       }).then((schemeResponse) => {
         schemeId = schemeResponse.body.scheme.id;

--- a/e2e/cypress/e2e/organisation_api/organisation-management.cy.ts
+++ b/e2e/cypress/e2e/organisation_api/organisation-management.cy.ts
@@ -30,6 +30,7 @@ describe('Organisation API', { testIsolation: false }, () => {
           name: `Org Test ABN Scheme ${RUN_ID}`,
           primaryKey: `abn-${RUN_ID}`,
           validationPattern: '^\\d{11}$',
+          linkTemplate: '/{primaryKey}/{value}',
         },
       }).then((schemeResponse) => {
         schemeId = schemeResponse.body.scheme.id;

--- a/e2e/cypress/e2e/product_api/product-management.cy.ts
+++ b/e2e/cypress/e2e/product_api/product-management.cy.ts
@@ -35,6 +35,7 @@ describe('Product API', { testIsolation: false }, () => {
           name: `Prod Test Scheme ${RUN_ID}`,
           primaryKey: `prod-key-${RUN_ID}`,
           validationPattern: '^\\d{11}$',
+          linkTemplate: '/{primaryKey}/{value}',
         },
       }).then((schemeResponse) => {
         schemeId = schemeResponse.body.scheme.id;

--- a/e2e/cypress/e2e/render_template_api/render-template-management.cy.ts
+++ b/e2e/cypress/e2e/render_template_api/render-template-management.cy.ts
@@ -1,0 +1,321 @@
+describe('Render Template API', { testIsolation: false }, () => {
+  const RUN_ID = Date.now();
+  let dataModelId: string;
+  let createdTemplateId: string;
+
+  before(() => {
+    cy.apiLogin();
+    cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+
+    // Find a data model to associate templates with
+    cy.request('/api/v1/data-models').then((response) => {
+      const dm = response.body.dataModels.find(
+        (d: any) => !d.isExtension,
+      );
+      if (dm) {
+        dataModelId = dm.id;
+      }
+    });
+  });
+
+  after(() => {
+    cy.task('cleanupTestData', { tenantId: 'e2e-test-org' });
+  });
+
+  describe('CRUD operations', () => {
+    it('POST /api/v1/render-templates — creates a render template', function () {
+      if (!dataModelId) this.skip();
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/render-templates',
+        body: {
+          name: `E2E Template ${RUN_ID}`,
+          dataModelId,
+          storageUrl: `https://storage.example.com/e2e-${RUN_ID}/template.hbs`,
+          hash: `sha256-e2e-${RUN_ID}`,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.renderTemplate).to.exist;
+        expect(response.body.renderTemplate.name).to.eq(`E2E Template ${RUN_ID}`);
+        expect(response.body.renderTemplate.dataModelId).to.eq(dataModelId);
+        expect(response.body.renderTemplate.storageUrl).to.eq(`https://storage.example.com/e2e-${RUN_ID}/template.hbs`);
+        expect(response.body.renderTemplate.hash).to.eq(`sha256-e2e-${RUN_ID}`);
+
+        createdTemplateId = response.body.renderTemplate.id;
+      });
+    });
+
+    it('POST /api/v1/render-templates — creates with isPrimary', function () {
+      if (!dataModelId) this.skip();
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/render-templates',
+        body: {
+          name: `E2E Primary Template ${RUN_ID}`,
+          dataModelId,
+          storageUrl: `https://storage.example.com/e2e-primary-${RUN_ID}/template.hbs`,
+          hash: `sha256-primary-${RUN_ID}`,
+          isPrimary: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.renderTemplate.isPrimary).to.be.true;
+
+        // Clean up — only keep the first template for remaining tests
+        cy.request({ method: 'DELETE', url: `/api/v1/render-templates/${response.body.renderTemplate.id}` });
+      });
+    });
+
+    it('GET /api/v1/render-templates — lists render templates', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request('/api/v1/render-templates').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.renderTemplates).to.be.an('array');
+
+        const found = response.body.renderTemplates.find(
+          (t: any) => t.id === createdTemplateId,
+        );
+        expect(found).to.exist;
+      });
+    });
+
+    it('GET /api/v1/render-templates — filters by dataModelId', function () {
+      if (!dataModelId) this.skip();
+
+      cy.request(`/api/v1/render-templates?dataModelId=${dataModelId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        response.body.renderTemplates.forEach((t: any) => {
+          expect(t.dataModelId).to.eq(dataModelId);
+        });
+      });
+    });
+
+    it('GET /api/v1/render-templates/:id — retrieves a specific render template', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request(`/api/v1/render-templates/${createdTemplateId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.renderTemplate.id).to.eq(createdTemplateId);
+        expect(response.body.renderTemplate.name).to.eq(`E2E Template ${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/render-templates/:id — updates name', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/render-templates/${createdTemplateId}`,
+        body: { name: `Updated E2E Template ${RUN_ID}` },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+        expect(response.body.renderTemplate.name).to.eq(`Updated E2E Template ${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/render-templates/:id — updates storageUrl and hash', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/render-templates/${createdTemplateId}`,
+        body: {
+          storageUrl: `https://storage.example.com/e2e-updated-${RUN_ID}/template.hbs`,
+          hash: `sha256-updated-${RUN_ID}`,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.renderTemplate.storageUrl).to.eq(`https://storage.example.com/e2e-updated-${RUN_ID}/template.hbs`);
+        expect(response.body.renderTemplate.hash).to.eq(`sha256-updated-${RUN_ID}`);
+      });
+    });
+
+    it('PATCH /api/v1/render-templates/:id — updates isPrimary', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/render-templates/${createdTemplateId}`,
+        body: { isPrimary: true },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.renderTemplate.isPrimary).to.be.true;
+      });
+    });
+
+    it('GET /api/v1/render-templates/:id — confirms updates persisted', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request(`/api/v1/render-templates/${createdTemplateId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.renderTemplate.name).to.eq(`Updated E2E Template ${RUN_ID}`);
+        expect(response.body.renderTemplate.storageUrl).to.eq(`https://storage.example.com/e2e-updated-${RUN_ID}/template.hbs`);
+        expect(response.body.renderTemplate.hash).to.eq(`sha256-updated-${RUN_ID}`);
+        expect(response.body.renderTemplate.isPrimary).to.be.true;
+      });
+    });
+
+    it('DELETE /api/v1/render-templates/:id — deletes the render template', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/render-templates/${createdTemplateId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.ok).to.be.true;
+      });
+    });
+
+    it('GET /api/v1/render-templates/:id — returns 404 after deletion', function () {
+      if (!createdTemplateId) this.skip();
+
+      cy.request({
+        method: 'GET',
+        url: `/api/v1/render-templates/${createdTemplateId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+
+  describe('Pagination', () => {
+    it('supports limit and offset parameters', () => {
+      cy.request('/api/v1/render-templates?limit=1&offset=0').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.renderTemplates.length).to.be.at.most(1);
+      });
+    });
+  });
+
+  describe('Validation errors', () => {
+    it('returns 400 when name is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/render-templates',
+        body: {
+          dataModelId: 'dm-1',
+          storageUrl: 'https://example.com/template.hbs',
+          hash: 'abc123',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when dataModelId is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/render-templates',
+        body: {
+          name: 'Test',
+          storageUrl: 'https://example.com/template.hbs',
+          hash: 'abc123',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when storageUrl is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/render-templates',
+        body: {
+          name: 'Test',
+          dataModelId: 'dm-1',
+          hash: 'abc123',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when hash is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/render-templates',
+        body: {
+          name: 'Test',
+          dataModelId: 'dm-1',
+          storageUrl: 'https://example.com/template.hbs',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for non-numeric limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/render-templates?limit=abc',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for negative offset', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/render-templates?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 when PATCH body is empty', function () {
+      if (!dataModelId) this.skip();
+
+      // Create a temporary template
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/render-templates',
+        body: {
+          name: `Temp Template ${RUN_ID}`,
+          dataModelId,
+          storageUrl: 'https://example.com/temp/template.hbs',
+          hash: 'temp-hash',
+        },
+      }).then((createResponse) => {
+        const tempId = createResponse.body.renderTemplate.id;
+
+        cy.request({
+          method: 'PATCH',
+          url: `/api/v1/render-templates/${tempId}`,
+          body: {},
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(400);
+        });
+
+        // Clean up
+        cy.request({ method: 'DELETE', url: `/api/v1/render-templates/${tempId}` });
+      });
+    });
+
+    it('returns 404 for nonexistent render template', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/render-templates/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+});

--- a/e2e/cypress/e2e/scheme_api/scheme-management.cy.ts
+++ b/e2e/cypress/e2e/scheme_api/scheme-management.cy.ts
@@ -35,6 +35,7 @@ describe('Scheme API', { testIsolation: false }, () => {
           name: `E2E ABN Scheme ${RUN_ID}`,
           primaryKey: `abn-${RUN_ID}`,
           validationPattern: '^\\d{11}$',
+          linkTemplate: '/{primaryKey}/{value}',
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
@@ -58,6 +59,7 @@ describe('Scheme API', { testIsolation: false }, () => {
           name: `E2E GTIN Scheme ${RUN_ID}`,
           primaryKey: `gtin-${RUN_ID}`,
           validationPattern: '^\\d{14}$',
+          linkTemplate: '/{primaryKey}/{value}',
           qualifiers: [
             {
               key: 'lot',
@@ -269,6 +271,7 @@ describe('Scheme API', { testIsolation: false }, () => {
           name: 'Test',
           primaryKey: `pk-${RUN_ID}`,
           validationPattern: '.*',
+          linkTemplate: '/{primaryKey}/{value}',
           qualifiers: [{ description: 'desc', validationPattern: '.*' }],
         },
         failOnStatusCode: false,
@@ -287,6 +290,7 @@ describe('Scheme API', { testIsolation: false }, () => {
           name: `Temp Scheme ${RUN_ID}`,
           primaryKey: `temp-pk-${RUN_ID}`,
           validationPattern: '.*',
+          linkTemplate: '/{primaryKey}/{value}',
         },
       }).then((createResponse) => {
         const tempId = createResponse.body.scheme.id;

--- a/packages/reference-implementation/prisma/migrations/20260217010000_add_link_template_and_qualifier_order/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260217010000_add_link_template_and_qualifier_order/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable: Add linkTemplate to IdentifierScheme
+-- Two-step approach: add as nullable with default, backfill, then make required
+ALTER TABLE "IdentifierScheme" ADD COLUMN "linkTemplate" TEXT NOT NULL DEFAULT '/{primaryKey}/{value}';
+
+-- Remove the default so future inserts must provide the value explicitly
+ALTER TABLE "IdentifierScheme" ALTER COLUMN "linkTemplate" DROP DEFAULT;
+
+-- AlterTable: Add order to SchemeQualifier with a default of 0
+ALTER TABLE "SchemeQualifier" ADD COLUMN "order" INTEGER NOT NULL DEFAULT 0;

--- a/packages/reference-implementation/prisma/migrations/20260217020000_add_batch_and_serial_to_product/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260217020000_add_batch_and_serial_to_product/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN "batchNumber" TEXT;
+ALTER TABLE "Product" ADD COLUMN "serialNumber" TEXT;

--- a/packages/reference-implementation/prisma/migrations/20260218000000_add_data_model_and_render_template/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260218000000_add_data_model_and_render_template/migration.sql
@@ -1,0 +1,53 @@
+-- CreateEnum
+CREATE TYPE "CredentialType" AS ENUM ('DigitalProductPassport', 'DigitalConformityCredential', 'DigitalFacilityRecord', 'DigitalIdentityAnchor', 'DigitalTraceabilityEvent');
+
+-- CreateTable
+CREATE TABLE "DataModel" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT,
+    "name" TEXT NOT NULL,
+    "credentialType" "CredentialType" NOT NULL,
+    "version" TEXT NOT NULL,
+    "isExtension" BOOLEAN NOT NULL DEFAULT true,
+    "parentConfigId" TEXT,
+    "schemaUrl" TEXT NOT NULL,
+    "contextUrl" TEXT NOT NULL,
+    "websiteUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DataModel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RenderTemplate" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "dataModelId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "storageUrl" TEXT NOT NULL,
+    "hash" TEXT NOT NULL,
+    "isPrimary" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RenderTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DataModel_credentialType_version_tenantId_isExtension_name_key" ON "DataModel"("credentialType", "version", "tenantId", "isExtension", "name");
+
+-- CreateIndex
+CREATE INDEX "RenderTemplate_tenantId_dataModelId_idx" ON "RenderTemplate"("tenantId", "dataModelId");
+
+-- AddForeignKey
+ALTER TABLE "DataModel" ADD CONSTRAINT "DataModel_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DataModel" ADD CONSTRAINT "DataModel_parentConfigId_fkey" FOREIGN KEY ("parentConfigId") REFERENCES "DataModel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RenderTemplate" ADD CONSTRAINT "RenderTemplate_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RenderTemplate" ADD CONSTRAINT "RenderTemplate_dataModelId_fkey" FOREIGN KEY ("dataModelId") REFERENCES "DataModel"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -110,7 +110,7 @@ model Tenant {
   organisations      OrganisationEntity[]
   facilities         Facility[]
   products             Product[]
-  credentialTypeConfigs CredentialTypeConfig[]
+  dataModels             DataModel[]
   renderTemplates      RenderTemplate[]
 
   @@map("Tenant")
@@ -407,11 +407,11 @@ model ProductSecondaryIdentifier {
 }
 
 /**
- * Credential type configuration for both core UNTP types and tenant extensions.
+ * Data model configuration for both core UNTP types and tenant extensions.
  * Stores schema URLs, context URLs, and version information.
  * Extensions reference a parent config via the self-relation.
  */
-model CredentialTypeConfig {
+model DataModel {
   id               String    @id @default(cuid())
   tenantId         String?
   tenant           Tenant?   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
@@ -422,8 +422,8 @@ model CredentialTypeConfig {
 
   isExtension      Boolean   @default(true)
   parentConfigId   String?
-  parentConfig     CredentialTypeConfig?  @relation("ExtensionParent", fields: [parentConfigId], references: [id], onDelete: Cascade)
-  extensions       CredentialTypeConfig[] @relation("ExtensionParent")
+  parentConfig     DataModel?  @relation("ExtensionParent", fields: [parentConfigId], references: [id], onDelete: Cascade)
+  extensions       DataModel[] @relation("ExtensionParent")
 
   schemaUrl        String
   contextUrl       String
@@ -446,8 +446,8 @@ model RenderTemplate {
   tenantId                 String
   tenant                   Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
-  credentialTypeConfigId   String
-  credentialTypeConfig     CredentialTypeConfig   @relation(fields: [credentialTypeConfigId], references: [id], onDelete: Cascade)
+  dataModelId              String
+  dataModel                DataModel              @relation(fields: [dataModelId], references: [id], onDelete: Cascade)
 
   name                     String
   storageUrl               String
@@ -457,5 +457,5 @@ model RenderTemplate {
   createdAt                DateTime  @default(now())
   updatedAt                DateTime  @updatedAt
 
-  @@index([tenantId, credentialTypeConfigId])
+  @@index([tenantId, dataModelId])
 }

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -46,6 +46,14 @@ enum ProductLevel {
   ITEM
 }
 
+enum CredentialType {
+  DigitalProductPassport
+  DigitalConformityCredential
+  DigitalFacilityRecord
+  DigitalIdentityAnchor
+  DigitalTraceabilityEvent
+}
+
 /**
  * Auth.js + Prisma adapter tables for OAuth + JWT sessions
  */
@@ -101,7 +109,9 @@ model Tenant {
   linkRegistrations  LinkRegistration[]
   organisations      OrganisationEntity[]
   facilities         Facility[]
-  products           Product[]
+  products             Product[]
+  credentialTypeConfigs CredentialTypeConfig[]
+  renderTemplates      RenderTemplate[]
 
   @@map("Tenant")
 }
@@ -394,4 +404,58 @@ model ProductSecondaryIdentifier {
   identifier    Identifier @relation("ProductSecondaryIdentifiers", fields: [identifierId], references: [id], onDelete: Cascade)
 
   @@id([productId, identifierId])
+}
+
+/**
+ * Credential type configuration for both core UNTP types and tenant extensions.
+ * Stores schema URLs, context URLs, and version information.
+ * Extensions reference a parent config via the self-relation.
+ */
+model CredentialTypeConfig {
+  id               String    @id @default(cuid())
+  tenantId         String?
+  tenant           Tenant?   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  name             String
+  credentialType   CredentialType
+  version          String
+
+  isExtension      Boolean   @default(true)
+  parentConfigId   String?
+  parentConfig     CredentialTypeConfig?  @relation("ExtensionParent", fields: [parentConfigId], references: [id], onDelete: Cascade)
+  extensions       CredentialTypeConfig[] @relation("ExtensionParent")
+
+  schemaUrl        String
+  contextUrl       String
+  websiteUrl       String?
+
+  renderTemplates  RenderTemplate[]
+
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  @@unique([credentialType, version, tenantId, isExtension, name])
+}
+
+/**
+ * Render template references for credential types.
+ * Stores storage URLs and hashes, with an isPrimary flag for tenant default selection.
+ */
+model RenderTemplate {
+  id                       String                @id @default(cuid())
+  tenantId                 String
+  tenant                   Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  credentialTypeConfigId   String
+  credentialTypeConfig     CredentialTypeConfig   @relation(fields: [credentialTypeConfigId], references: [id], onDelete: Cascade)
+
+  name                     String
+  storageUrl               String
+  hash                     String
+  isPrimary                Boolean   @default(false)
+
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
+
+  @@index([tenantId, credentialTypeConfigId])
 }

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -358,6 +358,8 @@ model Product {
   name                      String
   description               String?
   level                     ProductLevel
+  batchNumber               String?
+  serialNumber              String?
   parentId                  String?
   producedByOrganisationId       String?
   manufacturingFacilityId   String?

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -215,6 +215,7 @@ model IdentifierScheme {
   name                 String
   primaryKey           String
   validationPattern    String
+  linkTemplate         String   // ISO 18975 link template, e.g. "/{primaryKey}/{value}"
   namespace            String?
   idrServiceInstanceId String?
   isDefault            Boolean  @default(false)
@@ -241,6 +242,7 @@ model SchemeQualifier {
   key               String
   description       String
   validationPattern String
+  order             Int      @default(0)  // Qualifier precedence in URI (ascending)
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -156,6 +156,7 @@ async function main() {
       name: 'Australian Business Number',
       primaryKey: 'abn',
       validationPattern: '^\\d{11}$',
+      linkTemplate: '/{primaryKey}/{value}',
       isDefault: true,
     },
   });
@@ -170,6 +171,7 @@ async function main() {
       name: 'Australian Company Number',
       primaryKey: 'acn',
       validationPattern: '^\\d{9}$',
+      linkTemplate: '/{primaryKey}/{value}',
       isDefault: true,
     },
   });
@@ -184,6 +186,7 @@ async function main() {
       name: 'GS1 Global Location Number',
       primaryKey: 'gln',
       validationPattern: '^\\d{13}$',
+      linkTemplate: '/{primaryKey}/{value}',
       isDefault: true,
     },
   });
@@ -198,6 +201,7 @@ async function main() {
       name: 'GS1 Global Trade Item Number',
       primaryKey: '01',
       validationPattern: '^\\d{14}$',
+      linkTemplate: '/{primaryKey}/{value}',
       isDefault: true,
     },
   });
@@ -213,6 +217,7 @@ async function main() {
       key: '10',
       description: 'Batch/Lot Number',
       validationPattern: '^[A-Za-z0-9]{1,20}$',
+      order: 0,
     },
   });
 
@@ -225,6 +230,7 @@ async function main() {
       key: '21',
       description: 'Serial Number',
       validationPattern: '^[A-Za-z0-9]{1,20}$',
+      order: 1,
     },
   });
 

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -1,6 +1,9 @@
 import dotenv from 'dotenv';
 import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
 import {
+  CredentialType,
   DidMethod,
   DidStatus,
   DidType,
@@ -353,9 +356,168 @@ async function main() {
     );
   }
 
+  // ── Seed core data model configs ────────────────────────────────────────────
+  // Static UUIDs ensure idempotent seeding — if the record already exists, skip.
+
+  const UNTP_BASE = 'https://test.uncefact.org/vocabulary/untp';
+
+  const coreDataModels = [
+    {
+      id: 'a1b2c3d4-0001-4000-8000-000000000001',
+      templateId: 'b2c3d4e5-0001-4000-8000-000000000001',
+      credentialType: CredentialType.DigitalProductPassport,
+      version: '0.6.1',
+      name: 'Digital Product Passport v0.6.1',
+      slug: 'dpp/0.6.1',
+      templateDir: 'digital_product_passport',
+    },
+    {
+      id: 'a1b2c3d4-0002-4000-8000-000000000002',
+      templateId: 'b2c3d4e5-0002-4000-8000-000000000002',
+      credentialType: CredentialType.DigitalConformityCredential,
+      version: '0.6.1',
+      name: 'Digital Conformity Credential v0.6.1',
+      slug: 'dcc/0.6.1',
+      templateDir: 'digital_conformity_credential',
+    },
+    {
+      id: 'a1b2c3d4-0003-4000-8000-000000000003',
+      templateId: 'b2c3d4e5-0003-4000-8000-000000000003',
+      credentialType: CredentialType.DigitalFacilityRecord,
+      version: '0.6.1',
+      name: 'Digital Facility Record v0.6.1',
+      slug: 'dfr/0.6.1',
+      templateDir: 'digital_facility_record',
+    },
+    {
+      id: 'a1b2c3d4-0004-4000-8000-000000000004',
+      templateId: 'b2c3d4e5-0004-4000-8000-000000000004',
+      credentialType: CredentialType.DigitalIdentityAnchor,
+      version: '0.6.1',
+      name: 'Digital Identity Anchor v0.6.1',
+      slug: 'dia/0.6.1',
+      templateDir: 'digital_identity_anchor',
+    },
+    {
+      id: 'a1b2c3d4-0005-4000-8000-000000000005',
+      templateId: 'b2c3d4e5-0005-4000-8000-000000000005',
+      credentialType: CredentialType.DigitalTraceabilityEvent,
+      version: '0.6.1',
+      name: 'Digital Traceability Event v0.6.1',
+      slug: 'dte/0.6.1',
+      templateDir: 'digital_traceability_event',
+    },
+  ];
+
+  for (const dm of coreDataModels) {
+    const exists = await prisma.dataModel.findUnique({ where: { id: dm.id } });
+    if (exists) {
+      logger.info({ dataModelId: dm.id, credentialType: dm.credentialType }, 'Data model already exists, skipping');
+      continue;
+    }
+
+    await prisma.dataModel.create({
+      data: {
+        id: dm.id,
+        tenantId: SYSTEM_TENANT_ID,
+        name: dm.name,
+        credentialType: dm.credentialType,
+        version: dm.version,
+        isExtension: false,
+        schemaUrl: `${UNTP_BASE}/${dm.slug}/schema.json`,
+        contextUrl: `${UNTP_BASE}/${dm.slug}/`,
+      },
+    });
+
+    logger.info({ dataModelId: dm.id, credentialType: dm.credentialType }, 'Data model created');
+  }
+
+  // ── Seed default render templates ───────────────────────────────────────────
+  // Upload .hbs templates to the storage service and record the returned URIs.
+  // Requires the storage service to be available (skipped otherwise).
+
+  let templatesSeeded = false;
+  if (storageSeeded) {
+    try {
+      const { storageServiceUrl } = getStorageConfig();
+      const storageApiKey = process.env.UNCEFACT_STORAGE_API_KEY;
+      const storageBaseUrl = new URL(storageServiceUrl).origin;
+      const storageHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (storageApiKey) {
+        storageHeaders['X-API-Key'] = storageApiKey;
+      }
+
+      const TEMPLATES_DIR = path.resolve(__dirname, '../src/templates/v0.6.0');
+
+      for (const dm of coreDataModels) {
+        const exists = await prisma.renderTemplate.findUnique({ where: { id: dm.templateId } });
+        if (exists) {
+          logger.info(
+            { templateId: dm.templateId, credentialType: dm.credentialType },
+            'Template already exists, skipping',
+          );
+          continue;
+        }
+
+        const templatePath = path.join(TEMPLATES_DIR, dm.templateDir, 'template.hbs');
+        if (!fs.existsSync(templatePath)) {
+          logger.warn({ templatePath, credentialType: dm.credentialType }, 'Template file not found, skipping');
+          continue;
+        }
+
+        const templateContent = fs.readFileSync(templatePath, 'utf-8');
+        const hash = crypto.createHash('sha256').update(templateContent).digest('hex');
+
+        // Upload to the storage service public bucket
+        const uploadUrl = `${storageBaseUrl}/api/3.0.0/public`;
+        const response = await fetch(uploadUrl, {
+          method: 'POST',
+          headers: storageHeaders,
+          body: JSON.stringify({ data: templateContent, bucket: 'render-templates' }),
+        });
+
+        if (!response.ok) {
+          logger.warn(
+            { httpStatus: response.status, credentialType: dm.credentialType },
+            'Failed to upload template to storage, skipping',
+          );
+          continue;
+        }
+
+        const result = (await response.json()) as { uri: string; hash: string };
+
+        await prisma.renderTemplate.create({
+          data: {
+            id: dm.templateId,
+            tenantId: SYSTEM_TENANT_ID,
+            dataModelId: dm.id,
+            name: `${dm.name} Default Template`,
+            storageUrl: result.uri,
+            hash,
+            isPrimary: true,
+          },
+        });
+
+        logger.info(
+          { templateId: dm.templateId, uri: result.uri, credentialType: dm.credentialType },
+          'Template uploaded and seeded',
+        );
+      }
+      templatesSeeded = true;
+    } catch (error) {
+      logger.warn(
+        { error: error instanceof Error ? error.message : error },
+        'Skipping render template seed: storage service not available',
+      );
+    }
+  } else {
+    logger.warn('Skipping render template seed: storage service was not seeded');
+  }
+
   logger.info(
     'Seed complete: system tenant, default DID, DID service instance, ' +
-      'registrars, schemes, qualifiers' +
+      'registrars, schemes, qualifiers, data models' +
+      (templatesSeeded ? ', render templates' : '') +
       (idrSeeded ? ', IDR service instance' : '') +
       (storageSeeded ? ', storage service instance' : '') +
       (vcSeeded ? ', VC service instance' : '') +

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -484,7 +484,19 @@ async function main() {
           continue;
         }
 
-        const result = (await response.json()) as { uri: string; hash: string };
+        const result: unknown = await response.json();
+        if (
+          typeof result !== 'object' ||
+          result === null ||
+          typeof (result as Record<string, unknown>).uri !== 'string'
+        ) {
+          logger.warn(
+            { credentialType: dm.credentialType, responseBody: result },
+            'Storage service returned unexpected response shape, skipping template',
+          );
+          continue;
+        }
+        const { uri } = result as { uri: string };
 
         await prisma.renderTemplate.create({
           data: {
@@ -492,14 +504,14 @@ async function main() {
             tenantId: SYSTEM_TENANT_ID,
             dataModelId: dm.id,
             name: `${dm.name} Default Template`,
-            storageUrl: result.uri,
+            storageUrl: uri,
             hash,
             isPrimary: true,
           },
         });
 
         logger.info(
-          { templateId: dm.templateId, uri: result.uri, credentialType: dm.credentialType },
+          { templateId: dm.templateId, uri, credentialType: dm.credentialType },
           'Template uploaded and seeded',
         );
       }

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.test.ts
@@ -1,0 +1,209 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockGetDataModelById = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getDataModelById: (id: string, tenantId: string) => mockGetDataModelById(id, tenantId),
+}));
+
+import { GET } from './route';
+
+function createFakeRequest(): Request {
+  return {
+    method: 'GET',
+    url: 'http://localhost/api/v1/data-models/dm-1/form-config',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+  } as unknown as Request;
+}
+
+function createContext(id: string) {
+  return { tenantId: 'tenant-1', params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/v1/data-models/:id/form-config', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns form config with correct sections for DigitalProductPassport', async () => {
+    const dataModel = {
+      id: 'dm-1',
+      name: 'DPP v0.6.0',
+      credentialType: 'DigitalProductPassport',
+      version: '0.6.0',
+      schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+    };
+    mockGetDataModelById.mockResolvedValue(dataModel);
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('dm-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.formConfig).toEqual({
+      dataModelId: 'dm-1',
+      credentialType: 'DigitalProductPassport',
+      version: '0.6.0',
+      schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+      sections: [
+        { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+        { entityType: 'facility', label: 'Facility', endpoint: '/api/v1/facilities', required: true },
+        { entityType: 'product', label: 'Product', endpoint: '/api/v1/products', required: true },
+      ],
+    });
+    expect(mockGetDataModelById).toHaveBeenCalledWith('dm-1', 'tenant-1');
+  });
+
+  it('returns form config with correct sections for DigitalConformityCredential', async () => {
+    const dataModel = {
+      id: 'dm-2',
+      name: 'DCC v0.6.0',
+      credentialType: 'DigitalConformityCredential',
+      version: '0.6.0',
+      schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dcc/0.6.0/',
+    };
+    mockGetDataModelById.mockResolvedValue(dataModel);
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('dm-2') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.formConfig.sections).toHaveLength(1);
+    expect(json.formConfig.sections).toEqual([
+      { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+    ]);
+  });
+
+  it('returns form config with correct sections for DigitalFacilityRecord', async () => {
+    const dataModel = {
+      id: 'dm-3',
+      name: 'DFR v0.6.0',
+      credentialType: 'DigitalFacilityRecord',
+      version: '0.6.0',
+      schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dfr/0.6.0/',
+    };
+    mockGetDataModelById.mockResolvedValue(dataModel);
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('dm-3') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.formConfig.sections).toHaveLength(2);
+    expect(json.formConfig.sections).toEqual([
+      { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+      { entityType: 'facility', label: 'Facility', endpoint: '/api/v1/facilities', required: true },
+    ]);
+  });
+
+  it('returns form config with correct sections for DigitalIdentityAnchor', async () => {
+    const dataModel = {
+      id: 'dm-4',
+      name: 'DIA v0.6.0',
+      credentialType: 'DigitalIdentityAnchor',
+      version: '0.6.0',
+      schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dia/0.6.0/',
+    };
+    mockGetDataModelById.mockResolvedValue(dataModel);
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('dm-4') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.formConfig.sections).toHaveLength(1);
+    expect(json.formConfig.sections).toEqual([
+      { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+    ]);
+  });
+
+  it('returns form config with correct sections for DigitalTraceabilityEvent', async () => {
+    const dataModel = {
+      id: 'dm-5',
+      name: 'DTE v0.6.0',
+      credentialType: 'DigitalTraceabilityEvent',
+      version: '0.6.0',
+      schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dte/0.6.0/',
+    };
+    mockGetDataModelById.mockResolvedValue(dataModel);
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('dm-5') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.formConfig.sections).toHaveLength(2);
+    expect(json.formConfig.sections).toEqual([
+      { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+      { entityType: 'product', label: 'Product', endpoint: '/api/v1/products', required: true },
+    ]);
+  });
+
+  it('returns empty sections for unknown credential type', async () => {
+    const dataModel = {
+      id: 'dm-unknown',
+      name: 'Unknown',
+      credentialType: 'SomeUnknownType',
+      version: '1.0.0',
+      schemaUrl: 'https://example.com/schema',
+    };
+    mockGetDataModelById.mockResolvedValue(dataModel);
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('dm-unknown') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.formConfig.sections).toEqual([]);
+  });
+
+  it('returns 404 when data model not found', async () => {
+    mockGetDataModelById.mockResolvedValue(null);
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('nonexistent') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('Data model not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetDataModelById.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest();
+    const res = await GET(req, createContext('dm-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server';
+import { NotFoundError } from '@/lib/api/errors';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { getDataModelById } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/data-models/[id]/form-config' });
+
+/**
+ * Entity requirements per credential type.
+ * Defines which entity pickers are needed for SPA form rendering.
+ */
+const ENTITY_REQUIREMENTS: Record<
+  string,
+  Array<{ entityType: string; label: string; endpoint: string; required: boolean }>
+> = {
+  DigitalProductPassport: [
+    { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+    { entityType: 'facility', label: 'Facility', endpoint: '/api/v1/facilities', required: true },
+    { entityType: 'product', label: 'Product', endpoint: '/api/v1/products', required: true },
+  ],
+  DigitalConformityCredential: [
+    { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+  ],
+  DigitalFacilityRecord: [
+    { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+    { entityType: 'facility', label: 'Facility', endpoint: '/api/v1/facilities', required: true },
+  ],
+  DigitalIdentityAnchor: [
+    { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+  ],
+  DigitalTraceabilityEvent: [
+    { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },
+    { entityType: 'product', label: 'Product', endpoint: '/api/v1/products', required: true },
+  ],
+};
+
+/**
+ * @swagger
+ * /data-models/{id}/form-config:
+ *   get:
+ *     summary: Get form configuration for a data model
+ *     description: Returns entity picker metadata for SPA form rendering. Describes which entity types a credential type requires and where to fetch them.
+ *     tags:
+ *       - Data Models
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the data model
+ *     responses:
+ *       200:
+ *         description: Form configuration retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 formConfig:
+ *                   type: object
+ *                   properties:
+ *                     dataModelId:
+ *                       type: string
+ *                     credentialType:
+ *                       type: string
+ *                     version:
+ *                       type: string
+ *                     schemaUrl:
+ *                       type: string
+ *                     sections:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           entityType:
+ *                             type: string
+ *                           label:
+ *                             type: string
+ *                           endpoint:
+ *                             type: string
+ *                           required:
+ *                             type: boolean
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Data model not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+
+  logger.info({ tenantId, dataModelId: id }, 'Looking up data model for form config');
+  const dataModel = await getDataModelById(id, tenantId);
+  if (!dataModel) {
+    throw new NotFoundError('Data model not found');
+  }
+
+  const sections = ENTITY_REQUIREMENTS[dataModel.credentialType] ?? [];
+
+  logger.info(
+    { tenantId, dataModelId: id, credentialType: dataModel.credentialType, sectionCount: sections.length },
+    'Form config resolved',
+  );
+
+  return NextResponse.json({
+    ok: true,
+    formConfig: {
+      dataModelId: dataModel.id,
+      credentialType: dataModel.credentialType,
+      version: dataModel.version,
+      schemaUrl: dataModel.schemaUrl,
+      sections,
+    },
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
@@ -1,0 +1,245 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockGetDataModelById = jest.fn();
+const mockUpdateDataModel = jest.fn();
+const mockDeleteDataModel = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getDataModelById: (id: string, tenantId: string) => mockGetDataModelById(id, tenantId),
+  updateDataModel: (id: string, tenantId: string, input: unknown) => mockUpdateDataModel(id, tenantId, input),
+  deleteDataModel: (id: string, tenantId: string) => mockDeleteDataModel(id, tenantId),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { GET, PATCH, DELETE } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'GET', body, url = 'http://localhost/api/v1/data-models/dm-1' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createContext(id: string) {
+  return { tenantId: 'tenant-1', params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/v1/data-models/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the data model', async () => {
+    const dataModel = {
+      id: 'dm-1',
+      name: 'DPP v0.6.0',
+      credentialType: 'DigitalProductPassport',
+    };
+    mockGetDataModelById.mockResolvedValue(dataModel);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('dm-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.dataModel).toEqual(dataModel);
+    expect(mockGetDataModelById).toHaveBeenCalledWith('dm-1', 'tenant-1');
+  });
+
+  it('returns 404 when data model not found', async () => {
+    mockGetDataModelById.mockResolvedValue(null);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('nonexistent') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('Data model not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetDataModelById.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('dm-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('PATCH /api/v1/data-models/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates the data model', async () => {
+    const updated = {
+      id: 'dm-1',
+      name: 'Updated Extension',
+      schemaUrl: 'https://example.com/schema.json',
+    };
+    mockUpdateDataModel.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Extension' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.dataModel).toEqual(updated);
+    expect(mockUpdateDataModel).toHaveBeenCalledWith('dm-1', 'tenant-1', {
+      name: 'Updated Extension',
+    });
+  });
+
+  it('passes only provided fields to the repository', async () => {
+    mockUpdateDataModel.mockResolvedValue({ id: 'dm-1' });
+
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: { schemaUrl: 'https://example.com/new-schema.json', websiteUrl: 'https://example.com' },
+    });
+    await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(mockUpdateDataModel).toHaveBeenCalledWith('dm-1', 'tenant-1', {
+      schemaUrl: 'https://example.com/new-schema.json',
+      websiteUrl: 'https://example.com',
+    });
+  });
+
+  it('returns 400 when no updatable fields are provided', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: {} });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('At least one updatable field must be provided');
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name must be a non-empty string');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      method: 'PATCH',
+      url: 'http://localhost/api/v1/data-models/dm-1',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Request;
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockUpdateDataModel.mockRejectedValue(new NotFoundError('Data model not found or access denied'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Data model not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockUpdateDataModel.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('DELETE /api/v1/data-models/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the data model and returns it', async () => {
+    const deleted = { id: 'dm-1', name: 'Deleted Extension' };
+    mockDeleteDataModel.mockResolvedValue(deleted);
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('dm-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.dataModel).toEqual(deleted);
+    expect(mockDeleteDataModel).toHaveBeenCalledWith('dm-1', 'tenant-1');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockDeleteDataModel.mockRejectedValue(new NotFoundError('Data model not found or access denied'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('nonexistent') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Data model not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockDeleteDataModel.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('dm-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
@@ -163,6 +163,24 @@ describe('PATCH /api/v1/data-models/:id', () => {
     expect(json.error).toContain('name must be a non-empty string');
   });
 
+  it('returns 400 when schemaUrl is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { schemaUrl: '' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('schemaUrl must be a non-empty string');
+  });
+
+  it('returns 400 when contextUrl is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { contextUrl: '' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('contextUrl must be a non-empty string');
+  });
+
   it('returns 400 for invalid JSON body', async () => {
     const req = {
       method: 'PATCH',

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
@@ -158,6 +158,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   if (body.name !== undefined && !isNonEmptyString(body.name)) {
     throw new ValidationError('name must be a non-empty string');
   }
+  if (body.schemaUrl !== undefined && !isNonEmptyString(body.schemaUrl)) {
+    throw new ValidationError('schemaUrl must be a non-empty string');
+  }
+  if (body.contextUrl !== undefined && !isNonEmptyString(body.contextUrl)) {
+    throw new ValidationError('contextUrl must be a non-empty string');
+  }
 
   logger.info({ tenantId, dataModelId: id }, 'Updating data model');
   const dataModel = await updateDataModel(id, tenantId, {

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
@@ -1,0 +1,229 @@
+import { NextResponse } from 'next/server';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { getDataModelById, updateDataModel, deleteDataModel } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/data-models/[id]' });
+
+const UPDATABLE_FIELDS = ['name', 'schemaUrl', 'contextUrl', 'websiteUrl'] as const;
+
+/**
+ * @swagger
+ * /data-models/{id}:
+ *   get:
+ *     summary: Get a data model by ID
+ *     description: Retrieves a specific data model by its database ID. Returns system-provisioned (tenantId=null) or tenant-owned models.
+ *     tags:
+ *       - Data Models
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the data model
+ *     responses:
+ *       200:
+ *         description: Data model retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 dataModel:
+ *                   $ref: '#/components/schemas/DataModel'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Data model not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+  logger.info({ tenantId, dataModelId: id }, 'Looking up data model');
+  const dataModel = await getDataModelById(id, tenantId);
+  if (!dataModel) {
+    throw new NotFoundError('Data model not found');
+  }
+  return NextResponse.json({ ok: true, dataModel });
+});
+
+/**
+ * @swagger
+ * /data-models/{id}:
+ *   patch:
+ *     summary: Update a data model extension
+ *     description: Updates one or more fields of a tenant-owned data model extension. Only extensions (isExtension=true) owned by the tenant can be updated.
+ *     tags:
+ *       - Data Models
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the data model
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Updated name for the data model extension
+ *               schemaUrl:
+ *                 type: string
+ *                 description: Updated JSON schema URL
+ *               contextUrl:
+ *                 type: string
+ *                 description: Updated JSON-LD context URL
+ *               websiteUrl:
+ *                 type: string
+ *                 description: Updated website URL
+ *             minProperties: 1
+ *     responses:
+ *       200:
+ *         description: Data model updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 dataModel:
+ *                   $ref: '#/components/schemas/DataModel'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Data model not found or not a tenant-owned extension
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
+  const { id } = await params;
+
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
+  if (!hasUpdatableField) {
+    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
+  }
+
+  if (body.name !== undefined && !isNonEmptyString(body.name)) {
+    throw new ValidationError('name must be a non-empty string');
+  }
+
+  logger.info({ tenantId, dataModelId: id }, 'Updating data model');
+  const dataModel = await updateDataModel(id, tenantId, {
+    ...(body.name !== undefined && { name: body.name as string }),
+    ...(body.schemaUrl !== undefined && { schemaUrl: body.schemaUrl as string }),
+    ...(body.contextUrl !== undefined && { contextUrl: body.contextUrl as string }),
+    ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl as string }),
+  });
+
+  logger.info({ tenantId, dataModelId: id }, 'Data model updated');
+  return NextResponse.json({ ok: true, dataModel });
+});
+
+/**
+ * @swagger
+ * /data-models/{id}:
+ *   delete:
+ *     summary: Delete a data model extension
+ *     description: Deletes a tenant-owned data model extension. Only extensions (isExtension=true) owned by the tenant can be deleted.
+ *     tags:
+ *       - Data Models
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the data model
+ *     responses:
+ *       200:
+ *         description: Data model deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 dataModel:
+ *                   $ref: '#/components/schemas/DataModel'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Data model not found or not a tenant-owned extension
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+
+  logger.info({ tenantId, dataModelId: id }, 'Deleting data model');
+  const dataModel = await deleteDataModel(id, tenantId);
+
+  logger.info({ tenantId, dataModelId: id }, 'Data model deleted');
+  return NextResponse.json({ ok: true, dataModel });
+});

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
@@ -1,0 +1,556 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockListDataModels = jest.fn();
+const mockCreateDataModel = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  listDataModels: (tenantId: string, opts: unknown) => mockListDataModels(tenantId, opts),
+  createDataModel: (tenantId: string, input: unknown) => mockCreateDataModel(tenantId, input),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { GET, POST } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'POST', body, url = 'http://localhost/api/v1/data-models' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createBadJsonRequest(): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/data-models',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => {
+      throw new SyntaxError('Unexpected token n in JSON at position 0');
+    },
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'tenant-1', params: Promise.resolve({}) };
+
+describe('GET /api/v1/data-models', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists data models for the tenant with no filters', async () => {
+    const dataModels = [
+      { id: 'cfg-1', name: 'DPP v0.6.0', credentialType: 'DigitalProductPassport' },
+      { id: 'cfg-2', name: 'DCC v0.6.0', credentialType: 'DigitalConformityCredential' },
+    ];
+    mockListDataModels.mockResolvedValue(dataModels);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/data-models' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.dataModels).toEqual(dataModels);
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
+      isExtension: undefined,
+      credentialType: undefined,
+      version: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('passes isExtension=true filter correctly', async () => {
+    mockListDataModels.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?isExtension=true',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
+      isExtension: true,
+      credentialType: undefined,
+      version: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('passes isExtension=false filter correctly', async () => {
+    mockListDataModels.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?isExtension=false',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
+      isExtension: false,
+      credentialType: undefined,
+      version: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('returns 400 for invalid isExtension value', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?isExtension=maybe',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('isExtension must be "true" or "false"');
+  });
+
+  it('passes credentialType filter correctly', async () => {
+    mockListDataModels.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?credentialType=DigitalProductPassport',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
+      isExtension: undefined,
+      credentialType: 'DigitalProductPassport',
+      version: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('returns 400 for invalid credentialType', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?credentialType=InvalidType',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('credentialType must be one of');
+  });
+
+  it('passes version filter correctly', async () => {
+    mockListDataModels.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?version=0.6.0',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
+      isExtension: undefined,
+      credentialType: undefined,
+      version: '0.6.0',
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('passes pagination parameters correctly', async () => {
+    mockListDataModels.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?limit=10&offset=20',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
+      isExtension: undefined,
+      credentialType: undefined,
+      version: undefined,
+      limit: 10,
+      offset: 20,
+    });
+  });
+
+  it('passes all filters together', async () => {
+    mockListDataModels.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?isExtension=true&credentialType=DigitalFacilityRecord&version=0.6.0&limit=5&offset=0',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
+      isExtension: true,
+      credentialType: 'DigitalFacilityRecord',
+      version: '0.6.0',
+      limit: 5,
+      offset: 0,
+    });
+  });
+
+  it('returns 400 for non-numeric limit', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?limit=abc',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for negative offset', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?offset=-1',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset must be a non-negative integer');
+  });
+
+  it('returns 500 when listDataModels throws', async () => {
+    mockListDataModels.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/data-models' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('POST /api/v1/data-models', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a data model extension and returns 201', async () => {
+    const created = {
+      id: 'cfg-new',
+      name: 'Custom DPP Extension',
+      credentialType: 'DigitalProductPassport',
+      version: '0.6.0',
+      schemaUrl: 'https://example.com/schema.json',
+      contextUrl: 'https://example.com/context.jsonld',
+      isExtension: true,
+      parentConfigId: 'cfg-parent',
+    };
+    mockCreateDataModel.mockResolvedValue(created);
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Custom DPP Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.ok).toBe(true);
+    expect(json.dataModel).toEqual(created);
+  });
+
+  it('passes isExtension=true and all fields to the repository', async () => {
+    mockCreateDataModel.mockResolvedValue({ id: 'cfg-new' });
+
+    const req = createFakeRequest({
+      body: {
+        name: 'My Extension',
+        credentialType: 'DigitalConformityCredential',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+        websiteUrl: 'https://example.com',
+      },
+    });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateDataModel).toHaveBeenCalledWith('tenant-1', {
+      name: 'My Extension',
+      credentialType: 'DigitalConformityCredential',
+      version: '0.6.0',
+      schemaUrl: 'https://example.com/schema.json',
+      contextUrl: 'https://example.com/context.jsonld',
+      parentConfigId: 'cfg-parent',
+      websiteUrl: 'https://example.com',
+      isExtension: true,
+    });
+  });
+
+  it('defaults isExtension to true even when not provided', async () => {
+    mockCreateDataModel.mockResolvedValue({ id: 'cfg-new' });
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateDataModel).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ isExtension: true }));
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name is required');
+  });
+
+  it('returns 400 when credentialType is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('credentialType is required');
+  });
+
+  it('returns 400 when credentialType is invalid', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'InvalidType',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('credentialType must be one of');
+  });
+
+  it('returns 400 when version is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('version is required');
+  });
+
+  it('returns 400 when schemaUrl is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('schemaUrl is required');
+  });
+
+  it('returns 400 when contextUrl is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('contextUrl is required');
+  });
+
+  it('returns 400 when parentConfigId is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('parentConfigId is required');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = createBadJsonRequest();
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockCreateDataModel.mockRejectedValue(new NotFoundError('Parent config not found'));
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-nonexistent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Parent config not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockCreateDataModel.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+
+  it('includes optional websiteUrl when provided', async () => {
+    mockCreateDataModel.mockResolvedValue({ id: 'cfg-new' });
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+        websiteUrl: 'https://example.com',
+      },
+    });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateDataModel).toHaveBeenCalledWith(
+      'tenant-1',
+      expect.objectContaining({ websiteUrl: 'https://example.com' }),
+    );
+  });
+
+  it('omits websiteUrl when not provided', async () => {
+    mockCreateDataModel.mockResolvedValue({ id: 'cfg-new' });
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    const callArgs = mockCreateDataModel.mock.calls[0][1];
+    expect(callArgs).not.toHaveProperty('websiteUrl');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.ts
@@ -1,0 +1,251 @@
+import { NextResponse } from 'next/server';
+import {
+  ValidationError,
+  validateEnum,
+  isNonEmptyString,
+  parsePositiveInt,
+  parseNonNegativeInt,
+} from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { listDataModels, createDataModel } from '@/lib/prisma/repositories';
+import { CredentialType } from '@/lib/prisma/generated';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/data-models' });
+
+/**
+ * Parse a boolean string query parameter ("true" or "false").
+ * Returns undefined if the raw value is null/undefined.
+ * Throws ValidationError if the value is present but not "true" or "false".
+ */
+function parseBooleanParam(raw: string | null | undefined, paramName: string): boolean | undefined {
+  if (raw == null) return undefined;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  throw new ValidationError(`${paramName} must be "true" or "false"`);
+}
+
+/**
+ * @swagger
+ * /data-models:
+ *   get:
+ *     summary: List data models
+ *     description: Retrieves data models visible to the authenticated tenant, including system-provisioned and tenant-owned configs
+ *     tags:
+ *       - Data Models
+ *     parameters:
+ *       - in: query
+ *         name: isExtension
+ *         schema:
+ *           type: string
+ *           enum: ['true', 'false']
+ *         description: Filter by extension status
+ *       - in: query
+ *         name: credentialType
+ *         schema:
+ *           type: string
+ *           enum: [DigitalProductPassport, DigitalConformityCredential, DigitalFacilityRecord, DigitalIdentityAnchor, DigitalTraceabilityEvent]
+ *         description: Filter by credential type
+ *       - in: query
+ *         name: version
+ *         schema:
+ *           type: string
+ *         description: Filter by version string
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Maximum number of results to return
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *         description: Number of results to skip for pagination
+ *     responses:
+ *       200:
+ *         description: Data models retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 dataModels:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/DataModel'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (req, { tenantId }) => {
+  const url = new URL(req.url);
+
+  const isExtension = parseBooleanParam(url.searchParams.get('isExtension'), 'isExtension');
+  const credentialType = validateEnum(
+    url.searchParams.get('credentialType') ?? undefined,
+    Object.values(CredentialType),
+    'credentialType',
+  );
+  const version = url.searchParams.get('version') ?? undefined;
+  const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+
+  logger.info({ tenantId, filters: { isExtension, credentialType, version, limit, offset } }, 'Listing data models');
+  const dataModels = await listDataModels(tenantId, {
+    isExtension,
+    credentialType,
+    version,
+    limit,
+    offset,
+  });
+
+  logger.info({ tenantId, count: dataModels.length }, 'Data models listed');
+  return NextResponse.json({ ok: true, dataModels });
+});
+
+/**
+ * @swagger
+ * /data-models:
+ *   post:
+ *     summary: Create a data model extension
+ *     description: Creates a new data model extension for the authenticated tenant
+ *     tags:
+ *       - Data Models
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - credentialType
+ *               - version
+ *               - schemaUrl
+ *               - contextUrl
+ *               - parentConfigId
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Human-readable name for the data model extension
+ *               credentialType:
+ *                 type: string
+ *                 enum: [DigitalProductPassport, DigitalConformityCredential, DigitalFacilityRecord, DigitalIdentityAnchor, DigitalTraceabilityEvent]
+ *                 description: The credential type this extension applies to
+ *               version:
+ *                 type: string
+ *                 description: Specification version (e.g., "0.6.0")
+ *               schemaUrl:
+ *                 type: string
+ *                 description: URL to the JSON schema for this extension
+ *               contextUrl:
+ *                 type: string
+ *                 description: URL to the JSON-LD context for this extension
+ *               parentConfigId:
+ *                 type: string
+ *                 description: ID of the parent core data model
+ *               websiteUrl:
+ *                 type: string
+ *                 description: Optional website URL for the extension specification
+ *     responses:
+ *       201:
+ *         description: Data model extension created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 dataModel:
+ *                   $ref: '#/components/schemas/DataModel'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Parent config not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const POST = withTenantAuth(async (req, { tenantId }) => {
+  let body: {
+    name?: string;
+    credentialType?: string;
+    version?: string;
+    schemaUrl?: string;
+    contextUrl?: string;
+    parentConfigId?: string;
+    websiteUrl?: string;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
+
+  const credentialType = validateEnum(body.credentialType, Object.values(CredentialType), 'credentialType');
+  if (!credentialType) throw new ValidationError('credentialType is required');
+
+  if (!isNonEmptyString(body.version)) throw new ValidationError('version is required');
+  if (!isNonEmptyString(body.schemaUrl)) throw new ValidationError('schemaUrl is required');
+  if (!isNonEmptyString(body.contextUrl)) throw new ValidationError('contextUrl is required');
+  if (!isNonEmptyString(body.parentConfigId)) {
+    throw new ValidationError('parentConfigId is required');
+  }
+
+  logger.info({ tenantId, credentialType, name: body.name }, 'Creating data model extension');
+  const dataModel = await createDataModel(tenantId, {
+    name: body.name,
+    credentialType,
+    version: body.version,
+    schemaUrl: body.schemaUrl,
+    contextUrl: body.contextUrl,
+    parentConfigId: body.parentConfigId,
+    isExtension: true,
+    ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl }),
+  });
+
+  logger.info({ tenantId, dataModelId: dataModel.id }, 'Data model extension created');
+  return NextResponse.json({ ok: true, dataModel }, { status: 201 });
+});

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
@@ -121,6 +121,7 @@ const MOCK_IDR_SERVICE = {
   deleteLink: jest.fn(),
   getResolverDescription: jest.fn(),
   getLinkTypes: jest.fn(),
+  buildResolverUri: jest.fn(),
 };
 
 // -- Tests ---------------------------------------------------------------------

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.test.ts
@@ -101,6 +101,7 @@ const MOCK_IDR_SERVICE = {
   deleteLink: jest.fn(),
   getResolverDescription: jest.fn(),
   getLinkTypes: jest.fn(),
+  buildResolverUri: jest.fn(),
 };
 
 // -- Tests ---------------------------------------------------------------------

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
@@ -1,0 +1,256 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockGetRenderTemplateById = jest.fn();
+const mockUpdateRenderTemplate = jest.fn();
+const mockDeleteRenderTemplate = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getRenderTemplateById: (id: string, tenantId: string) => mockGetRenderTemplateById(id, tenantId),
+  updateRenderTemplate: (id: string, tenantId: string, input: unknown) => mockUpdateRenderTemplate(id, tenantId, input),
+  deleteRenderTemplate: (id: string, tenantId: string) => mockDeleteRenderTemplate(id, tenantId),
+}));
+
+import { NotFoundError } from '@/lib/api/errors';
+import { GET, PATCH, DELETE } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'GET', body, url = 'http://localhost/api/v1/render-templates/rt-1' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createContext(id: string) {
+  return { tenantId: 'tenant-1', params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/v1/render-templates/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the render template by id', async () => {
+    const renderTemplate = {
+      id: 'rt-1',
+      name: 'DPP Default Template',
+      storageUrl: 'https://storage.example.com/templates/dpp.html',
+      hash: 'abc123',
+      isPrimary: true,
+      dataModel: { id: 'dm-1', name: 'DPP v0.6.0' },
+    };
+    mockGetRenderTemplateById.mockResolvedValue(renderTemplate);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('rt-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.renderTemplate).toEqual(renderTemplate);
+    expect(mockGetRenderTemplateById).toHaveBeenCalledWith('rt-1', 'tenant-1');
+  });
+
+  it('returns 404 when render template not found', async () => {
+    mockGetRenderTemplateById.mockResolvedValue(null);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('nonexistent') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('Render template not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockGetRenderTemplateById.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('rt-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('PATCH /api/v1/render-templates/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates the render template metadata', async () => {
+    const updated = {
+      id: 'rt-1',
+      name: 'Updated Template',
+      storageUrl: 'https://storage.example.com/templates/dpp-v2.html',
+      hash: 'def456',
+      isPrimary: false,
+      dataModel: { id: 'dm-1', name: 'DPP v0.6.0' },
+    };
+    mockUpdateRenderTemplate.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Template' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.renderTemplate).toEqual(updated);
+    expect(mockUpdateRenderTemplate).toHaveBeenCalledWith('rt-1', 'tenant-1', {
+      name: 'Updated Template',
+    });
+  });
+
+  it('updates isPrimary', async () => {
+    const updated = {
+      id: 'rt-1',
+      name: 'DPP Default Template',
+      isPrimary: true,
+      dataModel: { id: 'dm-1', name: 'DPP v0.6.0' },
+    };
+    mockUpdateRenderTemplate.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { isPrimary: true } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.renderTemplate).toEqual(updated);
+    expect(mockUpdateRenderTemplate).toHaveBeenCalledWith('rt-1', 'tenant-1', {
+      isPrimary: true,
+    });
+  });
+
+  it('returns 400 for empty body (no updatable fields)', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: {} });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('At least one updatable field must be provided');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      method: 'PATCH',
+      url: 'http://localhost/api/v1/render-templates/rt-1',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Request;
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name must be a non-empty string');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockUpdateRenderTemplate.mockRejectedValue(new NotFoundError('Render template not found or access denied'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Render template not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockUpdateRenderTemplate.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('DELETE /api/v1/render-templates/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes the render template', async () => {
+    const deleted = { id: 'rt-1', name: 'Deleted Template' };
+    mockDeleteRenderTemplate.mockResolvedValue(deleted);
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('rt-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(mockDeleteRenderTemplate).toHaveBeenCalledWith('rt-1', 'tenant-1');
+  });
+
+  it('returns 404 when repository throws NotFoundError', async () => {
+    mockDeleteRenderTemplate.mockRejectedValue(new NotFoundError('Render template not found or access denied'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('nonexistent') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Render template not found');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockDeleteRenderTemplate.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({});
+    const res = await DELETE(req, createContext('rt-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
@@ -191,6 +191,33 @@ describe('PATCH /api/v1/render-templates/:id', () => {
     expect(json.error).toContain('name must be a non-empty string');
   });
 
+  it('returns 400 when storageUrl is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { storageUrl: '' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('storageUrl must be a non-empty string');
+  });
+
+  it('returns 400 when hash is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { hash: '' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('hash must be a non-empty string');
+  });
+
+  it('returns 400 when isPrimary is not a boolean', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { isPrimary: 'yes' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('isPrimary must be a boolean');
+  });
+
   it('returns 404 when repository throws NotFoundError', async () => {
     mockUpdateRenderTemplate.mockRejectedValue(new NotFoundError('Render template not found or access denied'));
 
@@ -219,7 +246,7 @@ describe('DELETE /api/v1/render-templates/:id', () => {
     jest.clearAllMocks();
   });
 
-  it('deletes the render template', async () => {
+  it('deletes the render template and returns it', async () => {
     const deleted = { id: 'rt-1', name: 'Deleted Template' };
     mockDeleteRenderTemplate.mockResolvedValue(deleted);
 
@@ -229,6 +256,7 @@ describe('DELETE /api/v1/render-templates/:id', () => {
 
     expect(res.status).toBe(200);
     expect(json.ok).toBe(true);
+    expect(json.renderTemplate).toEqual(deleted);
     expect(mockDeleteRenderTemplate).toHaveBeenCalledWith('rt-1', 'tenant-1');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
@@ -1,0 +1,227 @@
+import { NextResponse } from 'next/server';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { getRenderTemplateById, updateRenderTemplate, deleteRenderTemplate } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/render-templates/[id]' });
+
+const UPDATABLE_FIELDS = ['name', 'storageUrl', 'hash', 'isPrimary'] as const;
+
+/**
+ * @swagger
+ * /render-templates/{id}:
+ *   get:
+ *     summary: Get a render template by ID
+ *     description: Retrieves a specific render template by its database ID. Only templates owned by the authenticated tenant are returned.
+ *     tags:
+ *       - Render Templates
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the render template
+ *     responses:
+ *       200:
+ *         description: Render template retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 renderTemplate:
+ *                   $ref: '#/components/schemas/RenderTemplate'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Render template not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+  logger.info({ tenantId, renderTemplateId: id }, 'Looking up render template');
+  const renderTemplate = await getRenderTemplateById(id, tenantId);
+  if (!renderTemplate) {
+    throw new NotFoundError('Render template not found');
+  }
+  return NextResponse.json({ ok: true, renderTemplate });
+});
+
+/**
+ * @swagger
+ * /render-templates/{id}:
+ *   patch:
+ *     summary: Update a render template
+ *     description: Updates one or more fields of a tenant-owned render template. When setting isPrimary to true, any existing primary template for the same data model will be unset.
+ *     tags:
+ *       - Render Templates
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the render template
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Updated human-readable name for the render template
+ *               storageUrl:
+ *                 type: string
+ *                 description: Updated URL where the template file is stored
+ *               hash:
+ *                 type: string
+ *                 description: Updated content hash of the template file
+ *               isPrimary:
+ *                 type: boolean
+ *                 description: Whether this is the primary template for its data model
+ *             minProperties: 1
+ *     responses:
+ *       200:
+ *         description: Render template updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 renderTemplate:
+ *                   $ref: '#/components/schemas/RenderTemplate'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Render template not found or not owned by tenant
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
+  const { id } = await params;
+
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
+  if (!hasUpdatableField) {
+    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
+  }
+
+  if (body.name !== undefined && !isNonEmptyString(body.name)) {
+    throw new ValidationError('name must be a non-empty string');
+  }
+
+  logger.info({ tenantId, renderTemplateId: id }, 'Updating render template');
+  const renderTemplate = await updateRenderTemplate(id, tenantId, {
+    ...(body.name !== undefined && { name: body.name as string }),
+    ...(body.storageUrl !== undefined && { storageUrl: body.storageUrl as string }),
+    ...(body.hash !== undefined && { hash: body.hash as string }),
+    ...(body.isPrimary !== undefined && { isPrimary: body.isPrimary as boolean }),
+  });
+
+  logger.info({ tenantId, renderTemplateId: id }, 'Render template updated');
+  return NextResponse.json({ ok: true, renderTemplate });
+});
+
+/**
+ * @swagger
+ * /render-templates/{id}:
+ *   delete:
+ *     summary: Delete a render template
+ *     description: Deletes a tenant-owned render template. Only templates owned by the authenticated tenant can be deleted.
+ *     tags:
+ *       - Render Templates
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the render template
+ *     responses:
+ *       200:
+ *         description: Render template deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Render template not found or not owned by tenant
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+
+  logger.info({ tenantId, renderTemplateId: id }, 'Deleting render template');
+  await deleteRenderTemplate(id, tenantId);
+
+  logger.info({ tenantId, renderTemplateId: id }, 'Render template deleted');
+  return NextResponse.json({ ok: true });
+});

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
@@ -158,6 +158,15 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   if (body.name !== undefined && !isNonEmptyString(body.name)) {
     throw new ValidationError('name must be a non-empty string');
   }
+  if (body.storageUrl !== undefined && !isNonEmptyString(body.storageUrl)) {
+    throw new ValidationError('storageUrl must be a non-empty string');
+  }
+  if (body.hash !== undefined && !isNonEmptyString(body.hash)) {
+    throw new ValidationError('hash must be a non-empty string');
+  }
+  if (body.isPrimary !== undefined && typeof body.isPrimary !== 'boolean') {
+    throw new ValidationError('isPrimary must be a boolean');
+  }
 
   logger.info({ tenantId, renderTemplateId: id }, 'Updating render template');
   const renderTemplate = await updateRenderTemplate(id, tenantId, {
@@ -197,6 +206,8 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *                 ok:
  *                   type: boolean
  *                   example: true
+ *                 renderTemplate:
+ *                   $ref: '#/components/schemas/RenderTemplate'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -220,8 +231,8 @@ export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
   logger.info({ tenantId, renderTemplateId: id }, 'Deleting render template');
-  await deleteRenderTemplate(id, tenantId);
+  const renderTemplate = await deleteRenderTemplate(id, tenantId);
 
   logger.info({ tenantId, renderTemplateId: id }, 'Render template deleted');
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, renderTemplate });
 });

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
@@ -1,0 +1,316 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
+  return {
+    withTenantAuth:
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
+        try {
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
+        }
+      },
+  };
+});
+
+const mockListRenderTemplates = jest.fn();
+const mockCreateRenderTemplate = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  listRenderTemplates: (tenantId: string, opts: unknown) => mockListRenderTemplates(tenantId, opts),
+  createRenderTemplate: (tenantId: string, input: unknown) => mockCreateRenderTemplate(tenantId, input),
+}));
+
+import { GET, POST } from './route';
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'POST', body, url = 'http://localhost/api/v1/render-templates' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createBadJsonRequest(): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/render-templates',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => {
+      throw new SyntaxError('Unexpected token n in JSON at position 0');
+    },
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'tenant-1', params: Promise.resolve({}) };
+
+describe('GET /api/v1/render-templates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists render templates for the tenant with no filters', async () => {
+    const renderTemplates = [
+      {
+        id: 'rt-1',
+        name: 'DPP Template',
+        dataModelId: 'dm-1',
+        storageUrl: 'https://example.com/tpl1.html',
+        hash: 'abc123',
+      },
+      {
+        id: 'rt-2',
+        name: 'DCC Template',
+        dataModelId: 'dm-2',
+        storageUrl: 'https://example.com/tpl2.html',
+        hash: 'def456',
+      },
+    ];
+    mockListRenderTemplates.mockResolvedValue(renderTemplates);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/render-templates' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.renderTemplates).toEqual(renderTemplates);
+    expect(mockListRenderTemplates).toHaveBeenCalledWith('tenant-1', {
+      dataModelId: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('passes dataModelId, limit, and offset query params to the repository', async () => {
+    mockListRenderTemplates.mockResolvedValue([]);
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/render-templates?dataModelId=dm-1&limit=10&offset=20',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListRenderTemplates).toHaveBeenCalledWith('tenant-1', {
+      dataModelId: 'dm-1',
+      limit: 10,
+      offset: 20,
+    });
+  });
+
+  it('returns 400 for invalid limit', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/render-templates?limit=abc',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for invalid offset', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/render-templates?offset=-1',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('offset must be a non-negative integer');
+  });
+
+  it('returns 500 when listRenderTemplates throws', async () => {
+    mockListRenderTemplates.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/render-templates' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});
+
+describe('POST /api/v1/render-templates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a render template and returns 201', async () => {
+    const created = {
+      id: 'rt-new',
+      name: 'My Template',
+      dataModelId: 'dm-1',
+      storageUrl: 'https://example.com/template.html',
+      hash: 'sha256-abc123',
+      isPrimary: false,
+    };
+    mockCreateRenderTemplate.mockResolvedValue(created);
+
+    const req = createFakeRequest({
+      body: {
+        name: 'My Template',
+        dataModelId: 'dm-1',
+        storageUrl: 'https://example.com/template.html',
+        hash: 'sha256-abc123',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.ok).toBe(true);
+    expect(json.renderTemplate).toEqual(created);
+  });
+
+  it('passes isPrimary to the repository when provided', async () => {
+    mockCreateRenderTemplate.mockResolvedValue({ id: 'rt-new' });
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Primary Template',
+        dataModelId: 'dm-1',
+        storageUrl: 'https://example.com/template.html',
+        hash: 'sha256-abc123',
+        isPrimary: true,
+      },
+    });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateRenderTemplate).toHaveBeenCalledWith('tenant-1', {
+      name: 'Primary Template',
+      dataModelId: 'dm-1',
+      storageUrl: 'https://example.com/template.html',
+      hash: 'sha256-abc123',
+      isPrimary: true,
+    });
+  });
+
+  it('omits isPrimary when not provided', async () => {
+    mockCreateRenderTemplate.mockResolvedValue({ id: 'rt-new' });
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Template',
+        dataModelId: 'dm-1',
+        storageUrl: 'https://example.com/template.html',
+        hash: 'sha256-abc123',
+      },
+    });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    const callArgs = mockCreateRenderTemplate.mock.calls[0][1];
+    expect(callArgs).not.toHaveProperty('isPrimary');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        dataModelId: 'dm-1',
+        storageUrl: 'https://example.com/template.html',
+        hash: 'sha256-abc123',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name is required');
+  });
+
+  it('returns 400 when dataModelId is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Template',
+        storageUrl: 'https://example.com/template.html',
+        hash: 'sha256-abc123',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('dataModelId is required');
+  });
+
+  it('returns 400 when storageUrl is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Template',
+        dataModelId: 'dm-1',
+        hash: 'sha256-abc123',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('storageUrl is required');
+  });
+
+  it('returns 400 when hash is missing', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Template',
+        dataModelId: 'dm-1',
+        storageUrl: 'https://example.com/template.html',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('hash is required');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = createBadJsonRequest();
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockCreateRenderTemplate.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Template',
+        dataModelId: 'dm-1',
+        storageUrl: 'https://example.com/template.html',
+        hash: 'sha256-abc123',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from 'next/server';
+import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { withTenantAuth } from '@/lib/api/with-tenant-auth';
+import { listRenderTemplates, createRenderTemplate } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ route: '/api/v1/render-templates' });
+
+/**
+ * @swagger
+ * /render-templates:
+ *   get:
+ *     summary: List render templates
+ *     description: Retrieves render templates belonging to the authenticated tenant, with optional filtering by data model
+ *     tags:
+ *       - Render Templates
+ *     parameters:
+ *       - in: query
+ *         name: dataModelId
+ *         schema:
+ *           type: string
+ *         description: Filter by associated data model ID
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Maximum number of results to return
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *         description: Number of results to skip for pagination
+ *     responses:
+ *       200:
+ *         description: Render templates retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 renderTemplates:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/RenderTemplate'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (req, { tenantId }) => {
+  const url = new URL(req.url);
+
+  const dataModelId = url.searchParams.get('dataModelId') ?? undefined;
+  const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+
+  logger.info({ tenantId, filters: { dataModelId, limit, offset } }, 'Listing render templates');
+  const renderTemplates = await listRenderTemplates(tenantId, {
+    dataModelId,
+    limit,
+    offset,
+  });
+
+  logger.info({ tenantId, count: renderTemplates.length }, 'Render templates listed');
+  return NextResponse.json({ ok: true, renderTemplates });
+});
+
+/**
+ * @swagger
+ * /render-templates:
+ *   post:
+ *     summary: Create a render template
+ *     description: Creates a new render template for the authenticated tenant, associated with an existing data model
+ *     tags:
+ *       - Render Templates
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - dataModelId
+ *               - storageUrl
+ *               - hash
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Human-readable name for the render template
+ *               dataModelId:
+ *                 type: string
+ *                 description: ID of the data model this template renders
+ *               storageUrl:
+ *                 type: string
+ *                 description: URL where the template file is stored
+ *               hash:
+ *                 type: string
+ *                 description: Content hash of the template file for integrity verification
+ *               isPrimary:
+ *                 type: boolean
+ *                 description: Whether this is the primary template for the data model. Setting to true will unset any existing primary template for the same data model.
+ *     responses:
+ *       201:
+ *         description: Render template created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *                 renderTemplate:
+ *                   $ref: '#/components/schemas/RenderTemplate'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const POST = withTenantAuth(async (req, { tenantId }) => {
+  let body: {
+    name?: string;
+    dataModelId?: string;
+    storageUrl?: string;
+    hash?: string;
+    isPrimary?: boolean;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
+  if (!isNonEmptyString(body.dataModelId)) throw new ValidationError('dataModelId is required');
+  if (!isNonEmptyString(body.storageUrl)) throw new ValidationError('storageUrl is required');
+  if (!isNonEmptyString(body.hash)) throw new ValidationError('hash is required');
+
+  logger.info({ tenantId, dataModelId: body.dataModelId, name: body.name }, 'Creating render template');
+  const renderTemplate = await createRenderTemplate(tenantId, {
+    name: body.name,
+    dataModelId: body.dataModelId,
+    storageUrl: body.storageUrl,
+    hash: body.hash,
+    ...(body.isPrimary !== undefined && { isPrimary: body.isPrimary }),
+  });
+
+  logger.info({ tenantId, renderTemplateId: renderTemplate.id }, 'Render template created');
+  return NextResponse.json({ ok: true, renderTemplate }, { status: 201 });
+});

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -95,6 +95,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *               validationPattern:
  *                 type: string
  *                 description: New validation pattern
+ *               linkTemplate:
+ *                 type: string
+ *                 description: New ISO 18975 link template for URI construction
  *               namespace:
  *                 type: string
  *                 description: New namespace
@@ -164,12 +167,14 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     name?: string;
     primaryKey?: string;
     validationPattern?: string;
+    linkTemplate?: string;
     namespace?: string;
     idrServiceInstanceId?: string | null;
     qualifiers?: Array<{
       key: string;
       description: string;
       validationPattern: string;
+      order?: number;
     }>;
   };
 
@@ -182,6 +187,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const hasName = isNonEmptyString(body.name);
   const hasPrimaryKey = isNonEmptyString(body.primaryKey);
   const hasValidationPattern = isNonEmptyString(body.validationPattern);
+  const hasLinkTemplate = isNonEmptyString(body.linkTemplate);
   const hasNamespace = isNonEmptyString(body.namespace);
   const hasIdrServiceInstanceId = body.idrServiceInstanceId !== undefined;
   const hasQualifiers = body.qualifiers !== undefined;
@@ -190,6 +196,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     !hasName &&
     !hasPrimaryKey &&
     !hasValidationPattern &&
+    !hasLinkTemplate &&
     !hasNamespace &&
     !hasIdrServiceInstanceId &&
     !hasQualifiers
@@ -213,7 +220,15 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     {
       tenantId,
       schemeId: id,
-      fields: { hasName, hasPrimaryKey, hasValidationPattern, hasNamespace, hasIdrServiceInstanceId, hasQualifiers },
+      fields: {
+        hasName,
+        hasPrimaryKey,
+        hasValidationPattern,
+        hasLinkTemplate,
+        hasNamespace,
+        hasIdrServiceInstanceId,
+        hasQualifiers,
+      },
     },
     'Updating scheme',
   );
@@ -221,6 +236,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     ...(hasName && { name: body.name }),
     ...(hasPrimaryKey && { primaryKey: body.primaryKey }),
     ...(hasValidationPattern && { validationPattern: body.validationPattern }),
+    ...(hasLinkTemplate && { linkTemplate: body.linkTemplate }),
     ...(hasNamespace && { namespace: body.namespace }),
     ...(hasIdrServiceInstanceId && { idrServiceInstanceId: body.idrServiceInstanceId }),
     ...(hasQualifiers && { qualifiers: body.qualifiers }),

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
@@ -69,7 +69,13 @@ describe('POST /api/v1/schemes', () => {
   });
 
   it('creates a scheme and returns 201', async () => {
-    const scheme = { id: 'sch-1', name: 'GTIN', primaryKey: 'gtin', validationPattern: '^\\d{14}$' };
+    const scheme = {
+      id: 'sch-1',
+      name: 'GTIN',
+      primaryKey: 'gtin',
+      validationPattern: '^\\d{14}$',
+      linkTemplate: '/{primaryKey}/{value}',
+    };
     mockCreateIdentifierScheme.mockResolvedValue(scheme);
 
     const req = createFakeRequest({
@@ -78,6 +84,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
       },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
@@ -102,6 +109,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
         qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$' }],
       },
     });
@@ -127,6 +135,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
         namespace: 'gs1',
         idrServiceInstanceId: 'inst-1',
       },
@@ -192,6 +201,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
         qualifiers: [{ description: 'Lot number' }],
       },
     });
@@ -209,6 +219,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
         qualifiers: [{ key: 'lot' }],
       },
     });
@@ -226,6 +237,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
         qualifiers: [{ key: 'lot', description: 'Lot number' }],
       },
     });
@@ -243,6 +255,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
         qualifiers: 'not-an-array',
       },
     });
@@ -262,6 +275,17 @@ describe('POST /api/v1/schemes', () => {
     expect(json.error).toBe('Invalid JSON body');
   });
 
+  it('returns 400 for missing linkTemplate', async () => {
+    const req = createFakeRequest({
+      body: { registrarId: 'reg-1', name: 'GTIN', primaryKey: 'gtin', validationPattern: '^\\d{14}$' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('linkTemplate is required');
+  });
+
   it('returns 500 when repository throws', async () => {
     mockCreateIdentifierScheme.mockRejectedValue(new Error('Database error'));
 
@@ -271,6 +295,7 @@ describe('POST /api/v1/schemes', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
       },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.ts
@@ -25,6 +25,7 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *               - name
  *               - primaryKey
  *               - validationPattern
+ *               - linkTemplate
  *             properties:
  *               registrarId:
  *                 type: string
@@ -38,6 +39,9 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *               validationPattern:
  *                 type: string
  *                 description: Regular expression pattern for validating identifier values
+ *               linkTemplate:
+ *                 type: string
+ *                 description: ISO 18975 link template for URI construction (e.g. "/{primaryKey}/{value}")
  *               namespace:
  *                 type: string
  *                 description: Optional namespace for the scheme
@@ -104,12 +108,14 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     name?: string;
     primaryKey?: string;
     validationPattern?: string;
+    linkTemplate?: string;
     namespace?: string;
     idrServiceInstanceId?: string;
     qualifiers?: Array<{
       key: string;
       description: string;
       validationPattern: string;
+      order?: number;
     }>;
   };
 
@@ -123,6 +129,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
   if (!isNonEmptyString(body.primaryKey)) throw new ValidationError('primaryKey is required');
   if (!isNonEmptyString(body.validationPattern)) throw new ValidationError('validationPattern is required');
+  if (!isNonEmptyString(body.linkTemplate)) throw new ValidationError('linkTemplate is required');
 
   // Validate qualifiers if provided
   if (body.qualifiers !== undefined) {
@@ -151,6 +158,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     name: body.name,
     primaryKey: body.primaryKey,
     validationPattern: body.validationPattern,
+    linkTemplate: body.linkTemplate,
     namespace: body.namespace,
     idrServiceInstanceId: body.idrServiceInstanceId,
     qualifiers: body.qualifiers,

--- a/packages/reference-implementation/src/lib/api/validation.ts
+++ b/packages/reference-implementation/src/lib/api/validation.ts
@@ -30,16 +30,16 @@ export function validateEnum<T extends string>(
 }
 
 /**
- * Parse a string as a positive integer (>= 1).
- * Returns undefined if the raw value is null/undefined.
- */
-/**
  * Check that a value is a non-empty string.
  */
 export function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
+/**
+ * Parse a string as a positive integer (>= 1).
+ * Returns undefined if the raw value is null/undefined.
+ */
 export function parsePositiveInt(raw: string | null | undefined, paramName: string): number | undefined {
   if (raw == null) return undefined;
   const parsed = parseInt(raw, 10);

--- a/packages/reference-implementation/src/lib/mapping/mapper-registry.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mapper-registry.test.ts
@@ -1,0 +1,79 @@
+import { registerMapper, getMapper, listRegisteredMappers, clearRegistry } from './mapper-registry';
+import type { ICredentialMapper } from './types';
+
+// -- Helpers ------------------------------------------------------------------
+
+function createMockMapper(label = 'mock'): ICredentialMapper {
+  return {
+    buildPayload: jest.fn().mockResolvedValue({ _label: label }),
+    extractEntityRefs: jest.fn().mockReturnValue({}),
+  };
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe('mapper-registry', () => {
+  afterEach(() => {
+    clearRegistry();
+  });
+
+  // -- getMapper --------------------------------------------------------------
+
+  describe('getMapper', () => {
+    it('returns undefined for a completely unknown credential type', () => {
+      expect(getMapper('UnknownType', '0.6.0')).toBeUndefined();
+    });
+
+    it('returns undefined for an unknown version of a registered type', () => {
+      registerMapper('DigitalProductPassport', '0.6.0', createMockMapper());
+
+      expect(getMapper('DigitalProductPassport', '999.0.0')).toBeUndefined();
+    });
+
+    it('returns the mapper after it has been registered', () => {
+      const mapper = createMockMapper('dpp-0.6');
+      registerMapper('DigitalProductPassport', '0.6.0', mapper);
+
+      expect(getMapper('DigitalProductPassport', '0.6.0')).toBe(mapper);
+    });
+  });
+
+  // -- registerMapper ---------------------------------------------------------
+
+  describe('registerMapper', () => {
+    it('overwrites an existing mapper for the same type + version', () => {
+      const original = createMockMapper('original');
+      const replacement = createMockMapper('replacement');
+
+      registerMapper('DigitalProductPassport', '0.6.0', original);
+      registerMapper('DigitalProductPassport', '0.6.0', replacement);
+
+      expect(getMapper('DigitalProductPassport', '0.6.0')).toBe(replacement);
+    });
+  });
+
+  // -- listRegisteredMappers --------------------------------------------------
+
+  describe('listRegisteredMappers', () => {
+    it('returns an empty array when nothing is registered', () => {
+      expect(listRegisteredMappers()).toEqual([]);
+    });
+
+    it('returns all registered type + version combinations', () => {
+      registerMapper('DigitalProductPassport', '0.6.0', createMockMapper());
+      registerMapper('DigitalConformityCredential', '0.6.0', createMockMapper());
+      registerMapper('DigitalProductPassport', '0.7.0', createMockMapper());
+
+      const result = listRegisteredMappers();
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          { credentialType: 'DigitalProductPassport', version: '0.6.0' },
+          { credentialType: 'DigitalProductPassport', version: '0.7.0' },
+          { credentialType: 'DigitalConformityCredential', version: '0.6.0' },
+        ]),
+      );
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/mapping/mapper-registry.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mapper-registry.test.ts
@@ -1,5 +1,5 @@
 import { registerMapper, getMapper, listRegisteredMappers, clearRegistry } from './mapper-registry';
-import type { ICredentialMapper } from './types';
+import { ICredentialMapper } from './types';
 
 // -- Helpers ------------------------------------------------------------------
 

--- a/packages/reference-implementation/src/lib/mapping/mapper-registry.ts
+++ b/packages/reference-implementation/src/lib/mapping/mapper-registry.ts
@@ -1,0 +1,49 @@
+import { ICredentialMapper } from './types';
+
+/**
+ * Registry mapping credentialType + version to a mapper instance.
+ * Structure: { [credentialType]: { [version]: ICredentialMapper } }
+ */
+const registry: Record<string, Record<string, ICredentialMapper>> = {};
+
+/**
+ * Registers a mapper for a given credential type and version.
+ */
+export function registerMapper(credentialType: string, version: string, mapper: ICredentialMapper): void {
+  if (!registry[credentialType]) {
+    registry[credentialType] = {};
+  }
+  registry[credentialType][version] = mapper;
+}
+
+/**
+ * Retrieves the mapper for a given credential type and version.
+ * Returns undefined if no mapper is registered.
+ */
+export function getMapper(credentialType: string, version: string): ICredentialMapper | undefined {
+  return registry[credentialType]?.[version];
+}
+
+/**
+ * Returns all registered credential type + version combinations.
+ * Useful for diagnostics and listing supported types.
+ */
+export function listRegisteredMappers(): Array<{
+  credentialType: string;
+  version: string;
+}> {
+  const result: Array<{ credentialType: string; version: string }> = [];
+  for (const [credentialType, versions] of Object.entries(registry)) {
+    for (const version of Object.keys(versions)) {
+      result.push({ credentialType, version });
+    }
+  }
+  return result;
+}
+
+/** @internal -- for testing only */
+export function clearRegistry(): void {
+  for (const key of Object.keys(registry)) {
+    delete registry[key];
+  }
+}

--- a/packages/reference-implementation/src/lib/mapping/mappers/dcc-v061.mapper.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dcc-v061.mapper.test.ts
@@ -1,0 +1,531 @@
+import { DccV061Mapper } from './dcc-v061.mapper';
+import { getMapper } from '../mapper-registry';
+import { ResolvedEntities, DataModelConfig, MapperOutput } from '../types';
+
+// -- Mock data model configs --------------------------------------------------
+
+const mockCoreDataModel = {
+  id: 'dm-core-dcc',
+  tenantId: null,
+  name: 'Digital Conformity Credential v0.6.1',
+  credentialType: 'DigitalConformityCredential',
+  version: '0.6.1',
+  isExtension: false,
+  parentConfigId: null,
+  parentConfig: null,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/schema.json',
+  contextUrl: 'https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['core'];
+
+const mockExtensionDataModel = {
+  id: 'dm-ext-dcc',
+  tenantId: 'tenant-1',
+  name: 'Custom Conformity Extension',
+  credentialType: 'DigitalConformityCredential',
+  version: '0.6.1',
+  isExtension: true,
+  parentConfigId: 'dm-core-dcc',
+  parentConfig: mockCoreDataModel,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://example.org/conformity-ext/v1/schema.json',
+  contextUrl: 'https://example.org/conformity-ext/v1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['extension'];
+
+const mockExtensionDifferentType = {
+  ...mockExtensionDataModel!,
+  id: 'dm-ext-dcc-2',
+  name: 'Custom Product Extension',
+  credentialType: 'DigitalProductPassport',
+  contextUrl: 'https://example.org/product-ext/v1/',
+} as DataModelConfig['extension'];
+
+// -- Mock entities ------------------------------------------------------------
+
+const mockOrganisation = {
+  id: 'org-1',
+  name: 'Test Organisation',
+  description: 'A test org',
+  tenantId: 'tenant-1',
+  primaryIdentifier: {
+    id: 'id-1',
+    value: '1234567890',
+    scheme: {
+      id: 'scheme-1',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['organisation'];
+
+const mockFacility = {
+  id: 'facility-1',
+  name: 'Test Facility',
+  description: 'A test facility',
+  tenantId: 'tenant-1',
+  location: null,
+  primaryIdentifier: {
+    id: 'id-2',
+    value: '9876543210',
+    scheme: {
+      id: 'scheme-2',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['facility'];
+
+const mockProduct = {
+  id: 'product-1',
+  name: 'Test Product',
+  description: 'A test product',
+  tenantId: 'tenant-1',
+  level: 'MODEL',
+  batchNumber: 'BATCH-001',
+  serialNumber: 'SN-12345',
+  primaryIdentifier: {
+    id: 'id-3',
+    value: '01234567890123',
+    scheme: { id: 'scheme-3', primaryKey: 'gs1:gtin', name: 'GTIN', linkTemplate: '/{primaryKey}/{value}' },
+  },
+} as unknown as ResolvedEntities['product'];
+
+// -- Tests --------------------------------------------------------------------
+
+describe('DccV061Mapper', () => {
+  const mapper = new DccV061Mapper();
+  const coreConfig: DataModelConfig = { core: mockCoreDataModel };
+
+  const fullEntities: ResolvedEntities = {
+    organisation: mockOrganisation,
+    facility: mockFacility,
+    product: mockProduct,
+  };
+
+  // -- buildPayload: @context and type ----------------------------------------
+
+  describe('buildPayload', () => {
+    it('returns @context array containing the core context URL', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result['@context']).toEqual(['https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/']);
+    });
+
+    it('merges extension context URL into @context when extension is present', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result['@context']).toEqual([
+        'https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/',
+        'https://example.org/conformity-ext/v1/',
+      ]);
+    });
+
+    it('returns type array containing the core credentialType', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result.type).toEqual(['DigitalConformityCredential']);
+    });
+
+    it('deduplicates type when extension has the same credentialType as core', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result.type).toEqual(['DigitalConformityCredential']);
+    });
+
+    it('includes both types when extension has a different credentialType', async () => {
+      const configWithDifferentType: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDifferentType,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithDifferentType);
+
+      expect(result['@context']).toEqual([
+        'https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/',
+        'https://example.org/product-ext/v1/',
+      ]);
+      expect(result.type).toEqual(['DigitalConformityCredential', 'DigitalProductPassport']);
+    });
+
+    // -- credentialSubject type ------------------------------------------------
+
+    it('sets credentialSubject.type to ConformityAttestation + Attestation', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.type).toEqual(['ConformityAttestation', 'Attestation']);
+    });
+
+    // -- issuedToParty --------------------------------------------------------
+
+    it('maps organisation to issuedToParty with idScheme and description', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const party = subject.issuedToParty as Record<string, unknown>;
+
+      expect(party).toEqual({
+        id: 'org-1',
+        name: 'Test Organisation',
+        description: 'A test org',
+        registeredId: '1234567890',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'scheme-1',
+          name: 'Global Location Number (GLN)',
+        },
+      });
+    });
+
+    it('omits description on issuedToParty when organisation has none', async () => {
+      const orgNoDescription: ResolvedEntities = {
+        organisation: {
+          ...mockOrganisation!,
+          description: null,
+        } as unknown as ResolvedEntities['organisation'],
+      };
+
+      const result = await mapper.buildPayload(orgNoDescription, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const party = subject.issuedToParty as Record<string, unknown>;
+
+      expect(party.description).toBeUndefined();
+    });
+
+    it('omits registeredId and idScheme on issuedToParty when organisation has no primaryIdentifier', async () => {
+      const orgNoIdentifier: ResolvedEntities = {
+        organisation: {
+          ...mockOrganisation!,
+          primaryIdentifier: null,
+        } as unknown as ResolvedEntities['organisation'],
+      };
+
+      const result = await mapper.buildPayload(orgNoIdentifier, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const party = subject.issuedToParty as Record<string, unknown>;
+
+      expect(party.registeredId).toBeUndefined();
+      expect(party.idScheme).toBeUndefined();
+    });
+
+    // -- assessment: ConformityAssessment -------------------------------------
+
+    it('includes assessment array with ConformityAssessment type when entities are present', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const assessment = subject.assessment as Record<string, unknown>[];
+
+      expect(assessment).toHaveLength(1);
+      expect(assessment[0].type).toEqual(['ConformityAssessment', 'Declaration']);
+    });
+
+    it('includes assessedProduct with ProductVerification when product is provided', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const assessment = (subject.assessment as Record<string, unknown>[])[0];
+      const assessedProduct = assessment.assessedProduct as Record<string, unknown>[];
+
+      expect(assessedProduct).toHaveLength(1);
+      expect(assessedProduct[0]).toEqual({
+        type: ['ProductVerification'],
+        product: {
+          id: 'product-1',
+          name: 'Test Product',
+          registeredId: '01234567890123',
+          idScheme: {
+            type: ['IdentifierScheme'],
+            id: 'scheme-3',
+            name: 'GTIN',
+          },
+          batchNumber: 'BATCH-001',
+          serialNumber: 'SN-12345',
+        },
+      });
+    });
+
+    it('includes assessedFacility with FacilityVerification when facility is provided', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const assessment = (subject.assessment as Record<string, unknown>[])[0];
+      const assessedFacility = assessment.assessedFacility as Record<string, unknown>[];
+
+      expect(assessedFacility).toHaveLength(1);
+      expect(assessedFacility[0]).toEqual({
+        type: ['FacilityVerification'],
+        facility: {
+          id: 'facility-1',
+          name: 'Test Facility',
+          registeredId: '9876543210',
+          idScheme: {
+            type: ['IdentifierScheme'],
+            id: 'scheme-2',
+            name: 'Global Location Number (GLN)',
+          },
+        },
+      });
+    });
+
+    it('includes assessedOrganisation in assessment', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const assessment = (subject.assessment as Record<string, unknown>[])[0];
+      const assessedOrg = assessment.assessedOrganisation as Record<string, unknown>;
+
+      expect(assessedOrg).toEqual({
+        id: 'org-1',
+        name: 'Test Organisation',
+        description: 'A test org',
+        registeredId: '1234567890',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'scheme-1',
+          name: 'Global Location Number (GLN)',
+        },
+      });
+    });
+
+    it('omits assessedProduct when product is not provided', async () => {
+      const entitiesNoProduct: ResolvedEntities = {
+        organisation: mockOrganisation,
+        facility: mockFacility,
+      };
+
+      const result = await mapper.buildPayload(entitiesNoProduct, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const assessment = (subject.assessment as Record<string, unknown>[])[0];
+
+      expect(assessment.assessedProduct).toBeUndefined();
+      expect(assessment.assessedFacility).toBeDefined();
+    });
+
+    it('omits assessedFacility when facility is not provided', async () => {
+      const entitiesNoFacility: ResolvedEntities = {
+        organisation: mockOrganisation,
+        product: mockProduct,
+      };
+
+      const result = await mapper.buildPayload(entitiesNoFacility, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const assessment = (subject.assessment as Record<string, unknown>[])[0];
+
+      expect(assessment.assessedFacility).toBeUndefined();
+      expect(assessment.assessedProduct).toBeDefined();
+    });
+
+    it('creates assessment with only assessedOrganisation when no product or facility', async () => {
+      const orgOnly: ResolvedEntities = {
+        organisation: mockOrganisation,
+      };
+
+      const result = await mapper.buildPayload(orgOnly, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const assessment = (subject.assessment as Record<string, unknown>[])[0];
+
+      expect(assessment.type).toEqual(['ConformityAssessment', 'Declaration']);
+      expect(assessment.assessedOrganisation).toBeDefined();
+      expect(assessment.assessedProduct).toBeUndefined();
+      expect(assessment.assessedFacility).toBeUndefined();
+    });
+
+    it('omits assessment when no entities are provided', async () => {
+      const emptyEntities: ResolvedEntities = {};
+
+      const result = await mapper.buildPayload(emptyEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.assessment).toBeUndefined();
+    });
+
+    it('handles undefined organisation gracefully in issuedToParty', async () => {
+      const emptyEntities: ResolvedEntities = {};
+
+      const result = await mapper.buildPayload(emptyEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const party = subject.issuedToParty as Record<string, unknown>;
+
+      expect(party.id).toBeUndefined();
+      expect(party.name).toBeUndefined();
+    });
+  });
+
+  // -- extractEntityRefs ------------------------------------------------------
+
+  describe('extractEntityRefs', () => {
+    const stubContext = ['https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/'];
+    const stubType = ['DigitalConformityCredential'];
+
+    it('extracts organisation registeredId from issuedToParty', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ConformityAttestation'],
+          issuedToParty: { registeredId: '1234567890' },
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs.organisation).toEqual({ registeredId: '1234567890' });
+    });
+
+    it('extracts product registeredId from assessment.assessedProduct', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ConformityAttestation'],
+          issuedToParty: { registeredId: '1234567890' },
+          assessment: [
+            {
+              type: ['ConformityAssessment', 'Declaration'],
+              assessedProduct: [
+                {
+                  type: ['ProductVerification'],
+                  product: {
+                    registeredId: '01234567890123',
+                    batchNumber: 'BATCH-001',
+                    serialNumber: 'SN-12345',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs.product).toEqual({
+        registeredId: '01234567890123',
+        batchNumber: 'BATCH-001',
+        serialNumber: 'SN-12345',
+      });
+    });
+
+    it('extracts facility registeredId from assessment.assessedFacility', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ConformityAttestation'],
+          issuedToParty: { registeredId: '1234567890' },
+          assessment: [
+            {
+              type: ['ConformityAssessment', 'Declaration'],
+              assessedFacility: [
+                {
+                  type: ['FacilityVerification'],
+                  facility: { registeredId: '9876543210' },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs.facility).toEqual({ registeredId: '9876543210' });
+    });
+
+    it('extracts all three entity refs from a full payload', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ConformityAttestation'],
+          issuedToParty: { registeredId: '1234567890' },
+          assessment: [
+            {
+              type: ['ConformityAssessment', 'Declaration'],
+              assessedProduct: [
+                {
+                  type: ['ProductVerification'],
+                  product: { registeredId: '01234567890123' },
+                },
+              ],
+              assessedFacility: [
+                {
+                  type: ['FacilityVerification'],
+                  facility: { registeredId: '9876543210' },
+                },
+              ],
+              assessedOrganisation: { registeredId: '1234567890' },
+            },
+          ],
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({
+        organisation: { registeredId: '1234567890' },
+        product: { registeredId: '01234567890123' },
+        facility: { registeredId: '9876543210' },
+      });
+    });
+
+    it('falls back to assessedOrganisation when issuedToParty has no registeredId', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ConformityAttestation'],
+          issuedToParty: { name: 'Some org' },
+          assessment: [
+            {
+              type: ['ConformityAssessment', 'Declaration'],
+              assessedOrganisation: { registeredId: '1234567890' },
+            },
+          ],
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs.organisation).toEqual({ registeredId: '1234567890' });
+    });
+
+    it('returns empty object when issuedToParty is missing and no assessment', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: { type: ['ConformityAttestation'] },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+  });
+
+  // -- Self-registration ------------------------------------------------------
+
+  describe('self-registration', () => {
+    it('registers itself in the mapper registry as DigitalConformityCredential / 0.6.1', () => {
+      const registered = getMapper('DigitalConformityCredential', '0.6.1');
+      expect(registered).toBeDefined();
+      expect(registered).toBeInstanceOf(DccV061Mapper);
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/mapping/mappers/dcc-v061.mapper.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dcc-v061.mapper.ts
@@ -1,0 +1,225 @@
+import { ICredentialMapper, ResolvedEntities, ExtractedIdentifierRefs, DataModelConfig, MapperOutput } from '../types';
+import { registerMapper } from '../mapper-registry';
+import type { IdentifierScheme } from '@uncefact/untp-ri-services';
+
+// TODO: Consolidate shared types and helpers across v0.6.1 mappers into a
+// common module (e.g. ./shared-v061.ts). Candidates:
+//   - Party type (DccParty, DfrParty) and buildParty helper
+//   - IdentifierScheme type import and buildIdentifierScheme helper (identical in DCC, DFR, DIA)
+//   - Context/type array construction logic (identical in all four mappers)
+
+/**
+ * DCC v0.6.1 UNTP schema types.
+ *
+ * ConformityAttestation contains:
+ *   - issuedToParty: the party receiving the attestation
+ *   - assessment[]: ConformityAssessment entries, each targeting:
+ *       - assessedProduct[]: ProductVerification (product being assessed)
+ *       - assessedFacility[]: FacilityVerification (facility being assessed)
+ *       - assessedOrganisation: the organisation being assessed
+ *
+ * All party/entity references include idScheme per JSON-LD context and example data.
+ */
+type DccParty = {
+  id: string | undefined;
+  name: string | undefined;
+  description?: string;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+};
+
+type DccProduct = {
+  id: string | undefined;
+  name: string | undefined;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+  batchNumber?: string;
+  serialNumber?: string;
+};
+
+type DccFacility = {
+  id: string | undefined;
+  name: string | undefined;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+};
+
+type DccProductVerification = {
+  type: ['ProductVerification'];
+  product: DccProduct;
+};
+
+type DccFacilityVerification = {
+  type: ['FacilityVerification'];
+  facility: DccFacility;
+};
+
+type DccAssessment = {
+  type: ['ConformityAssessment', 'Declaration'];
+  assessedProduct?: DccProductVerification[];
+  assessedFacility?: DccFacilityVerification[];
+  assessedOrganisation?: DccParty;
+};
+
+/**
+ * Mapper for Digital Conformity Credential v0.6.1.
+ * Builds a UNTP DCC credential payload from organisation, facility, and product entities.
+ *
+ * A DCC attests conformity of a company, facility, or product via assessments.
+ *   - organisation maps to issuedToParty (recipient) and assessedOrganisation
+ *   - product maps to assessedProduct within an assessment
+ *   - facility maps to assessedFacility within an assessment
+ */
+export class DccV061Mapper implements ICredentialMapper {
+  async buildPayload(entities: ResolvedEntities, config: DataModelConfig): Promise<MapperOutput> {
+    const { organisation, facility, product } = entities;
+
+    const contexts: string[] = [config.core.contextUrl];
+    const types: string[] = [config.core.credentialType];
+
+    if (config.extension) {
+      contexts.push(config.extension.contextUrl);
+      if (config.extension.credentialType !== config.core.credentialType) {
+        types.push(config.extension.credentialType);
+      }
+    }
+
+    const assessment = this.buildAssessment(organisation, facility, product);
+
+    return {
+      '@context': contexts,
+      type: types,
+      credentialSubject: {
+        type: ['ConformityAttestation', 'Attestation'],
+        issuedToParty: this.buildParty(organisation),
+        ...(assessment ? { assessment: [assessment] } : {}),
+      },
+    };
+  }
+
+  private buildAssessment(
+    organisation: ResolvedEntities['organisation'],
+    facility: ResolvedEntities['facility'],
+    product: ResolvedEntities['product'],
+  ): DccAssessment | undefined {
+    if (!organisation && !facility && !product) return undefined;
+
+    return {
+      type: ['ConformityAssessment', 'Declaration'],
+      ...(product
+        ? {
+            assessedProduct: [
+              {
+                type: ['ProductVerification'] as ['ProductVerification'],
+                product: this.buildProduct(product),
+              },
+            ],
+          }
+        : {}),
+      ...(facility
+        ? {
+            assessedFacility: [
+              {
+                type: ['FacilityVerification'] as ['FacilityVerification'],
+                facility: this.buildFacility(facility),
+              },
+            ],
+          }
+        : {}),
+      ...(organisation
+        ? {
+            assessedOrganisation: this.buildParty(organisation),
+          }
+        : {}),
+    };
+  }
+
+  private buildParty(org: ResolvedEntities['organisation']): DccParty {
+    return {
+      id: org?.id,
+      name: org?.name,
+      ...(org?.description && { description: org.description }),
+      ...(org?.primaryIdentifier && {
+        registeredId: org.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(org.primaryIdentifier.scheme),
+      }),
+    };
+  }
+
+  private buildProduct(product: NonNullable<ResolvedEntities['product']>): DccProduct {
+    return {
+      id: product.id,
+      name: product.name,
+      ...(product.primaryIdentifier && {
+        registeredId: product.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(product.primaryIdentifier.scheme),
+      }),
+      ...(product.batchNumber && { batchNumber: product.batchNumber }),
+      ...(product.serialNumber && { serialNumber: product.serialNumber }),
+    };
+  }
+
+  private buildFacility(facility: NonNullable<ResolvedEntities['facility']>): DccFacility {
+    return {
+      id: facility.id,
+      name: facility.name,
+      ...(facility.primaryIdentifier && {
+        registeredId: facility.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(facility.primaryIdentifier.scheme),
+      }),
+    };
+  }
+
+  private buildIdentifierScheme(
+    scheme: { id?: string; name?: string } | null | undefined,
+  ): IdentifierScheme | undefined {
+    if (!scheme || !scheme.id || !scheme.name) return undefined;
+    return {
+      type: ['IdentifierScheme'],
+      id: scheme.id,
+      name: scheme.name,
+    };
+  }
+
+  extractEntityRefs(payload: MapperOutput): ExtractedIdentifierRefs {
+    const subject = payload.credentialSubject;
+    if (!subject) return {};
+
+    const refs: ExtractedIdentifierRefs = {};
+
+    // Extract organisation from issuedToParty
+    const issuedToParty = subject.issuedToParty as DccParty | undefined;
+    if (issuedToParty?.registeredId) {
+      refs.organisation = { registeredId: issuedToParty.registeredId };
+    }
+
+    // Extract from first assessment entry
+    const assessment = subject.assessment as DccAssessment[] | undefined;
+    if (assessment?.[0]) {
+      const a = assessment[0];
+
+      if (a.assessedProduct?.[0]?.product?.registeredId) {
+        const p = a.assessedProduct[0].product;
+        refs.product = {
+          registeredId: p.registeredId!,
+          ...(p.batchNumber ? { batchNumber: p.batchNumber } : {}),
+          ...(p.serialNumber ? { serialNumber: p.serialNumber } : {}),
+        };
+      }
+
+      if (a.assessedFacility?.[0]?.facility?.registeredId) {
+        refs.facility = { registeredId: a.assessedFacility[0].facility.registeredId };
+      }
+
+      // Fallback: organisation from assessedOrganisation if not from issuedToParty
+      if (!refs.organisation && a.assessedOrganisation?.registeredId) {
+        refs.organisation = { registeredId: a.assessedOrganisation.registeredId };
+      }
+    }
+
+    return refs;
+  }
+}
+
+// Self-register on import
+registerMapper('DigitalConformityCredential', '0.6.1', new DccV061Mapper());

--- a/packages/reference-implementation/src/lib/mapping/mappers/dfr-v061.mapper.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dfr-v061.mapper.test.ts
@@ -1,0 +1,351 @@
+import { DfrV061Mapper } from './dfr-v061.mapper';
+import { getMapper } from '../mapper-registry';
+import { ResolvedEntities, DataModelConfig, MapperOutput } from '../types';
+
+// -- Mock data model configs --------------------------------------------------
+
+const mockCoreDataModel = {
+  id: 'dm-core-dfr',
+  tenantId: null,
+  name: 'Digital Facility Record v0.6.1',
+  credentialType: 'DigitalFacilityRecord',
+  version: '0.6.1',
+  isExtension: false,
+  parentConfigId: null,
+  parentConfig: null,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/schema.json',
+  contextUrl: 'https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['core'];
+
+const mockExtensionDataModel = {
+  id: 'dm-ext-dfr',
+  tenantId: 'tenant-1',
+  name: 'Custom Facility Extension',
+  credentialType: 'DigitalFacilityRecord',
+  version: '0.6.1',
+  isExtension: true,
+  parentConfigId: 'dm-core-dfr',
+  parentConfig: mockCoreDataModel,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://example.org/facility-ext/v1/schema.json',
+  contextUrl: 'https://example.org/facility-ext/v1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['extension'];
+
+// -- Mock entities ------------------------------------------------------------
+
+const mockOrganisation = {
+  id: 'org-1',
+  name: 'Test Organisation',
+  description: 'A test org',
+  tenantId: 'tenant-1',
+  primaryIdentifier: {
+    id: 'id-1',
+    value: '1234567890',
+    scheme: {
+      id: 'scheme-1',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['organisation'];
+
+const mockFacility = {
+  id: 'facility-1',
+  name: 'Test Facility',
+  description: 'A test facility',
+  tenantId: 'tenant-1',
+  location: {
+    address: {
+      streetAddress: '123 Factory Lane',
+      postalCode: '3000',
+      addressLocality: 'Melbourne',
+      addressRegion: 'VIC',
+      addressCountry: 'AU',
+    },
+    plusCode: '4RJ75MH2+XP',
+    geoLocation: { type: 'Point', coordinates: [144.9631, -37.8136] },
+  },
+  primaryIdentifier: {
+    id: 'id-2',
+    value: '9876543210',
+    scheme: {
+      id: 'scheme-2',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['facility'];
+
+// -- Tests --------------------------------------------------------------------
+
+describe('DfrV061Mapper', () => {
+  const mapper = new DfrV061Mapper();
+  const coreConfig: DataModelConfig = { core: mockCoreDataModel };
+
+  const fullEntities: ResolvedEntities = {
+    organisation: mockOrganisation,
+    facility: mockFacility,
+  };
+
+  // -- buildPayload: @context and type ----------------------------------------
+
+  describe('buildPayload', () => {
+    it('returns @context array containing the core context URL', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result['@context']).toEqual(['https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/']);
+    });
+
+    it('merges extension context URL into @context when extension is present', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result['@context']).toEqual([
+        'https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/',
+        'https://example.org/facility-ext/v1/',
+      ]);
+    });
+
+    it('returns type array containing the core credentialType', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result.type).toEqual(['DigitalFacilityRecord']);
+    });
+
+    it('deduplicates type when extension has the same credentialType as core', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result.type).toEqual(['DigitalFacilityRecord']);
+    });
+
+    // -- buildPayload: credentialSubject type ----------------------------------
+
+    it('sets credentialSubject.type to FacilityRecord', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.type).toEqual(['FacilityRecord']);
+    });
+
+    // -- buildPayload: facility -----------------------------------------------
+
+    it('maps facility data into credentialSubject.facility', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+
+      expect(facility).toMatchObject({
+        type: ['Facility'],
+        id: 'facility-1',
+        name: 'Test Facility',
+        description: 'A test facility',
+        registeredId: '9876543210',
+      });
+    });
+
+    it('includes idScheme when facility has primaryIdentifier', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+
+      expect(facility.idScheme).toEqual({
+        type: ['IdentifierScheme'],
+        id: 'scheme-2',
+        name: 'Global Location Number (GLN)',
+      });
+    });
+
+    it('omits registeredId and idScheme when facility has no primaryIdentifier', async () => {
+      const facilityNoId: ResolvedEntities = {
+        ...fullEntities,
+        facility: {
+          ...mockFacility!,
+          primaryIdentifier: null,
+        } as unknown as ResolvedEntities['facility'],
+      };
+
+      const result = await mapper.buildPayload(facilityNoId, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+
+      expect(facility.registeredId).toBeUndefined();
+      expect(facility.idScheme).toBeUndefined();
+    });
+
+    // -- buildPayload: operatedByParty ----------------------------------------
+
+    it('maps organisation to facility.operatedByParty with registeredId and idScheme', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+      const party = facility.operatedByParty as Record<string, unknown>;
+
+      expect(party).toEqual({
+        id: 'org-1',
+        name: 'Test Organisation',
+        registeredId: '1234567890',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'scheme-1',
+          name: 'Global Location Number (GLN)',
+        },
+      });
+    });
+
+    // -- buildPayload: locationInformation and address ------------------------
+
+    it('includes locationInformation with geo data', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+
+      expect(facility.locationInformation).toEqual({
+        type: ['Location'],
+        plusCode: '4RJ75MH2+XP',
+        geoLocation: { type: 'Point', coordinates: [144.9631, -37.8136] },
+      });
+    });
+
+    it('includes address from facility location', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+
+      expect(facility.address).toEqual({
+        type: ['Address'],
+        streetAddress: '123 Factory Lane',
+        postalCode: '3000',
+        addressLocality: 'Melbourne',
+        addressRegion: 'VIC',
+        addressCountry: 'AU',
+      });
+    });
+
+    it('omits locationInformation when facility has no geo data', async () => {
+      const facilityNoGeo: ResolvedEntities = {
+        ...fullEntities,
+        facility: {
+          ...mockFacility!,
+          location: {
+            address: { streetAddress: '123 Factory Lane' },
+          },
+        } as unknown as ResolvedEntities['facility'],
+      };
+
+      const result = await mapper.buildPayload(facilityNoGeo, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+
+      expect(facility.locationInformation).toBeUndefined();
+      expect(facility.address).toEqual({
+        type: ['Address'],
+        streetAddress: '123 Factory Lane',
+      });
+    });
+
+    it('omits both location and address when facility has no location data', async () => {
+      const facilityNoLocation: ResolvedEntities = {
+        ...fullEntities,
+        facility: {
+          ...mockFacility!,
+          location: null,
+        } as unknown as ResolvedEntities['facility'],
+      };
+
+      const result = await mapper.buildPayload(facilityNoLocation, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const facility = subject.facility as Record<string, unknown>;
+
+      expect(facility.locationInformation).toBeUndefined();
+      expect(facility.address).toBeUndefined();
+    });
+  });
+
+  // -- extractEntityRefs ------------------------------------------------------
+
+  describe('extractEntityRefs', () => {
+    const stubContext = ['https://test.uncefact.org/vocabulary/untp/dfr/0.6.1/'];
+    const stubType = ['DigitalFacilityRecord'];
+
+    it('extracts facility and organisation registeredIds', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['FacilityRecord'],
+          facility: {
+            registeredId: '9876543210',
+            operatedByParty: { registeredId: '1234567890' },
+          },
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({
+        facility: { registeredId: '9876543210' },
+        organisation: { registeredId: '1234567890' },
+      });
+    });
+
+    it('returns empty object when facility is missing from credentialSubject', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: { type: ['FacilityRecord'] },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+
+    it('returns empty object when facility has no registeredId', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['FacilityRecord'],
+          facility: {
+            name: 'Some facility',
+            operatedByParty: { name: 'Some org' },
+          },
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+  });
+
+  // -- Self-registration ------------------------------------------------------
+
+  describe('self-registration', () => {
+    it('registers itself in the mapper registry as DigitalFacilityRecord / 0.6.1', () => {
+      const registered = getMapper('DigitalFacilityRecord', '0.6.1');
+      expect(registered).toBeDefined();
+      expect(registered).toBeInstanceOf(DfrV061Mapper);
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/mapping/mappers/dfr-v061.mapper.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dfr-v061.mapper.ts
@@ -1,0 +1,169 @@
+import { ICredentialMapper, ResolvedEntities, ExtractedIdentifierRefs, DataModelConfig, MapperOutput } from '../types';
+import { registerMapper } from '../mapper-registry';
+import type { IdentifierScheme } from '@uncefact/untp-ri-services';
+import type { UntpLocation } from '@/lib/types';
+
+// TODO: Consolidate shared types and helpers across v0.6.1 mappers into a
+// common module (e.g. ./shared-v061.ts). Candidates:
+//   - Party type (DccParty, DfrParty) and buildParty helper
+//   - IdentifierScheme type import and buildIdentifierScheme helper (identical in DCC, DFR, DIA)
+//   - Context/type array construction logic (identical in all four mappers)
+
+/**
+ * DFR v0.6.1 UNTP schema types.
+ * These mirror the JSON schema definitions for the Digital Facility Record.
+ */
+type DfrParty = {
+  id: string | undefined;
+  name: string | undefined;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+};
+
+type DfrLocation = {
+  type: ['Location'];
+  plusCode?: string;
+  geoLocation?: unknown;
+  geoBoundary?: unknown;
+};
+
+type DfrAddress = {
+  type: ['Address'];
+  streetAddress?: string;
+  postalCode?: string;
+  addressLocality?: string;
+  addressRegion?: string;
+  addressCountry?: string;
+};
+
+type DfrFacility = {
+  type: ['Facility'];
+  id: string | undefined;
+  name: string | undefined;
+  description?: string;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+  operatedByParty: DfrParty;
+  locationInformation?: DfrLocation;
+  address?: DfrAddress;
+};
+
+/**
+ * Mapper for Digital Facility Record v0.6.1.
+ * Builds a UNTP DFR credential payload from facility and organisation entities.
+ *
+ * Output structure follows the UNTP DFR JSON schema:
+ *   - credentialSubject is a FacilityRecord
+ *   - facility maps to credentialSubject.facility with location, address
+ *   - organisation maps to facility.operatedByParty with idScheme
+ */
+export class DfrV061Mapper implements ICredentialMapper {
+  async buildPayload(entities: ResolvedEntities, config: DataModelConfig): Promise<MapperOutput> {
+    const { organisation, facility } = entities;
+
+    const contexts: string[] = [config.core.contextUrl];
+    const types: string[] = [config.core.credentialType];
+
+    if (config.extension) {
+      contexts.push(config.extension.contextUrl);
+      if (config.extension.credentialType !== config.core.credentialType) {
+        types.push(config.extension.credentialType);
+      }
+    }
+
+    return {
+      '@context': contexts,
+      type: types,
+      credentialSubject: {
+        type: ['FacilityRecord'],
+        facility: this.buildFacility(facility, organisation),
+      },
+    };
+  }
+
+  private buildFacility(
+    facility: ResolvedEntities['facility'],
+    organisation: ResolvedEntities['organisation'],
+  ): DfrFacility {
+    const location = facility?.location as UntpLocation | null | undefined;
+
+    return {
+      type: ['Facility'],
+      id: facility?.id,
+      name: facility?.name,
+      ...(facility?.description && { description: facility.description }),
+      ...(facility?.primaryIdentifier && {
+        registeredId: facility.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(facility.primaryIdentifier.scheme),
+      }),
+      operatedByParty: this.buildParty(organisation),
+      ...(location?.geoLocation || location?.plusCode || location?.geoBoundary
+        ? {
+            locationInformation: {
+              type: ['Location'] as ['Location'],
+              ...(location.plusCode && { plusCode: location.plusCode }),
+              ...(location.geoLocation && { geoLocation: location.geoLocation }),
+              ...(location.geoBoundary && { geoBoundary: location.geoBoundary }),
+            },
+          }
+        : {}),
+      ...(location?.address
+        ? {
+            address: {
+              type: ['Address'] as ['Address'],
+              ...(location.address.streetAddress && { streetAddress: location.address.streetAddress }),
+              ...(location.address.postalCode && { postalCode: location.address.postalCode }),
+              ...(location.address.addressLocality && { addressLocality: location.address.addressLocality }),
+              ...(location.address.addressRegion && { addressRegion: location.address.addressRegion }),
+              ...(location.address.addressCountry && { addressCountry: location.address.addressCountry }),
+            },
+          }
+        : {}),
+    };
+  }
+
+  private buildParty(org: ResolvedEntities['organisation']): DfrParty {
+    return {
+      id: org?.id,
+      name: org?.name,
+      ...(org?.primaryIdentifier && {
+        registeredId: org.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(org.primaryIdentifier.scheme),
+      }),
+    };
+  }
+
+  private buildIdentifierScheme(
+    scheme: { id?: string; name?: string } | null | undefined,
+  ): IdentifierScheme | undefined {
+    if (!scheme || !scheme.id || !scheme.name) return undefined;
+    return {
+      type: ['IdentifierScheme'],
+      id: scheme.id,
+      name: scheme.name,
+    };
+  }
+
+  extractEntityRefs(payload: MapperOutput): ExtractedIdentifierRefs {
+    const subject = payload.credentialSubject;
+    if (!subject) return {};
+
+    const facility = subject.facility as DfrFacility | undefined;
+    if (!facility) return {};
+
+    const refs: ExtractedIdentifierRefs = {};
+
+    if (facility.registeredId) {
+      refs.facility = { registeredId: facility.registeredId };
+    }
+
+    if (facility.operatedByParty?.registeredId) {
+      refs.organisation = { registeredId: facility.operatedByParty.registeredId };
+    }
+
+    return refs;
+  }
+}
+
+// Self-register on import
+registerMapper('DigitalFacilityRecord', '0.6.1', new DfrV061Mapper());

--- a/packages/reference-implementation/src/lib/mapping/mappers/dia-v061.mapper.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dia-v061.mapper.test.ts
@@ -1,0 +1,212 @@
+import { DiaV061Mapper } from './dia-v061.mapper';
+import { getMapper } from '../mapper-registry';
+import { ResolvedEntities, DataModelConfig, MapperOutput } from '../types';
+
+// -- Mock data model configs --------------------------------------------------
+
+const mockCoreDataModel = {
+  id: 'dm-core-dia',
+  tenantId: null,
+  name: 'Digital Identity Anchor v0.6.1',
+  credentialType: 'DigitalIdentityAnchor',
+  version: '0.6.1',
+  isExtension: false,
+  parentConfigId: null,
+  parentConfig: null,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dia/0.6.1/schema.json',
+  contextUrl: 'https://test.uncefact.org/vocabulary/untp/dia/0.6.1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['core'];
+
+const mockExtensionDataModel = {
+  id: 'dm-ext-dia',
+  tenantId: 'tenant-1',
+  name: 'Custom Identity Extension',
+  credentialType: 'DigitalIdentityAnchor',
+  version: '0.6.1',
+  isExtension: true,
+  parentConfigId: 'dm-core-dia',
+  parentConfig: mockCoreDataModel,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://example.org/identity-ext/v1/schema.json',
+  contextUrl: 'https://example.org/identity-ext/v1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['extension'];
+
+// -- Mock entities ------------------------------------------------------------
+
+const mockOrganisation = {
+  id: 'org-1',
+  name: 'Test Organisation',
+  description: 'A test org',
+  tenantId: 'tenant-1',
+  primaryIdentifier: {
+    id: 'id-1',
+    value: '1234567890',
+    scheme: {
+      id: 'scheme-1',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['organisation'];
+
+// -- Tests --------------------------------------------------------------------
+
+describe('DiaV061Mapper', () => {
+  const mapper = new DiaV061Mapper();
+  const coreConfig: DataModelConfig = { core: mockCoreDataModel };
+
+  const fullEntities: ResolvedEntities = {
+    organisation: mockOrganisation,
+  };
+
+  // -- buildPayload: @context and type ----------------------------------------
+
+  describe('buildPayload', () => {
+    it('returns @context array containing the core context URL', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result['@context']).toEqual(['https://test.uncefact.org/vocabulary/untp/dia/0.6.1/']);
+    });
+
+    it('merges extension context URL into @context when extension is present', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result['@context']).toEqual([
+        'https://test.uncefact.org/vocabulary/untp/dia/0.6.1/',
+        'https://example.org/identity-ext/v1/',
+      ]);
+    });
+
+    it('returns type array containing the core credentialType', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result.type).toEqual(['DigitalIdentityAnchor']);
+    });
+
+    it('deduplicates type when extension has the same credentialType as core', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result.type).toEqual(['DigitalIdentityAnchor']);
+    });
+
+    // -- buildPayload: credentialSubject type ----------------------------------
+
+    it('sets credentialSubject.type to RegisteredIdentity', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.type).toEqual(['RegisteredIdentity']);
+    });
+
+    // -- buildPayload: organisation identity fields ----------------------------
+
+    it('maps organisation identity directly to credentialSubject', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.id).toBe('org-1');
+      expect(subject.name).toBe('Test Organisation');
+      expect(subject.registeredId).toBe('1234567890');
+      expect(subject.idScheme).toEqual({
+        type: ['IdentifierScheme'],
+        id: 'scheme-1',
+        name: 'Global Location Number (GLN)',
+      });
+    });
+
+    it('omits registeredId and idScheme when organisation has no primaryIdentifier', async () => {
+      const orgNoIdentifier: ResolvedEntities = {
+        organisation: {
+          ...mockOrganisation!,
+          primaryIdentifier: null,
+        } as unknown as ResolvedEntities['organisation'],
+      };
+
+      const result = await mapper.buildPayload(orgNoIdentifier, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.registeredId).toBeUndefined();
+      expect(subject.idScheme).toBeUndefined();
+    });
+
+    it('handles undefined organisation gracefully', async () => {
+      const emptyEntities: ResolvedEntities = {};
+
+      const result = await mapper.buildPayload(emptyEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.id).toBeUndefined();
+      expect(subject.name).toBeUndefined();
+      expect(subject.registeredId).toBeUndefined();
+    });
+  });
+
+  // -- extractEntityRefs ------------------------------------------------------
+
+  describe('extractEntityRefs', () => {
+    const stubContext = ['https://test.uncefact.org/vocabulary/untp/dia/0.6.1/'];
+    const stubType = ['DigitalIdentityAnchor'];
+
+    it('extracts organisation registeredId from credentialSubject', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['RegisteredIdentity'],
+          registeredId: '1234567890',
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({
+        organisation: { registeredId: '1234567890' },
+      });
+    });
+
+    it('returns empty object when registeredId is missing', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['RegisteredIdentity'],
+          name: 'Some org',
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+  });
+
+  // -- Self-registration ------------------------------------------------------
+
+  describe('self-registration', () => {
+    it('registers itself in the mapper registry as DigitalIdentityAnchor / 0.6.1', () => {
+      const registered = getMapper('DigitalIdentityAnchor', '0.6.1');
+      expect(registered).toBeDefined();
+      expect(registered).toBeInstanceOf(DiaV061Mapper);
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/mapping/mappers/dia-v061.mapper.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dia-v061.mapper.ts
@@ -1,0 +1,73 @@
+import { ICredentialMapper, ResolvedEntities, ExtractedIdentifierRefs, DataModelConfig, MapperOutput } from '../types';
+import { registerMapper } from '../mapper-registry';
+import type { IdentifierScheme } from '@uncefact/untp-ri-services';
+
+// TODO: Consolidate shared types and helpers across v0.6.1 mappers into a
+// common module (e.g. ./shared-v061.ts). Candidates:
+//   - Party type (DccParty, DfrParty) and buildParty helper
+//   - IdentifierScheme type import and buildIdentifierScheme helper (identical in DCC, DFR, DIA)
+//   - Context/type array construction logic (identical in all four mappers)
+
+/**
+ * Mapper for Digital Identity Anchor v0.6.1.
+ * Builds a UNTP DIA credential payload from the organisation entity.
+ *
+ * Output structure follows the UNTP DIA JSON schema:
+ *   - credentialSubject is a RegisteredIdentity
+ *   - organisation identity fields map directly to the top level
+ */
+export class DiaV061Mapper implements ICredentialMapper {
+  async buildPayload(entities: ResolvedEntities, config: DataModelConfig): Promise<MapperOutput> {
+    const { organisation } = entities;
+
+    const contexts: string[] = [config.core.contextUrl];
+    const types: string[] = [config.core.credentialType];
+
+    if (config.extension) {
+      contexts.push(config.extension.contextUrl);
+      if (config.extension.credentialType !== config.core.credentialType) {
+        types.push(config.extension.credentialType);
+      }
+    }
+
+    return {
+      '@context': contexts,
+      type: types,
+      credentialSubject: {
+        type: ['RegisteredIdentity'],
+        id: organisation?.id,
+        name: organisation?.name,
+        ...(organisation?.primaryIdentifier && {
+          registeredId: organisation.primaryIdentifier.value,
+          idScheme: this.buildIdentifierScheme(organisation.primaryIdentifier.scheme),
+        }),
+      },
+    };
+  }
+
+  private buildIdentifierScheme(
+    scheme: { id?: string; name?: string } | null | undefined,
+  ): IdentifierScheme | undefined {
+    if (!scheme || !scheme.id || !scheme.name) return undefined;
+    return {
+      type: ['IdentifierScheme'],
+      id: scheme.id,
+      name: scheme.name,
+    };
+  }
+
+  extractEntityRefs(payload: MapperOutput): ExtractedIdentifierRefs {
+    const subject = payload.credentialSubject;
+    if (!subject) return {};
+
+    const registeredId = subject.registeredId as string | undefined;
+    if (!registeredId) return {};
+
+    return {
+      organisation: { registeredId },
+    };
+  }
+}
+
+// Self-register on import
+registerMapper('DigitalIdentityAnchor', '0.6.1', new DiaV061Mapper());

--- a/packages/reference-implementation/src/lib/mapping/mappers/dpp-v060.mapper.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dpp-v060.mapper.test.ts
@@ -1,0 +1,507 @@
+import { DppV060Mapper } from './dpp-v060.mapper';
+import { getMapper } from '../mapper-registry';
+import { ResolvedEntities, DataModelConfig, MapperOutput } from '../types';
+
+// -- Mock data model configs --------------------------------------------------
+
+const mockCoreDataModel = {
+  id: 'dm-core-1',
+  tenantId: null,
+  name: 'Digital Product Passport v0.6.0',
+  credentialType: 'DigitalProductPassport',
+  version: '0.6.0',
+  isExtension: false,
+  parentConfigId: null,
+  parentConfig: null,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/schema.json',
+  contextUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['core'];
+
+const mockExtensionDataModel = {
+  id: 'dm-ext-1',
+  tenantId: 'tenant-1',
+  name: 'Australian Agriculture Extension',
+  credentialType: 'DigitalProductPassport',
+  version: '0.6.0',
+  isExtension: true,
+  parentConfigId: 'dm-core-1',
+  parentConfig: mockCoreDataModel,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://example.org/aus-agri/v1/schema.json',
+  contextUrl: 'https://example.org/aus-agri/v1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['extension'];
+
+const mockExtensionDifferentType = {
+  ...mockExtensionDataModel!,
+  id: 'dm-ext-2',
+  name: 'Custom Conformity Extension',
+  credentialType: 'DigitalConformityCredential',
+  contextUrl: 'https://example.org/conformity-ext/v1/',
+} as DataModelConfig['extension'];
+
+// -- Mock entities ------------------------------------------------------------
+
+const mockOrganisation = {
+  id: 'org-1',
+  name: 'Test Organisation',
+  description: 'A test org',
+  tenantId: 'tenant-1',
+  primaryIdentifier: {
+    id: 'id-1',
+    value: '1234567890',
+    scheme: {
+      id: 'scheme-1',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['organisation'];
+
+const mockFacility = {
+  id: 'facility-1',
+  name: 'Test Facility',
+  description: 'A test facility',
+  tenantId: 'tenant-1',
+  location: {
+    address: {
+      streetAddress: '123 Factory Lane',
+      postalCode: '3000',
+      addressLocality: 'Melbourne',
+      addressRegion: 'VIC',
+      addressCountry: 'AU',
+    },
+    plusCode: '4RJ75MH2+XP',
+    geoLocation: { type: 'Point', coordinates: [144.9631, -37.8136] },
+  },
+  primaryIdentifier: {
+    id: 'id-2',
+    value: '9876543210',
+    scheme: {
+      id: 'scheme-2',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['facility'];
+
+const mockProduct = {
+  id: 'product-1',
+  name: 'Test Product',
+  description: 'A test product',
+  tenantId: 'tenant-1',
+  level: 'MODEL',
+  batchNumber: null,
+  serialNumber: null,
+  primaryIdentifier: {
+    id: 'id-3',
+    value: '01234567890123',
+    scheme: { id: 'scheme-3', primaryKey: 'gs1:gtin', name: 'GTIN', linkTemplate: '/{primaryKey}/{value}' },
+  },
+} as unknown as ResolvedEntities['product'];
+
+// -- Tests --------------------------------------------------------------------
+
+describe('DppV060Mapper', () => {
+  const mapper = new DppV060Mapper();
+  const coreConfig: DataModelConfig = { core: mockCoreDataModel };
+
+  const fullEntities: ResolvedEntities = {
+    organisation: mockOrganisation,
+    facility: mockFacility,
+    product: mockProduct,
+  };
+
+  // -- buildPayload: @context and type ----------------------------------------
+
+  describe('buildPayload', () => {
+    it('returns @context array containing the core context URL', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result['@context']).toEqual(['https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/']);
+    });
+
+    it('merges extension context URL into @context when extension is present', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result['@context']).toEqual([
+        'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+        'https://example.org/aus-agri/v1/',
+      ]);
+    });
+
+    it('returns type array containing the core credentialType', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result.type).toEqual(['DigitalProductPassport']);
+    });
+
+    it('deduplicates type when extension has the same credentialType as core', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result.type).toEqual(['DigitalProductPassport']);
+    });
+
+    it('includes both types when extension has a different credentialType', async () => {
+      const configWithDifferentType: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDifferentType,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithDifferentType);
+
+      expect(result['@context']).toEqual([
+        'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+        'https://example.org/conformity-ext/v1/',
+      ]);
+      expect(result.type).toEqual(['DigitalProductPassport', 'DigitalConformityCredential']);
+    });
+
+    // -- buildPayload: credentialSubject type ----------------------------------
+
+    it('sets credentialSubject.type to ProductPassport', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.type).toEqual(['ProductPassport']);
+    });
+
+    // -- buildPayload: credentialSubject.product ------------------------------
+
+    it('maps product data into credentialSubject.product', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+
+      expect(product).toMatchObject({
+        type: ['Product'],
+        id: 'product-1',
+        name: 'Test Product',
+        description: 'A test product',
+      });
+    });
+
+    // -- buildPayload: registeredId and idScheme ------------------------------
+
+    it('includes registeredId and idScheme when primaryIdentifier is present', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+
+      expect(product.registeredId).toBe('01234567890123');
+      expect(product.idScheme).toEqual({
+        type: ['IdentifierScheme'],
+        id: 'scheme-3',
+        name: 'GTIN',
+      });
+    });
+
+    it('omits registeredId and idScheme when primaryIdentifier is absent', async () => {
+      const entitiesWithoutProductIdentifier: ResolvedEntities = {
+        organisation: mockOrganisation,
+        facility: mockFacility,
+        product: {
+          ...mockProduct!,
+          primaryIdentifier: null,
+        } as unknown as ResolvedEntities['product'],
+      };
+
+      const result = await mapper.buildPayload(entitiesWithoutProductIdentifier, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+
+      expect(product.registeredId).toBeUndefined();
+      expect(product.idScheme).toBeUndefined();
+    });
+
+    // -- buildPayload: batchNumber and serialNumber ---------------------------
+
+    it('includes batchNumber when present on product', async () => {
+      const productWithBatch: ResolvedEntities = {
+        ...fullEntities,
+        product: {
+          ...mockProduct!,
+          level: 'BATCH',
+          batchNumber: 'BATCH-2024-001',
+        } as unknown as ResolvedEntities['product'],
+      };
+
+      const result = await mapper.buildPayload(productWithBatch, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+
+      expect(product.batchNumber).toBe('BATCH-2024-001');
+      expect(subject.granularityLevel).toBe('batch');
+    });
+
+    it('includes serialNumber when present on product', async () => {
+      const productWithSerial: ResolvedEntities = {
+        ...fullEntities,
+        product: {
+          ...mockProduct!,
+          level: 'ITEM',
+          serialNumber: 'SN-12345678',
+        } as unknown as ResolvedEntities['product'],
+      };
+
+      const result = await mapper.buildPayload(productWithSerial, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+
+      expect(product.serialNumber).toBe('SN-12345678');
+      expect(subject.granularityLevel).toBe('item');
+    });
+
+    it('omits batchNumber and serialNumber when null', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+
+      expect(product.batchNumber).toBeUndefined();
+      expect(product.serialNumber).toBeUndefined();
+    });
+
+    // -- buildPayload: producedByParty ----------------------------------------
+
+    it('maps organisation to producedByParty with description and idScheme', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+      const party = product.producedByParty as Record<string, unknown>;
+
+      expect(party).toEqual({
+        id: 'org-1',
+        name: 'Test Organisation',
+        description: 'A test org',
+        registeredId: '1234567890',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'scheme-1',
+          name: 'Global Location Number (GLN)',
+        },
+      });
+    });
+
+    // -- buildPayload: producedAtFacility -------------------------------------
+
+    it('maps facility to producedAtFacility with description, idScheme, location, and address', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+      const facilityRef = product.producedAtFacility as Record<string, unknown>;
+
+      expect(facilityRef).toEqual({
+        id: 'facility-1',
+        name: 'Test Facility',
+        description: 'A test facility',
+        registeredId: '9876543210',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'scheme-2',
+          name: 'Global Location Number (GLN)',
+        },
+        locationInformation: {
+          type: ['Location'],
+          plusCode: '4RJ75MH2+XP',
+          geoLocation: { type: 'Point', coordinates: [144.9631, -37.8136] },
+        },
+        address: {
+          type: ['Address'],
+          streetAddress: '123 Factory Lane',
+          postalCode: '3000',
+          addressLocality: 'Melbourne',
+          addressRegion: 'VIC',
+          addressCountry: 'AU',
+        },
+      });
+    });
+
+    it('omits locationInformation when facility has no geo data', async () => {
+      const facilityNoGeo: ResolvedEntities = {
+        ...fullEntities,
+        facility: {
+          ...mockFacility!,
+          location: {
+            address: { streetAddress: '123 Factory Lane' },
+          },
+        } as unknown as ResolvedEntities['facility'],
+      };
+
+      const result = await mapper.buildPayload(facilityNoGeo, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+      const facilityRef = product.producedAtFacility as Record<string, unknown>;
+
+      expect(facilityRef.locationInformation).toBeUndefined();
+      expect(facilityRef.address).toEqual({
+        type: ['Address'],
+        streetAddress: '123 Factory Lane',
+      });
+    });
+
+    it('omits address when facility location has no address', async () => {
+      const facilityNoAddress: ResolvedEntities = {
+        ...fullEntities,
+        facility: {
+          ...mockFacility!,
+          location: {
+            geoLocation: { type: 'Point', coordinates: [144.9631, -37.8136] },
+          },
+        } as unknown as ResolvedEntities['facility'],
+      };
+
+      const result = await mapper.buildPayload(facilityNoAddress, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+      const facilityRef = product.producedAtFacility as Record<string, unknown>;
+
+      expect(facilityRef.address).toBeUndefined();
+      expect(facilityRef.locationInformation).toEqual({
+        type: ['Location'],
+        geoLocation: { type: 'Point', coordinates: [144.9631, -37.8136] },
+      });
+    });
+
+    it('omits both location and address when facility has no location data', async () => {
+      const facilityNoLocation: ResolvedEntities = {
+        ...fullEntities,
+        facility: {
+          ...mockFacility!,
+          location: null,
+        } as unknown as ResolvedEntities['facility'],
+      };
+
+      const result = await mapper.buildPayload(facilityNoLocation, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const product = subject.product as Record<string, unknown>;
+      const facilityRef = product.producedAtFacility as Record<string, unknown>;
+
+      expect(facilityRef.locationInformation).toBeUndefined();
+      expect(facilityRef.address).toBeUndefined();
+    });
+
+    // -- buildPayload: granularityLevel ---------------------------------------
+
+    it('maps product.level to credentialSubject.granularityLevel (lowercased)', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.granularityLevel).toBe('model');
+    });
+  });
+
+  // -- extractEntityRefs ------------------------------------------------------
+
+  describe('extractEntityRefs', () => {
+    const stubContext = ['https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/'];
+    const stubType = ['DigitalProductPassport'];
+
+    it('extracts registered IDs from a valid payload', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ProductPassport'],
+          product: {
+            registeredId: '01234567890123',
+            producedByParty: { registeredId: '1234567890' },
+            producedAtFacility: { registeredId: '9876543210' },
+          },
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({
+        product: { registeredId: '01234567890123' },
+        organisation: { registeredId: '1234567890' },
+        facility: { registeredId: '9876543210' },
+      });
+    });
+
+    it('includes batchNumber and serialNumber as qualifiers when present', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ProductPassport'],
+          product: {
+            registeredId: '01234567890123',
+            batchNumber: 'BATCH-001',
+            serialNumber: 'SN-999',
+            producedByParty: { registeredId: '1234567890' },
+            producedAtFacility: { registeredId: '9876543210' },
+          },
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs.product).toEqual({
+        registeredId: '01234567890123',
+        batchNumber: 'BATCH-001',
+        serialNumber: 'SN-999',
+      });
+    });
+
+    it('returns empty object when product is missing from credentialSubject', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: { type: ['ProductPassport'] },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+
+    it('returns empty object when product has no registeredId', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['ProductPassport'],
+          product: {
+            name: 'Some product',
+            producedByParty: { name: 'Some org' },
+          },
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+  });
+
+  // -- Self-registration ------------------------------------------------------
+
+  describe('self-registration', () => {
+    it('registers itself in the mapper registry as DigitalProductPassport / 0.6.0', () => {
+      const registered = getMapper('DigitalProductPassport', '0.6.0');
+      expect(registered).toBeDefined();
+      expect(registered).toBeInstanceOf(DppV060Mapper);
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/mapping/mappers/dpp-v060.mapper.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dpp-v060.mapper.ts
@@ -1,0 +1,203 @@
+import { ICredentialMapper, ResolvedEntities, ExtractedIdentifierRefs, DataModelConfig, MapperOutput } from '../types';
+import { registerMapper } from '../mapper-registry';
+import type { IdentifierScheme } from '@uncefact/untp-ri-services';
+import type { UntpLocation } from '@/lib/types';
+
+/**
+ * DPP v0.6.0 UNTP schema types.
+ * These mirror the JSON schema definitions for the Digital Product Passport.
+ */
+type DppProduct = {
+  type: ['Product'];
+  id: string | undefined;
+  name: string | undefined;
+  description?: string;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+  batchNumber?: string;
+  serialNumber?: string;
+  producedByParty: DppParty;
+  producedAtFacility: DppFacility;
+};
+
+type DppParty = {
+  id: string | undefined;
+  name: string | undefined;
+  description?: string;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+};
+
+type DppLocation = {
+  type: ['Location'];
+  plusCode?: string;
+  geoLocation?: unknown;
+  geoBoundary?: unknown;
+};
+
+type DppAddress = {
+  type: ['Address'];
+  streetAddress?: string;
+  postalCode?: string;
+  addressLocality?: string;
+  addressRegion?: string;
+  addressCountry?: string;
+};
+
+type DppFacility = {
+  id: string | undefined;
+  name: string | undefined;
+  description?: string;
+  registeredId?: string;
+  idScheme?: IdentifierScheme;
+  locationInformation?: DppLocation;
+  address?: DppAddress;
+};
+
+/**
+ * Mapper for Digital Product Passport v0.6.0.
+ * Builds a UNTP DPP credential payload from product, facility, and organisation entities.
+ *
+ * Output structure follows the UNTP DPP JSON schema:
+ *   - credentialSubject is a ProductPassport
+ *   - product uses registeredId + idScheme (not an identifiers array)
+ *   - product includes batchNumber, serialNumber when present
+ *   - organisation maps to producedByParty with idScheme + description
+ *   - facility maps to producedAtFacility with idScheme, description, location, address
+ */
+export class DppV060Mapper implements ICredentialMapper {
+  async buildPayload(entities: ResolvedEntities, config: DataModelConfig): Promise<MapperOutput> {
+    const { organisation, facility, product } = entities;
+
+    const contexts: string[] = [config.core.contextUrl];
+    const types: string[] = [config.core.credentialType];
+
+    if (config.extension) {
+      contexts.push(config.extension.contextUrl);
+      if (config.extension.credentialType !== config.core.credentialType) {
+        types.push(config.extension.credentialType);
+      }
+    }
+
+    return {
+      '@context': contexts,
+      type: types,
+      credentialSubject: {
+        type: ['ProductPassport'],
+        product: this.buildProduct(product, organisation, facility),
+        ...(product?.level && { granularityLevel: product.level.toLowerCase() }),
+      },
+    };
+  }
+
+  private buildProduct(
+    product: ResolvedEntities['product'],
+    organisation: ResolvedEntities['organisation'],
+    facility: ResolvedEntities['facility'],
+  ): DppProduct {
+    return {
+      type: ['Product'],
+      id: product?.id,
+      name: product?.name,
+      ...(product?.description && { description: product.description }),
+      ...(product?.primaryIdentifier && {
+        registeredId: product.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(product.primaryIdentifier.scheme),
+      }),
+      ...(product?.batchNumber && { batchNumber: product.batchNumber }),
+      ...(product?.serialNumber && { serialNumber: product.serialNumber }),
+      producedByParty: this.buildParty(organisation),
+      producedAtFacility: this.buildFacility(facility),
+    };
+  }
+
+  private buildParty(org: ResolvedEntities['organisation']): DppParty {
+    return {
+      id: org?.id,
+      name: org?.name,
+      ...(org?.description && { description: org.description }),
+      ...(org?.primaryIdentifier && {
+        registeredId: org.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(org.primaryIdentifier.scheme),
+      }),
+    };
+  }
+
+  private buildFacility(facility: ResolvedEntities['facility']): DppFacility {
+    const location = facility?.location as UntpLocation | null | undefined;
+
+    return {
+      id: facility?.id,
+      name: facility?.name,
+      ...(facility?.description && { description: facility.description }),
+      ...(facility?.primaryIdentifier && {
+        registeredId: facility.primaryIdentifier.value,
+        idScheme: this.buildIdentifierScheme(facility.primaryIdentifier.scheme),
+      }),
+      ...(location?.geoLocation || location?.plusCode || location?.geoBoundary
+        ? {
+            locationInformation: {
+              type: ['Location'] as ['Location'],
+              ...(location.plusCode && { plusCode: location.plusCode }),
+              ...(location.geoLocation && { geoLocation: location.geoLocation }),
+              ...(location.geoBoundary && { geoBoundary: location.geoBoundary }),
+            },
+          }
+        : {}),
+      ...(location?.address
+        ? {
+            address: {
+              type: ['Address'] as ['Address'],
+              ...(location.address.streetAddress && { streetAddress: location.address.streetAddress }),
+              ...(location.address.postalCode && { postalCode: location.address.postalCode }),
+              ...(location.address.addressLocality && { addressLocality: location.address.addressLocality }),
+              ...(location.address.addressRegion && { addressRegion: location.address.addressRegion }),
+              ...(location.address.addressCountry && { addressCountry: location.address.addressCountry }),
+            },
+          }
+        : {}),
+    };
+  }
+
+  private buildIdentifierScheme(
+    scheme: { id?: string; name?: string } | null | undefined,
+  ): IdentifierScheme | undefined {
+    if (!scheme || !scheme.id || !scheme.name) return undefined;
+    return {
+      type: ['IdentifierScheme'],
+      id: scheme.id,
+      name: scheme.name,
+    };
+  }
+
+  extractEntityRefs(payload: MapperOutput): ExtractedIdentifierRefs {
+    const subject = payload.credentialSubject;
+    if (!subject) return {};
+
+    const product = subject.product as DppProduct | undefined;
+    if (!product) return {};
+
+    const refs: ExtractedIdentifierRefs = {};
+
+    if (product.registeredId) {
+      refs.product = {
+        registeredId: product.registeredId,
+        ...(product.batchNumber ? { batchNumber: product.batchNumber } : {}),
+        ...(product.serialNumber ? { serialNumber: product.serialNumber } : {}),
+      };
+    }
+
+    if (product.producedByParty?.registeredId) {
+      refs.organisation = { registeredId: product.producedByParty.registeredId };
+    }
+
+    if (product.producedAtFacility?.registeredId) {
+      refs.facility = { registeredId: product.producedAtFacility.registeredId };
+    }
+
+    return refs;
+  }
+}
+
+// Self-register on import
+registerMapper('DigitalProductPassport', '0.6.0', new DppV060Mapper());

--- a/packages/reference-implementation/src/lib/mapping/mappers/dpp-v061.mapper.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dpp-v061.mapper.test.ts
@@ -1,4 +1,4 @@
-import { DppV060Mapper } from './dpp-v060.mapper';
+import { DppV061Mapper } from './dpp-v061.mapper';
 import { getMapper } from '../mapper-registry';
 import { ResolvedEntities, DataModelConfig, MapperOutput } from '../types';
 
@@ -7,16 +7,16 @@ import { ResolvedEntities, DataModelConfig, MapperOutput } from '../types';
 const mockCoreDataModel = {
   id: 'dm-core-1',
   tenantId: null,
-  name: 'Digital Product Passport v0.6.0',
+  name: 'Digital Product Passport v0.6.1',
   credentialType: 'DigitalProductPassport',
-  version: '0.6.0',
+  version: '0.6.1',
   isExtension: false,
   parentConfigId: null,
   parentConfig: null,
   extensions: [],
   renderTemplates: [],
-  schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/schema.json',
-  contextUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+  schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/schema.json',
+  contextUrl: 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/',
   websiteUrl: null,
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -27,7 +27,7 @@ const mockExtensionDataModel = {
   tenantId: 'tenant-1',
   name: 'Australian Agriculture Extension',
   credentialType: 'DigitalProductPassport',
-  version: '0.6.0',
+  version: '0.6.1',
   isExtension: true,
   parentConfigId: 'dm-core-1',
   parentConfig: mockCoreDataModel,
@@ -112,8 +112,8 @@ const mockProduct = {
 
 // -- Tests --------------------------------------------------------------------
 
-describe('DppV060Mapper', () => {
-  const mapper = new DppV060Mapper();
+describe('DppV061Mapper', () => {
+  const mapper = new DppV061Mapper();
   const coreConfig: DataModelConfig = { core: mockCoreDataModel };
 
   const fullEntities: ResolvedEntities = {
@@ -128,7 +128,7 @@ describe('DppV060Mapper', () => {
     it('returns @context array containing the core context URL', async () => {
       const result = await mapper.buildPayload(fullEntities, coreConfig);
 
-      expect(result['@context']).toEqual(['https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/']);
+      expect(result['@context']).toEqual(['https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/']);
     });
 
     it('merges extension context URL into @context when extension is present', async () => {
@@ -140,7 +140,7 @@ describe('DppV060Mapper', () => {
       const result = await mapper.buildPayload(fullEntities, configWithExt);
 
       expect(result['@context']).toEqual([
-        'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+        'https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/',
         'https://example.org/aus-agri/v1/',
       ]);
     });
@@ -171,7 +171,7 @@ describe('DppV060Mapper', () => {
       const result = await mapper.buildPayload(fullEntities, configWithDifferentType);
 
       expect(result['@context']).toEqual([
-        'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/',
+        'https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/',
         'https://example.org/conformity-ext/v1/',
       ]);
       expect(result.type).toEqual(['DigitalProductPassport', 'DigitalConformityCredential']);
@@ -413,7 +413,7 @@ describe('DppV060Mapper', () => {
   // -- extractEntityRefs ------------------------------------------------------
 
   describe('extractEntityRefs', () => {
-    const stubContext = ['https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/'];
+    const stubContext = ['https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/'];
     const stubType = ['DigitalProductPassport'];
 
     it('extracts registered IDs from a valid payload', () => {
@@ -498,10 +498,10 @@ describe('DppV060Mapper', () => {
   // -- Self-registration ------------------------------------------------------
 
   describe('self-registration', () => {
-    it('registers itself in the mapper registry as DigitalProductPassport / 0.6.0', () => {
-      const registered = getMapper('DigitalProductPassport', '0.6.0');
+    it('registers itself in the mapper registry as DigitalProductPassport / 0.6.1', () => {
+      const registered = getMapper('DigitalProductPassport', '0.6.1');
       expect(registered).toBeDefined();
-      expect(registered).toBeInstanceOf(DppV060Mapper);
+      expect(registered).toBeInstanceOf(DppV061Mapper);
     });
   });
 });

--- a/packages/reference-implementation/src/lib/mapping/mappers/dpp-v061.mapper.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dpp-v061.mapper.ts
@@ -4,7 +4,7 @@ import type { IdentifierScheme } from '@uncefact/untp-ri-services';
 import type { UntpLocation } from '@/lib/types';
 
 /**
- * DPP v0.6.0 UNTP schema types.
+ * DPP v0.6.1 UNTP schema types.
  * These mirror the JSON schema definitions for the Digital Product Passport.
  */
 type DppProduct = {
@@ -55,7 +55,7 @@ type DppFacility = {
 };
 
 /**
- * Mapper for Digital Product Passport v0.6.0.
+ * Mapper for Digital Product Passport v0.6.1.
  * Builds a UNTP DPP credential payload from product, facility, and organisation entities.
  *
  * Output structure follows the UNTP DPP JSON schema:
@@ -65,7 +65,7 @@ type DppFacility = {
  *   - organisation maps to producedByParty with idScheme + description
  *   - facility maps to producedAtFacility with idScheme, description, location, address
  */
-export class DppV060Mapper implements ICredentialMapper {
+export class DppV061Mapper implements ICredentialMapper {
   async buildPayload(entities: ResolvedEntities, config: DataModelConfig): Promise<MapperOutput> {
     const { organisation, facility, product } = entities;
 
@@ -200,4 +200,4 @@ export class DppV060Mapper implements ICredentialMapper {
 }
 
 // Self-register on import
-registerMapper('DigitalProductPassport', '0.6.0', new DppV060Mapper());
+registerMapper('DigitalProductPassport', '0.6.1', new DppV061Mapper());

--- a/packages/reference-implementation/src/lib/mapping/mappers/dte-v061.mapper.test.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dte-v061.mapper.test.ts
@@ -1,0 +1,224 @@
+import { DteV061Mapper } from './dte-v061.mapper';
+import { getMapper } from '../mapper-registry';
+import { ResolvedEntities, DataModelConfig, MapperOutput } from '../types';
+
+// -- Mock data model configs --------------------------------------------------
+
+const mockCoreDataModel = {
+  id: 'dm-core-dte',
+  tenantId: null,
+  name: 'Digital Traceability Event v0.6.1',
+  credentialType: 'DigitalTraceabilityEvent',
+  version: '0.6.1',
+  isExtension: false,
+  parentConfigId: null,
+  parentConfig: null,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://test.uncefact.org/vocabulary/untp/dte/0.6.1/schema.json',
+  contextUrl: 'https://test.uncefact.org/vocabulary/untp/dte/0.6.1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['core'];
+
+const mockExtensionDataModel = {
+  id: 'dm-ext-dte',
+  tenantId: 'tenant-1',
+  name: 'Custom Traceability Extension',
+  credentialType: 'DigitalTraceabilityEvent',
+  version: '0.6.1',
+  isExtension: true,
+  parentConfigId: 'dm-core-dte',
+  parentConfig: mockCoreDataModel,
+  extensions: [],
+  renderTemplates: [],
+  schemaUrl: 'https://example.org/traceability-ext/v1/schema.json',
+  contextUrl: 'https://example.org/traceability-ext/v1/',
+  websiteUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as DataModelConfig['extension'];
+
+// -- Mock entities ------------------------------------------------------------
+
+const mockOrganisation = {
+  id: 'org-1',
+  name: 'Test Organisation',
+  description: 'A test org',
+  tenantId: 'tenant-1',
+  primaryIdentifier: {
+    id: 'id-1',
+    value: '1234567890',
+    scheme: {
+      id: 'scheme-1',
+      primaryKey: 'gs1:gln',
+      name: 'Global Location Number (GLN)',
+      linkTemplate: '/{primaryKey}/{value}',
+    },
+  },
+} as unknown as ResolvedEntities['organisation'];
+
+const mockProduct = {
+  id: 'product-1',
+  name: 'Test Product',
+  description: 'A test product',
+  tenantId: 'tenant-1',
+  level: 'MODEL',
+  batchNumber: null,
+  serialNumber: null,
+  primaryIdentifier: {
+    id: 'id-3',
+    value: '01234567890123',
+    scheme: { id: 'scheme-3', primaryKey: 'gs1:gtin', name: 'GTIN', linkTemplate: '/{primaryKey}/{value}' },
+  },
+} as unknown as ResolvedEntities['product'];
+
+// -- Tests --------------------------------------------------------------------
+
+describe('DteV061Mapper', () => {
+  const mapper = new DteV061Mapper();
+  const coreConfig: DataModelConfig = { core: mockCoreDataModel };
+
+  const fullEntities: ResolvedEntities = {
+    organisation: mockOrganisation,
+    product: mockProduct,
+  };
+
+  // -- buildPayload: @context and type ----------------------------------------
+
+  describe('buildPayload', () => {
+    it('returns @context array containing the core context URL', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result['@context']).toEqual(['https://test.uncefact.org/vocabulary/untp/dte/0.6.1/']);
+    });
+
+    it('merges extension context URL into @context when extension is present', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result['@context']).toEqual([
+        'https://test.uncefact.org/vocabulary/untp/dte/0.6.1/',
+        'https://example.org/traceability-ext/v1/',
+      ]);
+    });
+
+    it('returns type array containing the core credentialType', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+
+      expect(result.type).toEqual(['DigitalTraceabilityEvent']);
+    });
+
+    it('deduplicates type when extension has the same credentialType as core', async () => {
+      const configWithExt: DataModelConfig = {
+        core: mockCoreDataModel,
+        extension: mockExtensionDataModel,
+      };
+
+      const result = await mapper.buildPayload(fullEntities, configWithExt);
+
+      expect(result.type).toEqual(['DigitalTraceabilityEvent']);
+    });
+
+    // -- buildPayload: credentialSubject type ----------------------------------
+
+    it('sets credentialSubject.type to Event', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.type).toEqual(['Event']);
+    });
+
+    // -- buildPayload: epcList ------------------------------------------------
+
+    it('maps product to an Item in epcList', async () => {
+      const result = await mapper.buildPayload(fullEntities, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+      const epcList = subject.epcList as Record<string, unknown>[];
+
+      expect(epcList).toHaveLength(1);
+      expect(epcList[0]).toEqual({
+        type: ['Item'],
+        id: 'product-1',
+        name: 'Test Product',
+      });
+    });
+
+    it('omits epcList when product is undefined', async () => {
+      const entitiesNoProduct: ResolvedEntities = {
+        organisation: mockOrganisation,
+      };
+
+      const result = await mapper.buildPayload(entitiesNoProduct, coreConfig);
+      const subject = result.credentialSubject as Record<string, unknown>;
+
+      expect(subject.epcList).toBeUndefined();
+    });
+  });
+
+  // -- extractEntityRefs ------------------------------------------------------
+
+  describe('extractEntityRefs', () => {
+    const stubContext = ['https://test.uncefact.org/vocabulary/untp/dte/0.6.1/'];
+    const stubType = ['DigitalTraceabilityEvent'];
+
+    it('extracts product id from the first item in epcList', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['Event'],
+          epcList: [{ type: ['Item'], id: 'product-1', name: 'Test Product' }],
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({
+        product: { registeredId: 'product-1' },
+      });
+    });
+
+    it('returns empty object when epcList is missing', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: { type: ['Event'] },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+
+    it('returns empty object when epcList is empty', () => {
+      const payload: MapperOutput = {
+        '@context': stubContext,
+        type: stubType,
+        credentialSubject: {
+          type: ['Event'],
+          epcList: [],
+        },
+      };
+
+      const refs = mapper.extractEntityRefs(payload);
+
+      expect(refs).toEqual({});
+    });
+  });
+
+  // -- Self-registration ------------------------------------------------------
+
+  describe('self-registration', () => {
+    it('registers itself in the mapper registry as DigitalTraceabilityEvent / 0.6.1', () => {
+      const registered = getMapper('DigitalTraceabilityEvent', '0.6.1');
+      expect(registered).toBeDefined();
+      expect(registered).toBeInstanceOf(DteV061Mapper);
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/mapping/mappers/dte-v061.mapper.ts
+++ b/packages/reference-implementation/src/lib/mapping/mappers/dte-v061.mapper.ts
@@ -1,0 +1,85 @@
+import { ICredentialMapper, ResolvedEntities, ExtractedIdentifierRefs, DataModelConfig, MapperOutput } from '../types';
+import { registerMapper } from '../mapper-registry';
+
+// TODO: Consolidate shared types and helpers across v0.6.1 mappers into a
+// common module (e.g. ./shared-v061.ts). Candidates:
+//   - Party type (DccParty, DfrParty) and buildParty helper
+//   - IdentifierScheme type import and buildIdentifierScheme helper (identical in DCC, DFR, DIA)
+//   - Context/type array construction logic (identical in all four mappers)
+
+/**
+ * DTE v0.6.1 UNTP schema types.
+ * These mirror the JSON schema definitions for the Digital Traceability Event.
+ */
+type DteItem = {
+  type: ['Item'];
+  id: string | undefined;
+  name: string | undefined;
+};
+
+/**
+ * Mapper for Digital Traceability Event v0.6.1.
+ * Builds a UNTP DTE credential payload from product and organisation entities.
+ *
+ * Output structure follows the UNTP DTE JSON schema:
+ *   - credentialSubject is an Event
+ *   - product maps to an Item in epcList
+ *   - organisation is referenced via the credential issuer (handled downstream)
+ *
+ * Note: DTE events are polymorphic (TransformationEvent, ObjectEvent, etc.)
+ * and event-specific fields (processType, eventTime, action, etc.) are not
+ * derived from entity resolution. This mapper provides the entity-derived
+ * skeleton; event details are populated separately during credential issuance.
+ */
+export class DteV061Mapper implements ICredentialMapper {
+  async buildPayload(entities: ResolvedEntities, config: DataModelConfig): Promise<MapperOutput> {
+    const { product } = entities;
+
+    const contexts: string[] = [config.core.contextUrl];
+    const types: string[] = [config.core.credentialType];
+
+    if (config.extension) {
+      contexts.push(config.extension.contextUrl);
+      if (config.extension.credentialType !== config.core.credentialType) {
+        types.push(config.extension.credentialType);
+      }
+    }
+
+    return {
+      '@context': contexts,
+      type: types,
+      credentialSubject: {
+        type: ['Event'],
+        ...(product ? { epcList: [this.buildItem(product)] } : {}),
+      },
+    };
+  }
+
+  private buildItem(product: NonNullable<ResolvedEntities['product']>): DteItem {
+    return {
+      type: ['Item'],
+      id: product.id,
+      name: product.name,
+    };
+  }
+
+  extractEntityRefs(payload: MapperOutput): ExtractedIdentifierRefs {
+    const subject = payload.credentialSubject;
+    if (!subject) return {};
+
+    const epcList = subject.epcList as DteItem[] | undefined;
+    if (!epcList || epcList.length === 0) return {};
+
+    const refs: ExtractedIdentifierRefs = {};
+
+    const firstItem = epcList[0];
+    if (firstItem?.id) {
+      refs.product = { registeredId: firstItem.id };
+    }
+
+    return refs;
+  }
+}
+
+// Self-register on import
+registerMapper('DigitalTraceabilityEvent', '0.6.1', new DteV061Mapper());

--- a/packages/reference-implementation/src/lib/mapping/types.ts
+++ b/packages/reference-implementation/src/lib/mapping/types.ts
@@ -1,6 +1,40 @@
+import { DataModelWithRelations } from '@/lib/prisma/repositories';
 import { ResolvedEntities, EntityReferences } from '@/lib/services/entity-resolution.service';
+import type { CredentialSubject } from '@uncefact/untp-ri-services';
 
 export type { ResolvedEntities, EntityReferences };
+
+/**
+ * Data model configuration for credential payload building.
+ * Contains the core data model and an optional extension.
+ */
+export type DataModelConfig = {
+  core: DataModelWithRelations;
+  extension?: DataModelWithRelations;
+};
+
+/**
+ * Output from a credential mapper's buildPayload method.
+ * Contains the @context, type, and credentialSubject — the parts
+ * that the mapper is responsible for. The issuer, status, and
+ * renderMethod are added downstream by the VC service.
+ */
+export type MapperOutput = {
+  '@context': string[];
+  type: string[];
+  credentialSubject: CredentialSubject;
+};
+
+/**
+ * Identifier references extracted from a credential payload.
+ * Contains registered IDs and qualifiers needed to find entities
+ * in the database given a credential payload.
+ */
+export type ExtractedIdentifierRefs = {
+  product?: { registeredId: string; batchNumber?: string; serialNumber?: string };
+  organisation?: { registeredId: string };
+  facility?: { registeredId: string };
+};
 
 /**
  * Interface for credential mappers.
@@ -9,14 +43,15 @@ export type { ResolvedEntities, EntityReferences };
  */
 export interface ICredentialMapper {
   /**
-   * Builds the credentialSubject payload from resolved entities.
-   * Sets UNTP-specific @context entries, type entries, and credentialSubject fields.
+   * Builds the credential payload from resolved entities.
+   * Uses the data model config for @context and type values.
    */
-  buildPayload(entities: ResolvedEntities, tenantId: string): Promise<Record<string, unknown>>;
+  buildPayload(entities: ResolvedEntities, config: DataModelConfig): Promise<MapperOutput>;
 
   /**
-   * Extracts entity ID references from a credential payload.
-   * Used for reverse-mapping (e.g., linking a stored credential back to its entities).
+   * Extracts identifier references from a credential payload.
+   * Returns registered IDs and qualifiers for each entity, used to
+   * associate a stored credential back to its database entities.
    */
-  extractEntityRefs(payload: Record<string, unknown>): EntityReferences;
+  extractEntityRefs(payload: MapperOutput): ExtractedIdentifierRefs;
 }

--- a/packages/reference-implementation/src/lib/mapping/types.ts
+++ b/packages/reference-implementation/src/lib/mapping/types.ts
@@ -1,0 +1,22 @@
+import { ResolvedEntities, EntityReferences } from '@/lib/services/entity-resolution.service';
+
+export type { ResolvedEntities, EntityReferences };
+
+/**
+ * Interface for credential mappers.
+ * Each credential type + version has a mapper that builds the credential payload
+ * from resolved master data entities.
+ */
+export interface ICredentialMapper {
+  /**
+   * Builds the credentialSubject payload from resolved entities.
+   * Sets UNTP-specific @context entries, type entries, and credentialSubject fields.
+   */
+  buildPayload(entities: ResolvedEntities, tenantId: string): Promise<Record<string, unknown>>;
+
+  /**
+   * Extracts entity ID references from a credential payload.
+   * Used for reverse-mapping (e.g., linking a stored credential back to its entities).
+   */
+  extractEntityRefs(payload: Record<string, unknown>): EntityReferences;
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/credential-type-config.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/credential-type-config.repository.test.ts
@@ -1,0 +1,388 @@
+import {
+  createCredentialTypeConfig,
+  getCredentialTypeConfigById,
+  listCredentialTypeConfigs,
+  updateCredentialTypeConfig,
+  deleteCredentialTypeConfig,
+} from './credential-type-config.repository';
+
+// Transaction mock — functions called via $transaction callback
+const mockTx = {
+  credentialTypeConfig: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
+// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+jest.mock('../prisma', () => ({
+  prisma: {
+    credentialTypeConfig: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+    },
+    $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
+  },
+}));
+
+// Import the mocked prisma after jest.mock
+import { prisma } from '../prisma';
+
+const mockCredentialTypeConfig = prisma.credentialTypeConfig as unknown as {
+  create: jest.Mock;
+  findFirst: jest.Mock;
+  findMany: jest.Mock;
+};
+
+const INCLUDE_SHAPE = {
+  parentConfig: true,
+  extensions: true,
+  renderTemplates: true,
+};
+
+describe('credential-type-config.repository', () => {
+  const TENANT_ID = 'tenant-1';
+  const CONFIG_RECORD = {
+    id: 'config-1',
+    tenantId: null,
+    name: 'Digital Product Passport v0.6.0',
+    credentialType: 'DigitalProductPassport',
+    version: '0.6.0',
+    isExtension: false,
+    parentConfigId: null,
+    parentConfig: null,
+    extensions: [],
+    renderTemplates: [],
+    schemaUrl: 'https://example.com/schema.json',
+    contextUrl: 'https://example.com/context.jsonld',
+    websiteUrl: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+
+  const EXTENSION_RECORD = {
+    ...CONFIG_RECORD,
+    id: 'config-ext-1',
+    tenantId: TENANT_ID,
+    name: 'Custom DPP Extension',
+    isExtension: true,
+    parentConfigId: 'config-1',
+    parentConfig: CONFIG_RECORD,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createCredentialTypeConfig', () => {
+    it('creates a core config successfully', async () => {
+      mockTx.credentialTypeConfig.create.mockResolvedValue(CONFIG_RECORD);
+
+      const result = await createCredentialTypeConfig(TENANT_ID, {
+        name: 'Digital Product Passport v0.6.0',
+        credentialType: 'DigitalProductPassport' as never,
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        isExtension: false,
+      });
+
+      expect(mockTx.credentialTypeConfig.create).toHaveBeenCalledWith({
+        data: {
+          tenantId: TENANT_ID,
+          name: 'Digital Product Passport v0.6.0',
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.0',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          isExtension: false,
+        },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(CONFIG_RECORD);
+    });
+
+    it('creates an extension config with valid parent', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(CONFIG_RECORD);
+      mockTx.credentialTypeConfig.create.mockResolvedValue(EXTENSION_RECORD);
+
+      const result = await createCredentialTypeConfig(TENANT_ID, {
+        name: 'Custom DPP Extension',
+        credentialType: 'DigitalProductPassport' as never,
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/ext-schema.json',
+        contextUrl: 'https://example.com/ext-context.jsonld',
+        isExtension: true,
+        parentConfigId: 'config-1',
+      });
+
+      expect(mockTx.credentialTypeConfig.findFirst).toHaveBeenCalledWith({
+        where: { id: 'config-1' },
+      });
+      expect(mockTx.credentialTypeConfig.create).toHaveBeenCalled();
+      expect(result).toEqual(EXTENSION_RECORD);
+    });
+
+    it('throws when isExtension is true but parentConfigId is missing', async () => {
+      await expect(
+        createCredentialTypeConfig(TENANT_ID, {
+          name: 'Extension Without Parent',
+          credentialType: 'DigitalProductPassport' as never,
+          version: '0.6.0',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          isExtension: true,
+        }),
+      ).rejects.toThrow('parentConfigId is required for extension configs');
+    });
+
+    it('throws when parent config does not exist', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createCredentialTypeConfig(TENANT_ID, {
+          name: 'Extension With Invalid Parent',
+          credentialType: 'DigitalProductPassport' as never,
+          version: '0.6.0',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          isExtension: true,
+          parentConfigId: 'nonexistent-id',
+        }),
+      ).rejects.toThrow('Parent config not found');
+    });
+
+    it('throws when parent config is itself an extension', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue({
+        ...CONFIG_RECORD,
+        isExtension: true,
+      });
+
+      await expect(
+        createCredentialTypeConfig(TENANT_ID, {
+          name: 'Extension With Extension Parent',
+          credentialType: 'DigitalProductPassport' as never,
+          version: '0.6.0',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          isExtension: true,
+          parentConfigId: 'config-1',
+        }),
+      ).rejects.toThrow('Parent config must be a core type (isExtension=false)');
+    });
+
+    it('defaults isExtension to true when not provided', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(CONFIG_RECORD);
+      mockTx.credentialTypeConfig.create.mockResolvedValue(EXTENSION_RECORD);
+
+      await createCredentialTypeConfig(TENANT_ID, {
+        name: 'Default Extension',
+        credentialType: 'DigitalProductPassport' as never,
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'config-1',
+      });
+
+      expect(mockTx.credentialTypeConfig.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          isExtension: true,
+          parentConfigId: 'config-1',
+        }),
+        include: INCLUDE_SHAPE,
+      });
+    });
+  });
+
+  describe('getCredentialTypeConfigById', () => {
+    it('returns config visible to tenant or system-provisioned', async () => {
+      mockCredentialTypeConfig.findFirst.mockResolvedValue(CONFIG_RECORD);
+
+      const result = await getCredentialTypeConfigById('config-1', TENANT_ID);
+
+      expect(mockCredentialTypeConfig.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'config-1',
+          OR: [{ tenantId: TENANT_ID }, { tenantId: null }],
+        },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(CONFIG_RECORD);
+    });
+
+    it('returns null when config is not found', async () => {
+      mockCredentialTypeConfig.findFirst.mockResolvedValue(null);
+
+      const result = await getCredentialTypeConfigById('nonexistent', TENANT_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listCredentialTypeConfigs', () => {
+    it('returns system and tenant configs', async () => {
+      mockCredentialTypeConfig.findMany.mockResolvedValue([CONFIG_RECORD, EXTENSION_RECORD]);
+
+      const result = await listCredentialTypeConfigs(TENANT_ID);
+
+      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ tenantId: TENANT_ID }, { tenantId: null }],
+        },
+        include: INCLUDE_SHAPE,
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('applies isExtension filter', async () => {
+      mockCredentialTypeConfig.findMany.mockResolvedValue([CONFIG_RECORD]);
+
+      await listCredentialTypeConfigs(TENANT_ID, { isExtension: false });
+
+      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          isExtension: false,
+        }),
+        include: INCLUDE_SHAPE,
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('applies credentialType filter', async () => {
+      mockCredentialTypeConfig.findMany.mockResolvedValue([]);
+
+      await listCredentialTypeConfigs(TENANT_ID, {
+        credentialType: 'DigitalProductPassport' as never,
+      });
+
+      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          credentialType: 'DigitalProductPassport',
+        }),
+        include: INCLUDE_SHAPE,
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('applies version filter', async () => {
+      mockCredentialTypeConfig.findMany.mockResolvedValue([]);
+
+      await listCredentialTypeConfigs(TENANT_ID, { version: '0.6.0' });
+
+      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          version: '0.6.0',
+        }),
+        include: INCLUDE_SHAPE,
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('applies pagination', async () => {
+      mockCredentialTypeConfig.findMany.mockResolvedValue([]);
+
+      await listCredentialTypeConfigs(TENANT_ID, { limit: 10, offset: 20 });
+
+      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+          skip: 20,
+        }),
+      );
+    });
+  });
+
+  describe('updateCredentialTypeConfig', () => {
+    it('updates a tenant-owned extension config', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      const updatedRecord = { ...EXTENSION_RECORD, name: 'Updated Name' };
+      mockTx.credentialTypeConfig.update.mockResolvedValue(updatedRecord);
+
+      const result = await updateCredentialTypeConfig('config-ext-1', TENANT_ID, {
+        name: 'Updated Name',
+      });
+
+      expect(mockTx.credentialTypeConfig.findFirst).toHaveBeenCalledWith({
+        where: { id: 'config-ext-1', tenantId: TENANT_ID, isExtension: true },
+      });
+      expect(mockTx.credentialTypeConfig.update).toHaveBeenCalledWith({
+        where: { id: 'config-ext-1' },
+        data: { name: 'Updated Name' },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result.name).toBe('Updated Name');
+    });
+
+    it('throws when config is not tenant-owned', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+
+      await expect(updateCredentialTypeConfig('config-1', 'other-tenant', { name: 'Updated' })).rejects.toThrow(
+        'Credential type config not found or access denied',
+      );
+    });
+
+    it('throws when config is not an extension', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+
+      await expect(updateCredentialTypeConfig('config-1', TENANT_ID, { name: 'Updated' })).rejects.toThrow(
+        'Credential type config not found or access denied',
+      );
+    });
+
+    it('applies partial update with conditional spreads', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.credentialTypeConfig.update.mockResolvedValue({
+        ...EXTENSION_RECORD,
+        schemaUrl: 'https://example.com/new-schema.json',
+      });
+
+      await updateCredentialTypeConfig('config-ext-1', TENANT_ID, {
+        schemaUrl: 'https://example.com/new-schema.json',
+      });
+
+      expect(mockTx.credentialTypeConfig.update).toHaveBeenCalledWith({
+        where: { id: 'config-ext-1' },
+        data: { schemaUrl: 'https://example.com/new-schema.json' },
+        include: INCLUDE_SHAPE,
+      });
+    });
+  });
+
+  describe('deleteCredentialTypeConfig', () => {
+    it('deletes a tenant-owned extension config', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.credentialTypeConfig.delete.mockResolvedValue(EXTENSION_RECORD);
+
+      const result = await deleteCredentialTypeConfig('config-ext-1', TENANT_ID);
+
+      expect(mockTx.credentialTypeConfig.findFirst).toHaveBeenCalledWith({
+        where: { id: 'config-ext-1', tenantId: TENANT_ID, isExtension: true },
+      });
+      expect(mockTx.credentialTypeConfig.delete).toHaveBeenCalledWith({
+        where: { id: 'config-ext-1' },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(EXTENSION_RECORD);
+    });
+
+    it('throws when config is not tenant-owned', async () => {
+      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+
+      await expect(deleteCredentialTypeConfig('config-1', 'other-tenant')).rejects.toThrow(
+        'Credential type config not found or access denied',
+      );
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/prisma/repositories/credential-type-config.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/credential-type-config.repository.ts
@@ -1,0 +1,214 @@
+import { CredentialType, Prisma } from '../generated';
+import { prisma } from '../prisma';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+
+/**
+ * Include shape used by all credential type config queries.
+ * Includes the parent config, extensions, and render templates.
+ */
+const CREDENTIAL_TYPE_CONFIG_INCLUDE = {
+  parentConfig: true,
+  extensions: true,
+  renderTemplates: true,
+} as const;
+
+/**
+ * A credential type config with its full relations.
+ * Matches the include shape defined by CREDENTIAL_TYPE_CONFIG_INCLUDE.
+ */
+export type CredentialTypeConfigWithRelations = Prisma.CredentialTypeConfigGetPayload<{
+  include: typeof CREDENTIAL_TYPE_CONFIG_INCLUDE;
+}>;
+
+/**
+ * Input for creating a new credential type config.
+ */
+export type CreateCredentialTypeConfigInput = {
+  name: string;
+  credentialType: CredentialType;
+  version: string;
+  schemaUrl: string;
+  contextUrl: string;
+  websiteUrl?: string;
+  isExtension?: boolean;
+  parentConfigId?: string;
+};
+
+/**
+ * Input for updating an existing credential type config.
+ * Only name, schemaUrl, contextUrl, and websiteUrl may be changed.
+ */
+export type UpdateCredentialTypeConfigInput = {
+  name?: string;
+  schemaUrl?: string;
+  contextUrl?: string;
+  websiteUrl?: string;
+};
+
+/**
+ * Options for listing credential type configs.
+ */
+export type ListCredentialTypeConfigOptions = {
+  isExtension?: boolean;
+  credentialType?: CredentialType;
+  version?: string;
+  limit?: number;
+  offset?: number;
+};
+
+/**
+ * Creates a new credential type config scoped to a tenant.
+ * If isExtension is true (the default), validates that parentConfigId is
+ * provided and that the parent is a core type (isExtension=false).
+ */
+export async function createCredentialTypeConfig(
+  tenantId: string,
+  input: CreateCredentialTypeConfigInput,
+): Promise<CredentialTypeConfigWithRelations> {
+  const isExtension = input.isExtension ?? true;
+
+  return prisma.$transaction(async (tx) => {
+    if (isExtension) {
+      if (!input.parentConfigId) {
+        throw new ValidationError('parentConfigId is required for extension configs');
+      }
+
+      const parent = await tx.credentialTypeConfig.findFirst({
+        where: { id: input.parentConfigId },
+      });
+
+      if (!parent) {
+        throw new NotFoundError('Parent config not found');
+      }
+
+      if (parent.isExtension) {
+        throw new ValidationError('Parent config must be a core type (isExtension=false)');
+      }
+    }
+
+    return tx.credentialTypeConfig.create({
+      data: {
+        tenantId,
+        name: input.name,
+        credentialType: input.credentialType,
+        version: input.version,
+        schemaUrl: input.schemaUrl,
+        contextUrl: input.contextUrl,
+        isExtension,
+        ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
+        ...(input.parentConfigId !== undefined && { parentConfigId: input.parentConfigId }),
+      },
+      include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Retrieves a credential type config by ID.
+ * Returns configs visible to the tenant OR system-provisioned (tenantId=null).
+ */
+export async function getCredentialTypeConfigById(
+  id: string,
+  tenantId: string,
+): Promise<CredentialTypeConfigWithRelations | null> {
+  return prisma.credentialTypeConfig.findFirst({
+    where: {
+      id,
+      OR: [{ tenantId }, { tenantId: null }],
+    },
+    include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+  });
+}
+
+/**
+ * Lists credential type configs for a tenant, including system-provisioned configs.
+ * Supports filtering by isExtension, credentialType, and version.
+ */
+export async function listCredentialTypeConfigs(
+  tenantId: string,
+  options: ListCredentialTypeConfigOptions = {},
+): Promise<CredentialTypeConfigWithRelations[]> {
+  const { isExtension, credentialType, version, limit, offset } = options;
+
+  const where: Prisma.CredentialTypeConfigWhereInput = {
+    OR: [{ tenantId }, { tenantId: null }],
+  };
+
+  if (isExtension !== undefined) {
+    where.isExtension = isExtension;
+  }
+
+  if (credentialType !== undefined) {
+    where.credentialType = credentialType;
+  }
+
+  if (version !== undefined) {
+    where.version = version;
+  }
+
+  return prisma.credentialTypeConfig.findMany({
+    where,
+    include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+    take: limit ?? 100,
+    skip: offset,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+/**
+ * Updates a credential type config.
+ * Only tenant-owned extension configs can be updated.
+ * System-provisioned and core configs are immutable from the tenant's perspective.
+ */
+export async function updateCredentialTypeConfig(
+  id: string,
+  tenantId: string,
+  input: UpdateCredentialTypeConfigInput,
+): Promise<CredentialTypeConfigWithRelations> {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.credentialTypeConfig.findFirst({
+      where: { id, tenantId, isExtension: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundError('Credential type config not found or access denied');
+    }
+
+    return tx.credentialTypeConfig.update({
+      where: { id },
+      data: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.schemaUrl !== undefined && { schemaUrl: input.schemaUrl }),
+        ...(input.contextUrl !== undefined && { contextUrl: input.contextUrl }),
+        ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
+      },
+      include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Deletes a credential type config.
+ * Only tenant-owned extension configs can be deleted.
+ * System-provisioned and core configs cannot be removed by tenants.
+ */
+export async function deleteCredentialTypeConfig(
+  id: string,
+  tenantId: string,
+): Promise<CredentialTypeConfigWithRelations> {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.credentialTypeConfig.findFirst({
+      where: { id, tenantId, isExtension: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundError('Credential type config not found or access denied');
+    }
+
+    return tx.credentialTypeConfig.delete({
+      where: { id },
+      include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+    });
+  });
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
@@ -1,14 +1,14 @@
 import {
-  createCredentialTypeConfig,
-  getCredentialTypeConfigById,
-  listCredentialTypeConfigs,
-  updateCredentialTypeConfig,
-  deleteCredentialTypeConfig,
-} from './credential-type-config.repository';
+  createDataModel,
+  getDataModelById,
+  listDataModels,
+  updateDataModel,
+  deleteDataModel,
+} from './data-model.repository';
 
 // Transaction mock — functions called via $transaction callback
 const mockTx = {
-  credentialTypeConfig: {
+  dataModel: {
     create: jest.fn(),
     findFirst: jest.fn(),
     findMany: jest.fn(),
@@ -20,7 +20,7 @@ const mockTx = {
 // Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
 jest.mock('../prisma', () => ({
   prisma: {
-    credentialTypeConfig: {
+    dataModel: {
       create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
@@ -32,7 +32,7 @@ jest.mock('../prisma', () => ({
 // Import the mocked prisma after jest.mock
 import { prisma } from '../prisma';
 
-const mockCredentialTypeConfig = prisma.credentialTypeConfig as unknown as {
+const mockDataModel = prisma.dataModel as unknown as {
   create: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
@@ -44,7 +44,7 @@ const INCLUDE_SHAPE = {
   renderTemplates: true,
 };
 
-describe('credential-type-config.repository', () => {
+describe('data-model.repository', () => {
   const TENANT_ID = 'tenant-1';
   const CONFIG_RECORD = {
     id: 'config-1',
@@ -78,11 +78,11 @@ describe('credential-type-config.repository', () => {
     jest.clearAllMocks();
   });
 
-  describe('createCredentialTypeConfig', () => {
+  describe('createDataModel', () => {
     it('creates a core config successfully', async () => {
-      mockTx.credentialTypeConfig.create.mockResolvedValue(CONFIG_RECORD);
+      mockTx.dataModel.create.mockResolvedValue(CONFIG_RECORD);
 
-      const result = await createCredentialTypeConfig(TENANT_ID, {
+      const result = await createDataModel(TENANT_ID, {
         name: 'Digital Product Passport v0.6.0',
         credentialType: 'DigitalProductPassport' as never,
         version: '0.6.0',
@@ -91,7 +91,7 @@ describe('credential-type-config.repository', () => {
         isExtension: false,
       });
 
-      expect(mockTx.credentialTypeConfig.create).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.create).toHaveBeenCalledWith({
         data: {
           tenantId: TENANT_ID,
           name: 'Digital Product Passport v0.6.0',
@@ -107,10 +107,10 @@ describe('credential-type-config.repository', () => {
     });
 
     it('creates an extension config with valid parent', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(CONFIG_RECORD);
-      mockTx.credentialTypeConfig.create.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.findFirst.mockResolvedValue(CONFIG_RECORD);
+      mockTx.dataModel.create.mockResolvedValue(EXTENSION_RECORD);
 
-      const result = await createCredentialTypeConfig(TENANT_ID, {
+      const result = await createDataModel(TENANT_ID, {
         name: 'Custom DPP Extension',
         credentialType: 'DigitalProductPassport' as never,
         version: '0.6.0',
@@ -120,16 +120,16 @@ describe('credential-type-config.repository', () => {
         parentConfigId: 'config-1',
       });
 
-      expect(mockTx.credentialTypeConfig.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.findFirst).toHaveBeenCalledWith({
         where: { id: 'config-1' },
       });
-      expect(mockTx.credentialTypeConfig.create).toHaveBeenCalled();
+      expect(mockTx.dataModel.create).toHaveBeenCalled();
       expect(result).toEqual(EXTENSION_RECORD);
     });
 
     it('throws when isExtension is true but parentConfigId is missing', async () => {
       await expect(
-        createCredentialTypeConfig(TENANT_ID, {
+        createDataModel(TENANT_ID, {
           name: 'Extension Without Parent',
           credentialType: 'DigitalProductPassport' as never,
           version: '0.6.0',
@@ -141,10 +141,10 @@ describe('credential-type-config.repository', () => {
     });
 
     it('throws when parent config does not exist', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+      mockTx.dataModel.findFirst.mockResolvedValue(null);
 
       await expect(
-        createCredentialTypeConfig(TENANT_ID, {
+        createDataModel(TENANT_ID, {
           name: 'Extension With Invalid Parent',
           credentialType: 'DigitalProductPassport' as never,
           version: '0.6.0',
@@ -157,13 +157,13 @@ describe('credential-type-config.repository', () => {
     });
 
     it('throws when parent config is itself an extension', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue({
+      mockTx.dataModel.findFirst.mockResolvedValue({
         ...CONFIG_RECORD,
         isExtension: true,
       });
 
       await expect(
-        createCredentialTypeConfig(TENANT_ID, {
+        createDataModel(TENANT_ID, {
           name: 'Extension With Extension Parent',
           credentialType: 'DigitalProductPassport' as never,
           version: '0.6.0',
@@ -176,10 +176,10 @@ describe('credential-type-config.repository', () => {
     });
 
     it('defaults isExtension to true when not provided', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(CONFIG_RECORD);
-      mockTx.credentialTypeConfig.create.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.findFirst.mockResolvedValue(CONFIG_RECORD);
+      mockTx.dataModel.create.mockResolvedValue(EXTENSION_RECORD);
 
-      await createCredentialTypeConfig(TENANT_ID, {
+      await createDataModel(TENANT_ID, {
         name: 'Default Extension',
         credentialType: 'DigitalProductPassport' as never,
         version: '0.6.0',
@@ -188,7 +188,7 @@ describe('credential-type-config.repository', () => {
         parentConfigId: 'config-1',
       });
 
-      expect(mockTx.credentialTypeConfig.create).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           isExtension: true,
           parentConfigId: 'config-1',
@@ -198,13 +198,13 @@ describe('credential-type-config.repository', () => {
     });
   });
 
-  describe('getCredentialTypeConfigById', () => {
+  describe('getDataModelById', () => {
     it('returns config visible to tenant or system-provisioned', async () => {
-      mockCredentialTypeConfig.findFirst.mockResolvedValue(CONFIG_RECORD);
+      mockDataModel.findFirst.mockResolvedValue(CONFIG_RECORD);
 
-      const result = await getCredentialTypeConfigById('config-1', TENANT_ID);
+      const result = await getDataModelById('config-1', TENANT_ID);
 
-      expect(mockCredentialTypeConfig.findFirst).toHaveBeenCalledWith({
+      expect(mockDataModel.findFirst).toHaveBeenCalledWith({
         where: {
           id: 'config-1',
           OR: [{ tenantId: TENANT_ID }, { tenantId: null }],
@@ -215,20 +215,20 @@ describe('credential-type-config.repository', () => {
     });
 
     it('returns null when config is not found', async () => {
-      mockCredentialTypeConfig.findFirst.mockResolvedValue(null);
+      mockDataModel.findFirst.mockResolvedValue(null);
 
-      const result = await getCredentialTypeConfigById('nonexistent', TENANT_ID);
+      const result = await getDataModelById('nonexistent', TENANT_ID);
       expect(result).toBeNull();
     });
   });
 
-  describe('listCredentialTypeConfigs', () => {
+  describe('listDataModels', () => {
     it('returns system and tenant configs', async () => {
-      mockCredentialTypeConfig.findMany.mockResolvedValue([CONFIG_RECORD, EXTENSION_RECORD]);
+      mockDataModel.findMany.mockResolvedValue([CONFIG_RECORD, EXTENSION_RECORD]);
 
-      const result = await listCredentialTypeConfigs(TENANT_ID);
+      const result = await listDataModels(TENANT_ID);
 
-      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+      expect(mockDataModel.findMany).toHaveBeenCalledWith({
         where: {
           OR: [{ tenantId: TENANT_ID }, { tenantId: null }],
         },
@@ -241,11 +241,11 @@ describe('credential-type-config.repository', () => {
     });
 
     it('applies isExtension filter', async () => {
-      mockCredentialTypeConfig.findMany.mockResolvedValue([CONFIG_RECORD]);
+      mockDataModel.findMany.mockResolvedValue([CONFIG_RECORD]);
 
-      await listCredentialTypeConfigs(TENANT_ID, { isExtension: false });
+      await listDataModels(TENANT_ID, { isExtension: false });
 
-      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+      expect(mockDataModel.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
           isExtension: false,
         }),
@@ -257,13 +257,13 @@ describe('credential-type-config.repository', () => {
     });
 
     it('applies credentialType filter', async () => {
-      mockCredentialTypeConfig.findMany.mockResolvedValue([]);
+      mockDataModel.findMany.mockResolvedValue([]);
 
-      await listCredentialTypeConfigs(TENANT_ID, {
+      await listDataModels(TENANT_ID, {
         credentialType: 'DigitalProductPassport' as never,
       });
 
-      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+      expect(mockDataModel.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
           credentialType: 'DigitalProductPassport',
         }),
@@ -275,11 +275,11 @@ describe('credential-type-config.repository', () => {
     });
 
     it('applies version filter', async () => {
-      mockCredentialTypeConfig.findMany.mockResolvedValue([]);
+      mockDataModel.findMany.mockResolvedValue([]);
 
-      await listCredentialTypeConfigs(TENANT_ID, { version: '0.6.0' });
+      await listDataModels(TENANT_ID, { version: '0.6.0' });
 
-      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith({
+      expect(mockDataModel.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
           version: '0.6.0',
         }),
@@ -291,11 +291,11 @@ describe('credential-type-config.repository', () => {
     });
 
     it('applies pagination', async () => {
-      mockCredentialTypeConfig.findMany.mockResolvedValue([]);
+      mockDataModel.findMany.mockResolvedValue([]);
 
-      await listCredentialTypeConfigs(TENANT_ID, { limit: 10, offset: 20 });
+      await listDataModels(TENANT_ID, { limit: 10, offset: 20 });
 
-      expect(mockCredentialTypeConfig.findMany).toHaveBeenCalledWith(
+      expect(mockDataModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           take: 10,
           skip: 20,
@@ -304,20 +304,20 @@ describe('credential-type-config.repository', () => {
     });
   });
 
-  describe('updateCredentialTypeConfig', () => {
+  describe('updateDataModel', () => {
     it('updates a tenant-owned extension config', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
       const updatedRecord = { ...EXTENSION_RECORD, name: 'Updated Name' };
-      mockTx.credentialTypeConfig.update.mockResolvedValue(updatedRecord);
+      mockTx.dataModel.update.mockResolvedValue(updatedRecord);
 
-      const result = await updateCredentialTypeConfig('config-ext-1', TENANT_ID, {
+      const result = await updateDataModel('config-ext-1', TENANT_ID, {
         name: 'Updated Name',
       });
 
-      expect(mockTx.credentialTypeConfig.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.findFirst).toHaveBeenCalledWith({
         where: { id: 'config-ext-1', tenantId: TENANT_ID, isExtension: true },
       });
-      expect(mockTx.credentialTypeConfig.update).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.update).toHaveBeenCalledWith({
         where: { id: 'config-ext-1' },
         data: { name: 'Updated Name' },
         include: INCLUDE_SHAPE,
@@ -326,33 +326,33 @@ describe('credential-type-config.repository', () => {
     });
 
     it('throws when config is not tenant-owned', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+      mockTx.dataModel.findFirst.mockResolvedValue(null);
 
-      await expect(updateCredentialTypeConfig('config-1', 'other-tenant', { name: 'Updated' })).rejects.toThrow(
-        'Credential type config not found or access denied',
+      await expect(updateDataModel('config-1', 'other-tenant', { name: 'Updated' })).rejects.toThrow(
+        'Data model not found or access denied',
       );
     });
 
     it('throws when config is not an extension', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+      mockTx.dataModel.findFirst.mockResolvedValue(null);
 
-      await expect(updateCredentialTypeConfig('config-1', TENANT_ID, { name: 'Updated' })).rejects.toThrow(
-        'Credential type config not found or access denied',
+      await expect(updateDataModel('config-1', TENANT_ID, { name: 'Updated' })).rejects.toThrow(
+        'Data model not found or access denied',
       );
     });
 
     it('applies partial update with conditional spreads', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(EXTENSION_RECORD);
-      mockTx.credentialTypeConfig.update.mockResolvedValue({
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.update.mockResolvedValue({
         ...EXTENSION_RECORD,
         schemaUrl: 'https://example.com/new-schema.json',
       });
 
-      await updateCredentialTypeConfig('config-ext-1', TENANT_ID, {
+      await updateDataModel('config-ext-1', TENANT_ID, {
         schemaUrl: 'https://example.com/new-schema.json',
       });
 
-      expect(mockTx.credentialTypeConfig.update).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.update).toHaveBeenCalledWith({
         where: { id: 'config-ext-1' },
         data: { schemaUrl: 'https://example.com/new-schema.json' },
         include: INCLUDE_SHAPE,
@@ -360,17 +360,17 @@ describe('credential-type-config.repository', () => {
     });
   });
 
-  describe('deleteCredentialTypeConfig', () => {
+  describe('deleteDataModel', () => {
     it('deletes a tenant-owned extension config', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(EXTENSION_RECORD);
-      mockTx.credentialTypeConfig.delete.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.delete.mockResolvedValue(EXTENSION_RECORD);
 
-      const result = await deleteCredentialTypeConfig('config-ext-1', TENANT_ID);
+      const result = await deleteDataModel('config-ext-1', TENANT_ID);
 
-      expect(mockTx.credentialTypeConfig.findFirst).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.findFirst).toHaveBeenCalledWith({
         where: { id: 'config-ext-1', tenantId: TENANT_ID, isExtension: true },
       });
-      expect(mockTx.credentialTypeConfig.delete).toHaveBeenCalledWith({
+      expect(mockTx.dataModel.delete).toHaveBeenCalledWith({
         where: { id: 'config-ext-1' },
         include: INCLUDE_SHAPE,
       });
@@ -378,10 +378,10 @@ describe('credential-type-config.repository', () => {
     });
 
     it('throws when config is not tenant-owned', async () => {
-      mockTx.credentialTypeConfig.findFirst.mockResolvedValue(null);
+      mockTx.dataModel.findFirst.mockResolvedValue(null);
 
-      await expect(deleteCredentialTypeConfig('config-1', 'other-tenant')).rejects.toThrow(
-        'Credential type config not found or access denied',
+      await expect(deleteDataModel('config-1', 'other-tenant')).rejects.toThrow(
+        'Data model not found or access denied',
       );
     });
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -4,27 +4,27 @@ import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 
 /**
- * Include shape used by all credential type config queries.
+ * Include shape used by all data model queries.
  * Includes the parent config, extensions, and render templates.
  */
-const CREDENTIAL_TYPE_CONFIG_INCLUDE = {
+const DATA_MODEL_INCLUDE = {
   parentConfig: true,
   extensions: true,
   renderTemplates: true,
 } as const;
 
 /**
- * A credential type config with its full relations.
- * Matches the include shape defined by CREDENTIAL_TYPE_CONFIG_INCLUDE.
+ * A data model with its full relations.
+ * Matches the include shape defined by DATA_MODEL_INCLUDE.
  */
-export type CredentialTypeConfigWithRelations = Prisma.CredentialTypeConfigGetPayload<{
-  include: typeof CREDENTIAL_TYPE_CONFIG_INCLUDE;
+export type DataModelWithRelations = Prisma.DataModelGetPayload<{
+  include: typeof DATA_MODEL_INCLUDE;
 }>;
 
 /**
- * Input for creating a new credential type config.
+ * Input for creating a new data model.
  */
-export type CreateCredentialTypeConfigInput = {
+export type CreateDataModelInput = {
   name: string;
   credentialType: CredentialType;
   version: string;
@@ -36,10 +36,10 @@ export type CreateCredentialTypeConfigInput = {
 };
 
 /**
- * Input for updating an existing credential type config.
+ * Input for updating an existing data model.
  * Only name, schemaUrl, contextUrl, and websiteUrl may be changed.
  */
-export type UpdateCredentialTypeConfigInput = {
+export type UpdateDataModelInput = {
   name?: string;
   schemaUrl?: string;
   contextUrl?: string;
@@ -47,9 +47,9 @@ export type UpdateCredentialTypeConfigInput = {
 };
 
 /**
- * Options for listing credential type configs.
+ * Options for listing data models.
  */
-export type ListCredentialTypeConfigOptions = {
+export type ListDataModelOptions = {
   isExtension?: boolean;
   credentialType?: CredentialType;
   version?: string;
@@ -58,14 +58,11 @@ export type ListCredentialTypeConfigOptions = {
 };
 
 /**
- * Creates a new credential type config scoped to a tenant.
+ * Creates a new data model scoped to a tenant.
  * If isExtension is true (the default), validates that parentConfigId is
  * provided and that the parent is a core type (isExtension=false).
  */
-export async function createCredentialTypeConfig(
-  tenantId: string,
-  input: CreateCredentialTypeConfigInput,
-): Promise<CredentialTypeConfigWithRelations> {
+export async function createDataModel(tenantId: string, input: CreateDataModelInput): Promise<DataModelWithRelations> {
   const isExtension = input.isExtension ?? true;
 
   return prisma.$transaction(async (tx) => {
@@ -74,7 +71,7 @@ export async function createCredentialTypeConfig(
         throw new ValidationError('parentConfigId is required for extension configs');
       }
 
-      const parent = await tx.credentialTypeConfig.findFirst({
+      const parent = await tx.dataModel.findFirst({
         where: { id: input.parentConfigId },
       });
 
@@ -87,7 +84,7 @@ export async function createCredentialTypeConfig(
       }
     }
 
-    return tx.credentialTypeConfig.create({
+    return tx.dataModel.create({
       data: {
         tenantId,
         name: input.name,
@@ -99,39 +96,36 @@ export async function createCredentialTypeConfig(
         ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
         ...(input.parentConfigId !== undefined && { parentConfigId: input.parentConfigId }),
       },
-      include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+      include: DATA_MODEL_INCLUDE,
     });
   });
 }
 
 /**
- * Retrieves a credential type config by ID.
- * Returns configs visible to the tenant OR system-provisioned (tenantId=null).
+ * Retrieves a data model by ID.
+ * Returns models visible to the tenant OR system-provisioned (tenantId=null).
  */
-export async function getCredentialTypeConfigById(
-  id: string,
-  tenantId: string,
-): Promise<CredentialTypeConfigWithRelations | null> {
-  return prisma.credentialTypeConfig.findFirst({
+export async function getDataModelById(id: string, tenantId: string): Promise<DataModelWithRelations | null> {
+  return prisma.dataModel.findFirst({
     where: {
       id,
       OR: [{ tenantId }, { tenantId: null }],
     },
-    include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+    include: DATA_MODEL_INCLUDE,
   });
 }
 
 /**
- * Lists credential type configs for a tenant, including system-provisioned configs.
+ * Lists data models for a tenant, including system-provisioned configs.
  * Supports filtering by isExtension, credentialType, and version.
  */
-export async function listCredentialTypeConfigs(
+export async function listDataModels(
   tenantId: string,
-  options: ListCredentialTypeConfigOptions = {},
-): Promise<CredentialTypeConfigWithRelations[]> {
+  options: ListDataModelOptions = {},
+): Promise<DataModelWithRelations[]> {
   const { isExtension, credentialType, version, limit, offset } = options;
 
-  const where: Prisma.CredentialTypeConfigWhereInput = {
+  const where: Prisma.DataModelWhereInput = {
     OR: [{ tenantId }, { tenantId: null }],
   };
 
@@ -147,9 +141,9 @@ export async function listCredentialTypeConfigs(
     where.version = version;
   }
 
-  return prisma.credentialTypeConfig.findMany({
+  return prisma.dataModel.findMany({
     where,
-    include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+    include: DATA_MODEL_INCLUDE,
     take: limit ?? 100,
     skip: offset,
     orderBy: { createdAt: 'desc' },
@@ -157,25 +151,25 @@ export async function listCredentialTypeConfigs(
 }
 
 /**
- * Updates a credential type config.
+ * Updates a data model.
  * Only tenant-owned extension configs can be updated.
  * System-provisioned and core configs are immutable from the tenant's perspective.
  */
-export async function updateCredentialTypeConfig(
+export async function updateDataModel(
   id: string,
   tenantId: string,
-  input: UpdateCredentialTypeConfigInput,
-): Promise<CredentialTypeConfigWithRelations> {
+  input: UpdateDataModelInput,
+): Promise<DataModelWithRelations> {
   return prisma.$transaction(async (tx) => {
-    const existing = await tx.credentialTypeConfig.findFirst({
+    const existing = await tx.dataModel.findFirst({
       where: { id, tenantId, isExtension: true },
     });
 
     if (!existing) {
-      throw new NotFoundError('Credential type config not found or access denied');
+      throw new NotFoundError('Data model not found or access denied');
     }
 
-    return tx.credentialTypeConfig.update({
+    return tx.dataModel.update({
       where: { id },
       data: {
         ...(input.name !== undefined && { name: input.name }),
@@ -183,32 +177,29 @@ export async function updateCredentialTypeConfig(
         ...(input.contextUrl !== undefined && { contextUrl: input.contextUrl }),
         ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
       },
-      include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+      include: DATA_MODEL_INCLUDE,
     });
   });
 }
 
 /**
- * Deletes a credential type config.
+ * Deletes a data model.
  * Only tenant-owned extension configs can be deleted.
  * System-provisioned and core configs cannot be removed by tenants.
  */
-export async function deleteCredentialTypeConfig(
-  id: string,
-  tenantId: string,
-): Promise<CredentialTypeConfigWithRelations> {
+export async function deleteDataModel(id: string, tenantId: string): Promise<DataModelWithRelations> {
   return prisma.$transaction(async (tx) => {
-    const existing = await tx.credentialTypeConfig.findFirst({
+    const existing = await tx.dataModel.findFirst({
       where: { id, tenantId, isExtension: true },
     });
 
     if (!existing) {
-      throw new NotFoundError('Credential type config not found or access denied');
+      throw new NotFoundError('Data model not found or access denied');
     }
 
-    return tx.credentialTypeConfig.delete({
+    return tx.dataModel.delete({
       where: { id },
-      include: CREDENTIAL_TYPE_CONFIG_INCLUDE,
+      include: DATA_MODEL_INCLUDE,
     });
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
@@ -198,8 +198,8 @@ describe('facility.repository', () => {
       expect(mockFacility.findFirst).toHaveBeenCalledWith({
         where: { id: 'facility-1', tenantId: TENANT_ID },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
           operatingOrganisation: true,
         },
       });
@@ -223,8 +223,8 @@ describe('facility.repository', () => {
       expect(mockFacility.findMany).toHaveBeenCalledWith({
         where: { tenantId: TENANT_ID },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
           operatingOrganisation: true,
         },
         take: 100,
@@ -310,8 +310,8 @@ describe('facility.repository', () => {
         where: { id: 'facility-1' },
         data: { name: 'Renamed Warehouse' },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
           operatingOrganisation: true,
         },
       });

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
@@ -6,11 +6,12 @@ import { UntpLocation } from '@/lib/types';
 
 /**
  * Include shape for facility queries — eagerly loads primary and secondary
- * identifiers (with their schemes) and the operating organisation.
+ * identifiers (with their schemes and registrars) and the operating organisation.
+ * The registrar is needed to construct ISO 18975 resolver URIs for UNTP credentials.
  */
 const FACILITY_INCLUDE = {
-  primaryIdentifier: { include: { scheme: true } },
-  secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+  primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+  secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
   operatingOrganisation: true,
 } as const;
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
@@ -49,6 +49,7 @@ describe('identifier-scheme.repository', () => {
     name: 'GTIN',
     primaryKey: 'gtin',
     validationPattern: '^\\d{13,14}$',
+    linkTemplate: '/{primaryKey}/{value}',
     namespace: 'gs1',
     idrServiceInstanceId: null,
     isDefault: false,
@@ -61,6 +62,7 @@ describe('identifier-scheme.repository', () => {
         key: 'batch',
         description: 'Batch number',
         validationPattern: null,
+        order: 0,
         createdAt: new Date('2024-01-01'),
         updatedAt: new Date('2024-01-01'),
       },
@@ -92,6 +94,7 @@ describe('identifier-scheme.repository', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{13,14}$',
+        linkTemplate: '/{primaryKey}/{value}',
         namespace: 'gs1',
         qualifiers: [{ key: 'batch', description: 'Batch number', validationPattern: '^[A-Za-z0-9]{1,20}$' }],
       });
@@ -103,6 +106,7 @@ describe('identifier-scheme.repository', () => {
           name: 'GTIN',
           primaryKey: 'gtin',
           validationPattern: '^\\d{13,14}$',
+          linkTemplate: '/{primaryKey}/{value}',
           namespace: 'gs1',
           isDefault: false,
           qualifiers: {
@@ -127,6 +131,7 @@ describe('identifier-scheme.repository', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{13,14}$',
+        linkTemplate: '/{primaryKey}/{value}',
       });
 
       expect(mockIdentifierScheme.create).toHaveBeenCalledWith({
@@ -149,6 +154,7 @@ describe('identifier-scheme.repository', () => {
         name: 'GTIN',
         primaryKey: 'gtin',
         validationPattern: '^\\d{13,14}$',
+        linkTemplate: '/{primaryKey}/{value}',
       });
 
       expect(mockIdentifierScheme.create).toHaveBeenCalledWith({

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
@@ -13,6 +13,7 @@ export type CreateIdentifierSchemeInput = {
   name: string;
   primaryKey: string;
   validationPattern: string;
+  linkTemplate: string;
   namespace?: string;
   idrServiceInstanceId?: string;
   isDefault?: boolean;
@@ -20,6 +21,7 @@ export type CreateIdentifierSchemeInput = {
     key: string;
     description: string;
     validationPattern: string;
+    order?: number;
   }>;
 };
 
@@ -30,12 +32,14 @@ export type UpdateIdentifierSchemeInput = {
   name?: string;
   primaryKey?: string;
   validationPattern?: string;
+  linkTemplate?: string;
   namespace?: string;
   idrServiceInstanceId?: string | null;
   qualifiers?: Array<{
     key: string;
     description: string;
     validationPattern: string;
+    order?: number;
   }>;
 };
 
@@ -59,6 +63,7 @@ export async function createIdentifierScheme(input: CreateIdentifierSchemeInput)
       name: input.name,
       primaryKey: input.primaryKey,
       validationPattern: input.validationPattern,
+      linkTemplate: input.linkTemplate,
       namespace: input.namespace,
       idrServiceInstanceId: input.idrServiceInstanceId,
       isDefault: input.isDefault ?? false,
@@ -68,6 +73,7 @@ export async function createIdentifierScheme(input: CreateIdentifierSchemeInput)
             key: q.key,
             description: q.description,
             validationPattern: q.validationPattern,
+            ...(q.order !== undefined && { order: q.order }),
           })),
         },
       }),
@@ -159,6 +165,7 @@ export async function updateIdentifierScheme(
         ...(input.name !== undefined && { name: input.name }),
         ...(input.primaryKey !== undefined && { primaryKey: input.primaryKey }),
         ...(input.validationPattern !== undefined && { validationPattern: input.validationPattern }),
+        ...(input.linkTemplate !== undefined && { linkTemplate: input.linkTemplate }),
         ...(input.namespace !== undefined && { namespace: input.namespace }),
         ...(input.idrServiceInstanceId !== undefined && {
           idrServiceInstanceId: input.idrServiceInstanceId,
@@ -169,6 +176,7 @@ export async function updateIdentifierScheme(
               key: q.key,
               description: q.description,
               validationPattern: q.validationPattern,
+              ...(q.order !== undefined && { order: q.order }),
             })),
           },
         }),

--- a/packages/reference-implementation/src/lib/prisma/repositories/index.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/index.ts
@@ -8,5 +8,5 @@ export * from './link-registration.repository';
 export * from './organisation.repository';
 export * from './facility.repository';
 export * from './product.repository';
-export * from './credential-type-config.repository';
+export * from './data-model.repository';
 export * from './render-template.repository';

--- a/packages/reference-implementation/src/lib/prisma/repositories/index.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/index.ts
@@ -9,3 +9,4 @@ export * from './organisation.repository';
 export * from './facility.repository';
 export * from './product.repository';
 export * from './credential-type-config.repository';
+export * from './render-template.repository';

--- a/packages/reference-implementation/src/lib/prisma/repositories/index.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/index.ts
@@ -8,3 +8,4 @@ export * from './link-registration.repository';
 export * from './organisation.repository';
 export * from './facility.repository';
 export * from './product.repository';
+export * from './credential-type-config.repository';

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
@@ -150,8 +150,8 @@ describe('organisation.repository', () => {
           primaryIdentifierId: 'ident-1',
         }),
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
       });
       expect(mockTx.organisationSecondaryIdentifier.createMany).toHaveBeenCalledWith({
@@ -293,8 +293,8 @@ describe('organisation.repository', () => {
       expect(mockOrganisationEntity.findFirst).toHaveBeenCalledWith({
         where: { id: 'org-1', tenantId: TENANT_ID },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
       });
       expect(result).toEqual(ORG_RECORD);
@@ -317,8 +317,8 @@ describe('organisation.repository', () => {
       expect(mockOrganisationEntity.findMany).toHaveBeenCalledWith({
         where: { tenantId: TENANT_ID },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
         take: 100,
         skip: undefined,
@@ -413,8 +413,8 @@ describe('organisation.repository', () => {
         where: { id: 'org-1' },
         data: { name: 'Acme Industries' },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
       });
       expect(result.name).toBe('Acme Industries');
@@ -527,8 +527,8 @@ describe('organisation.repository', () => {
       expect(mockTx.organisationEntity.delete).toHaveBeenCalledWith({
         where: { id: 'org-1' },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
       });
       expect(result).toEqual(ORG_RECORD);

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
@@ -6,12 +6,13 @@ import { UntpLocation } from '@/lib/types';
 
 /**
  * Include shape used by all organisation queries.
- * Includes the primary identifier (with scheme) and all secondary identifiers
- * (via the join table, each with its identifier and scheme).
+ * Includes the primary identifier (with scheme and registrar) and all secondary
+ * identifiers (via the join table, each with its identifier, scheme, and registrar).
+ * The registrar is needed to construct ISO 18975 resolver URIs for UNTP credentials.
  */
 const ORGANISATION_INCLUDE = {
-  primaryIdentifier: { include: { scheme: true } },
-  secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+  primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+  secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
 } as const;
 
 /**

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
@@ -280,11 +280,11 @@ describe('product.repository', () => {
       expect(mockProduct.findFirst).toHaveBeenCalledWith({
         where: { id: PRODUCT_ID, tenantId: TENANT_ID },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
           producedByOrganisation: true,
           manufacturingFacility: true,
-          parent: true,
+          parent: { include: { primaryIdentifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
       });
       expect(result).toEqual(PRODUCT_WITH_RELATIONS);
@@ -307,11 +307,11 @@ describe('product.repository', () => {
       expect(mockProduct.findMany).toHaveBeenCalledWith({
         where: { tenantId: TENANT_ID },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
           producedByOrganisation: true,
           manufacturingFacility: true,
-          parent: true,
+          parent: { include: { primaryIdentifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
         take: 100,
         skip: undefined,
@@ -435,11 +435,11 @@ describe('product.repository', () => {
         where: { id: PRODUCT_ID },
         data: { name: 'Updated Name' },
         include: {
-          primaryIdentifier: { include: { scheme: true } },
-          secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
           producedByOrganisation: true,
           manufacturingFacility: true,
-          parent: true,
+          parent: { include: { primaryIdentifier: { include: { scheme: { include: { registrar: true } } } } } },
         },
       });
       expect(result.name).toBe('Updated Name');

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -4,17 +4,25 @@ import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 
 /**
+ * Shared include fragment for an identifier with its scheme and registrar.
+ * Used for primary identifiers on both the product and its parent.
+ */
+const IDENTIFIER_INCLUDE = { include: { scheme: { include: { registrar: true } } } } as const;
+
+/**
  * Include shape used by all product queries.
- * Includes the primary identifier (with scheme), secondary identifiers
- * (via the join table, each with its identifier and scheme),
- * brand organisation, manufacturing facility, and parent product.
+ * Includes the primary identifier (with scheme and registrar), secondary
+ * identifiers (via the join table, each with its identifier, scheme, and
+ * registrar), brand organisation, manufacturing facility, and parent product
+ * (with its primary identifier for qualifier-based URI construction).
+ * The registrar is needed to construct ISO 18975 resolver URIs for UNTP credentials.
  */
 const PRODUCT_INCLUDE = {
-  primaryIdentifier: { include: { scheme: true } },
-  secondaryIdentifiers: { include: { identifier: { include: { scheme: true } } } },
+  primaryIdentifier: IDENTIFIER_INCLUDE,
+  secondaryIdentifiers: { include: { identifier: IDENTIFIER_INCLUDE } },
   producedByOrganisation: true,
   manufacturingFacility: true,
-  parent: true,
+  parent: { include: { primaryIdentifier: IDENTIFIER_INCLUDE } },
 } as const;
 
 /**

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
@@ -1,0 +1,352 @@
+import {
+  createRenderTemplate,
+  getRenderTemplateById,
+  listRenderTemplates,
+  updateRenderTemplate,
+  deleteRenderTemplate,
+  getPrimaryRenderTemplate,
+} from './render-template.repository';
+
+// Transaction mock — functions called via $transaction callback
+const mockTx = {
+  renderTemplate: {
+    create: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
+// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+jest.mock('../prisma', () => ({
+  prisma: {
+    renderTemplate: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+      delete: jest.fn(),
+    },
+    $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
+  },
+}));
+
+// Import the mocked prisma after jest.mock
+import { prisma } from '../prisma';
+
+const mockRenderTemplate = prisma.renderTemplate as unknown as {
+  create: jest.Mock;
+  findFirst: jest.Mock;
+  findMany: jest.Mock;
+  update: jest.Mock;
+  updateMany: jest.Mock;
+  delete: jest.Mock;
+};
+
+const INCLUDE_SHAPE = {
+  credentialTypeConfig: true,
+};
+
+describe('render-template.repository', () => {
+  const TENANT_ID = 'tenant-1';
+  const CONFIG_ID = 'config-1';
+  const TEMPLATE_RECORD = {
+    id: 'template-1',
+    tenantId: TENANT_ID,
+    credentialTypeConfigId: CONFIG_ID,
+    name: 'DPP Default Template',
+    storageUrl: 'https://storage.example.com/templates/dpp-default.html',
+    hash: 'sha256-abc123',
+    isPrimary: false,
+    credentialTypeConfig: {
+      id: CONFIG_ID,
+      name: 'Digital Product Passport v0.6.0',
+    },
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createRenderTemplate', () => {
+    it('creates a template successfully', async () => {
+      mockTx.renderTemplate.create.mockResolvedValue(TEMPLATE_RECORD);
+
+      const result = await createRenderTemplate(TENANT_ID, {
+        name: 'DPP Default Template',
+        credentialTypeConfigId: CONFIG_ID,
+        storageUrl: 'https://storage.example.com/templates/dpp-default.html',
+        hash: 'sha256-abc123',
+      });
+
+      expect(mockTx.renderTemplate.create).toHaveBeenCalledWith({
+        data: {
+          tenantId: TENANT_ID,
+          name: 'DPP Default Template',
+          credentialTypeConfigId: CONFIG_ID,
+          storageUrl: 'https://storage.example.com/templates/dpp-default.html',
+          hash: 'sha256-abc123',
+          isPrimary: false,
+        },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(TEMPLATE_RECORD);
+    });
+
+    it('defaults isPrimary to false', async () => {
+      mockTx.renderTemplate.create.mockResolvedValue(TEMPLATE_RECORD);
+
+      await createRenderTemplate(TENANT_ID, {
+        name: 'DPP Default Template',
+        credentialTypeConfigId: CONFIG_ID,
+        storageUrl: 'https://storage.example.com/templates/dpp-default.html',
+        hash: 'sha256-abc123',
+      });
+
+      expect(mockTx.renderTemplate.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          isPrimary: false,
+        }),
+        include: INCLUDE_SHAPE,
+      });
+    });
+
+    it('unsets existing primary when isPrimary is true', async () => {
+      const primaryRecord = { ...TEMPLATE_RECORD, isPrimary: true };
+      mockTx.renderTemplate.updateMany.mockResolvedValue({ count: 1 });
+      mockTx.renderTemplate.create.mockResolvedValue(primaryRecord);
+
+      await createRenderTemplate(TENANT_ID, {
+        name: 'DPP Primary Template',
+        credentialTypeConfigId: CONFIG_ID,
+        storageUrl: 'https://storage.example.com/templates/dpp-primary.html',
+        hash: 'sha256-def456',
+        isPrimary: true,
+      });
+
+      expect(mockTx.renderTemplate.updateMany).toHaveBeenCalledWith({
+        where: {
+          tenantId: TENANT_ID,
+          credentialTypeConfigId: CONFIG_ID,
+          isPrimary: true,
+        },
+        data: { isPrimary: false },
+      });
+      expect(mockTx.renderTemplate.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          isPrimary: true,
+        }),
+        include: INCLUDE_SHAPE,
+      });
+    });
+  });
+
+  describe('getRenderTemplateById', () => {
+    it('returns template scoped to tenant', async () => {
+      mockRenderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
+
+      const result = await getRenderTemplateById('template-1', TENANT_ID);
+
+      expect(mockRenderTemplate.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'template-1',
+          tenantId: TENANT_ID,
+        },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(TEMPLATE_RECORD);
+    });
+
+    it('returns null when template is not found', async () => {
+      mockRenderTemplate.findFirst.mockResolvedValue(null);
+
+      const result = await getRenderTemplateById('nonexistent', TENANT_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listRenderTemplates', () => {
+    it('lists templates for tenant', async () => {
+      mockRenderTemplate.findMany.mockResolvedValue([TEMPLATE_RECORD]);
+
+      const result = await listRenderTemplates(TENANT_ID);
+
+      expect(mockRenderTemplate.findMany).toHaveBeenCalledWith({
+        where: {
+          tenantId: TENANT_ID,
+        },
+        include: INCLUDE_SHAPE,
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toEqual([TEMPLATE_RECORD]);
+    });
+
+    it('filters by credentialTypeConfigId', async () => {
+      mockRenderTemplate.findMany.mockResolvedValue([TEMPLATE_RECORD]);
+
+      await listRenderTemplates(TENANT_ID, { credentialTypeConfigId: CONFIG_ID });
+
+      expect(mockRenderTemplate.findMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          tenantId: TENANT_ID,
+          credentialTypeConfigId: CONFIG_ID,
+        }),
+        include: INCLUDE_SHAPE,
+        take: 100,
+        skip: undefined,
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+
+    it('applies pagination', async () => {
+      mockRenderTemplate.findMany.mockResolvedValue([]);
+
+      await listRenderTemplates(TENANT_ID, { limit: 10, offset: 20 });
+
+      expect(mockRenderTemplate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+          skip: 20,
+        }),
+      );
+    });
+  });
+
+  describe('updateRenderTemplate', () => {
+    it('updates fields successfully', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
+      const updatedRecord = { ...TEMPLATE_RECORD, name: 'Updated Template' };
+      mockTx.renderTemplate.update.mockResolvedValue(updatedRecord);
+
+      const result = await updateRenderTemplate('template-1', TENANT_ID, {
+        name: 'Updated Template',
+      });
+
+      expect(mockTx.renderTemplate.findFirst).toHaveBeenCalledWith({
+        where: { id: 'template-1', tenantId: TENANT_ID },
+      });
+      expect(mockTx.renderTemplate.update).toHaveBeenCalledWith({
+        where: { id: 'template-1' },
+        data: { name: 'Updated Template' },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result.name).toBe('Updated Template');
+    });
+
+    it('throws when template is not tenant-owned', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(updateRenderTemplate('template-1', 'other-tenant', { name: 'Updated' })).rejects.toThrow(
+        'Render template not found or access denied',
+      );
+    });
+
+    it('unsets existing primary when setting isPrimary (excluding self)', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
+      mockTx.renderTemplate.updateMany.mockResolvedValue({ count: 1 });
+      mockTx.renderTemplate.update.mockResolvedValue({
+        ...TEMPLATE_RECORD,
+        isPrimary: true,
+      });
+
+      await updateRenderTemplate('template-1', TENANT_ID, { isPrimary: true });
+
+      expect(mockTx.renderTemplate.updateMany).toHaveBeenCalledWith({
+        where: {
+          tenantId: TENANT_ID,
+          credentialTypeConfigId: CONFIG_ID,
+          isPrimary: true,
+          NOT: { id: 'template-1' },
+        },
+        data: { isPrimary: false },
+      });
+      expect(mockTx.renderTemplate.update).toHaveBeenCalledWith({
+        where: { id: 'template-1' },
+        data: { isPrimary: true },
+        include: INCLUDE_SHAPE,
+      });
+    });
+
+    it('applies partial update with conditional spreads', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
+      mockTx.renderTemplate.update.mockResolvedValue({
+        ...TEMPLATE_RECORD,
+        storageUrl: 'https://storage.example.com/templates/updated.html',
+        hash: 'sha256-new789',
+      });
+
+      await updateRenderTemplate('template-1', TENANT_ID, {
+        storageUrl: 'https://storage.example.com/templates/updated.html',
+        hash: 'sha256-new789',
+      });
+
+      expect(mockTx.renderTemplate.update).toHaveBeenCalledWith({
+        where: { id: 'template-1' },
+        data: {
+          storageUrl: 'https://storage.example.com/templates/updated.html',
+          hash: 'sha256-new789',
+        },
+        include: INCLUDE_SHAPE,
+      });
+    });
+  });
+
+  describe('deleteRenderTemplate', () => {
+    it('deletes a tenant-owned template', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
+      mockTx.renderTemplate.delete.mockResolvedValue(TEMPLATE_RECORD);
+
+      const result = await deleteRenderTemplate('template-1', TENANT_ID);
+
+      expect(mockTx.renderTemplate.findFirst).toHaveBeenCalledWith({
+        where: { id: 'template-1', tenantId: TENANT_ID },
+      });
+      expect(mockTx.renderTemplate.delete).toHaveBeenCalledWith({
+        where: { id: 'template-1' },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(TEMPLATE_RECORD);
+    });
+
+    it('throws when template is not tenant-owned', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(deleteRenderTemplate('template-1', 'other-tenant')).rejects.toThrow(
+        'Render template not found or access denied',
+      );
+    });
+  });
+
+  describe('getPrimaryRenderTemplate', () => {
+    it('returns the primary template for a tenant and config', async () => {
+      const primaryRecord = { ...TEMPLATE_RECORD, isPrimary: true };
+      mockRenderTemplate.findFirst.mockResolvedValue(primaryRecord);
+
+      const result = await getPrimaryRenderTemplate(TENANT_ID, CONFIG_ID);
+
+      expect(mockRenderTemplate.findFirst).toHaveBeenCalledWith({
+        where: {
+          tenantId: TENANT_ID,
+          credentialTypeConfigId: CONFIG_ID,
+          isPrimary: true,
+        },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(primaryRecord);
+    });
+
+    it('returns null when no primary template exists', async () => {
+      mockRenderTemplate.findFirst.mockResolvedValue(null);
+
+      const result = await getPrimaryRenderTemplate(TENANT_ID, CONFIG_ID);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
@@ -47,7 +47,7 @@ const mockRenderTemplate = prisma.renderTemplate as unknown as {
 };
 
 const INCLUDE_SHAPE = {
-  credentialTypeConfig: true,
+  dataModel: true,
 };
 
 describe('render-template.repository', () => {
@@ -56,12 +56,12 @@ describe('render-template.repository', () => {
   const TEMPLATE_RECORD = {
     id: 'template-1',
     tenantId: TENANT_ID,
-    credentialTypeConfigId: CONFIG_ID,
+    dataModelId: CONFIG_ID,
     name: 'DPP Default Template',
     storageUrl: 'https://storage.example.com/templates/dpp-default.html',
     hash: 'sha256-abc123',
     isPrimary: false,
-    credentialTypeConfig: {
+    dataModel: {
       id: CONFIG_ID,
       name: 'Digital Product Passport v0.6.0',
     },
@@ -79,7 +79,7 @@ describe('render-template.repository', () => {
 
       const result = await createRenderTemplate(TENANT_ID, {
         name: 'DPP Default Template',
-        credentialTypeConfigId: CONFIG_ID,
+        dataModelId: CONFIG_ID,
         storageUrl: 'https://storage.example.com/templates/dpp-default.html',
         hash: 'sha256-abc123',
       });
@@ -88,7 +88,7 @@ describe('render-template.repository', () => {
         data: {
           tenantId: TENANT_ID,
           name: 'DPP Default Template',
-          credentialTypeConfigId: CONFIG_ID,
+          dataModelId: CONFIG_ID,
           storageUrl: 'https://storage.example.com/templates/dpp-default.html',
           hash: 'sha256-abc123',
           isPrimary: false,
@@ -103,7 +103,7 @@ describe('render-template.repository', () => {
 
       await createRenderTemplate(TENANT_ID, {
         name: 'DPP Default Template',
-        credentialTypeConfigId: CONFIG_ID,
+        dataModelId: CONFIG_ID,
         storageUrl: 'https://storage.example.com/templates/dpp-default.html',
         hash: 'sha256-abc123',
       });
@@ -123,7 +123,7 @@ describe('render-template.repository', () => {
 
       await createRenderTemplate(TENANT_ID, {
         name: 'DPP Primary Template',
-        credentialTypeConfigId: CONFIG_ID,
+        dataModelId: CONFIG_ID,
         storageUrl: 'https://storage.example.com/templates/dpp-primary.html',
         hash: 'sha256-def456',
         isPrimary: true,
@@ -132,7 +132,7 @@ describe('render-template.repository', () => {
       expect(mockTx.renderTemplate.updateMany).toHaveBeenCalledWith({
         where: {
           tenantId: TENANT_ID,
-          credentialTypeConfigId: CONFIG_ID,
+          dataModelId: CONFIG_ID,
           isPrimary: true,
         },
         data: { isPrimary: false },
@@ -188,15 +188,15 @@ describe('render-template.repository', () => {
       expect(result).toEqual([TEMPLATE_RECORD]);
     });
 
-    it('filters by credentialTypeConfigId', async () => {
+    it('filters by dataModelId', async () => {
       mockRenderTemplate.findMany.mockResolvedValue([TEMPLATE_RECORD]);
 
-      await listRenderTemplates(TENANT_ID, { credentialTypeConfigId: CONFIG_ID });
+      await listRenderTemplates(TENANT_ID, { dataModelId: CONFIG_ID });
 
       expect(mockRenderTemplate.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
           tenantId: TENANT_ID,
-          credentialTypeConfigId: CONFIG_ID,
+          dataModelId: CONFIG_ID,
         }),
         include: INCLUDE_SHAPE,
         take: 100,
@@ -261,7 +261,7 @@ describe('render-template.repository', () => {
       expect(mockTx.renderTemplate.updateMany).toHaveBeenCalledWith({
         where: {
           tenantId: TENANT_ID,
-          credentialTypeConfigId: CONFIG_ID,
+          dataModelId: CONFIG_ID,
           isPrimary: true,
           NOT: { id: 'template-1' },
         },
@@ -334,7 +334,7 @@ describe('render-template.repository', () => {
       expect(mockRenderTemplate.findFirst).toHaveBeenCalledWith({
         where: {
           tenantId: TENANT_ID,
-          credentialTypeConfigId: CONFIG_ID,
+          dataModelId: CONFIG_ID,
           isPrimary: true,
         },
         include: INCLUDE_SHAPE,

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
@@ -1,0 +1,207 @@
+import { Prisma } from '../generated';
+import { prisma } from '../prisma';
+import { NotFoundError } from '@/lib/api/errors';
+
+/**
+ * Include shape used by all render template queries.
+ * Includes the parent credential type config.
+ */
+const RENDER_TEMPLATE_INCLUDE = {
+  credentialTypeConfig: true,
+} as const;
+
+/**
+ * A render template with its credential type config relation.
+ * Matches the include shape defined by RENDER_TEMPLATE_INCLUDE.
+ */
+export type RenderTemplateWithRelations = Prisma.RenderTemplateGetPayload<{
+  include: typeof RENDER_TEMPLATE_INCLUDE;
+}>;
+
+/**
+ * Input for creating a new render template.
+ */
+export type CreateRenderTemplateInput = {
+  name: string;
+  credentialTypeConfigId: string;
+  storageUrl: string;
+  hash: string;
+  isPrimary?: boolean;
+};
+
+/**
+ * Input for updating an existing render template.
+ */
+export type UpdateRenderTemplateInput = {
+  name?: string;
+  storageUrl?: string;
+  hash?: string;
+  isPrimary?: boolean;
+};
+
+/**
+ * Options for listing render templates.
+ */
+export type ListRenderTemplatesOptions = {
+  credentialTypeConfigId?: string;
+  limit?: number;
+  offset?: number;
+};
+
+/**
+ * Creates a new render template scoped to a tenant.
+ * When isPrimary is true, first unsets any existing primary for the same
+ * tenant + credentialTypeConfigId combination.
+ */
+export async function createRenderTemplate(
+  tenantId: string,
+  input: CreateRenderTemplateInput,
+): Promise<RenderTemplateWithRelations> {
+  return prisma.$transaction(async (tx) => {
+    if (input.isPrimary) {
+      await tx.renderTemplate.updateMany({
+        where: {
+          tenantId,
+          credentialTypeConfigId: input.credentialTypeConfigId,
+          isPrimary: true,
+        },
+        data: { isPrimary: false },
+      });
+    }
+
+    return tx.renderTemplate.create({
+      data: {
+        tenantId,
+        name: input.name,
+        credentialTypeConfigId: input.credentialTypeConfigId,
+        storageUrl: input.storageUrl,
+        hash: input.hash,
+        isPrimary: input.isPrimary ?? false,
+      },
+      include: RENDER_TEMPLATE_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Retrieves a render template by ID, scoped to a tenant.
+ * Templates are always tenant-scoped (no system defaults).
+ */
+export async function getRenderTemplateById(id: string, tenantId: string): Promise<RenderTemplateWithRelations | null> {
+  return prisma.renderTemplate.findFirst({
+    where: {
+      id,
+      tenantId,
+    },
+    include: RENDER_TEMPLATE_INCLUDE,
+  });
+}
+
+/**
+ * Lists render templates for a tenant.
+ * Supports filtering by credentialTypeConfigId and pagination.
+ */
+export async function listRenderTemplates(
+  tenantId: string,
+  options: ListRenderTemplatesOptions = {},
+): Promise<RenderTemplateWithRelations[]> {
+  const { credentialTypeConfigId, limit, offset } = options;
+
+  const where: Prisma.RenderTemplateWhereInput = {
+    tenantId,
+  };
+
+  if (credentialTypeConfigId !== undefined) {
+    where.credentialTypeConfigId = credentialTypeConfigId;
+  }
+
+  return prisma.renderTemplate.findMany({
+    where,
+    include: RENDER_TEMPLATE_INCLUDE,
+    take: limit ?? 100,
+    skip: offset,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+/**
+ * Updates a render template. Only tenant-owned templates can be updated.
+ * When setting isPrimary to true, unsets any existing primary for the same
+ * tenant + credentialTypeConfigId combination (excluding self).
+ */
+export async function updateRenderTemplate(
+  id: string,
+  tenantId: string,
+  input: UpdateRenderTemplateInput,
+): Promise<RenderTemplateWithRelations> {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.renderTemplate.findFirst({
+      where: { id, tenantId },
+    });
+
+    if (!existing) {
+      throw new NotFoundError('Render template not found or access denied');
+    }
+
+    if (input.isPrimary) {
+      await tx.renderTemplate.updateMany({
+        where: {
+          tenantId,
+          credentialTypeConfigId: existing.credentialTypeConfigId,
+          isPrimary: true,
+          NOT: { id },
+        },
+        data: { isPrimary: false },
+      });
+    }
+
+    return tx.renderTemplate.update({
+      where: { id },
+      data: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.storageUrl !== undefined && { storageUrl: input.storageUrl }),
+        ...(input.hash !== undefined && { hash: input.hash }),
+        ...(input.isPrimary !== undefined && { isPrimary: input.isPrimary }),
+      },
+      include: RENDER_TEMPLATE_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Deletes a render template. Only tenant-owned templates can be deleted.
+ */
+export async function deleteRenderTemplate(id: string, tenantId: string): Promise<RenderTemplateWithRelations> {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.renderTemplate.findFirst({
+      where: { id, tenantId },
+    });
+
+    if (!existing) {
+      throw new NotFoundError('Render template not found or access denied');
+    }
+
+    return tx.renderTemplate.delete({
+      where: { id },
+      include: RENDER_TEMPLATE_INCLUDE,
+    });
+  });
+}
+
+/**
+ * Returns the primary render template for a tenant + credentialTypeConfigId
+ * combination, or null if none is set.
+ */
+export async function getPrimaryRenderTemplate(
+  tenantId: string,
+  credentialTypeConfigId: string,
+): Promise<RenderTemplateWithRelations | null> {
+  return prisma.renderTemplate.findFirst({
+    where: {
+      tenantId,
+      credentialTypeConfigId,
+      isPrimary: true,
+    },
+    include: RENDER_TEMPLATE_INCLUDE,
+  });
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
@@ -4,14 +4,14 @@ import { NotFoundError } from '@/lib/api/errors';
 
 /**
  * Include shape used by all render template queries.
- * Includes the parent credential type config.
+ * Includes the parent data model.
  */
 const RENDER_TEMPLATE_INCLUDE = {
-  credentialTypeConfig: true,
+  dataModel: true,
 } as const;
 
 /**
- * A render template with its credential type config relation.
+ * A render template with its data model relation.
  * Matches the include shape defined by RENDER_TEMPLATE_INCLUDE.
  */
 export type RenderTemplateWithRelations = Prisma.RenderTemplateGetPayload<{
@@ -23,7 +23,7 @@ export type RenderTemplateWithRelations = Prisma.RenderTemplateGetPayload<{
  */
 export type CreateRenderTemplateInput = {
   name: string;
-  credentialTypeConfigId: string;
+  dataModelId: string;
   storageUrl: string;
   hash: string;
   isPrimary?: boolean;
@@ -43,7 +43,7 @@ export type UpdateRenderTemplateInput = {
  * Options for listing render templates.
  */
 export type ListRenderTemplatesOptions = {
-  credentialTypeConfigId?: string;
+  dataModelId?: string;
   limit?: number;
   offset?: number;
 };
@@ -51,7 +51,7 @@ export type ListRenderTemplatesOptions = {
 /**
  * Creates a new render template scoped to a tenant.
  * When isPrimary is true, first unsets any existing primary for the same
- * tenant + credentialTypeConfigId combination.
+ * tenant + dataModelId combination.
  */
 export async function createRenderTemplate(
   tenantId: string,
@@ -62,7 +62,7 @@ export async function createRenderTemplate(
       await tx.renderTemplate.updateMany({
         where: {
           tenantId,
-          credentialTypeConfigId: input.credentialTypeConfigId,
+          dataModelId: input.dataModelId,
           isPrimary: true,
         },
         data: { isPrimary: false },
@@ -73,7 +73,7 @@ export async function createRenderTemplate(
       data: {
         tenantId,
         name: input.name,
-        credentialTypeConfigId: input.credentialTypeConfigId,
+        dataModelId: input.dataModelId,
         storageUrl: input.storageUrl,
         hash: input.hash,
         isPrimary: input.isPrimary ?? false,
@@ -99,20 +99,20 @@ export async function getRenderTemplateById(id: string, tenantId: string): Promi
 
 /**
  * Lists render templates for a tenant.
- * Supports filtering by credentialTypeConfigId and pagination.
+ * Supports filtering by dataModelId and pagination.
  */
 export async function listRenderTemplates(
   tenantId: string,
   options: ListRenderTemplatesOptions = {},
 ): Promise<RenderTemplateWithRelations[]> {
-  const { credentialTypeConfigId, limit, offset } = options;
+  const { dataModelId, limit, offset } = options;
 
   const where: Prisma.RenderTemplateWhereInput = {
     tenantId,
   };
 
-  if (credentialTypeConfigId !== undefined) {
-    where.credentialTypeConfigId = credentialTypeConfigId;
+  if (dataModelId !== undefined) {
+    where.dataModelId = dataModelId;
   }
 
   return prisma.renderTemplate.findMany({
@@ -127,7 +127,7 @@ export async function listRenderTemplates(
 /**
  * Updates a render template. Only tenant-owned templates can be updated.
  * When setting isPrimary to true, unsets any existing primary for the same
- * tenant + credentialTypeConfigId combination (excluding self).
+ * tenant + dataModelId combination (excluding self).
  */
 export async function updateRenderTemplate(
   id: string,
@@ -147,7 +147,7 @@ export async function updateRenderTemplate(
       await tx.renderTemplate.updateMany({
         where: {
           tenantId,
-          credentialTypeConfigId: existing.credentialTypeConfigId,
+          dataModelId: existing.dataModelId,
           isPrimary: true,
           NOT: { id },
         },
@@ -189,17 +189,17 @@ export async function deleteRenderTemplate(id: string, tenantId: string): Promis
 }
 
 /**
- * Returns the primary render template for a tenant + credentialTypeConfigId
+ * Returns the primary render template for a tenant + dataModelId
  * combination, or null if none is set.
  */
 export async function getPrimaryRenderTemplate(
   tenantId: string,
-  credentialTypeConfigId: string,
+  dataModelId: string,
 ): Promise<RenderTemplateWithRelations | null> {
   return prisma.renderTemplate.findFirst({
     where: {
       tenantId,
-      credentialTypeConfigId,
+      dataModelId,
       isPrimary: true,
     },
     include: RENDER_TEMPLATE_INCLUDE,

--- a/packages/reference-implementation/src/lib/services/entity-resolution.service.test.ts
+++ b/packages/reference-implementation/src/lib/services/entity-resolution.service.test.ts
@@ -58,10 +58,25 @@ describe('resolveEntities', () => {
     });
   });
 
-  it('fetches only organisation for DigitalConformityCredential', async () => {
+  it('fetches organisation and optional facility and product for DigitalConformityCredential when refs provided', async () => {
     setupAllEntitiesFound();
 
     const result = await resolveEntities('DigitalConformityCredential', ALL_REFS, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledWith('org-1', TENANT_ID);
+    expect(mockGetFacilityById).toHaveBeenCalledWith('fac-1', TENANT_ID);
+    expect(mockGetProductById).toHaveBeenCalledWith('prod-1', TENANT_ID);
+    expect(result).toEqual({
+      organisation: MOCK_ORGANISATION,
+      facility: MOCK_FACILITY,
+      product: MOCK_PRODUCT,
+    });
+  });
+
+  it('fetches only organisation for DigitalConformityCredential when optional refs omitted', async () => {
+    setupAllEntitiesFound();
+
+    const result = await resolveEntities('DigitalConformityCredential', { organisationId: 'org-1' }, TENANT_ID);
 
     expect(mockGetOrganisationById).toHaveBeenCalledWith('org-1', TENANT_ID);
     expect(mockGetFacilityById).not.toHaveBeenCalled();
@@ -194,7 +209,7 @@ describe('resolveEntities', () => {
 
   // ── Does not call unnecessary repos ──────────────────────────────────────
 
-  it('does not call facility or product repos for DigitalConformityCredential', async () => {
+  it('does not call facility or product repos for DigitalConformityCredential when optional refs omitted', async () => {
     mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
 
     await resolveEntities('DigitalConformityCredential', { organisationId: 'org-1' }, TENANT_ID);
@@ -202,6 +217,19 @@ describe('resolveEntities', () => {
     expect(mockGetOrganisationById).toHaveBeenCalledTimes(1);
     expect(mockGetFacilityById).not.toHaveBeenCalled();
     expect(mockGetProductById).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundError when optional facility ref is provided but not found for DCC', async () => {
+    mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+    mockGetFacilityById.mockResolvedValue(null);
+
+    await expect(
+      resolveEntities('DigitalConformityCredential', { organisationId: 'org-1', facilityId: 'missing-fac' }, TENANT_ID),
+    ).rejects.toThrow(NotFoundError);
+
+    await expect(
+      resolveEntities('DigitalConformityCredential', { organisationId: 'org-1', facilityId: 'missing-fac' }, TENANT_ID),
+    ).rejects.toThrow(/Facility not found: missing-fac/);
   });
 
   it('does not call product repo for DigitalFacilityRecord', async () => {

--- a/packages/reference-implementation/src/lib/services/entity-resolution.service.test.ts
+++ b/packages/reference-implementation/src/lib/services/entity-resolution.service.test.ts
@@ -1,0 +1,217 @@
+const mockGetOrganisationById = jest.fn();
+const mockGetFacilityById = jest.fn();
+const mockGetProductById = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getOrganisationById: (...args: unknown[]) => mockGetOrganisationById(...args),
+  getFacilityById: (...args: unknown[]) => mockGetFacilityById(...args),
+  getProductById: (...args: unknown[]) => mockGetProductById(...args),
+}));
+
+import { resolveEntities } from './entity-resolution.service';
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID = 'tenant-1';
+
+const MOCK_ORGANISATION = { id: 'org-1', name: 'Test Org' };
+const MOCK_FACILITY = { id: 'fac-1', name: 'Test Facility' };
+const MOCK_PRODUCT = { id: 'prod-1', name: 'Test Product' };
+
+const ALL_REFS = {
+  organisationId: 'org-1',
+  facilityId: 'fac-1',
+  productId: 'prod-1',
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function setupAllEntitiesFound() {
+  mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+  mockGetFacilityById.mockResolvedValue(MOCK_FACILITY);
+  mockGetProductById.mockResolvedValue(MOCK_PRODUCT);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('resolveEntities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Happy path: each credential type fetches the correct entities ────────
+
+  it('fetches organisation, facility, and product for DigitalProductPassport', async () => {
+    setupAllEntitiesFound();
+
+    const result = await resolveEntities('DigitalProductPassport', ALL_REFS, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledWith('org-1', TENANT_ID);
+    expect(mockGetFacilityById).toHaveBeenCalledWith('fac-1', TENANT_ID);
+    expect(mockGetProductById).toHaveBeenCalledWith('prod-1', TENANT_ID);
+    expect(result).toEqual({
+      organisation: MOCK_ORGANISATION,
+      facility: MOCK_FACILITY,
+      product: MOCK_PRODUCT,
+    });
+  });
+
+  it('fetches only organisation for DigitalConformityCredential', async () => {
+    setupAllEntitiesFound();
+
+    const result = await resolveEntities('DigitalConformityCredential', ALL_REFS, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledWith('org-1', TENANT_ID);
+    expect(mockGetFacilityById).not.toHaveBeenCalled();
+    expect(mockGetProductById).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      organisation: MOCK_ORGANISATION,
+    });
+  });
+
+  it('fetches organisation and facility for DigitalFacilityRecord', async () => {
+    setupAllEntitiesFound();
+
+    const result = await resolveEntities('DigitalFacilityRecord', ALL_REFS, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledWith('org-1', TENANT_ID);
+    expect(mockGetFacilityById).toHaveBeenCalledWith('fac-1', TENANT_ID);
+    expect(mockGetProductById).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      organisation: MOCK_ORGANISATION,
+      facility: MOCK_FACILITY,
+    });
+  });
+
+  it('fetches only organisation for DigitalIdentityAnchor', async () => {
+    setupAllEntitiesFound();
+
+    const result = await resolveEntities('DigitalIdentityAnchor', ALL_REFS, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledWith('org-1', TENANT_ID);
+    expect(mockGetFacilityById).not.toHaveBeenCalled();
+    expect(mockGetProductById).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      organisation: MOCK_ORGANISATION,
+    });
+  });
+
+  it('fetches organisation and product for DigitalTraceabilityEvent', async () => {
+    setupAllEntitiesFound();
+
+    const result = await resolveEntities('DigitalTraceabilityEvent', ALL_REFS, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledWith('org-1', TENANT_ID);
+    expect(mockGetFacilityById).not.toHaveBeenCalled();
+    expect(mockGetProductById).toHaveBeenCalledWith('prod-1', TENANT_ID);
+    expect(result).toEqual({
+      organisation: MOCK_ORGANISATION,
+      product: MOCK_PRODUCT,
+    });
+  });
+
+  // ── NotFoundError: entity not found in database ──────────────────────────
+
+  it('throws NotFoundError when organisation is not found', async () => {
+    mockGetOrganisationById.mockResolvedValue(null);
+
+    await expect(
+      resolveEntities('DigitalConformityCredential', { organisationId: 'missing-org' }, TENANT_ID),
+    ).rejects.toThrow(NotFoundError);
+
+    await expect(
+      resolveEntities('DigitalConformityCredential', { organisationId: 'missing-org' }, TENANT_ID),
+    ).rejects.toThrow(/Organisation not found: missing-org/);
+  });
+
+  it('throws NotFoundError when facility is not found', async () => {
+    mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+    mockGetFacilityById.mockResolvedValue(null);
+
+    await expect(
+      resolveEntities('DigitalFacilityRecord', { organisationId: 'org-1', facilityId: 'missing-fac' }, TENANT_ID),
+    ).rejects.toThrow(NotFoundError);
+
+    await expect(
+      resolveEntities('DigitalFacilityRecord', { organisationId: 'org-1', facilityId: 'missing-fac' }, TENANT_ID),
+    ).rejects.toThrow(/Facility not found: missing-fac/);
+  });
+
+  it('throws NotFoundError when product is not found', async () => {
+    mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+    mockGetProductById.mockResolvedValue(null);
+
+    await expect(
+      resolveEntities('DigitalTraceabilityEvent', { organisationId: 'org-1', productId: 'missing-prod' }, TENANT_ID),
+    ).rejects.toThrow(NotFoundError);
+
+    await expect(
+      resolveEntities('DigitalTraceabilityEvent', { organisationId: 'org-1', productId: 'missing-prod' }, TENANT_ID),
+    ).rejects.toThrow(/Product not found: missing-prod/);
+  });
+
+  // ── ValidationError: unknown credential type ─────────────────────────────
+
+  it('throws ValidationError for unknown credential type', async () => {
+    await expect(resolveEntities('UnknownType', ALL_REFS, TENANT_ID)).rejects.toThrow(ValidationError);
+    await expect(resolveEntities('UnknownType', ALL_REFS, TENANT_ID)).rejects.toThrow(
+      /Unknown credential type: UnknownType/,
+    );
+  });
+
+  // ── ValidationError: missing required refs ───────────────────────────────
+
+  it('throws ValidationError when organisationId is missing from refs', async () => {
+    await expect(resolveEntities('DigitalConformityCredential', {}, TENANT_ID)).rejects.toThrow(ValidationError);
+    await expect(resolveEntities('DigitalConformityCredential', {}, TENANT_ID)).rejects.toThrow(
+      /organisationId is required/,
+    );
+  });
+
+  it('throws ValidationError when facilityId is missing from refs', async () => {
+    mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+
+    await expect(resolveEntities('DigitalFacilityRecord', { organisationId: 'org-1' }, TENANT_ID)).rejects.toThrow(
+      ValidationError,
+    );
+    await expect(resolveEntities('DigitalFacilityRecord', { organisationId: 'org-1' }, TENANT_ID)).rejects.toThrow(
+      /facilityId is required/,
+    );
+  });
+
+  it('throws ValidationError when productId is missing from refs', async () => {
+    mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+
+    await expect(resolveEntities('DigitalTraceabilityEvent', { organisationId: 'org-1' }, TENANT_ID)).rejects.toThrow(
+      ValidationError,
+    );
+    await expect(resolveEntities('DigitalTraceabilityEvent', { organisationId: 'org-1' }, TENANT_ID)).rejects.toThrow(
+      /productId is required/,
+    );
+  });
+
+  // ── Does not call unnecessary repos ──────────────────────────────────────
+
+  it('does not call facility or product repos for DigitalConformityCredential', async () => {
+    mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+
+    await resolveEntities('DigitalConformityCredential', { organisationId: 'org-1' }, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledTimes(1);
+    expect(mockGetFacilityById).not.toHaveBeenCalled();
+    expect(mockGetProductById).not.toHaveBeenCalled();
+  });
+
+  it('does not call product repo for DigitalFacilityRecord', async () => {
+    mockGetOrganisationById.mockResolvedValue(MOCK_ORGANISATION);
+    mockGetFacilityById.mockResolvedValue(MOCK_FACILITY);
+
+    await resolveEntities('DigitalFacilityRecord', { organisationId: 'org-1', facilityId: 'fac-1' }, TENANT_ID);
+
+    expect(mockGetOrganisationById).toHaveBeenCalledTimes(1);
+    expect(mockGetFacilityById).toHaveBeenCalledTimes(1);
+    expect(mockGetProductById).not.toHaveBeenCalled();
+  });
+});

--- a/packages/reference-implementation/src/lib/services/entity-resolution.service.ts
+++ b/packages/reference-implementation/src/lib/services/entity-resolution.service.ts
@@ -1,0 +1,91 @@
+import { NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+import { CredentialType } from '@/lib/prisma/generated';
+import {
+  getOrganisationById,
+  getFacilityById,
+  getProductById,
+  OrganisationEntityWithRelations,
+  FacilityWithRelations,
+  ProductWithRelations,
+} from '@/lib/prisma/repositories';
+
+export interface ResolvedEntities {
+  organisation?: OrganisationEntityWithRelations;
+  facility?: FacilityWithRelations;
+  product?: ProductWithRelations;
+}
+
+export interface EntityReferences {
+  organisationId?: string;
+  facilityId?: string;
+  productId?: string;
+}
+
+type EntityType = 'organisation' | 'facility' | 'product';
+
+const entityRequirements: Record<string, EntityType[]> = {
+  [CredentialType.DigitalProductPassport]: ['organisation', 'facility', 'product'],
+  [CredentialType.DigitalConformityCredential]: ['organisation'],
+  [CredentialType.DigitalFacilityRecord]: ['organisation', 'facility'],
+  [CredentialType.DigitalIdentityAnchor]: ['organisation'],
+  [CredentialType.DigitalTraceabilityEvent]: ['organisation', 'product'],
+};
+
+/**
+ * Resolves master data entities required for a given credential type.
+ *
+ * Fetches only the entities that the credential type needs (organisation,
+ * facility, product) from the corresponding repositories.
+ *
+ * @throws {ValidationError} If the credential type is unknown or a required
+ *   entity reference is missing from the refs.
+ * @throws {NotFoundError} If any referenced entity does not exist.
+ */
+export async function resolveEntities(
+  credentialType: string,
+  refs: EntityReferences,
+  tenantId: string,
+): Promise<ResolvedEntities> {
+  const requirements = entityRequirements[credentialType];
+  if (!requirements) {
+    throw new ValidationError(`Unknown credential type: ${credentialType}`);
+  }
+
+  const resolved: ResolvedEntities = {};
+
+  if (requirements.includes('organisation')) {
+    if (!refs.organisationId) {
+      throw new ValidationError('organisationId is required for ' + credentialType);
+    }
+    const organisation = await getOrganisationById(refs.organisationId, tenantId);
+    if (!organisation) {
+      throw new NotFoundError(`Organisation not found: ${refs.organisationId}`);
+    }
+    resolved.organisation = organisation;
+  }
+
+  if (requirements.includes('facility')) {
+    if (!refs.facilityId) {
+      throw new ValidationError('facilityId is required for ' + credentialType);
+    }
+    const facility = await getFacilityById(refs.facilityId, tenantId);
+    if (!facility) {
+      throw new NotFoundError(`Facility not found: ${refs.facilityId}`);
+    }
+    resolved.facility = facility;
+  }
+
+  if (requirements.includes('product')) {
+    if (!refs.productId) {
+      throw new ValidationError('productId is required for ' + credentialType);
+    }
+    const product = await getProductById(refs.productId, tenantId);
+    if (!product) {
+      throw new NotFoundError(`Product not found: ${refs.productId}`);
+    }
+    resolved.product = product;
+  }
+
+  return resolved;
+}

--- a/packages/reference-implementation/src/lib/services/entity-resolution.service.ts
+++ b/packages/reference-implementation/src/lib/services/entity-resolution.service.ts
@@ -24,12 +24,17 @@ export interface EntityReferences {
 
 type EntityType = 'organisation' | 'facility' | 'product';
 
-const entityRequirements: Record<string, EntityType[]> = {
-  [CredentialType.DigitalProductPassport]: ['organisation', 'facility', 'product'],
-  [CredentialType.DigitalConformityCredential]: ['organisation'],
-  [CredentialType.DigitalFacilityRecord]: ['organisation', 'facility'],
-  [CredentialType.DigitalIdentityAnchor]: ['organisation'],
-  [CredentialType.DigitalTraceabilityEvent]: ['organisation', 'product'],
+type EntityRequirement = {
+  required: EntityType[];
+  optional: EntityType[];
+};
+
+const entityRequirements: Record<string, EntityRequirement> = {
+  [CredentialType.DigitalProductPassport]: { required: ['organisation', 'facility', 'product'], optional: [] },
+  [CredentialType.DigitalConformityCredential]: { required: ['organisation'], optional: ['facility', 'product'] },
+  [CredentialType.DigitalFacilityRecord]: { required: ['organisation', 'facility'], optional: [] },
+  [CredentialType.DigitalIdentityAnchor]: { required: ['organisation'], optional: [] },
+  [CredentialType.DigitalTraceabilityEvent]: { required: ['organisation', 'product'], optional: [] },
 };
 
 /**
@@ -47,45 +52,65 @@ export async function resolveEntities(
   refs: EntityReferences,
   tenantId: string,
 ): Promise<ResolvedEntities> {
-  const requirements = entityRequirements[credentialType];
-  if (!requirements) {
+  const requirement = entityRequirements[credentialType];
+  if (!requirement) {
     throw new ValidationError(`Unknown credential type: ${credentialType}`);
   }
 
   const resolved: ResolvedEntities = {};
 
-  if (requirements.includes('organisation')) {
-    if (!refs.organisationId) {
-      throw new ValidationError('organisationId is required for ' + credentialType);
-    }
-    const organisation = await getOrganisationById(refs.organisationId, tenantId);
-    if (!organisation) {
-      throw new NotFoundError(`Organisation not found: ${refs.organisationId}`);
-    }
-    resolved.organisation = organisation;
+  // Resolve required entities — throw if ref is missing or entity not found
+  for (const entity of requirement.required) {
+    await resolveEntity(entity, refs, tenantId, resolved, true);
   }
 
-  if (requirements.includes('facility')) {
-    if (!refs.facilityId) {
-      throw new ValidationError('facilityId is required for ' + credentialType);
-    }
-    const facility = await getFacilityById(refs.facilityId, tenantId);
-    if (!facility) {
-      throw new NotFoundError(`Facility not found: ${refs.facilityId}`);
-    }
-    resolved.facility = facility;
-  }
-
-  if (requirements.includes('product')) {
-    if (!refs.productId) {
-      throw new ValidationError('productId is required for ' + credentialType);
-    }
-    const product = await getProductById(refs.productId, tenantId);
-    if (!product) {
-      throw new NotFoundError(`Product not found: ${refs.productId}`);
-    }
-    resolved.product = product;
+  // Resolve optional entities — only if ref is provided, throw if provided but not found
+  for (const entity of requirement.optional) {
+    await resolveEntity(entity, refs, tenantId, resolved, false);
   }
 
   return resolved;
+}
+
+const refKeys: Record<EntityType, keyof EntityReferences> = {
+  organisation: 'organisationId',
+  facility: 'facilityId',
+  product: 'productId',
+};
+
+const fetchers: Record<EntityType, (id: string, tenantId: string) => Promise<unknown>> = {
+  organisation: getOrganisationById,
+  facility: getFacilityById,
+  product: getProductById,
+};
+
+const labels: Record<EntityType, string> = {
+  organisation: 'Organisation',
+  facility: 'Facility',
+  product: 'Product',
+};
+
+async function resolveEntity(
+  entity: EntityType,
+  refs: EntityReferences,
+  tenantId: string,
+  resolved: ResolvedEntities,
+  required: boolean,
+): Promise<void> {
+  const refKey = refKeys[entity];
+  const refId = refs[refKey];
+
+  if (!refId) {
+    if (required) {
+      throw new ValidationError(`${refKey} is required for this credential type`);
+    }
+    return; // Optional and not provided — skip
+  }
+
+  const result = await fetchers[entity](refId, tenantId);
+  if (!result) {
+    throw new NotFoundError(`${labels[entity]} not found: ${refId}`);
+  }
+
+  (resolved as Record<string, unknown>)[entity] = result;
 }

--- a/packages/reference-implementation/src/lib/services/resolve-idr-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-idr-service.test.ts
@@ -86,6 +86,7 @@ const MOCK_SERVICE = {
   deleteLink: jest.fn(),
   getResolverDescription: jest.fn(),
   getLinkTypes: jest.fn(),
+  buildResolverUri: jest.fn(),
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
@@ -28,6 +28,7 @@ describe('PyxIdentityResolverAdapter', () => {
 
   const mockConfig: PyxIdrConfig = {
     baseUrl: 'https://resolver.example.com',
+    uriPrefix: '/{namespace}',
     apiKey: 'test-api-key',
     apiVersion: '2.0.0',
     ianaLanguage: 'en',
@@ -273,7 +274,7 @@ describe('PyxIdentityResolverAdapter', () => {
       expect(result.links[0].idrLinkId).toBe('0');
     });
 
-    it('should construct resolverUri from parts when API response omits it', async () => {
+    it('should construct resolverUri via buildResolverUri when API response omits it', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: jest.fn().mockResolvedValue({
@@ -288,6 +289,7 @@ describe('PyxIdentityResolverAdapter', () => {
       const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
       const result = await adapter.publishLinks('abn', '51824753556', mockLinks, undefined, mockOptions);
 
+      // buildResolverUri uses uriPrefix (/{namespace}) + fallback linkTemplate (/abn/51824753556)
       expect(result.resolverUri).toBe('https://resolver.example.com/ato/abn/51824753556');
     });
 
@@ -686,6 +688,87 @@ describe('PyxIdentityResolverAdapter', () => {
     });
   });
 
+  describe('buildResolverUri', () => {
+    it('builds URI with namespace prefix and simple template', () => {
+      const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
+      const result = adapter.buildResolverUri({
+        linkTemplate: '/{primaryKey}/{value}',
+        primaryKey: 'abn',
+        value: '51824753556',
+        namespace: 'ato',
+      });
+
+      expect(result).toBe('https://resolver.example.com/ato/abn/51824753556');
+    });
+
+    it('builds URI with qualifiers appended in order', () => {
+      const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
+      const result = adapter.buildResolverUri({
+        linkTemplate: '/{primaryKey}/{value}',
+        primaryKey: '01',
+        value: '09520123456788',
+        namespace: 'untp',
+        qualifiers: [
+          { key: '10', value: 'ABC123' },
+          { key: '21', value: 'SER456' },
+        ],
+      });
+
+      expect(result).toBe('https://resolver.example.com/untp/01/09520123456788/10/ABC123/21/SER456');
+    });
+
+    it('builds URI with no qualifiers', () => {
+      const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
+      const result = adapter.buildResolverUri({
+        linkTemplate: '/{primaryKey}/{value}',
+        primaryKey: '01',
+        value: '09520123456788',
+        namespace: 'gs1',
+      });
+
+      expect(result).toBe('https://resolver.example.com/gs1/01/09520123456788');
+    });
+
+    it('builds URI with empty qualifiers array', () => {
+      const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
+      const result = adapter.buildResolverUri({
+        linkTemplate: '/{primaryKey}/{value}',
+        primaryKey: 'abn',
+        value: '51824753556',
+        namespace: 'ato',
+        qualifiers: [],
+      });
+
+      expect(result).toBe('https://resolver.example.com/ato/abn/51824753556');
+    });
+
+    it('uses custom uriPrefix from config', () => {
+      const customConfig = { ...mockConfig, uriPrefix: '/custom-prefix/{namespace}' };
+      const adapter = new PyxIdentityResolverAdapter(customConfig, mockLogger);
+      const result = adapter.buildResolverUri({
+        linkTemplate: '/{primaryKey}/{value}',
+        primaryKey: 'abn',
+        value: '51824753556',
+        namespace: 'ato',
+      });
+
+      expect(result).toBe('https://resolver.example.com/custom-prefix/ato/abn/51824753556');
+    });
+
+    it('handles empty uriPrefix', () => {
+      const customConfig = { ...mockConfig, uriPrefix: '' };
+      const adapter = new PyxIdentityResolverAdapter(customConfig, mockLogger);
+      const result = adapter.buildResolverUri({
+        linkTemplate: '/{primaryKey}/{value}',
+        primaryKey: '01',
+        value: '09520123456788',
+        namespace: 'gs1',
+      });
+
+      expect(result).toBe('https://resolver.example.com/01/09520123456788');
+    });
+  });
+
   describe('registerSchemes', () => {
     it('should POST each scheme to the identifiers endpoint', async () => {
       mockFetch.mockResolvedValue({
@@ -796,7 +879,7 @@ describe('PyxIdentityResolverAdapter', () => {
       expect(() => pyxIdrRegistryEntry.configSchema.parse({ baseUrl: 'not-a-url', apiKey: '' })).toThrow();
     });
 
-    it('should default apiVersion and fwqs when not provided', () => {
+    it('should default apiVersion, fwqs, and uriPrefix when not provided', () => {
       const config = {
         baseUrl: 'https://resolver.example.com',
         apiKey: 'test-key',
@@ -810,6 +893,7 @@ describe('PyxIdentityResolverAdapter', () => {
       const result = pyxIdrRegistryEntry.configSchema.parse(config);
       expect(result.apiVersion).toBe('2.0.0');
       expect(result.fwqs).toBe(false);
+      expect(result.uriPrefix).toBe('/{namespace}');
     });
 
     it('should reject an unsupported apiVersion', () => {

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
@@ -9,6 +9,7 @@ import type {
   PublishLinksOptions,
   ResolverDescription,
   LinkType,
+  ResolverUriParts,
 } from '../../types.js';
 
 import {
@@ -36,6 +37,7 @@ export const PYX_IDR_ADAPTER_TYPE = 'PYX_IDR' as const;
  */
 export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements IIdentityResolverService {
   private readonly baseURL: string;
+  private readonly uriPrefix: string;
   private readonly headers: Record<string, string>;
   private readonly apiVersion: string;
   private readonly ianaLanguage: string;
@@ -49,6 +51,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
   constructor(config: PyxIdrConfig, logger: LoggerService) {
     super(logger.child({ service: 'IDR - PyxIdentityResolver', apiVersion: config.apiVersion }));
     this.baseURL = config.baseUrl;
+    this.uriPrefix = config.uriPrefix;
     this.headers = {
       Authorization: `Bearer ${config.apiKey}`,
       'Content-Type': 'application/json',
@@ -128,7 +131,14 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
     }));
 
     return {
-      resolverUri: result.resolverUri ?? `${this.baseURL}/${namespace}/${identifierScheme}/${identifier}`,
+      resolverUri:
+        result.resolverUri ??
+        this.buildResolverUri({
+          linkTemplate: `/${identifierScheme}/${identifier}`,
+          primaryKey: identifierScheme,
+          value: identifier,
+          namespace,
+        }),
       identifierScheme,
       identifier,
       links: registeredLinks,
@@ -233,6 +243,23 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
     }
 
     return response.json();
+  }
+
+  buildResolverUri(parts: ResolverUriParts): string {
+    // Render IDR-specific prefix
+    const prefix = this.uriPrefix.replace('{namespace}', parts.namespace);
+
+    // Render scheme link template
+    let path = parts.linkTemplate.replace('{primaryKey}', parts.primaryKey).replace('{value}', parts.value);
+
+    // Append qualifiers in order
+    if (parts.qualifiers?.length) {
+      for (const q of parts.qualifiers) {
+        path += `/${q.key}/${q.value}`;
+      }
+    }
+
+    return `${this.baseURL}${prefix}${path}`;
   }
 
   /** Pyx-specific: Register identifier schemes with the IDR */

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.schema.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.schema.ts
@@ -2,6 +2,10 @@ import { z } from 'zod';
 
 export const pyxIdrConfigSchema = z.object({
   baseUrl: z.string().url().describe('Base URL||The base URL of the Pyx IDR instance (no path segments)'),
+  uriPrefix: z
+    .string()
+    .default('/{namespace}')
+    .describe('URI Prefix||IDR-specific prefix template prepended to scheme link templates (e.g., "/{namespace}")'),
   apiKey: z.string().min(1).describe('API Key||The API key for authenticating with the Pyx IDR'),
   apiVersion: z.enum(['2.0.0']).default('2.0.0').describe('API Version||The Pyx IDR API version to use'),
   ianaLanguage: z.string().min(1).describe('Language||IANA language tag applied to links (e.g., "en")'),

--- a/packages/services/src/identity-resolver/common/publish-credential.test.ts
+++ b/packages/services/src/identity-resolver/common/publish-credential.test.ts
@@ -62,6 +62,7 @@ function makeMockIdrService(): jest.Mocked<IIdentityResolverService> {
     deleteLink: jest.fn(),
     getResolverDescription: jest.fn(),
     getLinkTypes: jest.fn(),
+    buildResolverUri: jest.fn(),
   };
 }
 

--- a/packages/services/src/identity-resolver/schemas.ts
+++ b/packages/services/src/identity-resolver/schemas.ts
@@ -28,6 +28,7 @@ export const schemeQualifierSchema = z.object({
   key: z.string().describe('Qualifier key / application identifier code'),
   description: z.string().describe('Human-readable description'),
   validationPattern: z.string().describe('Regex for validating qualifier values'),
+  order: z.number().int().describe('Qualifier precedence in URI ordering (ascending)'),
   createdAt: z.string().datetime().describe('Timestamp when created'),
   updatedAt: z.string().datetime().describe('Timestamp when last updated'),
 });
@@ -42,6 +43,7 @@ export const identifierSchemeSchema = z.object({
   name: z.string().describe('Human-readable scheme name'),
   primaryKey: z.string().describe('Primary identifier key per ISO 18975'),
   validationPattern: z.string().describe('Regex for validating identifier values'),
+  linkTemplate: z.string().describe('ISO 18975 link template for URI construction'),
   namespace: z.string().nullable().describe('Optional namespace override'),
   idrServiceInstanceId: z.string().nullable().describe('Associated IDR service instance'),
   isDefault: z.boolean().describe('Whether this is a system default'),

--- a/packages/services/src/identity-resolver/types.ts
+++ b/packages/services/src/identity-resolver/types.ts
@@ -195,6 +195,24 @@ export type LinkType = {
   description?: string;
 };
 
+// ── Resolver URI types ───────────────────────────────────────────────────
+
+/**
+ * Parts needed to construct a resolver URI.
+ */
+export type ResolverUriParts = {
+  /** The ISO 18975 link template from the identifier scheme (e.g., "/{primaryKey}/{value}") */
+  linkTemplate: string;
+  /** Primary identifier key (e.g., "01" for GTIN, "abn" for ABN) */
+  primaryKey: string;
+  /** Primary identifier value */
+  value: string;
+  /** Namespace for the identifier scheme */
+  namespace: string;
+  /** Qualifiers in order of precedence, already sorted by order field */
+  qualifiers?: Array<{ key: string; value: string }>;
+};
+
 // ── Service interface ──────────────────────────────────────────────────────
 
 /**
@@ -262,4 +280,14 @@ export interface IIdentityResolverService {
    * @returns Array of supported link types
    */
   getLinkTypes(): Promise<LinkType[]>;
+
+  /**
+   * Builds a canonical resolver URI for an identifier.
+   * Combines the IDR service's base URL, any IDR-specific prefix, and the scheme's
+   * ISO 18975 link template, rendered with the given identifier parts.
+   *
+   * @param parts - The identifier parts to render into the URI
+   * @returns The fully constructed resolver URI
+   */
+  buildResolverUri(parts: ResolverUriParts): string;
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -17,6 +17,7 @@ export type {
   CredentialIssuer,
   CredentialSubject,
   CredentialStatus,
+  IdentifierScheme,
   EnvelopedVerifiableCredential,
   UNTPVerifiableCredential,
   RenderMethod,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -107,6 +107,10 @@ export {
   linkRegistrationSchema,
 } from './identity-resolver/schemas.js';
 
+// Schema cache
+export { SchemaFetchError, fetchSchema, clearSchemaCache, getSchemaCache } from './schema/index.js';
+export type { CachedSchema } from './schema/index.js';
+
 // Shared API response schemas
 export { errorResponseSchema } from './schemas.js';
 

--- a/packages/services/src/schema/index.ts
+++ b/packages/services/src/schema/index.ts
@@ -1,0 +1,2 @@
+export { SchemaFetchError, fetchSchema, clearSchemaCache, getSchemaCache } from './schema-cache.service.js';
+export type { CachedSchema } from './schema-cache.service.js';

--- a/packages/services/src/schema/schema-cache.service.test.ts
+++ b/packages/services/src/schema/schema-cache.service.test.ts
@@ -96,6 +96,34 @@ describe('schema-cache.service', () => {
     await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(/Invalid JSON/);
   });
 
+  it('deduplicates concurrent fetches for the same URL', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => MOCK_SCHEMA,
+      }),
+    );
+
+    const [r1, r2] = await Promise.all([fetchSchema(SCHEMA_URL), fetchSchema(SCHEMA_URL)]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual(MOCK_SCHEMA);
+    expect(r2).toEqual(MOCK_SCHEMA);
+  });
+
+  it('allows retry after a failed in-flight fetch', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('Network failure'))
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => MOCK_SCHEMA });
+
+    await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(SchemaFetchError);
+
+    const result = await fetchSchema(SCHEMA_URL);
+    expect(result).toEqual(MOCK_SCHEMA);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it('clears all cached entries', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/packages/services/src/schema/schema-cache.service.test.ts
+++ b/packages/services/src/schema/schema-cache.service.test.ts
@@ -1,0 +1,112 @@
+import { fetchSchema, clearSchemaCache, getSchemaCache, SchemaFetchError } from './schema-cache.service.js';
+
+const SCHEMA_URL = 'https://test.uncefact.org/vocabulary/untp/dcc/0.6.1/schema.json';
+const MOCK_SCHEMA = { $schema: 'https://json-schema.org/draft/2020-12/schema', type: 'object' };
+
+describe('schema-cache.service', () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    clearSchemaCache();
+    mockFetch = jest.fn();
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fetches schema from URL on cache miss', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_SCHEMA,
+    });
+
+    const result = await fetchSchema(SCHEMA_URL);
+
+    expect(mockFetch).toHaveBeenCalledWith(SCHEMA_URL);
+    expect(result).toEqual(MOCK_SCHEMA);
+  });
+
+  it('returns cached schema on cache hit without re-fetching', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_SCHEMA,
+    });
+
+    await fetchSchema(SCHEMA_URL);
+    const result = await fetchSchema(SCHEMA_URL);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(MOCK_SCHEMA);
+  });
+
+  it('re-fetches schema after TTL expires', async () => {
+    const updatedSchema = { ...MOCK_SCHEMA, description: 'updated' };
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => MOCK_SCHEMA })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => updatedSchema });
+
+    const nowSpy = jest.spyOn(Date, 'now');
+    const baseTime = 1_000_000;
+
+    // First fetch at t=0
+    nowSpy.mockReturnValue(baseTime);
+    await fetchSchema(SCHEMA_URL);
+
+    // Within TTL — should use cache
+    nowSpy.mockReturnValue(baseTime + 3_599_999);
+    const cachedResult = await fetchSchema(SCHEMA_URL);
+    expect(cachedResult).toEqual(MOCK_SCHEMA);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Past TTL — should re-fetch
+    nowSpy.mockReturnValue(baseTime + 3_600_001);
+    const freshResult = await fetchSchema(SCHEMA_URL);
+    expect(freshResult).toEqual(updatedSchema);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws SchemaFetchError on network error', async () => {
+    mockFetch.mockRejectedValue(new Error('Network failure'));
+
+    await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(SchemaFetchError);
+    await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(/Failed to fetch schema/);
+  });
+
+  it('throws SchemaFetchError on non-200 response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(SchemaFetchError);
+    await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(/status 404/);
+  });
+
+  it('throws SchemaFetchError on invalid JSON response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    });
+
+    await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(SchemaFetchError);
+    await expect(fetchSchema(SCHEMA_URL)).rejects.toThrow(/Invalid JSON/);
+  });
+
+  it('clears all cached entries', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_SCHEMA,
+    });
+
+    await fetchSchema(SCHEMA_URL);
+    expect(getSchemaCache().size).toBe(1);
+
+    clearSchemaCache();
+    expect(getSchemaCache().size).toBe(0);
+  });
+});

--- a/packages/services/src/schema/schema-cache.service.ts
+++ b/packages/services/src/schema/schema-cache.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Schema Cache Service
+ *
+ * Fetches JSON Schema from a URL and caches it in memory with a configurable
+ * TTL. Used downstream to validate credential payloads against their schema.
+ */
+
+// ── Custom Error ────────────────────────────────────────────────────────────
+
+export class SchemaFetchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SchemaFetchError';
+  }
+}
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface CachedSchema {
+  schema: object;
+  fetchedAt: number;
+}
+
+// ── Cache ───────────────────────────────────────────────────────────────────
+
+const schemaCache = new Map<string, CachedSchema>();
+
+/** Default TTL: 1 hour (3 600 000 ms). Override with SCHEMA_CACHE_TTL_MS. */
+const DEFAULT_TTL_MS = 3_600_000;
+
+function getTtlMs(): number {
+  const envValue = process.env.SCHEMA_CACHE_TTL_MS;
+  if (envValue !== undefined) {
+    const parsed = Number(envValue);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_TTL_MS;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetch a JSON Schema from the given URL, returning a cached copy when
+ * available and not yet expired.
+ *
+ * @throws {SchemaFetchError} If the network request fails, the server returns
+ *   a non-200 status, or the response body is not valid JSON.
+ */
+export async function fetchSchema(schemaUrl: string): Promise<object> {
+  const ttl = getTtlMs();
+  const cached = schemaCache.get(schemaUrl);
+
+  if (cached && Date.now() - cached.fetchedAt < ttl) {
+    return cached.schema;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(schemaUrl);
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new SchemaFetchError(`Failed to fetch schema from ${schemaUrl}: ${detail}`);
+  }
+
+  if (!response.ok) {
+    throw new SchemaFetchError(`Failed to fetch schema from ${schemaUrl}: received status ${response.status}`);
+  }
+
+  let schema: object;
+  try {
+    schema = (await response.json()) as object;
+  } catch {
+    throw new SchemaFetchError(`Invalid JSON returned from ${schemaUrl}`);
+  }
+
+  schemaCache.set(schemaUrl, { schema, fetchedAt: Date.now() });
+
+  return schema;
+}
+
+/** Clear all cached schema entries. */
+export function clearSchemaCache(): void {
+  schemaCache.clear();
+}
+
+/** Expose the cache map (for testing / diagnostics only). */
+export function getSchemaCache(): Map<string, CachedSchema> {
+  return schemaCache;
+}

--- a/packages/services/src/schema/schema-cache.service.ts
+++ b/packages/services/src/schema/schema-cache.service.ts
@@ -3,6 +3,9 @@
  *
  * Fetches JSON Schema from a URL and caches it in memory with a configurable
  * TTL. Used downstream to validate credential payloads against their schema.
+ *
+ * Concurrent requests for the same uncached URL are deduplicated: only one
+ * network request is made and all callers receive the same result.
  */
 
 // ── Custom Error ────────────────────────────────────────────────────────────
@@ -24,6 +27,7 @@ export interface CachedSchema {
 // ── Cache ───────────────────────────────────────────────────────────────────
 
 const schemaCache = new Map<string, CachedSchema>();
+const inflightRequests = new Map<string, Promise<object>>();
 
 /** Default TTL: 1 hour (3 600 000 ms). Override with SCHEMA_CACHE_TTL_MS. */
 const DEFAULT_TTL_MS = 3_600_000;
@@ -39,23 +43,9 @@ function getTtlMs(): number {
   return DEFAULT_TTL_MS;
 }
 
-// ── Public API ──────────────────────────────────────────────────────────────
+// ── Internal ────────────────────────────────────────────────────────────────
 
-/**
- * Fetch a JSON Schema from the given URL, returning a cached copy when
- * available and not yet expired.
- *
- * @throws {SchemaFetchError} If the network request fails, the server returns
- *   a non-200 status, or the response body is not valid JSON.
- */
-export async function fetchSchema(schemaUrl: string): Promise<object> {
-  const ttl = getTtlMs();
-  const cached = schemaCache.get(schemaUrl);
-
-  if (cached && Date.now() - cached.fetchedAt < ttl) {
-    return cached.schema;
-  }
-
+async function doFetch(schemaUrl: string): Promise<object> {
   let response: Response;
   try {
     response = await fetch(schemaUrl);
@@ -80,9 +70,42 @@ export async function fetchSchema(schemaUrl: string): Promise<object> {
   return schema;
 }
 
-/** Clear all cached schema entries. */
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetch a JSON Schema from the given URL, returning a cached copy when
+ * available and not yet expired. Concurrent requests for the same URL are
+ * deduplicated so only one network call is made.
+ *
+ * @throws {SchemaFetchError} If the network request fails, the server returns
+ *   a non-200 status, or the response body is not valid JSON.
+ */
+export async function fetchSchema(schemaUrl: string): Promise<object> {
+  const ttl = getTtlMs();
+  const cached = schemaCache.get(schemaUrl);
+
+  if (cached && Date.now() - cached.fetchedAt < ttl) {
+    return cached.schema;
+  }
+
+  const inflight = inflightRequests.get(schemaUrl);
+  if (inflight) {
+    return inflight;
+  }
+
+  const promise = doFetch(schemaUrl).finally(() => {
+    inflightRequests.delete(schemaUrl);
+  });
+
+  inflightRequests.set(schemaUrl, promise);
+
+  return promise;
+}
+
+/** Clear all cached schema entries and in-flight requests. */
 export function clearSchemaCache(): void {
   schemaCache.clear();
+  inflightRequests.clear();
 }
 
 /** Expose the cache map (for testing / diagnostics only). */


### PR DESCRIPTION
This PR adds the data model and render template management layer to the reference implementation, enabling tenants to configure which UNTP credential types they support and how those credentials are rendered. The seed script provisions the five core UNTP v0.6.1 credential types (DPP, DCC, DFR, DIA, DTE) with their schemas, contexts, and default HTML render templates out of the box.

## Changes

**Prisma schema and repositories**
- Add `DataModel` and `RenderTemplate` entities with tenant scoping and extension support
- Add `linkTemplate` to `IdentifierScheme` and `order` to `SchemeQualifier`
- Render template repository includes `isPrimary` toggle logic (only one primary per data model)
- Include registrar relation in entity identifier queries

**API routes** (`/api/v1/data-models`, `/api/v1/render-templates`)
- Full CRUD for data models and render templates with tenant isolation
- Form config endpoint exposing per-credential-type entity requirements
- Input validation for all PATCH fields with typed error responses
- Swagger annotations on every handler

**Credential mapping pipeline**
- Mapper interface and self-registering registry pattern
- Five typed mappers (DPP, DCC, DFR, DIA, DTE) producing UNTP v0.6.1 schema output
- Entity resolution service mapping credential types to required entity types

**Supporting infrastructure**
- Schema cache service with in-memory TTL caching (packages/services)
- `buildResolverUri` added to IDR service interface with Pyx implementation
- Seed script provisioning core data models and default render templates

## Test plan
- [x] Unit tests for all 5 mappers (115 tests), mapper registry, and entity resolution service
- [x] Route handler tests for data-models and render-templates CRUD (GET, POST, PATCH, DELETE)
- [x] Repository tests for data model and render template operations
- [x] Schema cache service tests (TTL expiry, concurrent fetch dedup, error handling)
- [x] E2E tests for data model API (30 tests) and render template API (20 tests)
- [x] All 788 unit tests pass; 8 pre-existing failures unrelated to this branch