### PR TITLE
refactor(services): clean up PYX IDR config schema

### DIFF
--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
@@ -205,8 +205,8 @@ describe('PyxIdentityResolverAdapter', () => {
         context: 'au',
         defaultLinkType: true, // 'untp:dpp' === config.defaultLinkType
         defaultMimeType: false, // 'application/json' !== config.defaultMimeType ('text/html')
-        defaultIanaLanguage: true, // defaultIanaLanguage === defaultIanaLanguage
-        defaultContext: true, // defaultContext === defaultContext
+        defaultIanaLanguage: true, // link language ('en') matches default language ('en')
+        defaultContext: true, // link context ('au') matches default context ('au')
         fwqs: false,
       });
     });

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
@@ -28,16 +28,13 @@ describe('PyxIdentityResolverAdapter', () => {
 
   const mockConfig: PyxIdrConfig = {
     baseUrl: 'https://resolver.example.com',
-    uriPrefix: '/{namespace}',
     apiKey: 'test-api-key',
     apiVersion: '2.0.0',
-    ianaLanguage: 'en',
-    context: 'au',
     defaultLinkType: 'untp:dpp',
     defaultMimeType: 'text/html',
     defaultIanaLanguage: 'en',
     defaultContext: 'au',
-    fwqs: false,
+    defaultFwqs: false,
   };
 
   const mockOptions = {
@@ -208,8 +205,8 @@ describe('PyxIdentityResolverAdapter', () => {
         context: 'au',
         defaultLinkType: true, // 'untp:dpp' === config.defaultLinkType
         defaultMimeType: false, // 'application/json' !== config.defaultMimeType ('text/html')
-        defaultIanaLanguage: true, // config.ianaLanguage === config.defaultIanaLanguage
-        defaultContext: true, // config.context === config.defaultContext
+        defaultIanaLanguage: true, // defaultIanaLanguage === defaultIanaLanguage
+        defaultContext: true, // defaultContext === defaultContext
         fwqs: false,
       });
     });
@@ -219,7 +216,7 @@ describe('PyxIdentityResolverAdapter', () => {
         ...mockOptions,
         ianaLanguage: 'de',
         context: 'us',
-        defaultLinkType: 'untp:dcc',
+        defaultLinkType: 'untp:dcc' as const,
         defaultMimeType: 'application/json',
         defaultIanaLanguage: 'de',
         defaultContext: 'us',
@@ -289,7 +286,7 @@ describe('PyxIdentityResolverAdapter', () => {
       const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
       const result = await adapter.publishLinks('abn', '51824753556', mockLinks, undefined, mockOptions);
 
-      // buildResolverUri uses uriPrefix (/{namespace}) + fallback linkTemplate (/abn/51824753556)
+      // buildResolverUri uses /{namespace} prefix + fallback linkTemplate (/abn/51824753556)
       expect(result.resolverUri).toBe('https://resolver.example.com/ato/abn/51824753556');
     });
 
@@ -741,32 +738,6 @@ describe('PyxIdentityResolverAdapter', () => {
 
       expect(result).toBe('https://resolver.example.com/ato/abn/51824753556');
     });
-
-    it('uses custom uriPrefix from config', () => {
-      const customConfig = { ...mockConfig, uriPrefix: '/custom-prefix/{namespace}' };
-      const adapter = new PyxIdentityResolverAdapter(customConfig, mockLogger);
-      const result = adapter.buildResolverUri({
-        linkTemplate: '/{primaryKey}/{value}',
-        primaryKey: 'abn',
-        value: '51824753556',
-        namespace: 'ato',
-      });
-
-      expect(result).toBe('https://resolver.example.com/custom-prefix/ato/abn/51824753556');
-    });
-
-    it('handles empty uriPrefix', () => {
-      const customConfig = { ...mockConfig, uriPrefix: '' };
-      const adapter = new PyxIdentityResolverAdapter(customConfig, mockLogger);
-      const result = adapter.buildResolverUri({
-        linkTemplate: '/{primaryKey}/{value}',
-        primaryKey: '01',
-        value: '09520123456788',
-        namespace: 'gs1',
-      });
-
-      expect(result).toBe('https://resolver.example.com/01/09520123456788');
-    });
   });
 
   describe('registerSchemes', () => {
@@ -862,8 +833,6 @@ describe('PyxIdentityResolverAdapter', () => {
       const validConfig = {
         baseUrl: 'https://resolver.example.com',
         apiKey: 'test-key',
-        ianaLanguage: 'en',
-        context: 'au',
         defaultLinkType: 'untp:dpp',
         defaultMimeType: 'text/html',
         defaultIanaLanguage: 'en',
@@ -879,12 +848,22 @@ describe('PyxIdentityResolverAdapter', () => {
       expect(() => pyxIdrRegistryEntry.configSchema.parse({ baseUrl: 'not-a-url', apiKey: '' })).toThrow();
     });
 
-    it('should default apiVersion, fwqs, and uriPrefix when not provided', () => {
+    it('should reject non-enum defaultLinkType values', () => {
       const config = {
         baseUrl: 'https://resolver.example.com',
         apiKey: 'test-key',
-        ianaLanguage: 'en',
-        context: 'au',
+        defaultLinkType: 'custom:link',
+        defaultMimeType: 'text/html',
+        defaultIanaLanguage: 'en',
+        defaultContext: 'au',
+      };
+      expect(() => pyxIdrRegistryEntry.configSchema.parse(config)).toThrow();
+    });
+
+    it('should default apiVersion and defaultFwqs when not provided', () => {
+      const config = {
+        baseUrl: 'https://resolver.example.com',
+        apiKey: 'test-key',
         defaultLinkType: 'untp:dpp',
         defaultMimeType: 'text/html',
         defaultIanaLanguage: 'en',
@@ -892,8 +871,7 @@ describe('PyxIdentityResolverAdapter', () => {
       };
       const result = pyxIdrRegistryEntry.configSchema.parse(config);
       expect(result.apiVersion).toBe('2.0.0');
-      expect(result.fwqs).toBe(false);
-      expect(result.uriPrefix).toBe('/{namespace}');
+      expect(result.defaultFwqs).toBe(false);
     });
 
     it('should reject an unsupported apiVersion', () => {
@@ -901,8 +879,6 @@ describe('PyxIdentityResolverAdapter', () => {
         baseUrl: 'https://resolver.example.com',
         apiKey: 'test-key',
         apiVersion: '1.0.0',
-        ianaLanguage: 'en',
-        context: 'au',
         defaultLinkType: 'untp:dpp',
         defaultMimeType: 'text/html',
         defaultIanaLanguage: 'en',
@@ -915,8 +891,6 @@ describe('PyxIdentityResolverAdapter', () => {
       const config = {
         baseUrl: 'https://resolver.example.com',
         apiKey: 'test-key',
-        ianaLanguage: 'en',
-        context: 'au',
         defaultLinkType: 'untp:dpp',
         defaultMimeType: 'text/html',
         defaultIanaLanguage: 'en',

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
@@ -37,33 +37,27 @@ export const PYX_IDR_ADAPTER_TYPE = 'PYX_IDR' as const;
  */
 export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements IIdentityResolverService {
   private readonly baseURL: string;
-  private readonly uriPrefix: string;
   private readonly headers: Record<string, string>;
   private readonly apiVersion: string;
-  private readonly ianaLanguage: string;
-  private readonly context: string;
   private readonly defaultLinkType: string;
   private readonly defaultMimeType: string;
   private readonly defaultIanaLanguage: string;
   private readonly defaultContext: string;
-  private readonly fwqs: boolean;
+  private readonly defaultFwqs: boolean;
 
   constructor(config: PyxIdrConfig, logger: LoggerService) {
     super(logger.child({ service: 'IDR - PyxIdentityResolver', apiVersion: config.apiVersion }));
     this.baseURL = config.baseUrl;
-    this.uriPrefix = config.uriPrefix;
     this.headers = {
       Authorization: `Bearer ${config.apiKey}`,
       'Content-Type': 'application/json',
     };
     this.apiVersion = config.apiVersion;
-    this.ianaLanguage = config.ianaLanguage;
-    this.context = config.context;
     this.defaultLinkType = config.defaultLinkType;
     this.defaultMimeType = config.defaultMimeType;
     this.defaultIanaLanguage = config.defaultIanaLanguage;
     this.defaultContext = config.defaultContext;
-    this.fwqs = config.fwqs;
+    this.defaultFwqs = config.defaultFwqs;
   }
 
   private get apiBasePath(): string {
@@ -78,13 +72,13 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
     options: PublishLinksOptions,
   ): Promise<LinkRegistration> {
     const namespace = options.namespace;
-    const ianaLanguage = options.ianaLanguage ?? this.ianaLanguage;
-    const context = options.context ?? this.context;
+    const ianaLanguage = options.ianaLanguage ?? this.defaultIanaLanguage;
+    const context = options.context ?? this.defaultContext;
     const defaultLinkType = options.defaultLinkType ?? this.defaultLinkType;
     const defaultMimeType = options.defaultMimeType ?? this.defaultMimeType;
     const defaultIanaLanguage = options.defaultIanaLanguage ?? this.defaultIanaLanguage;
     const defaultContext = options.defaultContext ?? this.defaultContext;
-    const fwqs = options.fwqs ?? this.fwqs;
+    const fwqs = options.fwqs ?? this.defaultFwqs;
 
     const payload = {
       namespace,
@@ -247,7 +241,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
 
   buildResolverUri(parts: ResolverUriParts): string {
     // Render IDR-specific prefix
-    const prefix = this.uriPrefix.replace('{namespace}', parts.namespace);
+    const prefix = `/${parts.namespace}`;
 
     // Render scheme link template
     let path = parts.linkTemplate.replace('{primaryKey}', parts.primaryKey).replace('{value}', parts.value);

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.schema.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.schema.ts
@@ -2,22 +2,18 @@ import { z } from 'zod';
 
 export const pyxIdrConfigSchema = z.object({
   baseUrl: z.string().url().describe('Base URL||The base URL of the Pyx IDR instance (no path segments)'),
-  uriPrefix: z
-    .string()
-    .default('/{namespace}')
-    .describe('URI Prefix||IDR-specific prefix template prepended to scheme link templates (e.g., "/{namespace}")'),
   apiKey: z.string().min(1).describe('API Key||The API key for authenticating with the Pyx IDR'),
   apiVersion: z.enum(['2.0.0']).default('2.0.0').describe('API Version||The Pyx IDR API version to use'),
-  ianaLanguage: z.string().min(1).describe('Language||IANA language tag applied to links (e.g., "en")'),
-  context: z.string().min(1).describe('Context||Regional/market context (e.g., "au", "us")'),
   defaultLinkType: z
-    .string()
-    .min(1)
-    .describe('Default Link Type||Link relation type to flag as default (e.g., "untp:dpp")'),
+    .enum(['untp:dpp', 'untp:dcc', 'untp:dte', 'untp:idr', 'untp:dfr', 'untp:dia', 'untp:cvc'])
+    .describe('Default Link Type||Link relation type to flag as default'),
   defaultMimeType: z.string().min(1).describe('Default MIME Type||MIME type to flag as default (e.g., "text/html")'),
   defaultIanaLanguage: z.string().min(1).describe('Default Language||Language to flag as default (e.g., "en")'),
   defaultContext: z.string().min(1).describe('Default Context||Regional context to flag as default (e.g., "au")'),
-  fwqs: z.boolean().default(false).describe('Forward Query String||Whether to forward query strings to target URLs'),
+  defaultFwqs: z
+    .boolean()
+    .default(false)
+    .describe('Forward Query String||Whether to forward query strings to target URLs'),
 });
 
 /** Fields whose values should be treated as sensitive (e.g. masked in UI, encrypted at rest). */


### PR DESCRIPTION
This PR removes redundant fields from the PYX IDR adapter config, constrains `defaultLinkType` to known UNTP link types, and renames `fwqs` to `defaultFwqs` for consistency with other default-prefixed fields.

- **Removed** `uriPrefix` (PYX always uses `/{namespace}`), `ianaLanguage` (redundant with `defaultIanaLanguage`), and `context` (redundant with `defaultContext`)
- **Changed** `defaultLinkType` from free-form string to `z.enum` restricted to UNTP link types
- **Renamed** `fwqs` to `defaultFwqs`

## Test plan
- [x] All 51 PYX IDR adapter tests pass
- [x] Schema validation rejects non-enum `defaultLinkType` values
- [x] Fallbacks now correctly use `defaultIanaLanguage`/`defaultContext` instead of the removed fields
- [x] Lint passes with no new errors