### PR TITLE
feat(api)!: add VERIFICATION_FAILED status and enforce DID eligibility on credential issuance

### DIFF
--- a/e2e/cypress/e2e/did_api/did-management.cy.ts
+++ b/e2e/cypress/e2e/did_api/did-management.cy.ts
@@ -149,6 +149,7 @@ describe('DID API', { testIsolation: false }, () => {
         expect(response.body.did.status).to.be.oneOf([
           'VERIFIED',
           'UNVERIFIED',
+          'VERIFICATION_FAILED',
         ]);
       });
     });
@@ -224,6 +225,7 @@ describe('DID API', { testIsolation: false }, () => {
         expect(response.body.did.status).to.be.oneOf([
           'VERIFIED',
           'UNVERIFIED',
+          'VERIFICATION_FAILED',
         ]);
       });
     });

--- a/packages/reference-implementation/prisma/migrations/20260302000000_add_verification_failed_status/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260302000000_add_verification_failed_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "DidStatus" ADD VALUE 'VERIFICATION_FAILED';

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -25,6 +25,7 @@ enum DidStatus {
   INACTIVE
   VERIFIED
   UNVERIFIED
+  VERIFICATION_FAILED
 }
 
 enum ServiceType {

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -121,6 +121,35 @@ describe('POST /api/v1/credentials', () => {
     mockCreateCredential.mockResolvedValue({ id: 'cred-1' });
   });
 
+  // ── Validation: body parsing ─────────────────────────────────────────────
+
+  it('returns 400 when body is not valid JSON', async () => {
+    const req = {
+      method: 'POST',
+      url: 'http://localhost/api/v1/credentials',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => {
+        throw new Error('Unexpected end of JSON input');
+      },
+    } as unknown as Request;
+
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 when credentialPayload is missing', async () => {
+    const res = await POST(fakeRequest({}), AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe('credentialPayload is required and must be an object');
+  });
+
   // ── Validation: missing issuer.id ────────────────────────────────────────
 
   it('returns 400 when credentialPayload.issuer.id is missing', async () => {
@@ -217,6 +246,7 @@ describe('POST /api/v1/credentials', () => {
     const json = await res.json();
 
     expect(res.status).toBe(201);
+    expect(json.ok).toBe(true);
     expect(json.credentialId).toBe('cred-1');
 
     // Verify the full happy path was executed
@@ -244,6 +274,7 @@ describe('POST /api/v1/credentials', () => {
     const json = await res.json();
 
     expect(res.status).toBe(201);
+    expect(json.ok).toBe(true);
     expect(json.credentialId).toBe('cred-1');
 
     // Verify the full happy path was executed

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -1,0 +1,263 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth to mirror handleRouteError behaviour
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { NotFoundError, UnprocessableError, errorMessage, ServiceRegistryError } =
+    jest.requireActual('@/lib/api/errors');
+  const { ValidationError } = jest.requireActual('@/lib/api/validation');
+  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
+
+  function jsonResponse(body: unknown, init?: { status?: number }) {
+    return { status: init?.status ?? 200, json: async () => body };
+  }
+
+  return {
+    withTenantAuth:
+      (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
+        try {
+          return await handler(req, ctx);
+        } catch (e: unknown) {
+          if (e instanceof ValidationError) {
+            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+          }
+          if (e instanceof NotFoundError) {
+            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+          }
+          if (e instanceof UnprocessableError) {
+            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 422 });
+          }
+          if (e instanceof ServiceRegistryError) {
+            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+          }
+          if (e instanceof ServiceError) {
+            const serviceErr = e as Error & { code?: string; statusCode?: number };
+            return jsonResponse(
+              { ok: false, error: serviceErr.message, code: serviceErr.code },
+              { status: serviceErr.statusCode },
+            );
+          }
+          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+        }
+      },
+  };
+});
+
+const mockGetDidByDid = jest.fn();
+const mockCreateCredential = jest.fn();
+const mockResolveVcService = jest.fn();
+const mockResolveStorageService = jest.fn();
+const mockResolveIdrService = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getDidByDid: (did: string, tenantId: string) => mockGetDidByDid(did, tenantId),
+  createCredential: (input: unknown) => mockCreateCredential(input),
+}));
+
+jest.mock('@/lib/services/resolve-vc-service', () => ({
+  resolveVcService: (...args: unknown[]) => mockResolveVcService(...args),
+}));
+
+jest.mock('@/lib/services/resolve-storage-service', () => ({
+  resolveStorageService: (...args: unknown[]) => mockResolveStorageService(...args),
+}));
+
+jest.mock('@/lib/services/resolve-idr-service', () => ({
+  resolveIdrService: (...args: unknown[]) => mockResolveIdrService(...args),
+}));
+
+import { POST } from './route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function fakeRequest(body: unknown): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/credentials',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => body,
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
+
+const validPayload = {
+  '@context': ['https://www.w3.org/ns/credentials/v2'],
+  type: ['VerifiableCredential'],
+  issuer: { type: ['Organization'], id: 'did:web:example.com', name: 'Test' },
+  credentialSubject: { id: 'subject-1' },
+};
+
+const signedCredential = { ...validPayload, proof: { type: 'Ed25519Signature2020' } };
+
+const storageResponse = {
+  uri: 'https://storage.example.com/creds/abc123',
+  hash: 'sha256-abc123',
+  decryptionKey: 'dec-key-1',
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/credentials', () => {
+  const mockVcService = { sign: jest.fn() };
+  const mockStorageService = { store: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockResolveVcService.mockResolvedValue({ service: mockVcService, instanceId: 'vc-inst-1' });
+    mockResolveStorageService.mockResolvedValue({ service: mockStorageService, instanceId: 'storage-inst-1' });
+    mockResolveIdrService.mockResolvedValue({ service: {}, instanceId: 'idr-inst-1' });
+
+    mockVcService.sign.mockResolvedValue(signedCredential);
+    mockStorageService.store.mockResolvedValue(storageResponse);
+    mockCreateCredential.mockResolvedValue({ id: 'cred-1' });
+  });
+
+  // ── Validation: missing issuer.id ────────────────────────────────────────
+
+  it('returns 400 when credentialPayload.issuer.id is missing', async () => {
+    const body = {
+      credentialPayload: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        issuer: { type: ['Organization'], name: 'No ID Issuer' },
+        credentialSubject: { id: 'subject-1' },
+      },
+    };
+
+    const res = await POST(fakeRequest(body), AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe('credentialPayload.issuer.id is required');
+  });
+
+  // ── DID not registered ───────────────────────────────────────────────────
+
+  it('returns 422 when issuer DID is not registered for the tenant', async () => {
+    mockGetDidByDid.mockResolvedValue(null);
+
+    const res = await POST(
+      fakeRequest({ credentialPayload: validPayload }),
+      AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.ok).toBe(false);
+    expect(json.error).toBe('Issuer DID is not registered for this tenant');
+    expect(mockGetDidByDid).toHaveBeenCalledWith('did:web:example.com', 'org-1');
+  });
+
+  // ── Non-issuable DID statuses ────────────────────────────────────────────
+
+  it('returns 422 when issuer DID status is VERIFICATION_FAILED', async () => {
+    mockGetDidByDid.mockResolvedValue({ id: 'did-1', did: 'did:web:example.com', status: 'VERIFICATION_FAILED' });
+
+    const res = await POST(
+      fakeRequest({ credentialPayload: validPayload }),
+      AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('VERIFICATION_FAILED');
+    expect(json.error).toContain('not eligible for credential issuance');
+  });
+
+  it('returns 422 when issuer DID status is UNVERIFIED', async () => {
+    mockGetDidByDid.mockResolvedValue({ id: 'did-2', did: 'did:web:example.com', status: 'UNVERIFIED' });
+
+    const res = await POST(
+      fakeRequest({ credentialPayload: validPayload }),
+      AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('UNVERIFIED');
+    expect(json.error).toContain('not eligible for credential issuance');
+  });
+
+  it('returns 422 when issuer DID status is INACTIVE', async () => {
+    mockGetDidByDid.mockResolvedValue({ id: 'did-3', did: 'did:web:example.com', status: 'INACTIVE' });
+
+    const res = await POST(
+      fakeRequest({ credentialPayload: validPayload }),
+      AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain('INACTIVE');
+    expect(json.error).toContain('not eligible for credential issuance');
+  });
+
+  // ── Issuable DID statuses (happy paths) ──────────────────────────────────
+
+  it('returns 201 when issuer DID status is ACTIVE', async () => {
+    mockGetDidByDid.mockResolvedValue({ id: 'did-4', did: 'did:web:example.com', status: 'ACTIVE' });
+
+    const res = await POST(
+      fakeRequest({ credentialPayload: validPayload }),
+      AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.credentialId).toBe('cred-1');
+
+    // Verify the full happy path was executed
+    expect(mockVcService.sign).toHaveBeenCalledWith(validPayload);
+    expect(mockStorageService.store).toHaveBeenCalledWith(signedCredential, true);
+    expect(mockCreateCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'org-1',
+        storageUri: storageResponse.uri,
+        hash: storageResponse.hash,
+        decryptionKey: storageResponse.decryptionKey,
+        credentialType: 'VerifiableCredential',
+        isPublished: false,
+      }),
+    );
+  });
+
+  it('returns 201 when issuer DID status is VERIFIED', async () => {
+    mockGetDidByDid.mockResolvedValue({ id: 'did-5', did: 'did:web:example.com', status: 'VERIFIED' });
+
+    const res = await POST(
+      fakeRequest({ credentialPayload: validPayload }),
+      AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.credentialId).toBe('cred-1');
+
+    // Verify the full happy path was executed
+    expect(mockVcService.sign).toHaveBeenCalledWith(validPayload);
+    expect(mockStorageService.store).toHaveBeenCalledWith(signedCredential, true);
+    expect(mockCreateCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'org-1',
+        storageUri: storageResponse.uri,
+        hash: storageResponse.hash,
+        decryptionKey: storageResponse.decryptionKey,
+        credentialType: 'VerifiableCredential',
+        isPublished: false,
+      }),
+    );
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -8,16 +8,9 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth to mirror handleRouteError behaviour
+// Mock withTenantAuth — delegates error handling to the real handleRouteError
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, UnprocessableError, errorMessage, ServiceRegistryError } =
-    jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
 
   return {
     withTenantAuth:
@@ -25,26 +18,7 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
         try {
           return await handler(req, ctx);
         } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
-          }
-          if (e instanceof UnprocessableError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 422 });
-          }
-          if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
-          }
-          if (e instanceof ServiceError) {
-            const serviceErr = e as Error & { code?: string; statusCode?: number };
-            return jsonResponse(
-              { ok: false, error: serviceErr.message, code: serviceErr.code },
-              { status: serviceErr.statusCode },
-            );
-          }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return handleRouteError(e);
         }
       },
   };

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -130,7 +130,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       'Credential issuance rejected — issuer DID status not eligible',
     );
     throw new UnprocessableError(
-      `Issuer DID status (${didRecord.status}) is not eligible for credential issuance. DID must be ACTIVE or VERIFIED.`,
+      `Issuer DID status (${
+        didRecord.status
+      }) is not eligible for credential issuance. DID must be ${ISSUABLE_DID_STATUSES.join(' or ')}.`,
     );
   }
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -62,6 +62,9 @@ const logger = apiLogger.child({ route: '/api/v1/credentials' });
  *             schema:
  *               type: object
  *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
  *                 credentialId:
  *                   type: string
  *                   description: Database record ID for the credential
@@ -118,9 +121,14 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   logger.info({ tenantId, issuerDid }, 'Verifying issuer DID is registered and issuable');
   const didRecord = await getDidByDid(issuerDid, tenantId);
   if (!didRecord) {
+    logger.warn({ tenantId, issuerDid }, 'Credential issuance rejected — issuer DID not registered');
     throw new UnprocessableError('Issuer DID is not registered for this tenant');
   }
-  if (!ISSUABLE_DID_STATUSES.includes(didRecord.status as (typeof ISSUABLE_DID_STATUSES)[number])) {
+  if (!(ISSUABLE_DID_STATUSES as readonly string[]).includes(didRecord.status)) {
+    logger.warn(
+      { tenantId, issuerDid, didStatus: didRecord.status, didId: didRecord.id },
+      'Credential issuance rejected — issuer DID status not eligible',
+    );
     throw new UnprocessableError(
       `Issuer DID status (${didRecord.status}) is not eligible for credential issuance. DID must be ACTIVE or VERIFIED.`,
     );
@@ -166,5 +174,5 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     'Credential issued and stored',
   );
 
-  return NextResponse.json({ credentialId: credentialRecord.id }, { status: 201 });
+  return NextResponse.json({ ok: true, credentialId: credentialRecord.id }, { status: 201 });
 });

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
 import { ValidationError } from '@/lib/api/validation';
+import { UnprocessableError } from '@/lib/api/errors';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
 import { resolveStorageService } from '@/lib/services/resolve-storage-service';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
-import { createCredential } from '@/lib/prisma/repositories';
+import { createCredential, getDidByDid } from '@/lib/prisma/repositories';
+import { ISSUABLE_DID_STATUSES } from '@uncefact/untp-ri-services';
 import type { CredentialPayload } from '@uncefact/untp-ri-services';
 
 const logger = apiLogger.child({ route: '/api/v1/credentials' });
@@ -75,6 +77,12 @@ const logger = apiLogger.child({ route: '/api/v1/credentials' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       422:
+ *         description: Issuer DID is not registered for this tenant or not in an issuable status (ACTIVE or VERIFIED)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error during credential issuance
  *         content:
@@ -100,6 +108,22 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   if (!body.credentialPayload || typeof body.credentialPayload !== 'object') {
     throw new ValidationError('credentialPayload is required and must be an object');
+  }
+
+  const issuerDid = body.credentialPayload.issuer?.id;
+  if (!issuerDid || typeof issuerDid !== 'string') {
+    throw new ValidationError('credentialPayload.issuer.id is required');
+  }
+
+  logger.info({ tenantId, issuerDid }, 'Verifying issuer DID is registered and issuable');
+  const didRecord = await getDidByDid(issuerDid, tenantId);
+  if (!didRecord) {
+    throw new UnprocessableError('Issuer DID is not registered for this tenant');
+  }
+  if (!ISSUABLE_DID_STATUSES.includes(didRecord.status as (typeof ISSUABLE_DID_STATUSES)[number])) {
+    throw new UnprocessableError(
+      `Issuer DID status (${didRecord.status}) is not eligible for credential issuance. DID must be ACTIVE or VERIFIED.`,
+    );
   }
 
   const shouldEncrypt = body.encrypt !== false;

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
@@ -69,5 +69,6 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   logger.info({ tenantId, didId: id, did: did.did }, 'Fetching DID document from provider');
   const document = await didService.getDocument(did.did);
 
+  logger.info({ tenantId, didId: id }, 'DID document retrieved');
   return NextResponse.json({ ok: true, document });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -56,11 +56,14 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]' });
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
+
   logger.info({ tenantId, didId: id }, 'Looking up DID');
   const did = await getDidById(id, tenantId);
   if (!did) {
     throw new NotFoundError('DID not found');
   }
+
+  logger.info({ tenantId, didId: id, did: did.did }, 'DID retrieved');
   return NextResponse.json({ ok: true, did });
 });
 
@@ -134,6 +137,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PUT = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
+  logger.info({ tenantId, didId: id }, 'Parsing request body');
   let body: { name?: string; description?: string };
   try {
     body = await req.json();
@@ -141,6 +145,7 @@ export const PUT = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
+  logger.info({ tenantId, didId: id }, 'Validating update fields');
   const hasName = isNonEmptyString(body.name);
   const hasDescription = isNonEmptyString(body.description);
 
@@ -148,7 +153,7 @@ export const PUT = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('At least one of name or description is required');
   }
 
-  logger.info({ tenantId, didId: id, fields: { hasName, hasDescription } }, 'Updating DID');
+  logger.info({ tenantId, didId: id, fields: { hasName, hasDescription } }, 'Updating DID record');
   const updated = await updateDid(id, tenantId, {
     ...(hasName && { name: body.name }),
     ...(hasDescription && { description: body.description }),

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -57,6 +57,7 @@ jest.mock('@uncefact/untp-ri-services', () => ({
     INACTIVE: 'INACTIVE',
     VERIFIED: 'VERIFIED',
     UNVERIFIED: 'UNVERIFIED',
+    VERIFICATION_FAILED: 'VERIFICATION_FAILED',
   },
 }));
 
@@ -113,7 +114,7 @@ describe('POST /api/v1/dids/:id/verify', () => {
     expect(mockUpdateDidStatus).toHaveBeenCalledWith('did-1', 'org-1', 'VERIFIED');
   });
 
-  it('updates status to UNVERIFIED when verification fails', async () => {
+  it('updates status to VERIFICATION_FAILED when verification fails', async () => {
     mockGetDidById.mockResolvedValue({ id: 'did-1', did: 'did:web:example.com' });
     const verification = {
       verified: false,
@@ -121,13 +122,13 @@ describe('POST /api/v1/dids/:id/verify', () => {
       errors: [{ check: 'resolve', message: 'Resolution failed' }],
     };
     mockDidService.verify.mockResolvedValue(verification);
-    mockUpdateDidStatus.mockResolvedValue({ id: 'did-1', status: 'UNVERIFIED' });
+    mockUpdateDidStatus.mockResolvedValue({ id: 'did-1', status: 'VERIFICATION_FAILED' });
 
     const res = await POST(createFakeRequest(), createContext('did-1') as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(json.verification.verified).toBe(false);
-    expect(mockUpdateDidStatus).toHaveBeenCalledWith('did-1', 'org-1', 'UNVERIFIED');
+    expect(mockUpdateDidStatus).toHaveBeenCalledWith('did-1', 'org-1', 'VERIFICATION_FAILED');
   });
 
   it('returns 404 when DID not found', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
@@ -1,10 +1,10 @@
-import { NextResponse } from 'next/server';
-import { resolveDidService } from '@/lib/services/resolve-did-service';
 import { NotFoundError } from '@/lib/api/errors';
-import { DidStatus } from '@uncefact/untp-ri-services';
+import { apiLogger } from '@/lib/api/logger';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getDidById, updateDidStatus } from '@/lib/prisma/repositories';
-import { apiLogger } from '@/lib/api/logger';
+import { resolveDidService } from '@/lib/services/resolve-did-service';
+import { DidStatus } from '@uncefact/untp-ri-services';
+import { NextResponse } from 'next/server';
 
 const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
 
@@ -16,7 +16,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
  *     description: |
  *       Verifies ownership of a DID and updates its status accordingly.
  *       If verification succeeds, the DID status is set to VERIFIED.
- *       If verification fails, the status remains UNVERIFIED.
+ *       If verification fails, the DID status is set to VERIFICATION_FAILED.
  *     tags:
  *       - DIDs
  *     parameters:
@@ -75,7 +75,7 @@ export const POST = withTenantAuth(async (_req, { tenantId, params }) => {
   logger.info({ tenantId, didId: id, did: did.did }, 'Verifying DID ownership');
   const verification = await didService.verify(did.did);
 
-  const newStatus = verification.verified ? DidStatus.VERIFIED : DidStatus.UNVERIFIED;
+  const newStatus = verification.verified ? DidStatus.VERIFIED : DidStatus.VERIFICATION_FAILED;
   logger.info({ tenantId, didId: id, verified: verification.verified, newStatus }, 'Updating DID status');
   const updatedDid = await updateDidStatus(id, tenantId, newStatus);
 

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -80,12 +80,14 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     serviceInstanceId?: string;
   };
 
+  logger.info({ tenantId }, 'Parsing request body');
   try {
     body = await req.json();
   } catch {
     throw new ValidationError('Invalid JSON body');
   }
 
+  logger.info({ tenantId, did: body.did, method: body.method }, 'Validating import parameters');
   if (!isNonEmptyString(body.did)) {
     throw new ValidationError('did is required');
   }
@@ -98,7 +100,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('method is required');
   }
 
-  logger.info({ tenantId, did: body.did, method }, 'Importing external DID');
+  logger.info({ tenantId, did: body.did, method }, 'Saving imported DID record');
   const record = await createDid({
     tenantId,
     did: body.did,

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -96,12 +96,14 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     serviceInstanceId?: string;
   };
 
+  logger.info({ tenantId }, 'Parsing request body');
   try {
     body = await req.json();
   } catch {
     throw new ValidationError('Invalid JSON body');
   }
 
+  logger.info({ tenantId, type: body.type, method: body.method, alias: body.alias }, 'Validating input parameters');
   const type = validateEnum(body.type, CREATABLE_DID_TYPES, 'type');
   if (!type) throw new ValidationError('type is required');
 
@@ -118,9 +120,11 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     body.serviceInstanceId,
   );
 
+  logger.info({ tenantId, serviceInstanceId }, 'Validating parameters against service capabilities');
   validateEnum(type, didService.getSupportedTypes(), 'type');
   validateEnum(method, didService.getSupportedMethods(), 'method');
 
+  logger.info({ tenantId, alias: body.alias, method }, 'Normalising alias');
   let normalisedAlias: string;
   try {
     normalisedAlias = didService.normaliseAlias(body.alias, method);
@@ -175,7 +179,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: status
  *         schema:
  *           type: string
- *           enum: [ACTIVE, UNVERIFIED, VERIFIED, REVOKED]
+ *           enum: [ACTIVE, INACTIVE, UNVERIFIED, VERIFIED, VERIFICATION_FAILED]
  *         description: Filter by DID status
  *       - in: query
  *         name: serviceInstanceId
@@ -231,13 +235,14 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   const url = new URL(req.url);
 
+  logger.info({ tenantId }, 'Parsing and validating query filters');
   const type = validateEnum(url.searchParams.get('type') ?? undefined, Object.values(DidType), 'type');
   const status = validateEnum(url.searchParams.get('status') ?? undefined, Object.values(DidStatus), 'status');
   const serviceInstanceId = url.searchParams.get('serviceInstanceId') ?? undefined;
   const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, filters: { type, status, serviceInstanceId, limit, offset } }, 'Listing DIDs');
+  logger.info({ tenantId, filters: { type, status, serviceInstanceId, limit, offset } }, 'Querying DIDs from database');
   const dids = await listDids(tenantId, {
     type,
     status,

--- a/packages/reference-implementation/src/lib/api/errors.ts
+++ b/packages/reference-implementation/src/lib/api/errors.ts
@@ -12,6 +12,13 @@ export class NotFoundError extends Error {
   }
 }
 
+export class UnprocessableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnprocessableError';
+  }
+}
+
 export class ServiceRegistryError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
@@ -9,6 +9,7 @@ jest.mock('next/server', () => ({
 
 import {
   NotFoundError,
+  UnprocessableError,
   ServiceRegistryError,
   ServiceInstanceNotFoundError,
   ServiceResolutionError,
@@ -46,6 +47,14 @@ describe('handleRouteError', () => {
     expect(res.status).toBe(404);
     const body = await (res as unknown as MockResponse).json();
     expect(body).toEqual({ ok: false, error: 'missing' });
+  });
+
+  it('maps UnprocessableError to 422', async () => {
+    const res = handleRouteError(new UnprocessableError('cannot process'));
+
+    expect(res.status).toBe(422);
+    const body = await (res as unknown as MockResponse).json();
+    expect(body).toEqual({ ok: false, error: 'cannot process' });
   });
 
   // --- ServiceRegistryError sub-types ---

--- a/packages/reference-implementation/src/lib/api/handle-route-error.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { NotFoundError, errorMessage, ServiceRegistryError } from '@/lib/api/errors';
+import { NotFoundError, UnprocessableError, errorMessage, ServiceRegistryError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { ServiceError } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
@@ -25,6 +25,10 @@ export function handleRouteError(e: unknown): Response {
   if (e instanceof NotFoundError) {
     logger.warn({ err: e }, 'Not found');
     return NextResponse.json({ ok: false, error: e.message }, { status: 404 });
+  }
+  if (e instanceof UnprocessableError) {
+    logger.warn({ err: e }, 'Unprocessable entity');
+    return NextResponse.json({ ok: false, error: e.message }, { status: 422 });
   }
   if (e instanceof ServiceRegistryError) {
     const status = e.name === 'ServiceInstanceNotFoundError' ? 404 : 500;

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -1,4 +1,12 @@
-import { createDid, getDidById, listDids, updateDid, updateDidStatus, getDefaultDid } from './did.repository';
+import {
+  createDid,
+  getDidById,
+  getDidByDid,
+  listDids,
+  updateDid,
+  updateDidStatus,
+  getDefaultDid,
+} from './did.repository';
 import type { DidStatus } from '../generated';
 
 // Transaction mock — functions called via $transaction callback
@@ -168,6 +176,44 @@ describe('did.repository', () => {
       mockDid.findFirst.mockResolvedValue(null);
 
       const result = await getDidById('did-record-1', 'other-org');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getDidByDid', () => {
+    it('returns the DID when found by DID string and tenantId', async () => {
+      mockDid.findFirst.mockResolvedValue(DID_RECORD);
+
+      const result = await getDidByDid('did:web:example.com:org:123', ORG_ID);
+
+      expect(mockDid.findFirst).toHaveBeenCalledWith({
+        where: {
+          did: 'did:web:example.com:org:123',
+          OR: [{ tenantId: ORG_ID }, { isDefault: true }],
+        },
+      });
+      expect(result).toEqual(DID_RECORD);
+    });
+
+    it('returns the system default DID even for a different tenant', async () => {
+      const defaultDid = { ...DID_RECORD, isDefault: true, tenantId: 'system' };
+      mockDid.findFirst.mockResolvedValue(defaultDid);
+
+      const result = await getDidByDid('did:web:example.com:org:123', 'other-org');
+
+      expect(mockDid.findFirst).toHaveBeenCalledWith({
+        where: {
+          did: 'did:web:example.com:org:123',
+          OR: [{ tenantId: 'other-org' }, { isDefault: true }],
+        },
+      });
+      expect(result).toEqual(defaultDid);
+    });
+
+    it('returns null when the DID does not exist', async () => {
+      mockDid.findFirst.mockResolvedValue(null);
+
+      const result = await getDidByDid('did:web:nonexistent', ORG_ID);
       expect(result).toBeNull();
     });
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -72,7 +72,8 @@ export async function getDidById(id: string, tenantId: string): Promise<Did | nu
 
 /**
  * Retrieves a DID by its DID string (e.g. "did:web:example.com"), scoped to an organisation.
- * Returns null if the DID does not exist or belongs to a different organisation.
+ * Also returns system default DIDs regardless of tenant. Returns null if the DID
+ * does not exist or belongs to a different non-default organisation.
  */
 export async function getDidByDid(did: string, tenantId: string): Promise<Did | null> {
   return prisma.did.findFirst({

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -14,7 +14,7 @@ export type CreateDidInput = {
   name?: string;
   description?: string;
   isDefault?: boolean;
-  status?: 'ACTIVE' | 'INACTIVE' | 'VERIFIED' | 'UNVERIFIED';
+  status?: 'ACTIVE' | 'INACTIVE' | 'VERIFIED' | 'UNVERIFIED' | 'VERIFICATION_FAILED';
   serviceInstanceId?: string;
 };
 
@@ -31,7 +31,7 @@ export type UpdateDidInput = {
  */
 export type ListDidsOptions = {
   type?: 'DEFAULT' | 'MANAGED' | 'SELF_MANAGED';
-  status?: 'ACTIVE' | 'INACTIVE' | 'VERIFIED' | 'UNVERIFIED';
+  status?: 'ACTIVE' | 'INACTIVE' | 'VERIFIED' | 'UNVERIFIED' | 'VERIFICATION_FAILED';
   serviceInstanceId?: string;
   limit?: number;
   offset?: number;
@@ -65,6 +65,19 @@ export async function getDidById(id: string, tenantId: string): Promise<Did | nu
   return prisma.did.findFirst({
     where: {
       id,
+      OR: [{ tenantId }, { isDefault: true }],
+    },
+  });
+}
+
+/**
+ * Retrieves a DID by its DID string (e.g. "did:web:example.com"), scoped to an organisation.
+ * Returns null if the DID does not exist or belongs to a different organisation.
+ */
+export async function getDidByDid(did: string, tenantId: string): Promise<Did | null> {
+  return prisma.did.findFirst({
+    where: {
+      did,
       OR: [{ tenantId }, { isDefault: true }],
     },
   });

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -40,10 +40,15 @@ export enum DidStatus {
   VERIFIED = 'VERIFIED',
   /** Self-managed DID created but not yet verified (initial state for SELF_MANAGED) */
   UNVERIFIED = 'UNVERIFIED',
+  /** Self-managed DID verification was attempted and failed */
+  VERIFICATION_FAILED = 'VERIFICATION_FAILED',
 }
 
 /** DID types that can be created via the API (excludes DEFAULT, which is system-managed). */
 export const CREATABLE_DID_TYPES = [DidType.MANAGED, DidType.SELF_MANAGED] as const;
+
+/** DID statuses that are eligible for credential issuance. */
+export const ISSUABLE_DID_STATUSES: readonly DidStatus[] = [DidStatus.ACTIVE, DidStatus.VERIFIED];
 
 // ── Input / option types ───────────────────────────────────────────────────
 

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -48,7 +48,7 @@ export enum DidStatus {
 export const CREATABLE_DID_TYPES = [DidType.MANAGED, DidType.SELF_MANAGED] as const;
 
 /** DID statuses that are eligible for credential issuance. */
-export const ISSUABLE_DID_STATUSES: readonly DidStatus[] = [DidStatus.ACTIVE, DidStatus.VERIFIED];
+export const ISSUABLE_DID_STATUSES = [DidStatus.ACTIVE, DidStatus.VERIFIED] as const;
 
 // ── Input / option types ───────────────────────────────────────────────────
 


### PR DESCRIPTION
This PR adds a `VERIFICATION_FAILED` DID status and enforces DID eligibility checks on credential issuance, preventing credentials from being issued against DIDs that are not `ACTIVE` or `VERIFIED`. Previously, a failed DID verification set the status back to `UNVERIFIED`, making it impossible to distinguish "never verified" from "verification attempted and failed".

## Changes

- **VERIFICATION_FAILED status**: New `DidStatus` enum value across the services package, Prisma schema, and database migration. The verify route now sets `VERIFICATION_FAILED` (not `UNVERIFIED`) when verification fails.
- **Credential issuance enforcement**: The `POST /credentials` route validates that the issuer DID is registered to the tenant and in an issuable status (`ACTIVE` or `VERIFIED`). Unregistered or ineligible DIDs are rejected with HTTP 422.
- **UnprocessableError**: New error class mapped to 422 in the centralised error handler, filling the gap between 400 (malformed input) and 404 (not found).
- **Step-level logging**: All DID route handlers now log each discrete operation for production debugging.

## Test plan
- [x] All five DID statuses tested against credential issuance (ACTIVE/VERIFIED pass, VERIFICATION_FAILED/UNVERIFIED/INACTIVE rejected)
- [x] Unregistered DID rejected with 422
- [x] Invalid JSON body and missing credentialPayload return 400
- [x] Verify route sets VERIFICATION_FAILED on failed verification
- [x] UnprocessableError maps to 422 in error handler
- [x] getDidByDid repository function tested (tenant scoping, system defaults, not found)
- [x] 884 tests pass across 76 suites, no regressions