### PR TITLE
fix(api): align Swagger schemas with runtime types

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -170,6 +170,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *     responses:
  *       204:
  *         description: DID deleted successfully
+ *       400:
+ *         description: Cannot delete the system default DID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -30,7 +30,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *                 description: The DID identifier to import (e.g., did:web:example.com)
  *               method:
  *                 type: string
- *                 enum: [DID_WEB, DID_WEB_VH]
+ *                 enum: [DID_WEB]
  *                 description: DID method
  *               keyId:
  *                 type: string
@@ -53,6 +53,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *               $ref: '#/components/schemas/Did'
  *       400:
  *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised - missing or invalid authentication
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -168,7 +168,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: type
  *         schema:
  *           type: string
- *           enum: [MANAGED, SELF_MANAGED]
+ *           enum: [DEFAULT, MANAGED, SELF_MANAGED]
  *         description: Filter by DID type
  *       - in: query
  *         name: status

--- a/packages/reference-implementation/src/lib/api/pagination.test.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.test.ts
@@ -1,4 +1,4 @@
-import { buildPaginatedResponse } from './pagination';
+import { buildPaginatedResponse, paginationMetaSchema } from './pagination';
 
 describe('buildPaginatedResponse', () => {
   it('returns correct pagination metadata with explicit limit and offset', () => {
@@ -71,5 +71,31 @@ describe('buildPaginatedResponse', () => {
         hasMore: false,
       },
     });
+  });
+});
+
+describe('paginationMetaSchema', () => {
+  it('parses valid pagination metadata', () => {
+    const result = paginationMetaSchema.parse({
+      total: 100,
+      limit: 20,
+      offset: 0,
+      hasMore: true,
+    });
+
+    expect(result).toEqual({
+      total: 100,
+      limit: 20,
+      offset: 0,
+      hasMore: true,
+    });
+  });
+
+  it('rejects non-integer total', () => {
+    expect(() => paginationMetaSchema.parse({ total: 1.5, limit: 20, offset: 0, hasMore: false })).toThrow();
+  });
+
+  it('rejects missing fields', () => {
+    expect(() => paginationMetaSchema.parse({ total: 10 })).toThrow();
   });
 });

--- a/packages/reference-implementation/src/lib/api/pagination.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.ts
@@ -1,9 +1,13 @@
-export interface PaginationMeta {
-  total: number;
-  limit: number;
-  offset: number;
-  hasMore: boolean;
-}
+import { z } from 'zod';
+
+export const paginationMetaSchema = z.object({
+  total: z.number().int().describe('Total number of records matching the query'),
+  limit: z.number().int().describe('Maximum records per page'),
+  offset: z.number().int().describe('Number of records skipped'),
+  hasMore: z.boolean().describe('Whether more records exist beyond this page'),
+});
+
+export type PaginationMeta = z.infer<typeof paginationMetaSchema>;
 
 export interface PaginatedResponse<T> {
   data: T[];

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -10,6 +10,8 @@ import zodToJsonSchema from 'zod-to-json-schema';
 import {
   // DID schemas
   didResponseSchema,
+  verificationCheckSchema,
+  verificationErrorSchema,
   verificationResultResponseSchema,
   didDocumentResponseSchema,
   // IDR schemas
@@ -21,6 +23,7 @@ import {
   // Shared schemas
   errorResponseSchema,
 } from '@uncefact/untp-ri-services';
+import { paginationMetaSchema } from '@/lib/api/pagination';
 
 // ============================================================================
 // Credential Schemas (remain local — no credential service directory yet)
@@ -68,6 +71,8 @@ export const credentialIssueRequestSchema = z.object({
 
 export {
   didResponseSchema,
+  verificationCheckSchema,
+  verificationErrorSchema,
   verificationResultResponseSchema,
   didDocumentResponseSchema,
   registrarSchema,
@@ -76,6 +81,7 @@ export {
   identifierSchema,
   linkRegistrationSchema,
   errorResponseSchema,
+  paginationMetaSchema,
 };
 
 // ============================================================================
@@ -97,6 +103,9 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     Did: didResponseSchema,
     ErrorResponse: errorResponseSchema,
     VerificationResult: verificationResultResponseSchema,
+    PaginationMeta: paginationMetaSchema,
+    VerificationCheck: verificationCheckSchema,
+    VerificationError: verificationErrorSchema,
     DidDocument: didDocumentResponseSchema,
     CredentialStorageResponse: credentialStorageResponseSchema,
     CredentialPublishResponse: credentialPublishResponseSchema,

--- a/packages/services/src/did-manager/schemas.ts
+++ b/packages/services/src/did-manager/schemas.ts
@@ -39,14 +39,23 @@ export const didResponseSchema = z.object({
   updatedAt: z.string().datetime().describe('Timestamp when the DID was last updated'),
 });
 
+const VERIFICATION_CHECK_NAMES = [
+  'resolve',
+  'structure',
+  'identity_match',
+  'https',
+  'key_material',
+  'jsonld_validity',
+] as const;
+
 export const verificationCheckSchema = z.object({
-  name: z.enum(['resolve', 'structure', 'identity_match', 'https', 'key_material', 'jsonld_validity']),
+  name: z.enum(VERIFICATION_CHECK_NAMES),
   passed: z.boolean(),
   message: z.string().optional(),
 });
 
 export const verificationErrorSchema = z.object({
-  check: z.enum(['resolve', 'structure', 'identity_match', 'https', 'key_material', 'jsonld_validity']),
+  check: z.enum(VERIFICATION_CHECK_NAMES),
   message: z.string(),
 });
 

--- a/packages/services/src/did-manager/schemas.ts
+++ b/packages/services/src/did-manager/schemas.ts
@@ -28,7 +28,9 @@ export const didResponseSchema = z.object({
   method: z.enum(['DID_WEB', 'DID_WEB_VH']).describe('DID method'),
   name: z.string().describe('Human-readable name'),
   description: z.string().nullable().describe('Description of the DID'),
-  status: z.enum(['ACTIVE', 'INACTIVE', 'VERIFIED', 'UNVERIFIED']).describe('Current status of the DID'),
+  status: z
+    .enum(['ACTIVE', 'INACTIVE', 'VERIFIED', 'UNVERIFIED', 'VERIFICATION_FAILED'])
+    .describe('Current status of the DID'),
   keyId: z.string().describe('Key identifier associated with the DID'),
   tenantId: z.string().describe('ID of the owning tenant'),
   serviceInstanceId: z.string().nullable().describe('ID of the service instance used to manage this DID'),
@@ -37,12 +39,24 @@ export const didResponseSchema = z.object({
   updatedAt: z.string().datetime().describe('Timestamp when the DID was last updated'),
 });
 
+export const verificationCheckSchema = z.object({
+  name: z.enum(['resolve', 'structure', 'identity_match', 'https', 'key_material', 'jsonld_validity']),
+  passed: z.boolean(),
+  message: z.string().optional(),
+});
+
+export const verificationErrorSchema = z.object({
+  check: z.enum(['resolve', 'structure', 'identity_match', 'https', 'key_material', 'jsonld_validity']),
+  message: z.string(),
+});
+
 /**
  * Verification result as returned by the REST API.
  */
 export const verificationResultResponseSchema = z.object({
   verified: z.boolean().describe('Whether the DID was successfully verified'),
-  message: z.string().describe('Verification result message'),
+  checks: z.array(verificationCheckSchema).describe('Individual verification checks performed'),
+  errors: z.array(verificationErrorSchema).optional().describe('Errors encountered during verification'),
 });
 
 /**

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -29,6 +29,8 @@ export {
   didDocumentSchema,
   verificationMethodSchema,
   didResponseSchema,
+  verificationCheckSchema,
+  verificationErrorSchema,
   verificationResultResponseSchema,
   didDocumentResponseSchema,
 } from './did-manager/schemas.js';

--- a/packages/services/src/schemas.ts
+++ b/packages/services/src/schemas.ts
@@ -8,6 +8,6 @@ import { z } from 'zod';
  * Standard error response returned by the REST API.
  */
 export const errorResponseSchema = z.object({
-  ok: z.literal(false),
   error: z.string().describe('Error message'),
+  code: z.string().optional().describe('Machine-readable error code (present for service-layer errors)'),
 });


### PR DESCRIPTION
## Summary

This PR fixes stale Zod schemas and Swagger annotations left over from the DID API cleanup, ensuring the OpenAPI documentation accurately reflects the actual API response shapes.

- Removed the obsolete `ok: false` envelope from `errorResponseSchema` and added the optional `code` field that `ServiceError` responses include
- Added `VERIFICATION_FAILED` to the DID status enum in `didResponseSchema` (already present in Prisma and TypeScript)
- Replaced the placeholder `verificationResultResponseSchema` (`{ verified, message }`) with the correct shape matching `DidVerificationResult` (`{ verified, checks[], errors?[] }`)
- Added `paginationMetaSchema` as a Zod schema, registered it as an OpenAPI component so `$ref: '#/components/schemas/PaginationMeta'` resolves
- Fixed GET `/dids` type filter enum to include `DEFAULT`
- Added missing 400 response to DELETE `/dids/{id}` and 401 to POST `/dids/import`
- Narrowed import route method enum to `[DID_WEB]` (only supported method)

Also created a local `auditing-api-routes` skill (`.claude/`, not tracked) with checklists for Swagger, schema alignment, and E2E coverage to guide future route migrations.

## Test plan

- [x] All 776 services tests pass
- [x] All 954 reference-implementation tests pass (including Prisma client regeneration for `VERIFICATION_FAILED`)
- [x] New `paginationMetaSchema` parse tests added (valid input, non-integer rejection, missing fields)
- [x] `yarn build:services` succeeds