### PR TITLE
chore(auth): remove unused service account client ID and secret env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,6 @@ AUTH_OIDC_ISSUER=http://localhost:8080/realms/untp-reference-implementation
 # AUTH_OIDC_AUTHORIZATION_URL=
 
 # Service Account Configuration (for machine-to-machine API access)
-# The service account client ID and secret are used to obtain access tokens via client credentials grant
-AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_ID=ri-service-account
-AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_SECRET=service-account-secret
 # Required: The expected audience claim in service account tokens.
 # Must match the audience configured in your IdP for the service account client.
 # Keycloak: Add an "audience" mapper to your service account client scope

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -177,8 +177,6 @@ services:
       - AUTH_OIDC_CLIENT_ID=ri-app-e2e
       - AUTH_OIDC_CLIENT_SECRET=e2e-test-secret
       - AUTH_OIDC_ISSUER=http://localhost:8081/realms/ri-e2e
-      - AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_ID=ri-service-account-e2e
-      - AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_SECRET=e2e-service-account-secret
       - AUTH_OIDC_SERVICE_ACCOUNT_AUDIENCE=ri-api
       - UNCEFACT_STORAGE_URL=http://storage-service:3334/api/3.0.0/public
       - UNCEFACT_STORAGE_API_KEY=test123

--- a/documentation/docs/reference-implementation/service-account-authentication.md
+++ b/documentation/docs/reference-implementation/service-account-authentication.md
@@ -114,6 +114,4 @@ Configure the following environment variables for service account support:
 |----------|-------------|---------|
 | `AUTH_OIDC_ISSUER` | OIDC provider issuer URL | Required |
 | `AUTH_OIDC_PROVIDER` | Provider type (`keycloak` or `zitadel`) | `keycloak` |
-| `AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_ID` | Service account client ID | `ri-service-account` |
-| `AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_SECRET` | Service account client secret | `service-account-secret` |
 | `AUTH_OIDC_SERVICE_ACCOUNT_AUDIENCE` | Expected token audience (must match IdP audience claim) | Required |


### PR DESCRIPTION
This PR removes `AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_ID` and `AUTH_OIDC_SERVICE_ACCOUNT_CLIENT_SECRET` from the codebase. The RI only validates incoming service account JWTs (checking issuer and audience); it never performs a client credentials exchange itself. These variables were configured but never read by any application code, making them dead config.

## Test plan
- [x] Confirmed no TypeScript/JS code references either variable
- [x] `AUTH_OIDC_SERVICE_ACCOUNT_AUDIENCE` (the only variable the RI actually uses) is preserved
- [x] Verified similarly named `AUTH_KEYCLOAK_*` variants (used by provisioning script) are unaffected