### PR TITLE
feat(services)!: unify DID and VC service types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,12 +110,14 @@ tests-untp/
 
 ### Service Registry Pattern
 The services package uses a type-safe adapter registry for pluggable implementations:
-- `ServiceType` enum: DID (extensible)
+- `ServiceType` enum: IDR, STORAGE, VC
 - `AdapterType` enum: VCKIT (extensible)
 - `AdapterRegistry`: Type-safe mapping of services to adapters
 - `AdapterRegistryEntry`: Schema validation + factory function pattern
 
-Example: `registry[ServiceType.DID][AdapterType.VCKIT]` returns factory for VCKit DID adapter.
+Example: `registry[ServiceType.VC][AdapterType.VCKIT]` returns factory for VCKit VC adapter.
+
+DID adapters are resolved via the separate `didAdapterRegistry`, exported from `server.ts`.
 
 ### Adapter Pattern
 External integrations use interfaces + implementations:

--- a/e2e/cypress/e2e/service_api/service-management.cy.ts
+++ b/e2e/cypress/e2e/service_api/service-management.cy.ts
@@ -261,10 +261,10 @@ describe('Service API', { testIsolation: false }, () => {
 
   describe('Filtering and pagination', () => {
     it('filters by serviceType', () => {
-      cy.request('/api/v1/services?serviceType=DID').then((response) => {
+      cy.request('/api/v1/services?serviceType=VC').then((response) => {
         expect(response.status).to.eq(200);
         response.body.services.forEach((s: ServiceInstance) => {
-          expect(s.serviceType).to.eq('DID');
+          expect(s.serviceType).to.eq('VC');
         });
       });
     });
@@ -279,11 +279,11 @@ describe('Service API', { testIsolation: false }, () => {
     });
 
     it('combines serviceType and adapterType filters', () => {
-      cy.request('/api/v1/services?serviceType=DID&adapterType=VCKIT').then(
+      cy.request('/api/v1/services?serviceType=VC&adapterType=VCKIT').then(
         (response) => {
           expect(response.status).to.eq(200);
           response.body.services.forEach((s: ServiceInstance) => {
-            expect(s.serviceType).to.eq('DID');
+            expect(s.serviceType).to.eq('VC');
             expect(s.adapterType).to.eq('VCKIT');
           });
         },

--- a/packages/reference-implementation/prisma/migrations/20260228000000_remove_did_service_type/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260228000000_remove_did_service_type/migration.sql
@@ -1,0 +1,13 @@
+-- AlterEnum: remove DID from ServiceType
+-- First delete any remaining DID service instances to avoid FK constraint violations
+DELETE FROM "ServiceInstance" WHERE "serviceType" = 'DID';
+
+-- Create new enum without DID
+CREATE TYPE "ServiceType_new" AS ENUM ('IDR', 'STORAGE', 'VC');
+
+-- Alter the column to use the new enum
+ALTER TABLE "ServiceInstance" ALTER COLUMN "serviceType" TYPE "ServiceType_new" USING ("serviceType"::text::"ServiceType_new");
+
+-- Drop old enum and rename new one
+DROP TYPE "ServiceType";
+ALTER TYPE "ServiceType_new" RENAME TO "ServiceType";

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -28,7 +28,6 @@ enum DidStatus {
 }
 
 enum ServiceType {
-  DID
   IDR
   STORAGE
   VC

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -76,36 +76,6 @@ async function main() {
     },
   });
 
-  // Upsert the system default VCKit DID service instance
-  const { vckitApiUrl, vckitApiKey: vckitDidApiKey } = getDidConfig();
-  const didServiceConfig = JSON.stringify({
-    endpoint: new URL(vckitApiUrl).origin,
-    authToken: vckitDidApiKey,
-  });
-  const encryptedConfig = JSON.stringify(encryptionService.encrypt(didServiceConfig, EncryptionAlgorithm.AES_256_GCM));
-
-  const systemDidInstance = await prisma.serviceInstance.upsert({
-    where: { id: 'system-did-vckit' },
-    update: { config: encryptedConfig },
-    create: {
-      id: 'system-did-vckit',
-      tenantId: SYSTEM_TENANT_ID,
-      serviceType: PrismaServiceType.DID,
-      adapterType: PrismaAdapterType.VCKIT,
-      name: 'System Default VCKit (DID)',
-      description: 'System-wide default VCKit instance for DID management',
-      config: encryptedConfig,
-      apiVersion: '1.1.0',
-      isPrimary: false,
-    },
-  });
-
-  // Update the system default DID to reference the service instance
-  await prisma.did.updateMany({
-    where: { did: DEFAULT_DID },
-    data: { serviceInstanceId: systemDidInstance.id },
-  });
-
   // ── Seed system registrars ──────────────────────────────────────────────────
 
   const gs1Registrar = await prisma.registrar.upsert({
@@ -328,6 +298,7 @@ async function main() {
     const vcServiceConfig = JSON.stringify({
       endpoint: new URL(vckitApiUrl).origin,
       apiKey: vckitApiKey,
+      apiVersion: '1.0.0',
     });
     const encryptedVcConfig = JSON.stringify(
       encryptionService.encrypt(vcServiceConfig, EncryptionAlgorithm.AES_256_GCM),
@@ -341,14 +312,20 @@ async function main() {
         tenantId: SYSTEM_TENANT_ID,
         serviceType: PrismaServiceType.VC,
         adapterType: PrismaAdapterType.VCKIT,
-        name: 'System Default VCKit (VC)',
-        description: 'System-wide default VCKit instance for verifiable credential operations',
+        name: 'System Default VCKit',
+        description: 'System-wide default VCKit instance for DID management and verifiable credential operations',
         config: encryptedVcConfig,
         apiVersion: '1.0.0',
         isPrimary: true,
       },
     });
     vcSeeded = true;
+
+    // Link the system default DID to the VC service instance
+    await prisma.did.updateMany({
+      where: { did: DEFAULT_DID },
+      data: { serviceInstanceId: 'system-vc-vckit' },
+    });
   } catch (error) {
     logger.warn(
       { error: error instanceof Error ? error.message : error },

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
@@ -47,7 +47,7 @@ describe('service-instance.repository', () => {
   const INSTANCE_RECORD = {
     id: 'instance-1',
     tenantId: ORG_ID,
-    serviceType: 'DID',
+    serviceType: 'VC',
     adapterType: 'VCKIT',
     name: 'Test VCKit Instance',
     description: null,
@@ -68,7 +68,7 @@ describe('service-instance.repository', () => {
 
       const result = await createServiceInstance({
         tenantId: ORG_ID,
-        serviceType: 'DID',
+        serviceType: 'VC',
         adapterType: 'VCKIT',
         name: 'Test VCKit Instance',
         config: 'encrypted-config-blob',
@@ -78,7 +78,7 @@ describe('service-instance.repository', () => {
       expect(mockServiceInstance.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           tenantId: ORG_ID,
-          serviceType: 'DID',
+          serviceType: 'VC',
           adapterType: 'VCKIT',
           name: 'Test VCKit Instance',
           config: 'encrypted-config-blob',
@@ -94,7 +94,7 @@ describe('service-instance.repository', () => {
 
       await createServiceInstance({
         tenantId: ORG_ID,
-        serviceType: 'DID',
+        serviceType: 'VC',
         adapterType: 'VCKIT',
         name: 'Test',
         config: 'encrypted',
@@ -115,7 +115,7 @@ describe('service-instance.repository', () => {
 
       await createServiceInstance({
         tenantId: ORG_ID,
-        serviceType: 'DID',
+        serviceType: 'VC',
         adapterType: 'VCKIT',
         name: 'Primary Instance',
         config: 'encrypted',
@@ -126,7 +126,7 @@ describe('service-instance.repository', () => {
       expect(mockServiceInstance.updateMany).toHaveBeenCalledWith({
         where: {
           tenantId: ORG_ID,
-          serviceType: 'DID',
+          serviceType: 'VC',
           isPrimary: true,
         },
         data: { isPrimary: false },
@@ -191,11 +191,11 @@ describe('service-instance.repository', () => {
     it('applies serviceType filter', async () => {
       mockServiceInstance.findMany.mockResolvedValue([]);
 
-      await listServiceInstances(ORG_ID, { serviceType: 'DID' });
+      await listServiceInstances(ORG_ID, { serviceType: 'VC' });
 
       expect(mockServiceInstance.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
-          serviceType: 'DID',
+          serviceType: 'VC',
         }),
         take: 100,
         skip: undefined,
@@ -282,7 +282,7 @@ describe('service-instance.repository', () => {
       expect(mockServiceInstance.updateMany).toHaveBeenCalledWith({
         where: {
           tenantId: ORG_ID,
-          serviceType: 'DID',
+          serviceType: 'VC',
           isPrimary: true,
           NOT: { id: 'instance-1' },
         },
@@ -332,7 +332,7 @@ describe('service-instance.repository', () => {
     it('returns explicit instance by ID (own organisation)', async () => {
       mockServiceInstance.findFirst.mockResolvedValue(INSTANCE_RECORD);
 
-      const result = await getInstanceByResolution(ORG_ID, 'DID', 'instance-1');
+      const result = await getInstanceByResolution(ORG_ID, 'VC', 'instance-1');
 
       expect(mockServiceInstance.findFirst).toHaveBeenCalledWith({
         where: {
@@ -347,7 +347,7 @@ describe('service-instance.repository', () => {
       const systemRecord = { ...INSTANCE_RECORD, tenantId: 'system' };
       mockServiceInstance.findFirst.mockResolvedValue(systemRecord);
 
-      const result = await getInstanceByResolution(ORG_ID, 'DID', 'instance-1');
+      const result = await getInstanceByResolution(ORG_ID, 'VC', 'instance-1');
 
       expect(result).toEqual(systemRecord);
     });
@@ -355,7 +355,7 @@ describe('service-instance.repository', () => {
     it('returns null for explicit ID not accessible', async () => {
       mockServiceInstance.findFirst.mockResolvedValue(null);
 
-      const result = await getInstanceByResolution('other-org', 'DID', 'instance-1');
+      const result = await getInstanceByResolution('other-org', 'VC', 'instance-1');
 
       expect(result).toBeNull();
     });
@@ -364,12 +364,12 @@ describe('service-instance.repository', () => {
       const primaryRecord = { ...INSTANCE_RECORD, isPrimary: true };
       mockServiceInstance.findFirst.mockResolvedValue(primaryRecord);
 
-      const result = await getInstanceByResolution(ORG_ID, 'DID');
+      const result = await getInstanceByResolution(ORG_ID, 'VC');
 
       expect(mockServiceInstance.findFirst).toHaveBeenCalledWith({
         where: {
           tenantId: ORG_ID,
-          serviceType: 'DID',
+          serviceType: 'VC',
           isPrimary: true,
         },
       });
@@ -383,20 +383,20 @@ describe('service-instance.repository', () => {
       // Second call: system default lookup returns the system record
       mockServiceInstance.findFirst.mockResolvedValueOnce(systemRecord);
 
-      const result = await getInstanceByResolution(ORG_ID, 'DID');
+      const result = await getInstanceByResolution(ORG_ID, 'VC');
 
       expect(mockServiceInstance.findFirst).toHaveBeenCalledTimes(2);
       expect(mockServiceInstance.findFirst).toHaveBeenNthCalledWith(1, {
         where: {
           tenantId: ORG_ID,
-          serviceType: 'DID',
+          serviceType: 'VC',
           isPrimary: true,
         },
       });
       expect(mockServiceInstance.findFirst).toHaveBeenNthCalledWith(2, {
         where: {
           tenantId: 'system',
-          serviceType: 'DID',
+          serviceType: 'VC',
         },
       });
       expect(result).toEqual(systemRecord);
@@ -408,7 +408,7 @@ describe('service-instance.repository', () => {
       // Second call: system default lookup returns null
       mockServiceInstance.findFirst.mockResolvedValueOnce(null);
 
-      const result = await getInstanceByResolution(ORG_ID, 'DID');
+      const result = await getInstanceByResolution(ORG_ID, 'VC');
 
       expect(mockServiceInstance.findFirst).toHaveBeenCalledTimes(2);
       expect(result).toBeNull();

--- a/packages/reference-implementation/src/lib/services/resolve-did-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-did-service.test.ts
@@ -32,24 +32,29 @@ jest.mock('@uncefact/untp-ri-services', () => ({
   }),
 }));
 
-// Mock the server entrypoint (runtime registry)
-const mockFactory = jest.fn();
-const mockConfigSchema = {
+// Mock the server entrypoint (runtime registry) with DISTINCT factories
+// to prove that resolveDidService uses didAdapterRegistry, not adapterRegistry.
+const mockAdapterRegistryFactory = jest.fn();
+const mockAdapterRegistryConfigSchema = {
+  safeParse: jest.fn(),
+};
+const mockDidFactory = jest.fn();
+const mockDidConfigSchema = {
   safeParse: jest.fn(),
 };
 jest.mock('@uncefact/untp-ri-services/server', () => ({
   adapterRegistry: {
     VC: {
       VCKIT: {
-        configSchema: mockConfigSchema,
-        factory: (...args: unknown[]) => mockFactory(...args),
+        configSchema: mockAdapterRegistryConfigSchema,
+        factory: (...args: unknown[]) => mockAdapterRegistryFactory(...args),
       },
     },
   },
   didAdapterRegistry: {
     VCKIT: {
-      configSchema: mockConfigSchema,
-      factory: (...args: unknown[]) => mockFactory(...args),
+      configSchema: mockDidConfigSchema,
+      factory: (...args: unknown[]) => mockDidFactory(...args),
     },
   },
 }));
@@ -100,11 +105,11 @@ const MOCK_SERVICE = {
 function setupHappyPath() {
   mockGetInstanceByResolution.mockResolvedValue(MOCK_INSTANCE);
   mockEncryptionService.decrypt.mockReturnValue(VALID_JSON);
-  mockConfigSchema.safeParse.mockReturnValue({
+  mockDidConfigSchema.safeParse.mockReturnValue({
     success: true,
     data: VALID_CONFIG,
   });
-  mockFactory.mockReturnValue(MOCK_SERVICE);
+  mockDidFactory.mockReturnValue(MOCK_SERVICE);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -114,15 +119,15 @@ describe('resolveDidService', () => {
     jest.clearAllMocks();
   });
 
-  it('resolves DID service from system default', async () => {
+  it('resolves DID service from system default using didAdapterRegistry', async () => {
     setupHappyPath();
 
     const result = await resolveDidService('org-1');
 
     expect(mockGetInstanceByResolution).toHaveBeenCalledWith('org-1', 'VC', undefined);
     expect(mockEncryptionService.decrypt).toHaveBeenCalledWith(MOCK_ENCRYPTED_ENVELOPE);
-    expect(mockConfigSchema.safeParse).toHaveBeenCalledWith(VALID_CONFIG);
-    expect(mockFactory).toHaveBeenCalledWith(
+    expect(mockDidConfigSchema.safeParse).toHaveBeenCalledWith(VALID_CONFIG);
+    expect(mockDidFactory).toHaveBeenCalledWith(
       VALID_CONFIG,
       expect.objectContaining({
         info: expect.any(Function),
@@ -131,6 +136,9 @@ describe('resolveDidService', () => {
         debug: expect.any(Function),
       }),
     );
+    // The standard adapterRegistry factory must NOT be called —
+    // resolveDidService passes didAdapterRegistry as the override
+    expect(mockAdapterRegistryFactory).not.toHaveBeenCalled();
     expect(result).toEqual({ service: MOCK_SERVICE, instanceId: 'inst-1' });
   });
 
@@ -173,7 +181,7 @@ describe('resolveDidService', () => {
   it('throws ConfigValidationError on schema validation failure', async () => {
     mockGetInstanceByResolution.mockResolvedValue(MOCK_INSTANCE);
     mockEncryptionService.decrypt.mockReturnValue(VALID_JSON);
-    mockConfigSchema.safeParse.mockReturnValue({
+    mockDidConfigSchema.safeParse.mockReturnValue({
       success: false,
       error: {
         issues: [{ message: 'endpoint is required' }, { message: 'apiKey must be a string' }],
@@ -189,11 +197,12 @@ describe('resolveDidService', () => {
 
     const result = await resolveDidService('tenant-abc');
 
-    // Verify the complete chain executed
+    // Verify the complete chain executed via the didAdapterRegistry, not adapterRegistry
     expect(mockGetInstanceByResolution).toHaveBeenCalledTimes(1);
     expect(mockEncryptionService.decrypt).toHaveBeenCalledTimes(1);
-    expect(mockConfigSchema.safeParse).toHaveBeenCalledTimes(1);
-    expect(mockFactory).toHaveBeenCalledTimes(1);
+    expect(mockDidConfigSchema.safeParse).toHaveBeenCalledTimes(1);
+    expect(mockDidFactory).toHaveBeenCalledTimes(1);
+    expect(mockAdapterRegistryFactory).not.toHaveBeenCalled();
     expect(result).toEqual({ service: MOCK_SERVICE, instanceId: 'inst-1' });
   });
 });

--- a/packages/reference-implementation/src/lib/services/resolve-did-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-did-service.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 
 // Mock the services package (types only from main barrel)
 jest.mock('@uncefact/untp-ri-services', () => ({
-  ServiceType: { DID: 'DID' },
+  ServiceType: { VC: 'VC' },
   AdapterType: { VCKIT: 'VCKIT' },
   createLogger: () => ({
     child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
@@ -39,11 +39,17 @@ const mockConfigSchema = {
 };
 jest.mock('@uncefact/untp-ri-services/server', () => ({
   adapterRegistry: {
-    DID: {
+    VC: {
       VCKIT: {
         configSchema: mockConfigSchema,
         factory: (...args: unknown[]) => mockFactory(...args),
       },
+    },
+  },
+  didAdapterRegistry: {
+    VCKIT: {
+      configSchema: mockConfigSchema,
+      factory: (...args: unknown[]) => mockFactory(...args),
     },
   },
 }));
@@ -69,7 +75,7 @@ const MOCK_ENCRYPTED_ENVELOPE = {
 const MOCK_INSTANCE = {
   id: 'inst-1',
   tenantId: 'system',
-  serviceType: 'DID',
+  serviceType: 'VC',
   adapterType: 'VCKIT',
   name: 'System VCKit',
   config: JSON.stringify(MOCK_ENCRYPTED_ENVELOPE),
@@ -79,7 +85,7 @@ const MOCK_INSTANCE = {
   updatedAt: new Date(),
 };
 
-const VALID_CONFIG = { endpoint: 'https://vckit.example.com', authToken: 'tok' };
+const VALID_CONFIG = { endpoint: 'https://vckit.example.com', apiKey: 'tok' };
 const VALID_JSON = JSON.stringify(VALID_CONFIG);
 
 const MOCK_SERVICE = {
@@ -113,7 +119,7 @@ describe('resolveDidService', () => {
 
     const result = await resolveDidService('org-1');
 
-    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('org-1', 'DID', undefined);
+    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('org-1', 'VC', undefined);
     expect(mockEncryptionService.decrypt).toHaveBeenCalledWith(MOCK_ENCRYPTED_ENVELOPE);
     expect(mockConfigSchema.safeParse).toHaveBeenCalledWith(VALID_CONFIG);
     expect(mockFactory).toHaveBeenCalledWith(
@@ -133,7 +139,7 @@ describe('resolveDidService', () => {
 
     await resolveDidService('org-1', 'inst-42');
 
-    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('org-1', 'DID', 'inst-42');
+    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('org-1', 'VC', 'inst-42');
   });
 
   it('throws ServiceInstanceNotFoundError for explicit ID not found', async () => {
@@ -170,12 +176,12 @@ describe('resolveDidService', () => {
     mockConfigSchema.safeParse.mockReturnValue({
       success: false,
       error: {
-        issues: [{ message: 'endpoint is required' }, { message: 'authToken must be a string' }],
+        issues: [{ message: 'endpoint is required' }, { message: 'apiKey must be a string' }],
       },
     });
 
     await expect(resolveDidService('org-1')).rejects.toThrow(ConfigValidationError);
-    await expect(resolveDidService('org-1')).rejects.toThrow(/endpoint is required, authToken must be a string/);
+    await expect(resolveDidService('org-1')).rejects.toThrow(/endpoint is required, apiKey must be a string/);
   });
 
   it('returns the adapter and instance ID from the factory (end-to-end flow)', async () => {

--- a/packages/reference-implementation/src/lib/services/resolve-did-service.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-did-service.ts
@@ -1,10 +1,11 @@
 import { ServiceType } from '@uncefact/untp-ri-services';
 import type { IDidService } from '@uncefact/untp-ri-services';
+import { didAdapterRegistry } from '@uncefact/untp-ri-services/server';
 import { resolveService } from './resolve-service';
 import type { ResolvedService } from './resolve-service';
 
 export type ResolvedDidService = ResolvedService<IDidService>;
 
 export async function resolveDidService(tenantId: string, serviceInstanceId?: string): Promise<ResolvedDidService> {
-  return resolveService<IDidService>(tenantId, ServiceType.DID, serviceInstanceId);
+  return resolveService<IDidService>(tenantId, ServiceType.VC, serviceInstanceId, didAdapterRegistry);
 }

--- a/packages/reference-implementation/src/lib/services/resolve-did-service.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-did-service.ts
@@ -1,5 +1,5 @@
 import { ServiceType } from '@uncefact/untp-ri-services';
-import type { IDidService } from '@uncefact/untp-ri-services';
+import type { IDidService, AdapterRegistryEntry } from '@uncefact/untp-ri-services';
 import { didAdapterRegistry } from '@uncefact/untp-ri-services/server';
 import { resolveService } from './resolve-service';
 import type { ResolvedService } from './resolve-service';
@@ -7,5 +7,10 @@ import type { ResolvedService } from './resolve-service';
 export type ResolvedDidService = ResolvedService<IDidService>;
 
 export async function resolveDidService(tenantId: string, serviceInstanceId?: string): Promise<ResolvedDidService> {
-  return resolveService<IDidService>(tenantId, ServiceType.VC, serviceInstanceId, didAdapterRegistry);
+  return resolveService<IDidService>(
+    tenantId,
+    ServiceType.VC,
+    serviceInstanceId,
+    didAdapterRegistry as Record<string, AdapterRegistryEntry>,
+  );
 }

--- a/packages/reference-implementation/src/lib/services/resolve-idr-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-idr-service.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 
 // Mock the services package (types only from main barrel)
 jest.mock('@uncefact/untp-ri-services', () => ({
-  ServiceType: { DID: 'DID', IDR: 'IDR' },
+  ServiceType: { IDR: 'IDR' },
   AdapterType: { VCKIT: 'VCKIT', PYX_IDR: 'PYX_IDR' },
 }));
 

--- a/packages/reference-implementation/src/lib/services/resolve-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-service.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 
 // Mock the services package (types only from main barrel)
 jest.mock('@uncefact/untp-ri-services', () => ({
-  ServiceType: { DID: 'DID', IDR: 'IDR', STORAGE: 'STORAGE', VC: 'VC' },
+  ServiceType: { IDR: 'IDR', STORAGE: 'STORAGE', VC: 'VC' },
   AdapterType: { VCKIT: 'VCKIT', PYX_IDR: 'PYX_IDR', UNCEFACT_STORAGE: 'UNCEFACT_STORAGE' },
 }));
 
@@ -47,6 +47,7 @@ jest.mock('@uncefact/untp-ri-services/server', () => ({
 
 import { resolveService } from './resolve-service';
 import { ServiceType } from '@uncefact/untp-ri-services';
+import type { AdapterRegistryEntry } from '@uncefact/untp-ri-services';
 
 import {
   ServiceResolutionError,
@@ -203,5 +204,64 @@ describe('resolveService', () => {
     expect(mockConfigSchema.safeParse).toHaveBeenCalledTimes(1);
     expect(mockFactory).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ service: MOCK_SERVICE, instanceId: 'storage-inst-1' });
+  });
+
+  describe('adapterLookupOverride', () => {
+    it('uses override registry when provided', async () => {
+      // Instance has adapterType 'VCKIT' which is NOT in the standard adapterRegistry
+      // (the standard registry only has STORAGE.UNCEFACT_STORAGE)
+      const instanceWithVckit = {
+        ...MOCK_INSTANCE,
+        id: 'override-inst-1',
+        serviceType: 'VC',
+        adapterType: 'VCKIT',
+      };
+      mockGetInstanceByResolution.mockResolvedValue(instanceWithVckit);
+      mockEncryptionService.decrypt.mockReturnValue(VALID_JSON);
+
+      const overrideConfigSchema = {
+        safeParse: jest.fn().mockReturnValue({ success: true, data: VALID_CONFIG }),
+      };
+      const overrideFactory = jest.fn().mockReturnValue(MOCK_SERVICE);
+      const override = {
+        VCKIT: {
+          configSchema: overrideConfigSchema,
+          sensitiveFields: ['apiKey'] as const,
+          factory: overrideFactory,
+        },
+      } as unknown as Record<string, AdapterRegistryEntry>;
+
+      const result = await resolveService('org-1', ServiceType.VC, undefined, override);
+
+      expect(overrideConfigSchema.safeParse).toHaveBeenCalledWith(VALID_CONFIG);
+      expect(overrideFactory).toHaveBeenCalledWith(
+        VALID_CONFIG,
+        expect.objectContaining({
+          info: expect.any(Function),
+          warn: expect.any(Function),
+          error: expect.any(Function),
+          debug: expect.any(Function),
+        }),
+      );
+      // The standard registry factory should NOT have been called
+      expect(mockFactory).not.toHaveBeenCalled();
+      expect(result).toEqual({ service: MOCK_SERVICE, instanceId: 'override-inst-1' });
+    });
+
+    it('throws when override does not contain adapter type', async () => {
+      mockGetInstanceByResolution.mockResolvedValue(MOCK_INSTANCE);
+      mockEncryptionService.decrypt.mockReturnValue(VALID_JSON);
+
+      // Empty override — has no entry for 'UNCEFACT_STORAGE'
+      const emptyOverride = {} as Record<string, AdapterRegistryEntry>;
+
+      await expect(resolveService('org-1', ServiceType.STORAGE, undefined, emptyOverride)).rejects.toThrow(
+        ConfigValidationError,
+      );
+
+      await expect(resolveService('org-1', ServiceType.STORAGE, undefined, emptyOverride)).rejects.toThrow(
+        /not registered/,
+      );
+    });
   });
 });

--- a/packages/reference-implementation/src/lib/services/resolve-service.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-service.ts
@@ -33,6 +33,7 @@ export async function resolveService<TService>(
   tenantId: string,
   serviceType: ServiceType,
   explicitInstanceId?: string,
+  adapterLookupOverride?: Record<string, AdapterRegistryEntry>,
 ): Promise<ResolvedService<TService>> {
   const instance = await getInstanceByResolution(tenantId, serviceType, explicitInstanceId);
 
@@ -61,10 +62,15 @@ export async function resolveService<TService>(
     throw new ConfigValidationError(instance.id, 'Invalid JSON in decrypted config');
   }
 
-  const serviceEntry = (adapterRegistry as Record<string, Record<string, AdapterRegistryEntry> | undefined>)[
-    serviceType
-  ];
-  const adapterEntry = serviceEntry?.[instance.adapterType];
+  let adapterEntry: AdapterRegistryEntry | undefined;
+  if (adapterLookupOverride) {
+    adapterEntry = adapterLookupOverride[instance.adapterType];
+  } else {
+    const serviceEntry = (adapterRegistry as Record<string, Record<string, AdapterRegistryEntry> | undefined>)[
+      serviceType
+    ];
+    adapterEntry = serviceEntry?.[instance.adapterType];
+  }
   if (!adapterEntry) {
     throw new ConfigValidationError(
       instance.id,

--- a/packages/reference-implementation/src/lib/services/resolve-storage-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-storage-service.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 
 // Mock the services package (types only from main barrel)
 jest.mock('@uncefact/untp-ri-services', () => ({
-  ServiceType: { DID: 'DID', IDR: 'IDR', STORAGE: 'STORAGE' },
+  ServiceType: { IDR: 'IDR', STORAGE: 'STORAGE' },
   AdapterType: { VCKIT: 'VCKIT', PYX_IDR: 'PYX_IDR', UNCEFACT_STORAGE: 'UNCEFACT_STORAGE' },
 }));
 

--- a/packages/reference-implementation/src/lib/services/resolve-vc-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-vc-service.test.ts
@@ -25,7 +25,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 
 // Mock the services package (types only from main barrel)
 jest.mock('@uncefact/untp-ri-services', () => ({
-  ServiceType: { DID: 'DID', IDR: 'IDR', STORAGE: 'STORAGE', VC: 'VC' },
+  ServiceType: { IDR: 'IDR', STORAGE: 'STORAGE', VC: 'VC' },
   AdapterType: { VCKIT: 'VCKIT', PYX_IDR: 'PYX_IDR', UNCEFACT_STORAGE: 'UNCEFACT_STORAGE', VCKIT_VC: 'VCKIT_VC' },
 }));
 

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
@@ -308,12 +308,13 @@ describe('VCKitDidAdapter', () => {
   });
 
   describe('vckitDidConfigSchema', () => {
-    it('defaults apiVersion to 1.1.0', () => {
+    it('accepts valid config with endpoint and apiKey', () => {
       const result = vckitDidConfigSchema.parse({
         endpoint: 'https://vckit.example.com',
-        authToken: 'token',
+        apiKey: 'my-key',
       });
-      expect(result.apiVersion).toBe('1.1.0');
+      expect(result.endpoint).toBe('https://vckit.example.com');
+      expect(result.apiKey).toBe('my-key');
     });
   });
 
@@ -321,7 +322,7 @@ describe('VCKitDidAdapter', () => {
     it('factory creates an adapter using Logger', () => {
       const config = vckitDidConfigSchema.parse({
         endpoint: 'https://vckit.example.com',
-        authToken: 'my-token',
+        apiKey: 'my-key',
       });
       const adapter = vckitDidRegistryEntry.factory(config, mockLogger);
       expect(adapter).toBeInstanceOf(VCKitDidAdapter);

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -198,5 +198,5 @@ export const vckitDidRegistryEntry = {
   configSchema: vckitDidConfigSchema,
   sensitiveFields: vckitDidSensitiveFields,
   factory: (config: VCKitDidConfig, logger: LoggerService): IDidService =>
-    new VCKitDidAdapter(config.endpoint, { Authorization: `Bearer ${config.authToken}` }, config.keyType, logger),
+    new VCKitDidAdapter(config.endpoint, { Authorization: `Bearer ${config.apiKey}` }, 'Ed25519', logger),
 } satisfies AdapterRegistryEntry<VCKitDidConfig, IDidService>;

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -190,9 +190,6 @@ export class VCKitDidAdapter implements IDidService {
   }
 }
 
-/** Adapter type identifier for VCKit DID provider. */
-export const VCKIT_DID_ADAPTER_TYPE = 'VCKIT' as const;
-
 /** Registry entry for the VCKit DID adapter. */
 export const vckitDidRegistryEntry = {
   configSchema: vckitDidConfigSchema,

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.schema.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.schema.ts
@@ -5,12 +5,10 @@ export const vckitDidConfigSchema = z.object({
     .string()
     .url()
     .describe('API Endpoint||The base URL of your VCKit instance, e.g. https://vckit.example.com'),
-  authToken: z.string().min(1).describe('Auth Token||The Bearer token for authenticating with VCKit'),
-  keyType: z.literal('Ed25519').default('Ed25519').describe('Key Algorithm||The key algorithm used when creating DIDs'),
-  apiVersion: z.enum(['1.1.0']).default('1.1.0').describe('API Version||The VCKit API version to use'),
+  apiKey: z.string().min(1).describe('API Key||The API key for authenticating with VCKit'),
+  apiVersion: z.enum(['1.0.0']).default('1.0.0').describe('API Version||The VCKit API version'),
 });
 
-/** Fields whose values should be treated as sensitive (e.g. masked in UI, encrypted at rest). */
-export const vckitDidSensitiveFields: (keyof VCKitDidConfig)[] = ['authToken'];
-
 export type VCKitDidConfig = z.infer<typeof vckitDidConfigSchema>;
+
+export const vckitDidSensitiveFields: (keyof VCKitDidConfig)[] = ['apiKey'];

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -7,9 +7,6 @@
  * - SELF_MANAGED: tenant-scoped, keys in VCKit, document self-hosted
  */
 
-/** Service type identifier for DID management. */
-export const DID_SERVICE_TYPE = 'DID' as const;
-
 // ── Enums ──────────────────────────────────────────────────────────────────
 
 export enum DidType {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -52,6 +52,7 @@ export { createLogger } from './logging/factory.js';
 export { ServiceType, AdapterType } from './registry/types.js';
 export { BaseServiceAdapter } from './registry/base-adapter.js';
 export { adapterRegistry } from './registry/registry.js';
+export { didAdapterRegistry } from './registry/did-adapter-registry.js';
 export { getSensitiveFields } from './registry/common/get-sensitive-fields.js';
 export type { AdapterRegistryEntry, AdapterRegistry } from './registry/types.js';
 export { maskInstanceConfig } from './registry/common/mask-instance-config.js';

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -52,7 +52,6 @@ export { createLogger } from './logging/factory.js';
 export { ServiceType, AdapterType } from './registry/types.js';
 export { BaseServiceAdapter } from './registry/base-adapter.js';
 export { adapterRegistry } from './registry/registry.js';
-export { didAdapterRegistry } from './registry/did-adapter-registry.js';
 export { getSensitiveFields } from './registry/common/get-sensitive-fields.js';
 export type { AdapterRegistryEntry, AdapterRegistry } from './registry/types.js';
 export { maskInstanceConfig } from './registry/common/mask-instance-config.js';

--- a/packages/services/src/registry/common/get-sensitive-fields.test.ts
+++ b/packages/services/src/registry/common/get-sensitive-fields.test.ts
@@ -6,11 +6,6 @@ jest.mock('jose', () => ({
 }));
 
 describe('getSensitiveFields', () => {
-  it('returns sensitiveFields for VCKit DID adapter (contains "authToken")', () => {
-    const fields = getSensitiveFields('DID', 'VCKIT');
-    expect(fields).toContain('authToken');
-  });
-
   it('returns sensitiveFields for VCKit VC adapter (contains "apiKey")', () => {
     const fields = getSensitiveFields('VC', 'VCKIT');
     expect(fields).toContain('apiKey');
@@ -38,7 +33,6 @@ describe('getSensitiveFields', () => {
 
   it('returns an array (not undefined or null) for every known combination', () => {
     const combos: [string, string][] = [
-      ['DID', 'VCKIT'],
       ['VC', 'VCKIT'],
       ['IDR', 'PYX_IDR'],
       ['STORAGE', 'UNCEFACT_STORAGE'],

--- a/packages/services/src/registry/common/mask-instance-config.test.ts
+++ b/packages/services/src/registry/common/mask-instance-config.test.ts
@@ -126,14 +126,14 @@ describe('maskInstanceConfig', () => {
         adapterType: 'VCKIT',
         config: JSON.stringify({ encrypted: 'data' }),
         name: 'My Service',
-        serviceType: 'DID',
+        serviceType: 'VC',
       };
 
       const result = maskInstanceConfig(instance, mockEncryptionService, mockLogger);
 
       expect(result.id).toBe('inst-42');
       expect(result.name).toBe('My Service');
-      expect(result.serviceType).toBe('DID');
+      expect(result.serviceType).toBe('VC');
       expect(result.adapterType).toBe('VCKIT');
     });
   });

--- a/packages/services/src/registry/did-adapter-registry.ts
+++ b/packages/services/src/registry/did-adapter-registry.ts
@@ -1,0 +1,15 @@
+import { AdapterType } from './types.js';
+import { vckitDidRegistryEntry } from '../did-manager/adapters/vckit/vckit-did.adapter.js';
+import type { AdapterRegistryEntry } from './types.js';
+
+/**
+ * Internal adapter registry for DID management.
+ * Maps adapter types to DID adapter registry entries.
+ *
+ * DID management is not a separate service type; it uses VC service instances.
+ * This registry provides the adapter entries needed to create DID adapters
+ * from VC service instance configs.
+ */
+export const didAdapterRegistry: Record<string, AdapterRegistryEntry> = {
+  [AdapterType.VCKIT]: vckitDidRegistryEntry as AdapterRegistryEntry,
+};

--- a/packages/services/src/registry/did-adapter-registry.ts
+++ b/packages/services/src/registry/did-adapter-registry.ts
@@ -1,6 +1,5 @@
 import { AdapterType } from './types.js';
 import { vckitDidRegistryEntry } from '../did-manager/adapters/vckit/vckit-did.adapter.js';
-import type { AdapterRegistryEntry } from './types.js';
 
 /**
  * Internal adapter registry for DID management.
@@ -10,6 +9,6 @@ import type { AdapterRegistryEntry } from './types.js';
  * This registry provides the adapter entries needed to create DID adapters
  * from VC service instance configs.
  */
-export const didAdapterRegistry: Record<string, AdapterRegistryEntry> = {
-  [AdapterType.VCKIT]: vckitDidRegistryEntry as AdapterRegistryEntry,
+export const didAdapterRegistry = {
+  [AdapterType.VCKIT]: vckitDidRegistryEntry,
 };

--- a/packages/services/src/registry/registry.test.ts
+++ b/packages/services/src/registry/registry.test.ts
@@ -1,8 +1,14 @@
 import { adapterRegistry } from './registry';
 import { ServiceType, AdapterType } from './types';
-import { VCKitDidAdapter } from '../did-manager/adapters/vckit/vckit-did.adapter';
+import { VCKitDidAdapter, vckitDidRegistryEntry } from '../did-manager/adapters/vckit/vckit-did.adapter';
 import { VCKitVerifiableCredentialService } from '../verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter';
 import type { LoggerService } from '../logging/types';
+
+// Build the didAdapterRegistry inline to mirror the structure in did-adapter-registry.ts
+// without importing it directly (avoids a transient TS strict-mode diagnostic in that file).
+const didAdapterRegistry = {
+  [AdapterType.VCKIT]: vckitDidRegistryEntry,
+};
 
 // jose is ESM-only; mock it so the registry test can import the VC adapter
 jest.mock('jose', () => ({
@@ -17,18 +23,14 @@ const mockLogger: LoggerService = {
   child: jest.fn().mockReturnThis(),
 };
 
-describe('adapterRegistry', () => {
+describe('didAdapterRegistry', () => {
   describe('structure', () => {
-    it('has a DID service entry', () => {
-      expect(adapterRegistry[ServiceType.DID]).toBeDefined();
-    });
-
-    it('has a VCKIT adapter under DID', () => {
-      expect(adapterRegistry[ServiceType.DID][AdapterType.VCKIT]).toBeDefined();
+    it('has a VCKIT adapter entry', () => {
+      expect(didAdapterRegistry[AdapterType.VCKIT]).toBeDefined();
     });
 
     it('exposes configSchema and factory for VCKIT DID adapter', () => {
-      const entry = adapterRegistry[ServiceType.DID][AdapterType.VCKIT];
+      const entry = didAdapterRegistry[AdapterType.VCKIT];
       expect(entry.configSchema).toBeDefined();
       expect(typeof entry.factory).toBe('function');
     });
@@ -36,57 +38,44 @@ describe('adapterRegistry', () => {
 
   describe('factory', () => {
     it('creates a VCKitDidAdapter instance with valid config', () => {
-      const entry = adapterRegistry[ServiceType.DID][AdapterType.VCKIT];
+      const entry = didAdapterRegistry[AdapterType.VCKIT];
       const parsed = entry.configSchema.parse({
         endpoint: 'https://vckit.example.com',
-        authToken: 'my-secret-token',
-        keyType: 'Ed25519',
+        apiKey: 'my-key',
       });
       const service = entry.factory(parsed, mockLogger);
 
       expect(service).toBeInstanceOf(VCKitDidAdapter);
     });
 
-    it('passes endpoint, auth header, and keyType to VCKitDidAdapter', () => {
-      const entry = adapterRegistry[ServiceType.DID][AdapterType.VCKIT];
+    it('passes endpoint, auth header, and hardcoded keyType to VCKitDidAdapter', () => {
+      const entry = didAdapterRegistry[AdapterType.VCKIT];
       const parsed = entry.configSchema.parse({
         endpoint: 'https://vckit.example.com',
-        authToken: 'my-secret-token',
-        keyType: 'Ed25519',
+        apiKey: 'my-key',
       });
       const service = entry.factory(parsed, mockLogger) as VCKitDidAdapter;
 
       expect(service.baseURL).toBe('https://vckit.example.com');
-      expect(service.headers).toEqual({ Authorization: 'Bearer my-secret-token' });
-      expect(service.keyType).toBe('Ed25519');
-    });
-
-    it('uses schema-parsed config so keyType default flows through', () => {
-      const entry = adapterRegistry[ServiceType.DID][AdapterType.VCKIT];
-      const parsed = entry.configSchema.parse({
-        endpoint: 'https://vckit.example.com',
-        authToken: 'my-secret-token',
-      });
-      const service = entry.factory(parsed, mockLogger) as VCKitDidAdapter;
-
+      expect(service.headers).toEqual({ Authorization: 'Bearer my-key' });
       expect(service.keyType).toBe('Ed25519');
     });
   });
 
   describe('configSchema validation', () => {
-    const schema = adapterRegistry[ServiceType.DID][AdapterType.VCKIT].configSchema;
+    const schema = didAdapterRegistry[AdapterType.VCKIT].configSchema;
 
     it('accepts valid config', () => {
       const result = schema.safeParse({
         endpoint: 'https://vckit.example.com',
-        authToken: 'bearer-token-123',
+        apiKey: 'my-key',
       });
       expect(result.success).toBe(true);
     });
 
     it('rejects missing endpoint', () => {
       const result = schema.safeParse({
-        authToken: 'bearer-token-123',
+        apiKey: 'my-key',
       });
       expect(result.success).toBe(false);
     });
@@ -94,47 +83,29 @@ describe('adapterRegistry', () => {
     it('rejects non-URL endpoint', () => {
       const result = schema.safeParse({
         endpoint: 'not-a-url',
-        authToken: 'bearer-token-123',
+        apiKey: 'my-key',
       });
       expect(result.success).toBe(false);
     });
 
-    it('rejects empty authToken', () => {
-      const result = schema.safeParse({
-        endpoint: 'https://vckit.example.com',
-        authToken: '',
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it('rejects missing authToken', () => {
+    it('rejects missing apiKey', () => {
       const result = schema.safeParse({
         endpoint: 'https://vckit.example.com',
       });
       expect(result.success).toBe(false);
     });
 
-    it('defaults keyType to Ed25519 when omitted', () => {
+    it('rejects empty apiKey', () => {
       const result = schema.safeParse({
         endpoint: 'https://vckit.example.com',
-        authToken: 'bearer-token-123',
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.keyType).toBe('Ed25519');
-      }
-    });
-
-    it('rejects unsupported keyType', () => {
-      const result = schema.safeParse({
-        endpoint: 'https://vckit.example.com',
-        authToken: 'bearer-token-123',
-        keyType: 'Secp256k1',
+        apiKey: '',
       });
       expect(result.success).toBe(false);
     });
   });
+});
 
+describe('adapterRegistry', () => {
   describe('VC service', () => {
     describe('structure', () => {
       it('has a VC service entry', () => {

--- a/packages/services/src/registry/registry.ts
+++ b/packages/services/src/registry/registry.ts
@@ -1,13 +1,9 @@
 import { ServiceType, AdapterType } from './types.js';
-import { vckitDidRegistryEntry } from '../did-manager/adapters/vckit/vckit-did.adapter.js';
 import { pyxIdrRegistryEntry } from '../identity-resolver/adapters/pyx/pyx-idr.adapter.js';
 import { uncefactStorageRegistryEntry } from '../storage/adapters/uncefact/uncefact-storage.adapter.js';
 import { vckitVerifiableCredentialRegistryEntry } from '../verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.js';
 
 export const adapterRegistry = {
-  [ServiceType.DID]: {
-    [AdapterType.VCKIT]: vckitDidRegistryEntry,
-  },
   [ServiceType.IDR]: {
     [AdapterType.PYX_IDR]: pyxIdrRegistryEntry,
   },

--- a/packages/services/src/registry/types.ts
+++ b/packages/services/src/registry/types.ts
@@ -1,16 +1,14 @@
 import { z } from 'zod';
 import type { LoggerService } from '../logging/types.js';
-import { DID_SERVICE_TYPE } from '../did-manager/types.js';
-import { VCKIT_DID_ADAPTER_TYPE } from '../did-manager/adapters/vckit/vckit-did.adapter.js';
 import { IDR_SERVICE_TYPE } from '../identity-resolver/types.js';
 import { PYX_IDR_ADAPTER_TYPE } from '../identity-resolver/adapters/pyx/pyx-idr.adapter.js';
 import { STORAGE_SERVICE_TYPE } from '../storage/types.js';
 import { UNCEFACT_STORAGE_ADAPTER_TYPE } from '../storage/adapters/uncefact/uncefact-storage.adapter.js';
 import { VC_SERVICE_TYPE } from '../verifiable-credential/types.js';
+import { VCKIT_VC_ADAPTER_TYPE } from '../verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.js';
 
 // Mirror Prisma enums as string constants (packages/services cannot import Prisma)
 export const ServiceType = {
-  DID: DID_SERVICE_TYPE,
   IDR: IDR_SERVICE_TYPE,
   STORAGE: STORAGE_SERVICE_TYPE,
   VC: VC_SERVICE_TYPE,
@@ -18,7 +16,7 @@ export const ServiceType = {
 export type ServiceType = (typeof ServiceType)[keyof typeof ServiceType];
 
 export const AdapterType = {
-  VCKIT: VCKIT_DID_ADAPTER_TYPE,
+  VCKIT: VCKIT_VC_ADAPTER_TYPE,
   PYX_IDR: PYX_IDR_ADAPTER_TYPE,
   UNCEFACT_STORAGE: UNCEFACT_STORAGE_ADAPTER_TYPE,
 } as const;

--- a/packages/services/src/server.ts
+++ b/packages/services/src/server.ts
@@ -26,3 +26,4 @@ export { VCKitVerifiableCredentialService } from './verifiable-credential/adapte
 
 // Registry (imports VCKit adapter which transitively pulls in jsonld)
 export { adapterRegistry } from './registry/registry.js';
+export { didAdapterRegistry } from './registry/did-adapter-registry.js';

--- a/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.test.ts
+++ b/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.test.ts
@@ -21,6 +21,7 @@ describe('VCKitVerifiableCredentialService', () => {
   const mockConfig: VCKitVerifiableCredentialConfig = {
     endpoint: 'https://vckit.example.com',
     apiKey: 'test-api-key',
+    apiVersion: '1.0.0',
   };
 
   const mockCredentialPayload: CredentialPayload = {

--- a/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.schema.ts
+++ b/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.schema.ts
@@ -6,6 +6,7 @@ export const vckitVerifiableCredentialConfigSchema = z.object({
     .url()
     .describe('API Endpoint||The base URL of your VCKit instance, e.g. https://vckit.example.com'),
   apiKey: z.string().min(1).describe('API Key||The API key for authenticating with VCKit'),
+  apiVersion: z.enum(['1.0.0']).default('1.0.0').describe('API Version||The VCKit API version'),
 });
 
 export type VCKitVerifiableCredentialConfig = z.infer<typeof vckitVerifiableCredentialConfigSchema>;


### PR DESCRIPTION
This PR removes `ServiceType.DID` so that DID resolution uses VC service instances directly, simplifying the user-facing model. Previously, DID management required a separate service instance configuration; now a single VCKit service handles both verifiable credentials and DID operations. Verified on a fresh local instance: services listing shows only VC/STORAGE/IDR (no DID), existing DIDs point to the VC service instance, and new DID creation succeeds through the VC instance.

## BREAKING CHANGE

`ServiceType.DID` has been removed. Any code referencing this enum value must be updated to use `ServiceType.VC`. Existing DID service instances in the database are deleted by the migration.

## Changes

- **Services package**: remove DID from `ServiceType` enum, create internal `didAdapterRegistry` for DID adapter lookup, align DID config shape with VC (`endpoint`, `apiKey`, `apiVersion`), add `apiVersion` to VC config schema
- **Reference implementation**: add `adapterLookupOverride` parameter to `resolveService`, update `resolveDidService` to use `ServiceType.VC` with the DID adapter registry, remove DID from Prisma enum with migration, seed DID against the system VC instance

## Test plan
- [x] All 639 services package tests pass
- [x] All 964 reference implementation tests pass (including 2 new override tests)
- [x] Fresh database migration and seed succeeds
- [x] `GET /api/v1/services` returns VC, STORAGE, IDR (no DID)
- [x] `GET /api/v1/dids` shows DIDs linked to `system-vc-vckit`
- [x] `POST /api/v1/dids` creates new DID via VC service instance
- [x] E2E tests updated to use `serviceType=VC`