### PR TITLE
test(services): add missing error class tests for VC and storage modules

### DIFF
--- a/packages/services/src/storage/errors.test.ts
+++ b/packages/services/src/storage/errors.test.ts
@@ -1,0 +1,26 @@
+import { ServiceError } from '../errors.js';
+import { StorageError, StorageStoreError } from './errors.js';
+
+describe('Storage errors', () => {
+  describe('StorageError', () => {
+    it('extends ServiceError', () => {
+      const err = new StorageError('test', 'STORAGE_TEST', 500);
+      expect(err).toBeInstanceOf(ServiceError);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('StorageError');
+    });
+  });
+
+  describe('StorageStoreError', () => {
+    it('constructs message from httpStatus and detail', () => {
+      const err = new StorageStoreError(503, 'service unavailable');
+      expect(err.message).toBe('Failed to store credential: HTTP 503: service unavailable');
+      expect(err.code).toBe('STORAGE_STORE_FAILED');
+      expect(err.statusCode).toBe(502);
+      expect(err.context).toEqual({ httpStatus: 503 });
+      expect(err.name).toBe('StorageStoreError');
+      expect(err).toBeInstanceOf(StorageError);
+      expect(err).toBeInstanceOf(ServiceError);
+    });
+  });
+});

--- a/packages/services/src/verifiable-credential/errors.test.ts
+++ b/packages/services/src/verifiable-credential/errors.test.ts
@@ -1,0 +1,82 @@
+import { ServiceError } from '../errors.js';
+import { VcServiceError, VcSignError, VcVerifyError, VcDecodeError, VcCredentialStatusError } from './errors.js';
+
+describe('VC errors', () => {
+  describe('VcServiceError', () => {
+    it('extends ServiceError', () => {
+      const err = new VcServiceError('test', 'VC_TEST', 500);
+      expect(err).toBeInstanceOf(ServiceError);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('VcServiceError');
+    });
+  });
+
+  describe('VcSignError', () => {
+    it('constructs message from detail and httpStatus', () => {
+      const err = new VcSignError('upstream timeout', 504);
+      expect(err.message).toBe('Failed to sign credential: upstream timeout');
+      expect(err.code).toBe('VC_SIGN_FAILED');
+      expect(err.statusCode).toBe(504);
+      expect(err.context).toEqual({ httpStatus: 504 });
+      expect(err.name).toBe('VcSignError');
+      expect(err).toBeInstanceOf(VcServiceError);
+      expect(err).toBeInstanceOf(ServiceError);
+    });
+
+    it('defaults httpStatus to 502', () => {
+      const err = new VcSignError('network failure');
+      expect(err.statusCode).toBe(502);
+      expect(err.context).toEqual({ httpStatus: undefined });
+    });
+  });
+
+  describe('VcVerifyError', () => {
+    it('constructs message from detail and httpStatus', () => {
+      const err = new VcVerifyError('invalid signature', 400);
+      expect(err.message).toBe('Failed to verify credential: invalid signature');
+      expect(err.code).toBe('VC_VERIFY_FAILED');
+      expect(err.statusCode).toBe(400);
+      expect(err.context).toEqual({ httpStatus: 400 });
+      expect(err.name).toBe('VcVerifyError');
+      expect(err).toBeInstanceOf(VcServiceError);
+      expect(err).toBeInstanceOf(ServiceError);
+    });
+
+    it('defaults httpStatus to 502', () => {
+      const err = new VcVerifyError('network failure');
+      expect(err.statusCode).toBe(502);
+      expect(err.context).toEqual({ httpStatus: undefined });
+    });
+  });
+
+  describe('VcDecodeError', () => {
+    it('constructs message from detail', () => {
+      const err = new VcDecodeError('malformed JWT');
+      expect(err.message).toBe('Failed to decode credential: malformed JWT');
+      expect(err.code).toBe('VC_DECODE_FAILED');
+      expect(err.statusCode).toBe(422);
+      expect(err.name).toBe('VcDecodeError');
+      expect(err).toBeInstanceOf(VcServiceError);
+      expect(err).toBeInstanceOf(ServiceError);
+    });
+  });
+
+  describe('VcCredentialStatusError', () => {
+    it('constructs message from detail and httpStatus', () => {
+      const err = new VcCredentialStatusError('service unavailable', 503);
+      expect(err.message).toBe('Failed to issue credential status: service unavailable');
+      expect(err.code).toBe('VC_STATUS_FAILED');
+      expect(err.statusCode).toBe(503);
+      expect(err.context).toEqual({ httpStatus: 503 });
+      expect(err.name).toBe('VcCredentialStatusError');
+      expect(err).toBeInstanceOf(VcServiceError);
+      expect(err).toBeInstanceOf(ServiceError);
+    });
+
+    it('defaults httpStatus to 502', () => {
+      const err = new VcCredentialStatusError('network failure');
+      expect(err.statusCode).toBe(502);
+      expect(err.context).toEqual({ httpStatus: undefined });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds unit tests for the VC and storage error classes, which were the only error modules in the services package without dedicated test coverage.

- `VcServiceError`, `VcSignError`, `VcVerifyError`, `VcDecodeError`, `VcCredentialStatusError` (8 tests)
- `StorageError`, `StorageStoreError` (2 tests)

## Test plan
- [x] All 10 new tests pass (`yarn test:services --testPathPattern='(storage|verifiable-credential)/errors\.test'`)
- [x] Every `errors.ts` in `packages/services/src/` now has a corresponding `errors.test.ts`