### PR TITLE
refactor(api)!: standardise DID routes with REST conventions

### DIFF
--- a/e2e/cypress/e2e/closed_mode/closed-mode-crud.cy.ts
+++ b/e2e/cypress/e2e/closed_mode/closed-mode-crud.cy.ts
@@ -39,22 +39,21 @@ describe('Closed mode — DID CRUD', { testIsolation: false }, () => {
       },
     }).then((response) => {
       expect(response.status).to.eq(201);
-      expect(response.body.ok).to.be.true;
-      expect(response.body.did.did).to.match(/^did:web:/);
-      expect(response.body.did.type).to.eq('MANAGED');
-      expect(response.body.did.status).to.eq('ACTIVE');
+      expect(response.body.did).to.match(/^did:web:/);
+      expect(response.body.type).to.eq('MANAGED');
+      expect(response.body.status).to.eq('ACTIVE');
 
-      createdDidId = response.body.did.id;
+      createdDidId = response.body.id;
     });
   });
 
   it('GET /api/v1/dids — lists DIDs including the one just created', () => {
     cy.request('/api/v1/dids').then((response) => {
       expect(response.status).to.eq(200);
-      expect(response.body.ok).to.be.true;
-      expect(response.body.dids).to.be.an('array');
+      expect(response.body.data).to.be.an('array');
+      expect(response.body.pagination).to.exist;
 
-      const found = response.body.dids.find((d: any) => d.id === createdDidId);
+      const found = response.body.data.find((d: any) => d.id === createdDidId);
       expect(found).to.exist;
     });
   });
@@ -62,9 +61,8 @@ describe('Closed mode — DID CRUD', { testIsolation: false }, () => {
   it('GET /api/v1/dids/:id — retrieves the specific DID', () => {
     cy.request(`/api/v1/dids/${createdDidId}`).then((response) => {
       expect(response.status).to.eq(200);
-      expect(response.body.ok).to.be.true;
-      expect(response.body.did.id).to.eq(createdDidId);
-      expect(response.body.did.name).to.eq(`Closed Mode DID ${RUN_ID}`);
+      expect(response.body.id).to.eq(createdDidId);
+      expect(response.body.name).to.eq(`Closed Mode DID ${RUN_ID}`);
     });
   });
 });

--- a/e2e/cypress/e2e/closed_mode/service-account-api.cy.ts
+++ b/e2e/cypress/e2e/closed_mode/service-account-api.cy.ts
@@ -33,8 +33,8 @@ describe('Closed mode — service account API', { testIsolation: false }, () => 
       headers: { Authorization: `Bearer ${accessToken}` },
     }).then((response) => {
       expect(response.status).to.eq(200);
-      expect(response.body.ok).to.be.true;
-      expect(response.body.dids).to.be.an('array');
+      expect(response.body.data).to.be.an('array');
+      expect(response.body.pagination).to.exist;
     });
   });
 
@@ -54,8 +54,7 @@ describe('Closed mode — service account API', { testIsolation: false }, () => 
       },
     }).then((response) => {
       expect(response.status).to.eq(201);
-      expect(response.body.ok).to.be.true;
-      expect(response.body.did.did).to.match(/^did:web:/);
+      expect(response.body.did).to.match(/^did:web:/);
     });
   });
 
@@ -85,7 +84,7 @@ describe('Closed mode — service account API', { testIsolation: false }, () => 
           headers: { Authorization: `Bearer ${accessToken}` },
         }).then((response) => {
           expect(response.status).to.eq(200);
-          expect(response.body.ok).to.be.true;
+          expect(response.body.data).to.be.an('array');
         });
       },
     );

--- a/e2e/cypress/e2e/closed_mode/tenant-resolution.cy.ts
+++ b/e2e/cypress/e2e/closed_mode/tenant-resolution.cy.ts
@@ -30,7 +30,7 @@ describe('Closed mode — tenant resolution', { testIsolation: false }, () => {
       // group claim.  Verify the session works by hitting a protected endpoint.
       cy.request('/api/v1/dids').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
+        expect(response.body.data).to.be.an('array');
       });
     });
 
@@ -54,7 +54,7 @@ describe('Closed mode — tenant resolution', { testIsolation: false }, () => {
 
       cy.request('/api/v1/dids').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
+        expect(response.body.data).to.be.an('array');
       });
     });
 

--- a/e2e/cypress/e2e/credential_api/credential-management.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-management.cy.ts
@@ -84,7 +84,7 @@ describe('Credential API', { testIsolation: false }, () => {
     it('looks up the system default DID to use as issuer', () => {
       cy.request('/api/v1/dids').then((response) => {
         expect(response.status).to.eq(200);
-        const defaultDid = response.body.dids.find(
+        const defaultDid = response.body.data.find(
           (d: any) => d.isDefault === true,
         );
         expect(defaultDid).to.exist;
@@ -195,7 +195,6 @@ describe('Credential API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
-        expect(response.body.ok).to.be.false;
         expect(response.body.error).to.be.a('string').and.not.be.empty;
       });
     });

--- a/e2e/cypress/e2e/did_api/did-management.cy.ts
+++ b/e2e/cypress/e2e/did_api/did-management.cy.ts
@@ -2,6 +2,7 @@ describe('DID API', { testIsolation: false }, () => {
   const TEST_ORG_ID = 'e2e-test-org';
   const RUN_ID = Date.now();
   let createdDidId: string;
+  let createdDid: string;
   let defaultDidId: string;
 
   before(() => {
@@ -30,22 +31,38 @@ describe('DID API', { testIsolation: false }, () => {
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.did.did).to.match(/^did:web:/);
-        expect(response.body.did.type).to.eq('MANAGED');
-        expect(response.body.did.status).to.eq('ACTIVE');
+        expect(response.body).to.not.have.property('ok');
+        expect(response.body.did).to.match(/^did:web:/);
+        expect(response.body.type).to.eq('MANAGED');
+        expect(response.body.status).to.eq('ACTIVE');
+        expect(response.body.id).to.be.a('string');
+        expect(response.body.name).to.eq(`E2E Test DID ${RUN_ID}`);
+        expect(response.body.description).to.eq('Created by Cypress E2E test');
+        expect(response.body.method).to.eq('DID_WEB');
+        expect(response.body.serviceInstanceId).to.be.a('string');
 
-        createdDidId = response.body.did.id;
+        createdDidId = response.body.id;
+        createdDid = response.body.did;
       });
     });
 
-    it('GET /api/v1/dids — lists DIDs including system default', () => {
+    it('GET /api/v1/dids — lists DIDs with pagination metadata', () => {
       cy.request('/api/v1/dids').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.dids).to.be.an('array');
+        expect(response.body).to.not.have.property('ok');
 
-        const defaultDid = response.body.dids.find(
+        // Paginated response shape
+        expect(response.body.data).to.be.an('array');
+        expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.total).to.be.a('number');
+        expect(response.body.pagination.limit).to.be.a('number');
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination).to.have.property('hasMore');
+
+        // Should contain at least the created DID and the system default
+        expect(response.body.data.length).to.be.at.least(2);
+
+        const defaultDid = response.body.data.find(
           (d: any) => d.isDefault === true,
         );
         expect(defaultDid).to.exist;
@@ -57,21 +74,43 @@ describe('DID API', { testIsolation: false }, () => {
     it('GET /api/v1/dids/:id — retrieves a specific DID', () => {
       cy.request(`/api/v1/dids/${createdDidId}`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.did.id).to.eq(createdDidId);
-        expect(response.body.did.name).to.eq(`E2E Test DID ${RUN_ID}`);
+        expect(response.body).to.not.have.property('ok');
+        expect(response.body.id).to.eq(createdDidId);
+        expect(response.body.name).to.eq(`E2E Test DID ${RUN_ID}`);
+        expect(response.body.did).to.eq(createdDid);
+        expect(response.body.type).to.eq('MANAGED');
       });
     });
 
-    it('PUT /api/v1/dids/:id — updates DID name', () => {
+    it('PATCH /api/v1/dids/:id — updates DID name', () => {
       cy.request({
-        method: 'PUT',
+        method: 'PATCH',
         url: `/api/v1/dids/${createdDidId}`,
         body: { name: `Updated E2E DID ${RUN_ID}` },
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.did.name).to.eq(`Updated E2E DID ${RUN_ID}`);
+        expect(response.body).to.not.have.property('ok');
+        expect(response.body.name).to.eq(`Updated E2E DID ${RUN_ID}`);
+        expect(response.body.id).to.eq(createdDidId);
+      });
+    });
+
+    it('PATCH /api/v1/dids/:id — updates DID description', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/dids/${createdDidId}`,
+        body: { description: `Updated description ${RUN_ID}` },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.description).to.eq(`Updated description ${RUN_ID}`);
+      });
+    });
+
+    it('GET /api/v1/dids/:id — confirms updates persisted', () => {
+      cy.request(`/api/v1/dids/${createdDidId}`).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.name).to.eq(`Updated E2E DID ${RUN_ID}`);
+        expect(response.body.description).to.eq(`Updated description ${RUN_ID}`);
       });
     });
 
@@ -81,21 +120,43 @@ describe('DID API', { testIsolation: false }, () => {
       // cannot be resolved over HTTPS.
       cy.request(`/api/v1/dids/${defaultDidId}/document`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.document).to.exist;
-        expect(response.body.document.id).to.match(/^did:web:/);
+        expect(response.body).to.not.have.property('ok');
+        expect(response.body.id).to.match(/^did:web:/);
+        expect(response.body).to.have.property('verificationMethod');
       });
     });
 
-    it('POST /api/v1/dids/:id/verify — verifies DID document', () => {
+    it('POST /api/v1/dids/:id/verify — verifies DID', () => {
       cy.request({
         method: 'POST',
         url: `/api/v1/dids/${createdDidId}/verify`,
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.verification).to.exist;
         expect(response.body.verification.checks).to.be.an('array');
+        expect(response.body.did).to.exist;
+        expect(response.body.did.id).to.eq(createdDidId);
+      });
+    });
+
+    it('DELETE /api/v1/dids/:id — deletes a managed DID', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/dids/${createdDidId}`,
+      }).then((response) => {
+        expect(response.status).to.eq(204);
+        expect(response.body).to.be.empty;
+      });
+    });
+
+    it('GET /api/v1/dids/:id — returns 404 after deletion', () => {
+      cy.request({
+        method: 'GET',
+        url: `/api/v1/dids/${createdDidId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
       });
     });
   });
@@ -104,16 +165,63 @@ describe('DID API', { testIsolation: false }, () => {
     it('filters DIDs by type', () => {
       cy.request('/api/v1/dids?type=MANAGED').then((response) => {
         expect(response.status).to.eq(200);
-        response.body.dids.forEach((did: any) => {
+        expect(response.body.data).to.be.an('array');
+        response.body.data.forEach((did: any) => {
           expect(did.type).to.eq('MANAGED');
         });
       });
     });
 
-    it('supports pagination', () => {
+    it('filters DIDs by status', () => {
+      cy.request('/api/v1/dids?status=ACTIVE').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.data).to.be.an('array');
+        response.body.data.forEach((did: any) => {
+          expect(did.status).to.eq('ACTIVE');
+        });
+      });
+    });
+
+    it('supports limit and offset', () => {
       cy.request('/api/v1/dids?limit=1&offset=0').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.dids.length).to.be.at.most(1);
+        expect(response.body.data.length).to.be.at.most(1);
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
+      });
+    });
+
+    it('returns correct pagination metadata', () => {
+      // First get total count
+      cy.request('/api/v1/dids').then((allResponse) => {
+        const total = allResponse.body.pagination.total;
+
+        // Request with limit smaller than total
+        cy.request(`/api/v1/dids?limit=1&offset=0`).then((response) => {
+          expect(response.body.pagination.total).to.eq(total);
+          expect(response.body.pagination.hasMore).to.eq(total > 1);
+        });
+      });
+    });
+
+    it('returns 400 for invalid type filter', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/dids?type=INVALID',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/dids?limit=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
       });
     });
   });
@@ -133,10 +241,10 @@ describe('DID API', { testIsolation: false }, () => {
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.did.type).to.eq('SELF_MANAGED');
-        expect(response.body.did.status).to.eq('UNVERIFIED');
+        expect(response.body.type).to.eq('SELF_MANAGED');
+        expect(response.body.status).to.eq('UNVERIFIED');
 
-        selfManagedDidId = response.body.did.id;
+        selfManagedDidId = response.body.id;
       });
     });
 
@@ -146,6 +254,7 @@ describe('DID API', { testIsolation: false }, () => {
         url: `/api/v1/dids/${selfManagedDidId}/verify`,
       }).then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body.verification).to.exist;
         expect(response.body.did.status).to.be.oneOf([
           'VERIFIED',
           'UNVERIFIED',
@@ -153,27 +262,23 @@ describe('DID API', { testIsolation: false }, () => {
         ]);
       });
     });
-  });
 
-  describe('Error handling', () => {
-    it('returns 404 for nonexistent DID', () => {
+    it('DELETE — deletes a self-managed DID', () => {
       cy.request({
-        method: 'GET',
-        url: '/api/v1/dids/nonexistent-id',
-        failOnStatusCode: false,
+        method: 'DELETE',
+        url: `/api/v1/dids/${selfManagedDidId}`,
       }).then((response) => {
-        expect(response.status).to.eq(404);
+        expect(response.status).to.eq(204);
       });
     });
 
-    it('returns 400 for invalid type', () => {
+    it('GET — returns 404 after self-managed DID deletion', () => {
       cy.request({
-        method: 'POST',
-        url: '/api/v1/dids',
-        body: { type: 'INVALID' },
+        method: 'GET',
+        url: `/api/v1/dids/${selfManagedDidId}`,
         failOnStatusCode: false,
       }).then((response) => {
-        expect(response.status).to.eq(400);
+        expect(response.status).to.eq(404);
       });
     });
   });
@@ -195,22 +300,22 @@ describe('DID API', { testIsolation: false }, () => {
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.did.type).to.eq('SELF_MANAGED');
-        expect(response.body.did.status).to.eq('UNVERIFIED');
-        expect(response.body.did.did).to.eq(importedDidString);
+        expect(response.body).to.not.have.property('ok');
+        expect(response.body.type).to.eq('SELF_MANAGED');
+        expect(response.body.status).to.eq('UNVERIFIED');
+        expect(response.body.did).to.eq(importedDidString);
+        expect(response.body.name).to.eq(`E2E Imported DID ${RUN_ID}`);
 
-        importedDidId = response.body.did.id;
+        importedDidId = response.body.id;
       });
     });
 
     it('GET /api/v1/dids/:id — retrieves the imported DID', () => {
       cy.request(`/api/v1/dids/${importedDidId}`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.did.name).to.eq(`E2E Imported DID ${RUN_ID}`);
-        expect(response.body.did.type).to.eq('SELF_MANAGED');
-        expect(response.body.did.status).to.eq('UNVERIFIED');
+        expect(response.body.name).to.eq(`E2E Imported DID ${RUN_ID}`);
+        expect(response.body.type).to.eq('SELF_MANAGED');
+        expect(response.body.status).to.eq('UNVERIFIED');
       });
     });
 
@@ -220,7 +325,6 @@ describe('DID API', { testIsolation: false }, () => {
         url: `/api/v1/dids/${importedDidId}/verify`,
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
         expect(response.body.verification).to.exist;
         expect(response.body.did.status).to.be.oneOf([
           'VERIFIED',
@@ -238,6 +342,37 @@ describe('DID API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('POST /api/v1/dids/import — returns 400 for missing method', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/dids/import',
+        body: {
+          did: `did:web:missing-method-${RUN_ID}.example.com`,
+          keyId: 'some-key',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('POST /api/v1/dids/import — returns 400 for missing keyId', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/dids/import',
+        body: {
+          did: `did:web:missing-key-${RUN_ID}.example.com`,
+          method: 'DID_WEB',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -255,6 +390,136 @@ describe('DID API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.not.eq(201);
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('GET — returns 404 for non-existent DID', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/dids/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH — returns 404 for non-existent DID', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/dids/nonexistent-id',
+        body: { name: 'Should not work' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE — returns 404 for non-existent DID', () => {
+      cy.request({
+        method: 'DELETE',
+        url: '/api/v1/dids/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE — returns 400 when deleting the default DID', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/dids/${defaultDidId}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.include('default');
+      });
+    });
+
+    it('POST — returns 400 for invalid type', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/dids',
+        body: { type: 'INVALID', method: 'DID_WEB', alias: 'test' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('POST — returns 400 for missing method', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/dids',
+        body: { type: 'MANAGED', alias: 'test' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('POST — returns 400 for missing alias', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/dids',
+        body: { type: 'MANAGED', method: 'DID_WEB' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('POST — returns 400 for invalid method', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/dids',
+        body: { type: 'MANAGED', method: 'INVALID', alias: 'test' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH — returns 400 for empty body', () => {
+      // Need a valid DID to test — use the default
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/dids/${defaultDidId}`,
+        body: {},
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('GET /document — returns 404 for non-existent DID', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/dids/nonexistent-id/document',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('POST /verify — returns 404 for non-existent DID', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/dids/nonexistent-id/verify',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });

--- a/e2e/cypress/e2e/open_mode/service-account-api.cy.ts
+++ b/e2e/cypress/e2e/open_mode/service-account-api.cy.ts
@@ -39,8 +39,8 @@ describe('Open mode — service account API', { testIsolation: false }, () => {
       headers: { Authorization: `Bearer ${accessToken}` },
     }).then((response) => {
       expect(response.status).to.eq(200);
-      expect(response.body.ok).to.be.true;
-      expect(response.body.dids).to.be.an('array');
+      expect(response.body.data).to.be.an('array');
+      expect(response.body.pagination).to.exist;
     });
   });
 
@@ -60,8 +60,7 @@ describe('Open mode — service account API', { testIsolation: false }, () => {
       },
     }).then((response) => {
       expect(response.status).to.eq(201);
-      expect(response.body.ok).to.be.true;
-      expect(response.body.did.did).to.match(/^did:web:/);
+      expect(response.body.did).to.match(/^did:web:/);
     });
   });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -26,22 +26,22 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
           if (e instanceof ServiceError) {
             const serviceErr = e as Error & { code?: string; statusCode?: number };
             return jsonResponse(
-              { ok: false, error: serviceErr.message, code: serviceErr.code },
+              { error: serviceErr.message, code: serviceErr.code },
               { status: serviceErr.statusCode },
             );
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -220,7 +220,6 @@ describe('POST /api/v1/credentials', () => {
       const json = await res.json();
 
       expect(res.status).toBe(400);
-      expect(json.ok).toBe(false);
       expect(json.error).toBe('Invalid JSON body');
     });
 
@@ -230,7 +229,6 @@ describe('POST /api/v1/credentials', () => {
       const json = await res.json();
 
       expect(res.status).toBe(400);
-      expect(json.ok).toBe(false);
       expect(json.error).toContain('credentialPayload is required');
     });
 

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.test.ts
@@ -192,7 +192,6 @@ describe('GET /api/v1/data-models/:id/form-config', () => {
     const json = await res.json();
 
     expect(res.status).toBe(404);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('Data model not found');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
@@ -88,7 +88,6 @@ describe('GET /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(404);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('Data model not found');
   });
 
@@ -150,7 +149,6 @@ describe('PATCH /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('At least one updatable field must be provided');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
@@ -137,7 +137,6 @@ describe('GET /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('isExtension must be "true" or "false"');
   });
 
@@ -168,7 +167,6 @@ describe('GET /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('credentialType must be one of');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.test.ts
@@ -25,22 +25,22 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
           if (e instanceof ServiceError) {
             const serviceErr = e as Error & { code?: string; statusCode?: number };
             return jsonResponse(
-              { ok: false, error: serviceErr.message, code: serviceErr.code },
+              { error: serviceErr.message, code: serviceErr.code },
               { status: serviceErr.statusCode },
             );
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -93,8 +93,7 @@ describe('GET /api/v1/dids/:id/document', () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
-    expect(json.document).toEqual(document);
+    expect(json).toEqual(document);
   });
 
   it('returns 404 when DID not found', async () => {
@@ -122,7 +121,6 @@ describe('GET /api/v1/dids/:id/document', () => {
 
     expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('No service instance available');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
@@ -28,13 +28,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/document' });
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 document:
- *                   $ref: '#/components/schemas/DidDocument'
+ *               $ref: '#/components/schemas/DidDocument'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
  *         content:
@@ -70,5 +64,5 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const document = await didService.getDocument(did.did);
 
   logger.info({ tenantId, didId: id }, 'DID document retrieved');
-  return NextResponse.json({ ok: true, document });
+  return NextResponse.json(document);
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
@@ -1,3 +1,14 @@
+// Provide a minimal Response constructor for the DELETE handler
+// (jsdom does not expose the Fetch API's Response)
+global.Response = class Response {
+  status: number;
+  body: unknown;
+  constructor(body: unknown, init?: { status?: number }) {
+    this.body = body;
+    this.status = init?.status ?? 200;
+  }
+} as unknown as typeof globalThis.Response;
+
 // Mock next/server before importing route handlers
 jest.mock('next/server', () => ({
   NextResponse: {
@@ -12,6 +23,7 @@ jest.mock('next/server', () => ({
 jest.mock('@/lib/api/with-tenant-auth', () => {
   const { NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
   const { ValidationError } = jest.requireActual('@/lib/api/validation');
+  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
 
   function jsonResponse(body: unknown, init?: { status?: number }) {
     return { status: init?.status ?? 200, json: async () => body };
@@ -24,15 +36,22 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          if (e instanceof ServiceError) {
+            const serviceErr = e as Error & { code?: string; statusCode?: number };
+            return jsonResponse(
+              { error: serviceErr.message, code: serviceErr.code },
+              { status: serviceErr.statusCode },
+            );
+          }
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -40,14 +59,21 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
 
 const mockGetDidById = jest.fn();
 const mockUpdateDid = jest.fn();
+const mockDeleteDid = jest.fn();
+const mockResolveDidService = jest.fn();
 
 jest.mock('@/lib/prisma/repositories', () => ({
   getDidById: (id: string, orgId: string) => mockGetDidById(id, orgId),
   updateDid: (id: string, orgId: string, input: unknown) => mockUpdateDid(id, orgId, input),
+  deleteDid: (id: string, orgId: string) => mockDeleteDid(id, orgId),
+}));
+
+jest.mock('@/lib/services/resolve-did-service', () => ({
+  resolveDidService: (...args: unknown[]) => mockResolveDidService(...args),
 }));
 
 import { NotFoundError } from '@/lib/api/errors';
-import { GET, PUT } from './route';
+import { GET, PATCH, DELETE } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
   const { method = 'GET', body, url = 'http://localhost/api/v1/dids/did-1' } = options;
@@ -83,8 +109,7 @@ describe('GET /api/v1/dids/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
-    expect(json.did).toEqual(did);
+    expect(json).toEqual(did);
   });
 
   it('returns 404 when DID not found', async () => {
@@ -97,7 +122,7 @@ describe('GET /api/v1/dids/:id', () => {
   });
 });
 
-describe('PUT /api/v1/dids/:id', () => {
+describe('PATCH /api/v1/dids/:id', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -106,17 +131,17 @@ describe('PUT /api/v1/dids/:id', () => {
     const updated = { id: 'did-1', name: 'New Name', description: 'New desc' };
     mockUpdateDid.mockResolvedValue(updated);
 
-    const req = createFakeRequest({ method: 'PUT', body: { name: 'New Name', description: 'New desc' } });
-    const res = await PUT(req, createContext('did-1') as unknown as Parameters<typeof PUT>[1]);
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'New Name', description: 'New desc' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.did.name).toBe('New Name');
+    expect(json.name).toBe('New Name');
   });
 
   it('returns 400 when no fields provided', async () => {
-    const req = createFakeRequest({ method: 'PUT', body: {} });
-    const res = await PUT(req, createContext('did-1') as unknown as Parameters<typeof PUT>[1]);
+    const req = createFakeRequest({ method: 'PATCH', body: {} });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
 
     expect(res.status).toBe(400);
   });
@@ -124,9 +149,76 @@ describe('PUT /api/v1/dids/:id', () => {
   it('returns 404 when DID not found or access denied', async () => {
     mockUpdateDid.mockRejectedValue(new NotFoundError('DID not found or access denied'));
 
-    const req = createFakeRequest({ method: 'PUT', body: { name: 'New Name' } });
-    const res = await PUT(req, createContext('did-1') as unknown as Parameters<typeof PUT>[1]);
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'New Name' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/v1/dids/:id', () => {
+  const mockDidService = { delete: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveDidService.mockResolvedValue({ service: mockDidService, instanceId: 'inst-1' });
+  });
+
+  it('returns 204 with no body on success', async () => {
+    mockGetDidById.mockResolvedValue({
+      id: 'did-1',
+      did: 'did:web:example.com',
+      serviceInstanceId: 'inst-1',
+    });
+    mockDidService.delete.mockResolvedValue(undefined);
+    mockDeleteDid.mockResolvedValue(undefined);
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('did-1') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 404 when DID not found', async () => {
+    mockGetDidById.mockResolvedValue(null);
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('nonexistent') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('calls service.delete for managed DIDs with a serviceInstanceId', async () => {
+    mockGetDidById.mockResolvedValue({
+      id: 'did-1',
+      did: 'did:web:example.com',
+      serviceInstanceId: 'inst-1',
+    });
+    mockDidService.delete.mockResolvedValue(undefined);
+    mockDeleteDid.mockResolvedValue(undefined);
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    await DELETE(req, createContext('did-1') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(mockResolveDidService).toHaveBeenCalledWith('org-1', 'inst-1');
+    expect(mockDidService.delete).toHaveBeenCalledWith('did:web:example.com');
+    expect(mockDeleteDid).toHaveBeenCalledWith('did-1', 'org-1');
+  });
+
+  it('does not call service.delete for self-managed DIDs without a serviceInstanceId', async () => {
+    mockGetDidById.mockResolvedValue({
+      id: 'did-1',
+      did: 'did:web:example.com',
+      serviceInstanceId: null,
+    });
+    mockDeleteDid.mockResolvedValue(undefined);
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('did-1') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(204);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockDidService.delete).not.toHaveBeenCalled();
+    expect(mockDeleteDid).toHaveBeenCalledWith('did-1', 'org-1');
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
@@ -221,4 +221,57 @@ describe('DELETE /api/v1/dids/:id', () => {
     expect(mockDidService.delete).not.toHaveBeenCalled();
     expect(mockDeleteDid).toHaveBeenCalledWith('did-1', 'org-1');
   });
+
+  it('returns 400 when trying to delete a default DID', async () => {
+    mockGetDidById.mockResolvedValue({
+      id: 'did-1',
+      did: 'did:web:example.com',
+      serviceInstanceId: 'inst-1',
+      isDefault: true,
+    });
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('did-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await (res as { status: number; json: () => Promise<{ error: string }> }).json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('Cannot delete system default DID');
+    expect(mockDeleteDid).not.toHaveBeenCalled();
+    expect(mockDidService.delete).not.toHaveBeenCalled();
+  });
+
+  it('returns 204 even when upstream service.delete() throws', async () => {
+    mockGetDidById.mockResolvedValue({
+      id: 'did-1',
+      did: 'did:web:example.com',
+      serviceInstanceId: 'inst-1',
+    });
+    mockDeleteDid.mockResolvedValue(undefined);
+    mockDidService.delete.mockRejectedValue(new Error('Upstream provider unreachable'));
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('did-1') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(204);
+    expect(mockDeleteDid).toHaveBeenCalledWith('did-1', 'org-1');
+    expect(mockDidService.delete).toHaveBeenCalledWith('did:web:example.com');
+  });
+
+  it('returns 204 even when resolveDidService throws', async () => {
+    mockGetDidById.mockResolvedValue({
+      id: 'did-1',
+      did: 'did:web:example.com',
+      serviceInstanceId: 'inst-1',
+    });
+    mockDeleteDid.mockResolvedValue(undefined);
+    mockResolveDidService.mockRejectedValue(new Error('Service registry unavailable'));
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('did-1') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(204);
+    expect(mockDeleteDid).toHaveBeenCalledWith('did-1', 'org-1');
+    expect(mockResolveDidService).toHaveBeenCalledWith('org-1', 'inst-1');
+    expect(mockDidService.delete).not.toHaveBeenCalled();
+  });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { getDidById, updateDid } from '@/lib/prisma/repositories';
+import { getDidById, updateDid, deleteDid } from '@/lib/prisma/repositories';
+import { resolveDidService } from '@/lib/services/resolve-did-service';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/dids/[id]' });
@@ -28,13 +29,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]' });
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 did:
- *                   $ref: '#/components/schemas/Did'
+ *               $ref: '#/components/schemas/Did'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
  *         content:
@@ -64,13 +59,13 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   }
 
   logger.info({ tenantId, didId: id, did: did.did }, 'DID retrieved');
-  return NextResponse.json({ ok: true, did });
+  return NextResponse.json(did);
 });
 
 /**
  * @swagger
  * /dids/{id}:
- *   put:
+ *   patch:
  *     summary: Update a DID
  *     description: Updates the name and/or description of a specific DID
  *     tags:
@@ -102,13 +97,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 did:
- *                   $ref: '#/components/schemas/Did'
+ *               $ref: '#/components/schemas/Did'
  *       400:
  *         description: Validation error - at least one field required
  *         content:
@@ -134,7 +123,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
-export const PUT = withTenantAuth(async (req, { tenantId, params }) => {
+export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
   logger.info({ tenantId, didId: id }, 'Parsing request body');
@@ -160,5 +149,67 @@ export const PUT = withTenantAuth(async (req, { tenantId, params }) => {
   });
 
   logger.info({ tenantId, didId: id }, 'DID updated');
-  return NextResponse.json({ ok: true, did: updated });
+  return NextResponse.json(updated);
+});
+
+/**
+ * @swagger
+ * /dids/{id}:
+ *   delete:
+ *     summary: Delete a DID
+ *     description: Deletes a DID. If the DID is managed (has a serviceInstanceId), it is also removed from the upstream provider.
+ *     tags:
+ *       - DIDs
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The database ID of the DID
+ *     responses:
+ *       204:
+ *         description: DID deleted successfully
+ *       401:
+ *         description: Unauthorized - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: DID not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
+  const { id } = await params;
+
+  logger.info({ tenantId, didId: id }, 'Looking up DID for deletion');
+  const did = await getDidById(id, tenantId);
+  if (!did) {
+    throw new NotFoundError('DID not found');
+  }
+
+  if (did.serviceInstanceId) {
+    logger.info(
+      { tenantId, didId: id, did: did.did, serviceInstanceId: did.serviceInstanceId },
+      'Removing DID from upstream provider',
+    );
+    const { service: didService } = await resolveDidService(tenantId, did.serviceInstanceId);
+    await didService.delete(did.did);
+  }
+
+  logger.info({ tenantId, didId: id }, 'Deleting DID from database');
+  await deleteDid(id, tenantId);
+
+  logger.info({ tenantId, didId: id }, 'DID deleted');
+  return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -198,17 +198,28 @@ export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
     throw new NotFoundError('DID not found');
   }
 
-  if (did.serviceInstanceId) {
-    logger.info(
-      { tenantId, didId: id, did: did.did, serviceInstanceId: did.serviceInstanceId },
-      'Removing DID from upstream provider',
-    );
-    const { service: didService } = await resolveDidService(tenantId, did.serviceInstanceId);
-    await didService.delete(did.did);
+  if (did.isDefault) {
+    throw new ValidationError('Cannot delete system default DID');
   }
 
   logger.info({ tenantId, didId: id }, 'Deleting DID from database');
   await deleteDid(id, tenantId);
+
+  if (did.serviceInstanceId) {
+    try {
+      logger.info(
+        { tenantId, didId: id, did: did.did, serviceInstanceId: did.serviceInstanceId },
+        'Removing DID from upstream provider',
+      );
+      const { service: didService } = await resolveDidService(tenantId, did.serviceInstanceId);
+      await didService.delete(did.did);
+    } catch (err) {
+      logger.error(
+        { tenantId, didId: id, did: did.did, error: err },
+        'Best-effort upstream DID deletion failed; orphaned upstream DID is harmless',
+      );
+    }
+  }
 
   logger.info({ tenantId, didId: id }, 'DID deleted');
   return new Response(null, { status: 204 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -25,22 +25,22 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
           if (e instanceof ServiceError) {
             const serviceErr = e as Error & { code?: string; statusCode?: number };
             return jsonResponse(
-              { ok: false, error: serviceErr.message, code: serviceErr.code },
+              { error: serviceErr.message, code: serviceErr.code },
               { status: serviceErr.statusCode },
             );
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -108,7 +108,6 @@ describe('POST /api/v1/dids/:id/verify', () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
     expect(json.verification.verified).toBe(true);
     expect(json.did.status).toBe('VERIFIED');
     expect(mockUpdateDidStatus).toHaveBeenCalledWith('did-1', 'org-1', 'VERIFIED');
@@ -176,7 +175,6 @@ describe('POST /api/v1/dids/:id/verify', () => {
 
     expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('No service instance available');
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
@@ -34,9 +34,6 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
  *             schema:
  *               type: object
  *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
  *                 verification:
  *                   $ref: '#/components/schemas/VerificationResult'
  *                 did:
@@ -80,5 +77,5 @@ export const POST = withTenantAuth(async (_req, { tenantId, params }) => {
   const updatedDid = await updateDidStatus(id, tenantId, newStatus);
 
   logger.info({ tenantId, didId: id, verified: verification.verified }, 'DID verification complete');
-  return NextResponse.json({ ok: true, verification, did: updatedDid });
+  return NextResponse.json({ verification, did: updatedDid });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -22,15 +22,15 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -98,8 +98,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(201);
-    expect(body.ok).toBe(true);
-    expect(body.did).toEqual(MOCK_DID_RECORD);
+    expect(body).toEqual(MOCK_DID_RECORD);
 
     // Verify createDid was called with correct params -- NOT calling adapter
     expect(mockCreateDid).toHaveBeenCalledWith({
@@ -187,7 +186,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('did is required');
   });
 
@@ -198,7 +196,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('keyId is required');
   });
 
@@ -209,7 +206,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('method is required');
   });
 
@@ -220,7 +216,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('method must be one of');
   });
 
@@ -268,7 +263,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(500);
-    expect(body.ok).toBe(false);
     expect(body.error).toBeDefined();
   });
 
@@ -285,7 +279,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(500);
-    expect(body.ok).toBe(false);
     expect(body.error).toBeDefined();
   });
 
@@ -296,7 +289,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('did is required');
   });
 
@@ -307,7 +299,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('keyId is required');
   });
 
@@ -318,7 +309,6 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('method');
   });
 
@@ -331,10 +321,8 @@ describe('POST /api/v1/dids/import', () => {
     });
 
     const res = await POST(req, createContext());
-    const body = await res.json();
 
     expect(res.status).toBe(201);
-    expect(body.ok).toBe(true);
 
     expect(mockCreateDid).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -50,13 +50,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 did:
- *                   $ref: '#/components/schemas/Did'
+ *               $ref: '#/components/schemas/Did'
  *       400:
  *         description: Validation error
  *         content:
@@ -114,5 +108,5 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   });
 
   logger.info({ tenantId, didId: record.id, did: record.did }, 'DID imported');
-  return NextResponse.json({ ok: true, did: record }, { status: 201 });
+  return NextResponse.json(record, { status: 201 });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -25,22 +25,22 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
           if (e instanceof ServiceError) {
             const serviceErr = e as Error & { code?: string; statusCode?: number };
             return jsonResponse(
-              { ok: false, error: serviceErr.message, code: serviceErr.code },
+              { error: serviceErr.message, code: serviceErr.code },
               { status: serviceErr.statusCode },
             );
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -125,8 +125,7 @@ describe('POST /api/v1/dids', () => {
     const json = await res.json();
 
     expect(res.status).toBe(201);
-    expect(json.ok).toBe(true);
-    expect(json.did.did).toBe('did:web:example.com:org:123');
+    expect(json.did).toBe('did:web:example.com:org:123');
   });
 
   it('creates a self-managed DID with UNVERIFIED status and serviceInstanceId', async () => {
@@ -249,7 +248,6 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('No service instance available');
   });
 
@@ -334,21 +332,26 @@ describe('GET /api/v1/dids', () => {
     jest.clearAllMocks();
   });
 
-  it('lists DIDs for the organisation', async () => {
+  it('lists DIDs for the organisation with pagination', async () => {
     const dids = [{ id: '1', did: 'did:web:example.com' }];
-    mockListDids.mockResolvedValue(dids);
+    mockListDids.mockResolvedValue({ data: dids, total: 1 });
 
     const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/dids' });
     const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
-    expect(json.dids).toEqual(dids);
+    expect(json.data).toEqual(dids);
+    expect(json.pagination).toEqual({
+      total: 1,
+      limit: 20,
+      offset: 0,
+      hasMore: false,
+    });
   });
 
   it('passes query parameters to listDids', async () => {
-    mockListDids.mockResolvedValue([]);
+    mockListDids.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
@@ -366,7 +369,7 @@ describe('GET /api/v1/dids', () => {
   });
 
   it('handles no query parameters', async () => {
-    mockListDids.mockResolvedValue([]);
+    mockListDids.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/dids' });
     await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
@@ -377,6 +380,25 @@ describe('GET /api/v1/dids', () => {
       serviceInstanceId: undefined,
       limit: undefined,
       offset: undefined,
+    });
+  });
+
+  it('returns hasMore: true when more results exist', async () => {
+    const dids = [{ id: '1' }, { id: '2' }];
+    mockListDids.mockResolvedValue({ data: dids, total: 5 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/dids?limit=2&offset=0',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(json.pagination).toEqual({
+      total: 5,
+      limit: 2,
+      offset: 0,
+      hasMore: true,
     });
   });
 

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -4,6 +4,7 @@ import { errorMessage } from '@/lib/api/errors';
 import { ValidationError, validateEnum, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createDid, listDids } from '@/lib/prisma/repositories';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { CREATABLE_DID_TYPES, DidType, DidMethod, DidStatus } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 
@@ -54,13 +55,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 did:
- *                   $ref: '#/components/schemas/Did'
+ *               $ref: '#/components/schemas/Did'
  *       400:
  *         description: Validation error
  *         content:
@@ -157,7 +152,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   });
 
   logger.info({ tenantId, didId: record.id, did: record.did }, 'DID created');
-  return NextResponse.json({ ok: true, did: record }, { status: 201 });
+  return NextResponse.json(record, { status: 201 });
 });
 
 /**
@@ -206,13 +201,12 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               type: object
  *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 dids:
+ *                 data:
  *                   type: array
  *                   items:
  *                     $ref: '#/components/schemas/Did'
+ *                 pagination:
+ *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
  *         description: Validation error
  *         content:
@@ -243,7 +237,7 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
   logger.info({ tenantId, filters: { type, status, serviceInstanceId, limit, offset } }, 'Querying DIDs from database');
-  const dids = await listDids(tenantId, {
+  const { data, total } = await listDids(tenantId, {
     type,
     status,
     serviceInstanceId,
@@ -251,6 +245,6 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
     offset,
   });
 
-  logger.info({ tenantId, count: dids.length }, 'DIDs listed');
-  return NextResponse.json({ ok: true, dids });
+  logger.info({ tenantId, count: data.length }, 'DIDs listed');
+  return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -35,7 +35,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *                 description: Type of DID to create
  *               method:
  *                 type: string
- *                 enum: [did:web, did:key]
+ *                 enum: [DID_WEB, DID_WEB_VH]
  *                 description: DID method to use
  *               alias:
  *                 type: string

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -35,7 +35,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *                 description: Type of DID to create
  *               method:
  *                 type: string
- *                 enum: [DID_WEB, DID_WEB_VH]
+ *                 enum: [DID_WEB]
  *                 description: DID method to use
  *               alias:
  *                 type: string

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
@@ -23,22 +23,22 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
           if (e instanceof ServiceError) {
             const serviceErr = e as Error & { code?: string; statusCode?: number };
             return jsonResponse(
-              { ok: false, error: serviceErr.message, code: serviceErr.code },
+              { error: serviceErr.message, code: serviceErr.code },
               { status: serviceErr.statusCode },
             );
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -173,7 +173,6 @@ describe('GET /api/v1/identifiers/[id]/links/[linkId]', () => {
     const res = await GET(req, createContext());
 
     expect(res.status).toBe(404);
-    expect((await res.json()).ok).toBe(false);
   });
 
   it('returns 404 when link registration not found', async () => {
@@ -183,7 +182,6 @@ describe('GET /api/v1/identifiers/[id]/links/[linkId]', () => {
     const res = await GET(req, createContext());
 
     expect(res.status).toBe(404);
-    expect((await res.json()).ok).toBe(false);
   });
 
   it('returns IDR service error with proper status when getLinkById fails', async () => {
@@ -194,7 +192,6 @@ describe('GET /api/v1/identifiers/[id]/links/[linkId]', () => {
     const body = await res.json();
 
     expect(res.status).toBe(502);
-    expect(body.ok).toBe(false);
     expect(body.code).toBe('IDR_LINK_FETCH_FAILED');
   });
 });
@@ -237,7 +234,6 @@ describe('PATCH /api/v1/identifiers/[id]/links/[linkId]', () => {
     const body = await res.json();
 
     expect(res.status).toBe(409);
-    expect(body.ok).toBe(false);
     expect(body.desync).toBe(true);
     expect(body.error).toContain('no longer exists on the upstream IDR');
   });
@@ -249,7 +245,6 @@ describe('PATCH /api/v1/identifiers/[id]/links/[linkId]', () => {
     const res = await PATCH(req, createContext());
 
     expect(res.status).toBe(404);
-    expect((await res.json()).ok).toBe(false);
   });
 });
 
@@ -298,6 +293,5 @@ describe('DELETE /api/v1/identifiers/[id]/links/[linkId]', () => {
     const res = await DELETE(req, createContext());
 
     expect(res.status).toBe(404);
-    expect((await res.json()).ok).toBe(false);
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
@@ -163,7 +163,6 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
       logger.warn({ tenantId, identifierId, linkId }, 'Link desync — cannot update, missing from upstream IDR');
       return NextResponse.json(
         {
-          ok: false,
           error: `Link "${linkId}" no longer exists on the upstream IDR. It may have been removed out-of-band. Delete the local record to resolve this desynchronisation.`,
           desync: true,
         },

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.test.ts
@@ -23,22 +23,22 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           return await handler(req, ctx);
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 400 });
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
           }
           if (e instanceof NotFoundError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 404 });
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ ok: false, error: (e as Error).message }, { status: 500 });
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
           }
           if (e instanceof ServiceError) {
             const serviceErr = e as Error & { code?: string; statusCode?: number };
             return jsonResponse(
-              { ok: false, error: serviceErr.message, code: serviceErr.code },
+              { error: serviceErr.message, code: serviceErr.code },
               { status: serviceErr.statusCode },
             );
           }
-          return jsonResponse({ ok: false, error: errorMessage(e) }, { status: 500 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
         }
       },
   };
@@ -143,20 +143,16 @@ describe('POST /api/v1/identifiers/[id]/links', () => {
     const req = createFakeRequest({});
 
     const res = await POST(req, createContext());
-    const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
   });
 
   it('returns 400 for empty links array', async () => {
     const req = createFakeRequest({ links: [] });
 
     const res = await POST(req, createContext());
-    const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.ok).toBe(false);
   });
 
   it('returns 404 when identifier not found', async () => {
@@ -167,10 +163,8 @@ describe('POST /api/v1/identifiers/[id]/links', () => {
     });
 
     const res = await POST(req, createContext());
-    const body = await res.json();
 
     expect(res.status).toBe(404);
-    expect(body.ok).toBe(false);
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -201,7 +195,6 @@ describe('POST /api/v1/identifiers/[id]/links', () => {
     const body = await res.json();
 
     expect(res.status).toBe(502);
-    expect(body.ok).toBe(false);
     expect(body.code).toBe('IDR_PUBLISH_FAILED');
   });
 });
@@ -229,9 +222,7 @@ describe('GET /api/v1/identifiers/[id]/links', () => {
 
     const req = { url: 'http://localhost/test' } as unknown as Request;
     const res = await GET(req, createContext());
-    const body = await res.json();
 
     expect(res.status).toBe(404);
-    expect(body.ok).toBe(false);
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
@@ -91,7 +91,6 @@ describe('GET /api/v1/render-templates/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(404);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('Render template not found');
   });
 
@@ -162,7 +161,6 @@ describe('PATCH /api/v1/render-templates/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('At least one updatable field must be provided');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
@@ -126,7 +126,6 @@ describe('GET /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('limit must be a positive integer');
   });
 
@@ -139,7 +138,6 @@ describe('GET /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.ok).toBe(false);
     expect(json.error).toContain('offset must be a non-negative integer');
   });
 

--- a/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
@@ -21,7 +21,7 @@ import { ServiceError } from '@uncefact/untp-ri-services';
 import { handleRouteError } from './handle-route-error';
 
 interface MockResponse {
-  json: () => Promise<{ ok: boolean; error: string; code?: string }>;
+  json: () => Promise<{ error: string; code?: string }>;
 }
 
 beforeEach(() => {
@@ -38,7 +38,7 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(400);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'bad input' });
+    expect(body).toEqual({ error: 'bad input' });
   });
 
   it('maps NotFoundError to 404', async () => {
@@ -46,7 +46,7 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(404);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'missing' });
+    expect(body).toEqual({ error: 'missing' });
   });
 
   it('maps UnprocessableError to 422', async () => {
@@ -54,7 +54,7 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(422);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'cannot process' });
+    expect(body).toEqual({ error: 'cannot process' });
   });
 
   // --- ServiceRegistryError sub-types ---
@@ -64,7 +64,7 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(404);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'Service instance not found: inst-42' });
+    expect(body).toEqual({ error: 'Service instance not found: inst-42' });
   });
 
   it('maps ServiceResolutionError to 500', async () => {
@@ -72,7 +72,6 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('No service instance available');
   });
 
@@ -81,7 +80,6 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('Failed to decrypt');
   });
 
@@ -90,7 +88,6 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toContain('Configuration validation failed');
   });
 
@@ -99,7 +96,7 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'config bad' });
+    expect(body).toEqual({ error: 'config bad' });
   });
 
   // --- ServiceError ---
@@ -109,7 +106,7 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(502);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'upstream fail', code: 'TEST_ERR' });
+    expect(body).toEqual({ error: 'upstream fail', code: 'TEST_ERR' });
   });
 
   // --- Generic / unknown errors ---
@@ -119,7 +116,7 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'kaboom' });
+    expect(body).toEqual({ error: 'kaboom' });
   });
 
   it('maps a non-Error value to 500 with fallback message', async () => {
@@ -127,6 +124,6 @@ describe('handleRouteError', () => {
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body).toEqual({ ok: false, error: 'An unexpected error has occurred.' });
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
   });
 });

--- a/packages/reference-implementation/src/lib/api/handle-route-error.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.ts
@@ -20,25 +20,25 @@ const logger = apiLogger.child({ handler: 'error' });
 export function handleRouteError(e: unknown): Response {
   if (e instanceof ValidationError) {
     logger.warn({ err: e }, 'Validation error');
-    return NextResponse.json({ ok: false, error: e.message }, { status: 400 });
+    return NextResponse.json({ error: e.message }, { status: 400 });
   }
   if (e instanceof NotFoundError) {
     logger.warn({ err: e }, 'Not found');
-    return NextResponse.json({ ok: false, error: e.message }, { status: 404 });
+    return NextResponse.json({ error: e.message }, { status: 404 });
   }
   if (e instanceof UnprocessableError) {
     logger.warn({ err: e }, 'Unprocessable entity');
-    return NextResponse.json({ ok: false, error: e.message }, { status: 422 });
+    return NextResponse.json({ error: e.message }, { status: 422 });
   }
   if (e instanceof ServiceRegistryError) {
     const status = e.name === 'ServiceInstanceNotFoundError' ? 404 : 500;
     logger.error({ err: e, status }, 'Service registry error');
-    return NextResponse.json({ ok: false, error: e.message }, { status });
+    return NextResponse.json({ error: e.message }, { status });
   }
   if (e instanceof ServiceError) {
     logger.error({ err: e, code: e.code, status: e.statusCode }, 'Service error');
-    return NextResponse.json({ ok: false, error: e.message, code: e.code }, { status: e.statusCode });
+    return NextResponse.json({ error: e.message, code: e.code }, { status: e.statusCode });
   }
   logger.error({ err: e }, 'Unexpected error');
-  return NextResponse.json({ ok: false, error: errorMessage(e) }, { status: 500 });
+  return NextResponse.json({ error: errorMessage(e) }, { status: 500 });
 }

--- a/packages/reference-implementation/src/lib/api/pagination.test.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.test.ts
@@ -1,0 +1,75 @@
+import { buildPaginatedResponse } from './pagination';
+
+describe('buildPaginatedResponse', () => {
+  it('returns correct pagination metadata with explicit limit and offset', () => {
+    const items = [{ id: 1 }, { id: 2 }];
+
+    const result = buildPaginatedResponse(items, 10, 2, 0);
+
+    expect(result).toEqual({
+      data: items,
+      pagination: {
+        total: 10,
+        limit: 2,
+        offset: 0,
+        hasMore: true,
+      },
+    });
+  });
+
+  it('sets hasMore to false on the last page', () => {
+    const items = [{ id: 9 }, { id: 10 }];
+
+    const result = buildPaginatedResponse(items, 10, 5, 8);
+
+    expect(result).toEqual({
+      data: items,
+      pagination: {
+        total: 10,
+        limit: 5,
+        offset: 8,
+        hasMore: false,
+      },
+    });
+  });
+
+  it('defaults limit to 20 and offset to 0 when not provided', () => {
+    const items = [{ id: 1 }];
+
+    const result = buildPaginatedResponse(items, 50);
+
+    expect(result.pagination.limit).toBe(20);
+    expect(result.pagination.offset).toBe(0);
+    expect(result.pagination.hasMore).toBe(true);
+  });
+
+  it('returns empty data with hasMore false when there are zero results', () => {
+    const result = buildPaginatedResponse([], 0);
+
+    expect(result).toEqual({
+      data: [],
+      pagination: {
+        total: 0,
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+      },
+    });
+  });
+
+  it('sets hasMore to false when offset + data length equals total', () => {
+    const items = [{ id: 3 }, { id: 4 }];
+
+    const result = buildPaginatedResponse(items, 4, 2, 2);
+
+    expect(result).toEqual({
+      data: items,
+      pagination: {
+        total: 4,
+        limit: 2,
+        offset: 2,
+        hasMore: false,
+      },
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/api/pagination.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.ts
@@ -1,0 +1,30 @@
+export interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: PaginationMeta;
+}
+
+export function buildPaginatedResponse<T>(
+  data: T[],
+  total: number,
+  limit?: number,
+  offset?: number,
+): PaginatedResponse<T> {
+  const effectiveLimit = limit ?? 20;
+  const effectiveOffset = offset ?? 0;
+  return {
+    data,
+    pagination: {
+      total,
+      limit: effectiveLimit,
+      offset: effectiveOffset,
+      hasMore: effectiveOffset + data.length < total,
+    },
+  };
+}

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
@@ -100,7 +100,7 @@ import { ServiceError } from '@uncefact/untp-ri-services';
 import { withTenantAuth, handleRouteError } from './with-tenant-auth';
 
 interface MockResponse {
-  json: () => Promise<{ ok: boolean; error: string; code?: string }>;
+  json: () => Promise<{ error: string; code?: string }>;
 }
 
 beforeEach(() => {
@@ -138,7 +138,7 @@ describe('withTenantAuth — open mode, session path', () => {
     const res = await wrapped(fakeRequest(), emptyRouteContext);
 
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ ok: false, error: 'Unauthorized' });
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -151,7 +151,7 @@ describe('withTenantAuth — open mode, session path', () => {
     const res = await wrapped(fakeRequest(), emptyRouteContext);
 
     expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ ok: false, error: 'No tenant found for user' });
+    expect(await res.json()).toEqual({ error: 'No tenant found for user' });
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -197,7 +197,7 @@ describe('withTenantAuth — open mode, session path', () => {
     const res = await wrapped(fakeRequest(), emptyRouteContext);
 
     expect(res.status).toBe(404);
-    expect(await res.json()).toEqual({ ok: false, error: 'not found' });
+    expect(await res.json()).toEqual({ error: 'not found' });
   });
 
   it('does not attempt service account resolution when session exists', async () => {
@@ -261,7 +261,7 @@ describe('withTenantAuth — open mode, service account path', () => {
     const res = await wrapped(req, emptyRouteContext);
 
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ ok: false, error: 'Unauthorized' });
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -295,7 +295,7 @@ describe('withTenantAuth — open mode, service account path', () => {
     const res = await wrapped(req, emptyRouteContext);
 
     expect(res.status).toBe(404);
-    expect(await res.json()).toEqual({ ok: false, error: 'not found' });
+    expect(await res.json()).toEqual({ error: 'not found' });
   });
 });
 
@@ -383,7 +383,6 @@ describe('withTenantAuth — closed mode, session path', () => {
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual(
       expect.objectContaining({
-        ok: false,
         error: 'Session expired — please sign in again',
       }),
     );
@@ -402,7 +401,6 @@ describe('withTenantAuth — closed mode, session path', () => {
     expect(res.status).toBe(403);
     expect(await res.json()).toEqual(
       expect.objectContaining({
-        ok: false,
         error: 'No group assignment found',
       }),
     );
@@ -423,7 +421,6 @@ describe('withTenantAuth — closed mode, session path', () => {
     expect(res.status).toBe(403);
     expect(await res.json()).toEqual(
       expect.objectContaining({
-        ok: false,
         error: 'No tenant found for group',
       }),
     );
@@ -439,7 +436,7 @@ describe('withTenantAuth — closed mode, session path', () => {
     const res = await wrapped(fakeRequest(), emptyRouteContext);
 
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ ok: false, error: 'Unauthorized' });
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
   });
 });
 
@@ -731,7 +728,6 @@ describe('handleRouteError', () => {
     const res = handleRouteError(new ValidationError('bad input'));
     expect(res.status).toBe(400);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toBe('bad input');
   });
 
@@ -739,7 +735,6 @@ describe('handleRouteError', () => {
     const res = handleRouteError(new NotFoundError('missing'));
     expect(res.status).toBe(404);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toBe('missing');
   });
 
@@ -747,7 +742,6 @@ describe('handleRouteError', () => {
     const res = handleRouteError(new ServiceRegistryError('config bad'));
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toBe('config bad');
   });
 
@@ -755,7 +749,6 @@ describe('handleRouteError', () => {
     const res = handleRouteError(new ServiceError('upstream fail', 'TEST_ERR', 502));
     expect(res.status).toBe(502);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toBe('upstream fail');
     expect(body.code).toBe('TEST_ERR');
   });
@@ -764,7 +757,6 @@ describe('handleRouteError', () => {
     const res = handleRouteError(new Error('kaboom'));
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
-    expect(body.ok).toBe(false);
     expect(body.error).toBe('kaboom');
   });
 });

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
@@ -71,7 +71,7 @@ async function handleClosedMode(
         { method, path, userId: session.user.id, durationMs: Date.now() - start },
         'Unauthorised — session token refresh failed',
       );
-      return NextResponse.json({ ok: false, error: 'Session expired — please sign in again' }, { status: 401 });
+      return NextResponse.json({ error: 'Session expired — please sign in again' }, { status: 401 });
     }
 
     if (!session.group_claim) {
@@ -79,7 +79,7 @@ async function handleClosedMode(
         { method, path, userId: session.user.id, durationMs: Date.now() - start },
         'Forbidden — no group claim in session',
       );
-      return NextResponse.json({ ok: false, error: 'No group assignment found' }, { status: 403 });
+      return NextResponse.json({ error: 'No group assignment found' }, { status: 403 });
     }
 
     // Look up tenant by group claim
@@ -93,7 +93,7 @@ async function handleClosedMode(
         { method, path, groupClaim: session.group_claim, durationMs: Date.now() - start },
         'Forbidden — no tenant for group claim',
       );
-      return NextResponse.json({ ok: false, error: 'No tenant found for group' }, { status: 403 });
+      return NextResponse.json({ error: 'No tenant found for group' }, { status: 403 });
     }
 
     // Ensure user is linked to the correct tenant (handles group changes)
@@ -136,12 +136,12 @@ async function handleClosedMode(
         { method, path, error: validationResult.error, durationMs: Date.now() - start },
         'Unauthorised — invalid bearer token',
       );
-      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const payload = validationResult.payload;
     if (!payload.sub) {
-      return NextResponse.json({ ok: false, error: 'Token missing required sub claim' }, { status: 401 });
+      return NextResponse.json({ error: 'Token missing required sub claim' }, { status: 401 });
     }
 
     const groupClaim = extractGroupClaim(payload as Record<string, unknown>, tenantConfig);
@@ -151,7 +151,7 @@ async function handleClosedMode(
         { method, path, sub: payload.sub, durationMs: Date.now() - start },
         'Forbidden — no group claim in bearer token',
       );
-      return NextResponse.json({ ok: false, error: 'No group assignment found in token' }, { status: 403 });
+      return NextResponse.json({ error: 'No group assignment found in token' }, { status: 403 });
     }
 
     const resolved = await resolveClosedModeTenant(groupClaim, payload.sub, {
@@ -164,7 +164,7 @@ async function handleClosedMode(
         { method, path, sub: payload.sub, durationMs: Date.now() - start },
         'Failed to resolve closed mode tenant for bearer token',
       );
-      return NextResponse.json({ ok: false, error: 'Failed to resolve tenant' }, { status: 500 });
+      return NextResponse.json({ error: 'Failed to resolve tenant' }, { status: 500 });
     }
 
     const azp = payload.azp;
@@ -185,7 +185,7 @@ async function handleClosedMode(
   }
 
   apiLogger.warn({ method, path, durationMs: Date.now() - start }, 'Unauthorised — no session or bearer token');
-  return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 }
 
 async function handleOpenMode(
@@ -202,7 +202,7 @@ async function handleOpenMode(
     const tenantId = await getTenantId(sessionUserId);
     if (!tenantId) {
       apiLogger.warn({ method, path, userId: sessionUserId, durationMs: Date.now() - start }, 'Forbidden — no tenant');
-      return NextResponse.json({ ok: false, error: 'No tenant found for user' }, { status: 403 });
+      return NextResponse.json({ error: 'No tenant found for user' }, { status: 403 });
     }
 
     return executeHandler(
@@ -235,7 +235,7 @@ async function handleOpenMode(
         { method, path, sub, error, durationMs: Date.now() - start },
         'Service account user resolution failed unexpectedly',
       );
-      return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 });
+      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
 
     if (!resolved) {
@@ -243,7 +243,7 @@ async function handleOpenMode(
         { method, path, sub, durationMs: Date.now() - start },
         'Unauthorised — service account user resolution failed',
       );
-      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     return executeHandler(
@@ -263,7 +263,7 @@ async function handleOpenMode(
   }
 
   apiLogger.warn({ method, path, durationMs: Date.now() - start }, 'Unauthorised — no session or service account');
-  return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 }
 
 async function executeHandler(

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -5,6 +5,7 @@ import {
   listDids,
   updateDid,
   updateDidStatus,
+  deleteDid,
   getDefaultDid,
 } from './did.repository';
 import type { DidStatus } from '../generated';
@@ -14,6 +15,7 @@ const mockTx = {
   did: {
     findFirst: jest.fn(),
     update: jest.fn(),
+    delete: jest.fn(),
   },
 };
 
@@ -24,6 +26,7 @@ jest.mock('../prisma', () => ({
       create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
+      count: jest.fn(),
     },
     $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
   },
@@ -36,6 +39,7 @@ const mockDid = prisma.did as unknown as {
   create: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
+  count: jest.Mock;
 };
 
 describe('did.repository', () => {
@@ -221,6 +225,7 @@ describe('did.repository', () => {
   describe('listDids', () => {
     it('lists DIDs for the organisation including defaults', async () => {
       mockDid.findMany.mockResolvedValue([DID_RECORD]);
+      mockDid.count.mockResolvedValue(1);
 
       const result = await listDids(ORG_ID);
 
@@ -228,15 +233,21 @@ describe('did.repository', () => {
         where: {
           OR: [{ tenantId: ORG_ID }, { isDefault: true }],
         },
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
-      expect(result).toEqual([DID_RECORD]);
+      expect(mockDid.count).toHaveBeenCalledWith({
+        where: {
+          OR: [{ tenantId: ORG_ID }, { isDefault: true }],
+        },
+      });
+      expect(result).toEqual({ data: [DID_RECORD], total: 1 });
     });
 
     it('applies type and status filters', async () => {
       mockDid.findMany.mockResolvedValue([]);
+      mockDid.count.mockResolvedValue(0);
 
       await listDids(ORG_ID, { type: 'MANAGED', status: 'ACTIVE' });
 
@@ -245,7 +256,7 @@ describe('did.repository', () => {
           type: 'MANAGED',
           status: 'ACTIVE',
         }),
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
@@ -253,6 +264,7 @@ describe('did.repository', () => {
 
     it('applies serviceInstanceId filter', async () => {
       mockDid.findMany.mockResolvedValue([]);
+      mockDid.count.mockResolvedValue(0);
 
       await listDids(ORG_ID, { serviceInstanceId: 'inst-1' });
 
@@ -260,7 +272,7 @@ describe('did.repository', () => {
         where: expect.objectContaining({
           serviceInstanceId: 'inst-1',
         }),
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
@@ -268,6 +280,7 @@ describe('did.repository', () => {
 
     it('applies pagination', async () => {
       mockDid.findMany.mockResolvedValue([]);
+      mockDid.count.mockResolvedValue(0);
 
       await listDids(ORG_ID, { limit: 10, offset: 20 });
 
@@ -326,6 +339,36 @@ describe('did.repository', () => {
       await expect(updateDidStatus('did-record-1', 'other-org', 'VERIFIED' as DidStatus)).rejects.toThrow(
         'DID not found or access denied',
       );
+    });
+  });
+
+  describe('deleteDid', () => {
+    it('deletes the DID when it belongs to the organisation', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      mockTx.did.delete.mockResolvedValue(DID_RECORD);
+
+      await deleteDid('did-record-1', ORG_ID);
+
+      expect(mockTx.did.findFirst).toHaveBeenCalledWith({
+        where: { id: 'did-record-1', tenantId: ORG_ID },
+      });
+      expect(mockTx.did.delete).toHaveBeenCalledWith({
+        where: { id: 'did-record-1' },
+      });
+    });
+
+    it('throws NotFoundError when DID does not exist', async () => {
+      mockTx.did.findFirst.mockResolvedValue(null);
+
+      await expect(deleteDid('nonexistent', ORG_ID)).rejects.toThrow('DID not found or access denied');
+      expect(mockTx.did.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundError when DID belongs to a different organisation', async () => {
+      mockTx.did.findFirst.mockResolvedValue(null);
+
+      await expect(deleteDid('did-record-1', 'other-org')).rejects.toThrow('DID not found or access denied');
+      expect(mockTx.did.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -86,8 +86,12 @@ export async function getDidByDid(did: string, tenantId: string): Promise<Did | 
 
 /**
  * Lists DIDs for an organisation, including system defaults.
+ * Returns the matching records along with the total count for pagination.
  */
-export async function listDids(tenantId: string, options: ListDidsOptions = {}): Promise<Did[]> {
+export async function listDids(
+  tenantId: string,
+  options: ListDidsOptions = {},
+): Promise<{ data: Did[]; total: number }> {
   const { type, status, serviceInstanceId, limit, offset } = options;
 
   const where: Prisma.DidWhereInput = {
@@ -106,12 +110,17 @@ export async function listDids(tenantId: string, options: ListDidsOptions = {}):
     where.serviceInstanceId = serviceInstanceId;
   }
 
-  return prisma.did.findMany({
-    where,
-    take: limit ?? 100,
-    skip: offset,
-    orderBy: { createdAt: 'desc' },
-  });
+  const [data, total] = await Promise.all([
+    prisma.did.findMany({
+      where,
+      take: limit ?? 20,
+      skip: offset,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.did.count({ where }),
+  ]);
+
+  return { data, total };
 }
 
 /**
@@ -155,6 +164,26 @@ export async function updateDidStatus(id: string, tenantId: string, status: DidS
     return tx.did.update({
       where: { id },
       data: { status },
+    });
+  });
+}
+
+/**
+ * Deletes a DID.
+ * Validates that the DID exists and belongs to the specified organisation.
+ */
+export async function deleteDid(id: string, tenantId: string): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    const existing = await tx.did.findFirst({
+      where: { id, tenantId },
+    });
+
+    if (!existing) {
+      throw new NotFoundError('DID not found or access denied');
+    }
+
+    await tx.did.delete({
+      where: { id },
     });
   });
 }

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
@@ -8,6 +8,7 @@ import {
   DidMethodNotSupportedError,
   DidInputError,
   DidCreateError,
+  DidDeleteError,
   DidDocumentFetchError,
 } from '../../errors';
 
@@ -180,6 +181,40 @@ describe('VCKitDidAdapter', () => {
 
       const payload = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
       expect(payload.alias).toBe('my-org');
+    });
+  });
+
+  // delete() tests
+  describe('delete', () => {
+    it('calls didManagerDelete endpoint and returns void', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(createMockResponse(true));
+
+      await expect(service.delete('did:web:example.com:org:123')).resolves.toBeUndefined();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE_URL}/agent/didManagerDelete`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+          body: JSON.stringify({ did: 'did:web:example.com:org:123' }),
+        }),
+      );
+    });
+
+    it('throws DidInputError if DID string is empty', async () => {
+      await expect(service.delete('')).rejects.toThrow(DidInputError);
+    });
+
+    it('throws DidDeleteError on HTTP error', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(createMockResponse({}, false, 500));
+
+      await expect(service.delete('did:web:example.com:org:123')).rejects.toThrow(DidDeleteError);
+    });
+
+    it('throws DidDeleteError on network failure', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+      await expect(service.delete('did:web:example.com:org:123')).rejects.toThrow(DidDeleteError);
     });
   });
 

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
@@ -1,6 +1,6 @@
 import { VCKitDidAdapter, vckitDidRegistryEntry } from './vckit-did.adapter';
 import { vckitDidConfigSchema } from './vckit-did.schema';
-import { DidMethod, DidType } from '../../types';
+import { DidMethod, DidType, DidVerificationCheckName } from '../../types';
 import { verifyDid } from '../../common/verify';
 import type { LoggerService } from '../../../logging/types';
 import {
@@ -297,15 +297,57 @@ describe('VCKitDidAdapter', () => {
       await expect(service.verify('')).rejects.toThrow(DidInputError);
     });
 
-    it('passes empty providerKeys when VCKit key fetch fails', async () => {
+    it('passes empty providerKeys and adds KEY_MATERIAL error when key fetch throws', async () => {
       const mockResult = { verified: true, checks: [], errors: undefined };
       (verifyDid as jest.Mock).mockResolvedValue(mockResult);
       (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
 
-      await service.verify('did:web:example.com');
+      const result = await service.verify('did:web:example.com');
 
       expect(verifyDid).toHaveBeenCalledWith('did:web:example.com', {
         providerKeys: [],
+      });
+
+      expect(result.errors).toEqual([
+        {
+          check: DidVerificationCheckName.KEY_MATERIAL,
+          message: 'Provider key material could not be fetched — key_material check may be incomplete',
+        },
+      ]);
+    });
+
+    it('adds KEY_MATERIAL error when key fetch returns non-OK status', async () => {
+      const mockResult = { verified: true, checks: [], errors: undefined };
+      (verifyDid as jest.Mock).mockResolvedValue(mockResult);
+      (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse({}, false, 500));
+
+      const result = await service.verify('did:web:example.com');
+
+      expect(verifyDid).toHaveBeenCalledWith('did:web:example.com', {
+        providerKeys: [],
+      });
+
+      expect(result.errors).toEqual([
+        {
+          check: DidVerificationCheckName.KEY_MATERIAL,
+          message: 'Provider key material could not be fetched — key_material check may be incomplete',
+        },
+      ]);
+    });
+
+    it('appends KEY_MATERIAL error to existing errors when key fetch fails', async () => {
+      const existingError = { check: DidVerificationCheckName.RESOLVE, message: 'Could not resolve' };
+      const mockResult = { verified: false, checks: [], errors: [existingError] };
+      (verifyDid as jest.Mock).mockResolvedValue(mockResult);
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await service.verify('did:web:example.com');
+
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors![0]).toEqual(existingError);
+      expect(result.errors![1]).toEqual({
+        check: DidVerificationCheckName.KEY_MATERIAL,
+        message: 'Provider key material could not be fetched — key_material check may be incomplete',
       });
     });
   });

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -1,5 +1,5 @@
 import type { IDidService, CreateDidOptions, DidRecord, DidDocument, DidVerificationResult } from '../../types.js';
-import { DidMethod, DidType } from '../../types.js';
+import { DidMethod, DidType, DidVerificationCheckName } from '../../types.js';
 import { verifyDid } from '../../common/verify.js';
 import { normaliseDidWebAlias } from '../../common/utils.js';
 import type { AdapterRegistryEntry } from '../../../registry/types.js';
@@ -187,6 +187,7 @@ export class VCKitDidAdapter implements IDidService {
     this.logger.debug({ did }, 'Verifying DID');
 
     let providerKeys: Array<{ kid: string }> = [];
+    let keyFetchFailed = false;
     try {
       const response = await fetch(`${this.baseURL}/agent/didManagerGet`, {
         method: 'POST',
@@ -197,14 +198,26 @@ export class VCKitDidAdapter implements IDidService {
         const vckitDid = await response.json();
         providerKeys = vckitDid.keys ?? [];
         this.logger.debug({ did, keyCount: providerKeys.length }, 'Fetched provider keys');
+      } else {
+        keyFetchFailed = true;
+        this.logger.warn({ did, status: response.status }, 'Provider key fetch returned non-OK status');
       }
     } catch (error) {
       // If we can't fetch keys, the key_material check will still run with empty keys
-
+      keyFetchFailed = true;
       this.logger.warn({ error, did }, 'Failed to fetch provider keys, continuing with empty keys');
     }
 
     const result = await verifyDid(did, { providerKeys });
+
+    if (keyFetchFailed) {
+      if (!result.errors) result.errors = [];
+      result.errors.push({
+        check: DidVerificationCheckName.KEY_MATERIAL,
+        message: 'Provider key material could not be fetched — key_material check may be incomplete',
+      });
+    }
+
     this.logger.info({ did, verified: result.verified }, 'DID verification completed');
     return result;
   }

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -12,6 +12,7 @@ import {
   DidMethodNotSupportedError,
   DidInputError,
   DidCreateError,
+  DidDeleteError,
   DidDocumentFetchError,
 } from '../../errors.js';
 import { ServiceError } from '../../../errors.js';
@@ -103,6 +104,37 @@ export class VCKitDidAdapter implements IDidService {
       this.logger.error({ error }, 'Failed to create DID');
       const detail = error instanceof Error ? error.message : 'Unknown error';
       throw new DidCreateError(detail);
+    }
+  }
+
+  async delete(did: string): Promise<void> {
+    if (!did) {
+      throw new DidInputError('DID string is required');
+    }
+
+    this.logger.debug({ did }, 'Deleting DID');
+
+    try {
+      const response = await fetch(`${this.baseURL}/agent/didManagerDelete`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.headers,
+        },
+        body: JSON.stringify({ did }),
+      });
+
+      if (!response.ok) {
+        this.logger.error({ status: response.status, statusText: response.statusText, did }, 'Failed to delete DID');
+        throw new DidDeleteError(`HTTP ${response.status}: ${response.statusText}`, response.status);
+      }
+
+      this.logger.info({ did }, 'DID deleted successfully');
+    } catch (error) {
+      if (error instanceof ServiceError) throw error;
+      this.logger.error({ error, did }, 'Failed to delete DID');
+      const detail = error instanceof Error ? error.message : 'Unknown error';
+      throw new DidDeleteError(detail);
     }
   }
 

--- a/packages/services/src/did-manager/errors.test.ts
+++ b/packages/services/src/did-manager/errors.test.ts
@@ -5,6 +5,7 @@ import {
   DidMethodNotSupportedError,
   DidInputError,
   DidCreateError,
+  DidDeleteError,
   DidDocumentFetchError,
   DidParseError,
 } from './errors.js';
@@ -79,6 +80,25 @@ describe('DID errors', () => {
     it('handles missing httpStatus', () => {
       const err = new DidCreateError('network failure');
       expect(err.message).toBe('Failed to create DID: network failure');
+      expect(err.context).toEqual({ httpStatus: undefined });
+    });
+  });
+
+  describe('DidDeleteError', () => {
+    it('constructs message from detail and httpStatus', () => {
+      const err = new DidDeleteError('upstream timeout', 504);
+      expect(err.message).toBe('Failed to delete DID: upstream timeout');
+      expect(err.code).toBe('DID_DELETE_FAILED');
+      expect(err.statusCode).toBe(502);
+      expect(err.context).toEqual({ httpStatus: 504 });
+      expect(err.name).toBe('DidDeleteError');
+      expect(err).toBeInstanceOf(DidError);
+      expect(err).toBeInstanceOf(ServiceError);
+    });
+
+    it('handles missing httpStatus', () => {
+      const err = new DidDeleteError('network failure');
+      expect(err.message).toBe('Failed to delete DID: network failure');
       expect(err.context).toEqual({ httpStatus: undefined });
     });
   });

--- a/packages/services/src/did-manager/errors.ts
+++ b/packages/services/src/did-manager/errors.ts
@@ -36,6 +36,13 @@ export class DidCreateError extends DidError {
   }
 }
 
+/** Failed to delete a DID via the upstream provider. */
+export class DidDeleteError extends DidError {
+  constructor(detail: string, httpStatus?: number) {
+    super(`Failed to delete DID: ${detail}`, 'DID_DELETE_FAILED', 502, { httpStatus });
+  }
+}
+
 /** Failed to fetch a DID document from the upstream provider. */
 export class DidDocumentFetchError extends DidError {
   constructor(did: string, detail: string, httpStatus?: number) {

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -134,6 +134,8 @@ export interface IDidService {
   getSupportedTypes(): DidType[];
   /** DID methods this adapter supports */
   getSupportedMethods(): DidMethod[];
+  /** Delete a DID from the provider */
+  delete(did: string): Promise<void>;
   /** Key algorithms this adapter supports */
   getSupportedKeyTypes(): string[];
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -68,6 +68,7 @@ export {
   DidMethodNotSupportedError,
   DidInputError,
   DidCreateError,
+  DidDeleteError,
   DidDocumentFetchError,
   DidParseError,
 } from './did-manager/errors.js';


### PR DESCRIPTION
This PR standardises the DID API routes as the template for all other API routes. Resources are returned directly on success (no `{ ok }` envelope), list endpoints include pagination metadata, partial updates use PATCH semantics, and a DELETE endpoint is added.

The error envelope change (`ok: false` removed from all error responses) applies globally via `handleRouteError` and `withTenantAuth`, so non-DID route tests are updated too.

## Changes

**Global (affects all routes):**
- Remove `ok: false` from error responses in `handleRouteError` and `withTenantAuth`

**Services package:**
- Add `delete(did)` to `IDidService` interface and VCKit adapter
- Add `DidDeleteError` to error hierarchy
- Fix verify method to track key fetch failures and inject `KEY_MATERIAL` error when degraded

**DID routes:**
- `POST /dids` and `POST /dids/import`: return resource directly, status 201
- `GET /dids`: return `{ data, pagination: { total, limit, offset, hasMore } }`
- `GET /dids/:id`: return resource directly
- `PUT /dids/:id` renamed to `PATCH /dids/:id`
- `DELETE /dids/:id`: new endpoint, 204 No Content. DB-first delete with best-effort upstream cleanup. Guards against deleting system default DIDs.
- `GET /dids/:id/document`: return document directly
- `POST /dids/:id/verify`: return `{ verification, did }` (no envelope)

**Infrastructure:**
- Add `buildPaginatedResponse` helper (`src/lib/api/pagination.ts`)
- Add `deleteDid` to DID repository with transactional tenant ownership check
- Update `listDids` to return `{ data, total }` with default limit of 20

## Test plan
- [x] 951 RI tests pass (82 suites)
- [x] 776 services tests pass (60 suites)
- [x] DELETE handler: success, 404, managed vs self-managed, default DID guard, upstream failure resilience
- [x] Pagination: standard case, last page, defaults, zero results, hasMore edge case
- [x] Verify degradation: key fetch throw, non-OK response, appends to existing errors
- [x] All non-DID route error assertions updated for new envelope shape