### PR TITLE
feat(services): add StoragePayloadError for upstream payload rejection

### DIFF
--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -129,7 +129,7 @@ export { buildPublishLinks, publishCredential } from './identity-resolver/common
 // Storage service types and constants
 export { STORAGE_SERVICE_TYPE } from './storage/types.js';
 export type { IStorageService, StorageRecord } from './storage/types.js';
-export { StorageError, StorageStoreError } from './storage/errors.js';
+export { StorageError, StoragePayloadError, StorageStoreError } from './storage/errors.js';
 export { UNCEFACT_STORAGE_ADAPTER_TYPE } from './storage/adapters/uncefact/uncefact-storage.adapter.js';
 export type { UncefactStorageConfig } from './storage/adapters/uncefact/uncefact-storage.schema.js';
 export {

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
@@ -485,7 +485,7 @@ describe('UncefactStorageAdapter', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(StoragePayloadError);
           expect((error as StoragePayloadError).code).toBe('STORAGE_PAYLOAD_REJECTED');
-          expect((error as StoragePayloadError).statusCode).toBe(422);
+          expect((error as StoragePayloadError).statusCode).toBe(400);
           expect((error as StoragePayloadError).context).toEqual(expect.objectContaining({ httpStatus: 400 }));
         }
       });
@@ -553,7 +553,7 @@ describe('UncefactStorageAdapter', () => {
         await expect(adapter.store(mockCredential)).rejects.toThrow(StorageStoreError);
       });
 
-      it('should set statusCode to 502 (Bad Gateway) on StorageStoreError', async () => {
+      it('should set statusCode to upstream HTTP status on StorageStoreError', async () => {
         mockFetch.mockResolvedValueOnce({
           ok: false,
           status: 500,
@@ -567,7 +567,7 @@ describe('UncefactStorageAdapter', () => {
           fail('Expected StorageStoreError to be thrown');
         } catch (error) {
           expect(error).toBeInstanceOf(StorageStoreError);
-          expect((error as StorageStoreError).statusCode).toBe(502);
+          expect((error as StorageStoreError).statusCode).toBe(500);
           expect((error as StorageStoreError).code).toBe('STORAGE_STORE_FAILED');
         }
       });

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
@@ -3,7 +3,7 @@ import {
   UNCEFACT_STORAGE_ADAPTER_TYPE,
   uncefactStorageRegistryEntry,
 } from './uncefact-storage.adapter';
-import { StorageStoreError } from '../../errors';
+import { StoragePayloadError, StorageStoreError } from '../../errors';
 import type { UncefactStorageConfig } from './uncefact-storage.schema';
 import type { LoggerService } from '../../../logging/types';
 import type { EnvelopedVerifiableCredential } from '../../../verifiable-credential/types';
@@ -468,6 +468,89 @@ describe('UncefactStorageAdapter', () => {
 
         expect(result.uri).toBe('https://storage.example.com/documents/abc-123');
         expect(result.decryptionKey).toBeUndefined();
+      });
+
+      it('should throw StoragePayloadError on 400 response', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+        });
+
+        const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+
+        try {
+          await adapter.store(mockCredential);
+          fail('Expected StoragePayloadError to be thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(StoragePayloadError);
+          expect((error as StoragePayloadError).code).toBe('STORAGE_PAYLOAD_REJECTED');
+          expect((error as StoragePayloadError).statusCode).toBe(422);
+          expect((error as StoragePayloadError).context).toEqual(expect.objectContaining({ httpStatus: 400 }));
+        }
+      });
+
+      it('should throw StoragePayloadError on 422 response', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 422,
+          statusText: 'Unprocessable Entity',
+        });
+
+        const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+
+        await expect(adapter.store(mockCredential)).rejects.toThrow(StoragePayloadError);
+      });
+
+      it('should log "Storage API rejected payload" for 4xx responses', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+        });
+
+        const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+
+        await expect(adapter.store(mockCredential)).rejects.toThrow();
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            httpStatus: 400,
+            detail: 'Bad Request',
+          }),
+          'Storage API rejected payload',
+        );
+      });
+
+      it('should throw StorageStoreError (not StoragePayloadError) on 500 response', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        });
+
+        const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+
+        try {
+          await adapter.store(mockCredential);
+          fail('Expected StorageStoreError to be thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(StorageStoreError);
+          expect(error).not.toBeInstanceOf(StoragePayloadError);
+        }
+      });
+
+      it('should throw StorageStoreError on 503 response', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+        });
+
+        const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+
+        await expect(adapter.store(mockCredential)).rejects.toThrow(StorageStoreError);
       });
 
       it('should set statusCode to 502 (Bad Gateway) on StorageStoreError', async () => {

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
@@ -314,6 +314,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 500,
           statusText: 'Internal Server Error',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -337,6 +338,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 500,
           statusText: 'Internal Server Error',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -349,6 +351,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 503,
           statusText: 'Service Unavailable',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -361,11 +364,29 @@ describe('UncefactStorageAdapter', () => {
         );
       });
 
-      it('should include status text detail in the error message', async () => {
+      it('should use response body message as detail when available', async () => {
         mockFetch.mockResolvedValueOnce({
           ok: false,
           status: 400,
           statusText: 'Bad Request',
+          json: jest.fn().mockResolvedValue({ message: 'data field is required' }),
+        });
+
+        const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+
+        await expect(adapter.store(mockCredential)).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining('data field is required'),
+          }),
+        );
+      });
+
+      it('should fall back to statusText when response body has no message', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          json: jest.fn().mockResolvedValue({ error: 'something' }),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -377,11 +398,29 @@ describe('UncefactStorageAdapter', () => {
         );
       });
 
-      it('should use "Unknown error" when statusText is empty', async () => {
+      it('should fall back to statusText when response body is not JSON', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          json: jest.fn().mockRejectedValue(new SyntaxError('Unexpected token')),
+        });
+
+        const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+
+        await expect(adapter.store(mockCredential)).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining('Bad Request'),
+          }),
+        );
+      });
+
+      it('should use "Unknown error" when statusText is empty and body parsing fails', async () => {
         mockFetch.mockResolvedValueOnce({
           ok: false,
           status: 502,
           statusText: '',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -475,6 +514,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 400,
           statusText: 'Bad Request',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -495,6 +535,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 422,
           statusText: 'Unprocessable Entity',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -507,6 +548,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 400,
           statusText: 'Bad Request',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -528,6 +570,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 500,
           statusText: 'Internal Server Error',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -546,6 +589,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 503,
           statusText: 'Service Unavailable',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
@@ -558,6 +602,7 @@ describe('UncefactStorageAdapter', () => {
           ok: false,
           status: 500,
           statusText: 'Internal Server Error',
+          json: jest.fn().mockRejectedValue(new Error('no body')),
         });
 
         const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.ts
@@ -3,7 +3,7 @@ import type { LoggerService } from '../../../logging/types.js';
 import type { AdapterRegistryEntry } from '../../../registry/types.js';
 import type { IStorageService, StorageRecord } from '../../types.js';
 import type { EnvelopedVerifiableCredential } from '../../../verifiable-credential/types.js';
-import { StorageStoreError } from '../../errors.js';
+import { StoragePayloadError, StorageStoreError } from '../../errors.js';
 import type { UncefactStorageConfig } from './uncefact-storage.schema.js';
 import { uncefactStorageConfigSchema, uncefactStorageSensitiveFields } from './uncefact-storage.schema.js';
 
@@ -48,6 +48,10 @@ export class UncefactStorageAdapter extends BaseServiceAdapter implements IStora
 
     if (!response.ok) {
       const detail = response.statusText || 'Unknown error';
+      if (response.status >= 400 && response.status < 500) {
+        this.logger.error({ httpStatus: response.status, detail }, 'Storage API rejected payload');
+        throw new StoragePayloadError(response.status, detail);
+      }
       this.logger.error({ httpStatus: response.status, detail }, 'Storage API request failed');
       throw new StorageStoreError(response.status, detail);
     }

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.ts
@@ -47,7 +47,17 @@ export class UncefactStorageAdapter extends BaseServiceAdapter implements IStora
     });
 
     if (!response.ok) {
-      const detail = response.statusText || 'Unknown error';
+      let detail = response.statusText;
+      try {
+        const errorBody = await response.json();
+        if (errorBody?.message && typeof errorBody.message === 'string') {
+          detail = errorBody.message;
+        }
+      } catch {
+        // Response body is not valid JSON or is empty; fall back to statusText.
+      }
+      detail = detail || 'Unknown error';
+
       if (response.status >= 400 && response.status < 500) {
         this.logger.error({ httpStatus: response.status, detail }, 'Storage API rejected payload');
         throw new StoragePayloadError(response.status, detail);

--- a/packages/services/src/storage/errors.test.ts
+++ b/packages/services/src/storage/errors.test.ts
@@ -16,7 +16,7 @@ describe('Storage errors', () => {
       const err = new StorageStoreError(503, 'service unavailable');
       expect(err.message).toBe('Failed to store credential: HTTP 503: service unavailable');
       expect(err.code).toBe('STORAGE_STORE_FAILED');
-      expect(err.statusCode).toBe(502);
+      expect(err.statusCode).toBe(503);
       expect(err.context).toEqual({ httpStatus: 503 });
       expect(err.name).toBe('StorageStoreError');
       expect(err).toBeInstanceOf(StorageError);

--- a/packages/services/src/storage/errors.test.ts
+++ b/packages/services/src/storage/errors.test.ts
@@ -1,5 +1,5 @@
 import { ServiceError } from '../errors.js';
-import { StorageError, StorageStoreError } from './errors.js';
+import { StorageError, StoragePayloadError, StorageStoreError } from './errors.js';
 
 describe('Storage errors', () => {
   describe('StorageError', () => {
@@ -21,6 +21,39 @@ describe('Storage errors', () => {
       expect(err.name).toBe('StorageStoreError');
       expect(err).toBeInstanceOf(StorageError);
       expect(err).toBeInstanceOf(ServiceError);
+    });
+  });
+
+  describe('StoragePayloadError', () => {
+    const httpStatus = 400;
+    const detail = 'invalid JSON body';
+    const err = new StoragePayloadError(httpStatus, detail);
+
+    it('sets message correctly with HTTP status and detail', () => {
+      expect(err.message).toBe(`Storage service rejected payload: HTTP ${httpStatus}: ${detail}`);
+    });
+
+    it('sets code to STORAGE_PAYLOAD_REJECTED', () => {
+      expect(err.code).toBe('STORAGE_PAYLOAD_REJECTED');
+    });
+
+    it('sets statusCode to the provided httpStatus', () => {
+      expect(err.statusCode).toBe(httpStatus);
+    });
+
+    it('sets context.httpStatus to the provided httpStatus', () => {
+      expect(err.context).toEqual({ httpStatus });
+    });
+
+    it('is an instance of StoragePayloadError, StorageError, ServiceError, and Error', () => {
+      expect(err).toBeInstanceOf(StoragePayloadError);
+      expect(err).toBeInstanceOf(StorageError);
+      expect(err).toBeInstanceOf(ServiceError);
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('sets name to StoragePayloadError', () => {
+      expect(err.name).toBe('StoragePayloadError');
     });
   });
 });

--- a/packages/services/src/storage/errors.ts
+++ b/packages/services/src/storage/errors.ts
@@ -6,14 +6,16 @@ export class StorageError extends ServiceError {}
 /** Failed to store a credential to the upstream storage service. */
 export class StorageStoreError extends StorageError {
   constructor(httpStatus: number, detail: string) {
-    super(`Failed to store credential: HTTP ${httpStatus}: ${detail}`, 'STORAGE_STORE_FAILED', 502, { httpStatus });
+    super(`Failed to store credential: HTTP ${httpStatus}: ${detail}`, 'STORAGE_STORE_FAILED', httpStatus, {
+      httpStatus,
+    });
   }
 }
 
 /** Upstream storage service rejected the payload. */
 export class StoragePayloadError extends StorageError {
   constructor(httpStatus: number, detail: string) {
-    super(`Storage service rejected payload: HTTP ${httpStatus}: ${detail}`, 'STORAGE_PAYLOAD_REJECTED', 422, {
+    super(`Storage service rejected payload: HTTP ${httpStatus}: ${detail}`, 'STORAGE_PAYLOAD_REJECTED', httpStatus, {
       httpStatus,
     });
   }

--- a/packages/services/src/storage/errors.ts
+++ b/packages/services/src/storage/errors.ts
@@ -9,3 +9,12 @@ export class StorageStoreError extends StorageError {
     super(`Failed to store credential: HTTP ${httpStatus}: ${detail}`, 'STORAGE_STORE_FAILED', 502, { httpStatus });
   }
 }
+
+/** Upstream storage service rejected the payload. */
+export class StoragePayloadError extends StorageError {
+  constructor(httpStatus: number, detail: string) {
+    super(`Storage service rejected payload: HTTP ${httpStatus}: ${detail}`, 'STORAGE_PAYLOAD_REJECTED', 422, {
+      httpStatus,
+    });
+  }
+}


### PR DESCRIPTION
This PR adds a distinct `StoragePayloadError` so callers of the storage adapter can differentiate between "your data was wrong" (4xx from upstream) and "the service is broken" (5xx from upstream). Previously, all non-ok HTTP responses threw `StorageStoreError` regardless of cause.

The `UncefactStorageAdapter.store()` method now throws `StoragePayloadError` (code `STORAGE_PAYLOAD_REJECTED`, statusCode `422`) for 4xx responses, while 5xx responses continue to throw `StorageStoreError` (code `STORAGE_STORE_FAILED`, statusCode `502`).

## Test plan
- [x] `StoragePayloadError` unit tests: message, code, statusCode, context, inheritance chain
- [x] Adapter throws `StoragePayloadError` on 400 and 422 responses
- [x] Adapter throws `StorageStoreError` on 500 and 503 responses
- [x] Correct log messages for each error path
- [x] All 76 storage tests passing