### PR TITLE
fix(ri): return system defaults in data model listings and extract shared tenant constant

### DIFF
--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -17,6 +17,7 @@ import { getDidConfig } from '../src/lib/config/did.config';
 import { getIdrConfig } from '../src/lib/config/idr.config';
 import { getStorageConfig } from '../src/lib/config/storage.config';
 import { getVcConfig } from '../src/lib/config/vc.config';
+import { SYSTEM_TENANT_ID } from '../src/lib/prisma/constants';
 
 const logger = createLogger().child({ module: 'prisma-seed' });
 
@@ -32,8 +33,6 @@ if (RI_POSTGRES_USER && RI_POSTGRES_PASSWORD && RI_POSTGRES_DB && RI_POSTGRES_HO
 
 const prisma = new PrismaClient();
 const { defaultDid: DEFAULT_DID } = getDidConfig();
-
-import { SYSTEM_TENANT_ID } from '../src/lib/prisma/constants';
 
 const ENCRYPTION_KEY = process.env.SERVICE_ENCRYPTION_KEY;
 if (!ENCRYPTION_KEY) {

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -17,7 +17,12 @@ import { getDidConfig } from '../src/lib/config/did.config';
 import { getIdrConfig } from '../src/lib/config/idr.config';
 import { getStorageConfig } from '../src/lib/config/storage.config';
 import { getVcConfig } from '../src/lib/config/vc.config';
-import { SYSTEM_TENANT_ID } from '../src/lib/prisma/constants';
+/**
+ * Must match the value in src/lib/prisma/constants.ts.
+ * Inlined here because seed.ts runs via tsx outside the Next.js build,
+ * so ../src/ path aliases are unavailable in the Docker container.
+ */
+const SYSTEM_TENANT_ID = 'system';
 
 const logger = createLogger().child({ module: 'prisma-seed' });
 

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -33,7 +33,7 @@ if (RI_POSTGRES_USER && RI_POSTGRES_PASSWORD && RI_POSTGRES_DB && RI_POSTGRES_HO
 const prisma = new PrismaClient();
 const { defaultDid: DEFAULT_DID } = getDidConfig();
 
-const SYSTEM_TENANT_ID = 'system';
+import { SYSTEM_TENANT_ID } from '../src/lib/prisma/constants';
 
 const ENCRYPTION_KEY = process.env.SERVICE_ENCRYPTION_KEY;
 if (!ENCRYPTION_KEY) {

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
@@ -14,7 +14,7 @@ const UPDATABLE_FIELDS = ['name', 'schemaUrl', 'contextUrl', 'websiteUrl'] as co
  * /data-models/{id}:
  *   get:
  *     summary: Get a data model by ID
- *     description: Retrieves a specific data model by its database ID. Returns system-provisioned (tenantId=null) or tenant-owned models.
+ *     description: Retrieves a specific data model by its database ID. Returns system-provisioned or tenant-owned models.
  *     tags:
  *       - Data Models
  *     parameters:

--- a/packages/reference-implementation/src/lib/prisma/constants.ts
+++ b/packages/reference-implementation/src/lib/prisma/constants.ts
@@ -1,0 +1,2 @@
+/** Tenant ID used for system-wide default records (DIDs, services, registrars, schemes, data models). */
+export const SYSTEM_TENANT_ID = 'system';

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
@@ -31,6 +31,7 @@ jest.mock('../prisma', () => ({
 
 // Import the mocked prisma after jest.mock
 import { prisma } from '../prisma';
+import { SYSTEM_TENANT_ID } from '../constants';
 
 const mockDataModel = prisma.dataModel as unknown as {
   create: jest.Mock;
@@ -45,7 +46,6 @@ const INCLUDE_SHAPE = {
 };
 
 describe('data-model.repository', () => {
-  const SYSTEM_TENANT_ID = 'system';
   const TENANT_ID = 'tenant-1';
   const CONFIG_RECORD = {
     id: 'config-1',

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
@@ -45,10 +45,11 @@ const INCLUDE_SHAPE = {
 };
 
 describe('data-model.repository', () => {
+  const SYSTEM_TENANT_ID = 'system';
   const TENANT_ID = 'tenant-1';
   const CONFIG_RECORD = {
     id: 'config-1',
-    tenantId: null,
+    tenantId: SYSTEM_TENANT_ID,
     name: 'Digital Product Passport v0.6.0',
     credentialType: 'DigitalProductPassport',
     version: '0.6.0',
@@ -207,7 +208,7 @@ describe('data-model.repository', () => {
       expect(mockDataModel.findFirst).toHaveBeenCalledWith({
         where: {
           id: 'config-1',
-          OR: [{ tenantId: TENANT_ID }, { tenantId: null }],
+          OR: [{ tenantId: TENANT_ID }, { tenantId: SYSTEM_TENANT_ID }],
         },
         include: INCLUDE_SHAPE,
       });
@@ -230,7 +231,7 @@ describe('data-model.repository', () => {
 
       expect(mockDataModel.findMany).toHaveBeenCalledWith({
         where: {
-          OR: [{ tenantId: TENANT_ID }, { tenantId: null }],
+          OR: [{ tenantId: TENANT_ID }, { tenantId: SYSTEM_TENANT_ID }],
         },
         include: INCLUDE_SHAPE,
         take: 100,

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -1,5 +1,6 @@
 import { CredentialType, Prisma } from '../generated';
 import { prisma } from '../prisma';
+import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 
@@ -103,13 +104,13 @@ export async function createDataModel(tenantId: string, input: CreateDataModelIn
 
 /**
  * Retrieves a data model by ID.
- * Returns models visible to the tenant OR system-provisioned (tenantId=null).
+ * Returns models visible to the tenant OR system-provisioned.
  */
 export async function getDataModelById(id: string, tenantId: string): Promise<DataModelWithRelations | null> {
   return prisma.dataModel.findFirst({
     where: {
       id,
-      OR: [{ tenantId }, { tenantId: null }],
+      OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
     },
     include: DATA_MODEL_INCLUDE,
   });
@@ -126,7 +127,7 @@ export async function listDataModels(
   const { isExtension, credentialType, version, limit, offset } = options;
 
   const where: Prisma.DataModelWhereInput = {
-    OR: [{ tenantId }, { tenantId: null }],
+    OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
   };
 
   if (isExtension !== undefined) {

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
@@ -1,8 +1,7 @@
 import { IdentifierScheme, Prisma } from '../generated';
 import { prisma } from '../prisma';
+import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
-
-const SYSTEM_TENANT_ID = 'system';
 
 /**
  * Input for creating a new identifier scheme

--- a/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
@@ -1,8 +1,7 @@
 import { Registrar, Prisma } from '../generated';
 import { prisma } from '../prisma';
+import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
-
-const SYSTEM_TENANT_ID = 'system';
 
 /**
  * Input for creating a new registrar

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -1,8 +1,7 @@
 import { ServiceInstance, ServiceType, AdapterType, Prisma } from '../generated';
 import { prisma } from '../prisma';
+import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
-
-const SYSTEM_TENANT_ID = 'system';
 
 export type CreateServiceInstanceInput = {
   tenantId: string;


### PR DESCRIPTION
This PR fixes a bug where system-seeded data models were invisible in listing and get-by-ID responses. The data model repository queried for `tenantId: null` in its OR conditions, while `seed.ts` stores system records with `tenantId: 'system'`. All other repositories (registrar, identifier scheme, service instance) already used the correct `SYSTEM_TENANT_ID` constant.

Additionally, the duplicated `SYSTEM_TENANT_ID = 'system'` constant (defined locally in each repository file and seed.ts) has been extracted to a single shared `constants.ts` module that all consumers now import from.

## Test plan
- [x] All 203 repository tests pass
- [x] Manually verified all 5 listing endpoints return system defaults via live API
- [x] Manually verified users cannot update or delete system defaults across all entity types
- [x] Confirmed no remaining instances of local `SYSTEM_TENANT_ID` definitions or `tenantId: null` in OR conditions