### PR TITLE
fix(api): include system-provisioned render templates in tenant queries

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
@@ -14,7 +14,7 @@ const UPDATABLE_FIELDS = ['name', 'storageUrl', 'hash', 'isPrimary'] as const;
  * /render-templates/{id}:
  *   get:
  *     summary: Get a render template by ID
- *     description: Retrieves a specific render template by its database ID. Only templates owned by the authenticated tenant are returned.
+ *     description: Retrieves a specific render template by its database ID. Returns templates owned by the authenticated tenant or system-provisioned templates.
  *     tags:
  *       - Render Templates
  *     parameters:

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
@@ -11,7 +11,7 @@ const logger = apiLogger.child({ route: '/api/v1/render-templates' });
  * /render-templates:
  *   get:
  *     summary: List render templates
- *     description: Retrieves render templates belonging to the authenticated tenant, with optional filtering by data model
+ *     description: Retrieves render templates belonging to the authenticated tenant and system-provisioned templates, with optional filtering by data model
  *     tags:
  *       - Render Templates
  *     parameters:

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
@@ -155,11 +155,25 @@ describe('render-template.repository', () => {
       expect(mockRenderTemplate.findFirst).toHaveBeenCalledWith({
         where: {
           id: 'template-1',
-          tenantId: TENANT_ID,
+          OR: [{ tenantId: TENANT_ID }, { tenantId: 'system' }],
         },
         include: INCLUDE_SHAPE,
       });
       expect(result).toEqual(TEMPLATE_RECORD);
+    });
+
+    it('returns system-provisioned template for any tenant', async () => {
+      const SYSTEM_TEMPLATE_RECORD = {
+        ...TEMPLATE_RECORD,
+        id: 'system-template-1',
+        tenantId: 'system',
+        name: 'DPP System Default Template',
+      };
+      mockRenderTemplate.findFirst.mockResolvedValue(SYSTEM_TEMPLATE_RECORD);
+
+      const result = await getRenderTemplateById('system-template-1', TENANT_ID);
+
+      expect(result).toEqual(SYSTEM_TEMPLATE_RECORD);
     });
 
     it('returns null when template is not found', async () => {
@@ -178,7 +192,7 @@ describe('render-template.repository', () => {
 
       expect(mockRenderTemplate.findMany).toHaveBeenCalledWith({
         where: {
-          tenantId: TENANT_ID,
+          OR: [{ tenantId: TENANT_ID }, { tenantId: 'system' }],
         },
         include: INCLUDE_SHAPE,
         take: 100,
@@ -195,7 +209,7 @@ describe('render-template.repository', () => {
 
       expect(mockRenderTemplate.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
-          tenantId: TENANT_ID,
+          OR: [{ tenantId: TENANT_ID }, { tenantId: 'system' }],
           dataModelId: CONFIG_ID,
         }),
         include: INCLUDE_SHAPE,
@@ -203,6 +217,21 @@ describe('render-template.repository', () => {
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
+    });
+
+    it('includes system-provisioned templates in results', async () => {
+      const SYSTEM_TEMPLATE_RECORD = {
+        ...TEMPLATE_RECORD,
+        id: 'system-template-1',
+        tenantId: 'system',
+        name: 'DPP System Default Template',
+      };
+      mockRenderTemplate.findMany.mockResolvedValue([TEMPLATE_RECORD, SYSTEM_TEMPLATE_RECORD]);
+
+      const result = await listRenderTemplates(TENANT_ID);
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual([TEMPLATE_RECORD, SYSTEM_TEMPLATE_RECORD]);
     });
 
     it('applies pagination', async () => {
@@ -333,7 +362,7 @@ describe('render-template.repository', () => {
 
       expect(mockRenderTemplate.findFirst).toHaveBeenCalledWith({
         where: {
-          tenantId: TENANT_ID,
+          OR: [{ tenantId: TENANT_ID }, { tenantId: 'system' }],
           dataModelId: CONFIG_ID,
           isPrimary: true,
         },

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '../generated';
 import { prisma } from '../prisma';
+import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
 
 /**
@@ -84,21 +85,21 @@ export async function createRenderTemplate(
 }
 
 /**
- * Retrieves a render template by ID, scoped to a tenant.
- * Templates are always tenant-scoped (no system defaults).
+ * Retrieves a render template by ID.
+ * Returns templates visible to the tenant OR system-provisioned.
  */
 export async function getRenderTemplateById(id: string, tenantId: string): Promise<RenderTemplateWithRelations | null> {
   return prisma.renderTemplate.findFirst({
     where: {
       id,
-      tenantId,
+      OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
     },
     include: RENDER_TEMPLATE_INCLUDE,
   });
 }
 
 /**
- * Lists render templates for a tenant.
+ * Lists render templates for a tenant, including system-provisioned templates.
  * Supports filtering by dataModelId and pagination.
  */
 export async function listRenderTemplates(
@@ -108,7 +109,7 @@ export async function listRenderTemplates(
   const { dataModelId, limit, offset } = options;
 
   const where: Prisma.RenderTemplateWhereInput = {
-    tenantId,
+    OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
   };
 
   if (dataModelId !== undefined) {
@@ -190,7 +191,8 @@ export async function deleteRenderTemplate(id: string, tenantId: string): Promis
 
 /**
  * Returns the primary render template for a tenant + dataModelId
- * combination, or null if none is set.
+ * combination, including system-provisioned templates.
+ * Returns null if none is set.
  */
 export async function getPrimaryRenderTemplate(
   tenantId: string,
@@ -198,7 +200,7 @@ export async function getPrimaryRenderTemplate(
 ): Promise<RenderTemplateWithRelations | null> {
   return prisma.renderTemplate.findFirst({
     where: {
-      tenantId,
+      OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
       dataModelId,
       isPrimary: true,
     },


### PR DESCRIPTION
This PR fixes render template queries to include system-provisioned templates, aligning with the pattern used by all other tenant-scoped entities (DIDs, services, registrars, identifier schemes, data models). Previously, the five system-seeded render templates (DPP, DCC, DFR, DIA, DTE) were invisible to regular tenants because the repository queries only filtered by `{ tenantId }` instead of including `SYSTEM_TENANT_ID`.

## Changes

- `getRenderTemplateById`, `listRenderTemplates`, and `getPrimaryRenderTemplate` now use `OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }]`
- `updateRenderTemplate` and `deleteRenderTemplate` remain strictly tenant-scoped (system templates are immutable)
- Swagger descriptions updated for GET endpoints

## Test plan
- [x] System-provisioned templates returned by `getRenderTemplateById`
- [x] System-provisioned templates included in `listRenderTemplates` results
- [x] System-provisioned templates included in `getPrimaryRenderTemplate` lookup
- [x] Update and delete remain restricted to tenant-owned templates
- [x] Filtering by dataModelId works with system templates included
- [x] 884 tests pass across 76 suites, no regressions