### PR TITLE
refactor(api)!: remove redundant apiVersion column from ServiceInstance

### DIFF
--- a/RELEASE_MANAGEMENT_GUIDE.md
+++ b/RELEASE_MANAGEMENT_GUIDE.md
@@ -99,7 +99,6 @@ The version.json file serves as a central metadata file to define the versioning
 // version.json
 {
   "version": "1.0.0",
-  "apiVersion": "1.0.0",
   "docVersion": "1.0.0",
   "dependencies": {
     // Example dependency service
@@ -114,7 +113,6 @@ The version.json file serves as a central metadata file to define the versioning
 ### Key Fields
 
 - version: The version of the current service. Must align with the Git tag.
-- apiVersion: The API version exposed by the service, the field is optional.
 - docVersion: The version of the documentation.
 - dependencies: A list of dependent services with their repositories and compatible version list, the field is optional.
 - repoUrl: URL of the repository for the dependent service.

--- a/e2e/cypress/e2e/service_api/service-management.cy.ts
+++ b/e2e/cypress/e2e/service_api/service-management.cy.ts
@@ -168,7 +168,7 @@ describe('Service API', { testIsolation: false }, () => {
           url: '/api/v1/dids',
           body: {
             type: 'MANAGED',
-            method: 'did:web',
+            method: 'DID_WEB',
             alias: `ref-test-${RUN_ID}`,
             serviceInstanceId: refServiceId,
           },

--- a/e2e/cypress/e2e/service_api/service-management.cy.ts
+++ b/e2e/cypress/e2e/service_api/service-management.cy.ts
@@ -5,7 +5,6 @@ interface ServiceInstance {
   name: string;
   description?: string;
   config: Record<string, unknown>;
-  apiVersion: string;
   isPrimary: boolean;
 }
 
@@ -36,22 +35,27 @@ describe('Service API', { testIsolation: false }, () => {
             endpoint: 'https://vckit-e2e.example.com',
             apiKey: 'e2e-test-key-123',
           },
-          apiVersion: '1.0.0',
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.serviceInstanceId).to.be.a('string');
+        expect(response.body.id).to.be.a('string');
+        expect(response.body.serviceType).to.eq('VC');
+        expect(response.body.adapterType).to.eq('VCKIT');
+        expect(response.body.name).to.eq(`E2E Test VC Service ${RUN_ID}`);
 
-        createdServiceId = response.body.serviceInstanceId;
+        createdServiceId = response.body.id;
       });
     });
 
     it('GET /api/v1/services — lists service instances including the created one', () => {
       cy.request('/api/v1/services').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.services).to.be.an('array');
+        expect(response.body.data).to.be.an('array');
+        expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.total).to.be.a('number');
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
 
-        const created = response.body.services.find(
+        const created = response.body.data.find(
           (s: ServiceInstance) => s.id === createdServiceId,
         );
         expect(created).to.exist;
@@ -62,18 +66,17 @@ describe('Service API', { testIsolation: false }, () => {
     it('GET /api/v1/services/:id — retrieves a specific service instance', () => {
       cy.request(`/api/v1/services/${createdServiceId}`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.service).to.exist;
-        expect(response.body.service.id).to.eq(createdServiceId);
-        expect(response.body.service.serviceType).to.eq('VC');
-        expect(response.body.service.adapterType).to.eq('VCKIT');
-        expect(response.body.service.name).to.eq(`E2E Test VC Service ${RUN_ID}`);
-        expect(response.body.service.description).to.eq('Created by Cypress E2E test');
+        expect(response.body.id).to.eq(createdServiceId);
+        expect(response.body.serviceType).to.eq('VC');
+        expect(response.body.adapterType).to.eq('VCKIT');
+        expect(response.body.name).to.eq(`E2E Test VC Service ${RUN_ID}`);
+        expect(response.body.description).to.eq('Created by Cypress E2E test');
       });
     });
 
     it('GET /api/v1/services/:id — masks sensitive config fields', () => {
       cy.request(`/api/v1/services/${createdServiceId}`).then((response) => {
-        const config = response.body.service.config;
+        const config = response.body.config;
         expect(config).to.be.an('object');
         expect(config.endpoint).to.eq('https://vckit-e2e.example.com');
         expect(config.apiKey).to.eq('***');
@@ -87,7 +90,7 @@ describe('Service API', { testIsolation: false }, () => {
         body: { name: `Updated E2E VC Service ${RUN_ID}` },
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.service.name).to.eq(`Updated E2E VC Service ${RUN_ID}`);
+        expect(response.body.name).to.eq(`Updated E2E VC Service ${RUN_ID}`);
       });
     });
 
@@ -98,7 +101,7 @@ describe('Service API', { testIsolation: false }, () => {
         body: { description: 'Updated description' },
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.service.description).to.eq('Updated description');
+        expect(response.body.description).to.eq('Updated description');
       });
     });
 
@@ -114,50 +117,91 @@ describe('Service API', { testIsolation: false }, () => {
       }).then((response) => {
         expect(response.status).to.eq(200);
         // Updated field reflected
-        expect(response.body.service.config.endpoint).to.eq(
+        expect(response.body.config.endpoint).to.eq(
           'https://vckit-e2e-updated.example.com',
         );
         // apiKey preserved from original config (merged) and masked
-        expect(response.body.service.config.apiKey).to.eq('***');
+        expect(response.body.config.apiKey).to.eq('***');
       });
     });
 
     it('GET /api/v1/services/:id — confirms all updates persisted', () => {
       cy.request(`/api/v1/services/${createdServiceId}`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.service.name).to.eq(`Updated E2E VC Service ${RUN_ID}`);
-        expect(response.body.service.description).to.eq('Updated description');
-        expect(response.body.service.config.endpoint).to.eq(
+        expect(response.body.name).to.eq(`Updated E2E VC Service ${RUN_ID}`);
+        expect(response.body.description).to.eq('Updated description');
+        expect(response.body.config.endpoint).to.eq(
           'https://vckit-e2e-updated.example.com',
         );
       });
     });
 
-    it('DELETE /api/v1/services/:id — warns without force flag', () => {
+    it('DELETE /api/v1/services/:id — deletes the service instance', () => {
       cy.request({
         method: 'DELETE',
         url: `/api/v1/services/${createdServiceId}`,
       }).then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body.deleted).to.be.false;
-        expect(response.body.warning).to.exist;
+        expect(response.status).to.eq(204);
       });
     });
 
-    it('GET /api/v1/services/:id — still exists after delete without force', () => {
-      cy.request(`/api/v1/services/${createdServiceId}`).then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body.service.id).to.eq(createdServiceId);
-      });
-    });
-
-    it('DELETE /api/v1/services/:id?force=true — deletes the service instance', () => {
+    it('DELETE /api/v1/services/:id — returns 409 when instance has references', () => {
+      // Create a service instance that will be referenced by a DID
       cy.request({
-        method: 'DELETE',
-        url: `/api/v1/services/${createdServiceId}?force=true`,
-      }).then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body.deleted).to.be.true;
+        method: 'POST',
+        url: '/api/v1/services',
+        body: {
+          serviceType: 'VC',
+          adapterType: 'VCKIT',
+          name: `E2E Ref Check ${RUN_ID}`,
+          config: {
+            endpoint: 'https://ref-check.example.com',
+            apiKey: 'ref-key',
+          },
+        },
+      }).then((createRes) => {
+        const refServiceId = createRes.body.id;
+
+        // Create a DID that references this service instance
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/dids',
+          body: {
+            type: 'MANAGED',
+            method: 'did:web',
+            alias: `ref-test-${RUN_ID}`,
+            serviceInstanceId: refServiceId,
+          },
+        }).then((didRes) => {
+          const didId = didRes.body.id;
+
+          // Attempt to delete without force — should get 409
+          cy.request({
+            method: 'DELETE',
+            url: `/api/v1/services/${refServiceId}`,
+            failOnStatusCode: false,
+          }).then((deleteRes) => {
+            expect(deleteRes.status).to.eq(409);
+            expect(deleteRes.body.error).to.include('Cannot delete');
+            expect(deleteRes.body.error).to.include('DID(s)');
+          });
+
+          // Delete with force=true — should succeed
+          cy.request({
+            method: 'DELETE',
+            url: `/api/v1/services/${refServiceId}?force=true`,
+          }).then((forceRes) => {
+            expect(forceRes.status).to.eq(204);
+          });
+
+          // Clean up DID (it still exists, serviceInstanceId is now null)
+          cy.request({
+            method: 'GET',
+            url: `/api/v1/dids/${didId}`,
+          }).then((didGetRes) => {
+            expect(didGetRes.body.serviceInstanceId).to.be.null;
+          });
+        });
       });
     });
 
@@ -188,18 +232,17 @@ describe('Service API', { testIsolation: false }, () => {
             endpoint: 'https://primary.example.com',
             apiKey: 'primary-key',
           },
-          apiVersion: '1.0.0',
           isPrimary: true,
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        primaryServiceId = response.body.serviceInstanceId;
+        primaryServiceId = response.body.id;
       });
     });
 
     it('verifies the first instance is primary', () => {
       cy.request(`/api/v1/services/${primaryServiceId}`).then((response) => {
-        expect(response.body.service.isPrimary).to.be.true;
+        expect(response.body.isPrimary).to.be.true;
       });
     });
 
@@ -215,18 +258,17 @@ describe('Service API', { testIsolation: false }, () => {
             endpoint: 'https://second.example.com',
             apiKey: 'second-key',
           },
-          apiVersion: '1.0.0',
           isPrimary: true,
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        secondServiceId = response.body.serviceInstanceId;
+        secondServiceId = response.body.id;
       });
     });
 
     it('second instance is primary, first is demoted', () => {
       cy.request('/api/v1/services').then((response) => {
-        const services = response.body.services;
+        const services = response.body.data;
         const second = services.find((s: ServiceInstance) => s.id === secondServiceId);
         const first = services.find((s: ServiceInstance) => s.id === primaryServiceId);
 
@@ -242,7 +284,7 @@ describe('Service API', { testIsolation: false }, () => {
         body: { isPrimary: true },
       }).then(() => {
         cy.request('/api/v1/services').then((response) => {
-          const services = response.body.services;
+          const services = response.body.data;
           const first = services.find((s: ServiceInstance) => s.id === primaryServiceId);
           const second = services.find((s: ServiceInstance) => s.id === secondServiceId);
 
@@ -253,7 +295,7 @@ describe('Service API', { testIsolation: false }, () => {
     });
 
     after(() => {
-      // Clean up both instances (ignore 404 if already deleted or never created)
+      // Clean up both instances (force to bypass referential integrity checks)
       cy.request({ method: 'DELETE', url: `/api/v1/services/${primaryServiceId}?force=true`, failOnStatusCode: false });
       cy.request({ method: 'DELETE', url: `/api/v1/services/${secondServiceId}?force=true`, failOnStatusCode: false });
     });
@@ -263,7 +305,7 @@ describe('Service API', { testIsolation: false }, () => {
     it('filters by serviceType', () => {
       cy.request('/api/v1/services?serviceType=VC').then((response) => {
         expect(response.status).to.eq(200);
-        response.body.services.forEach((s: ServiceInstance) => {
+        response.body.data.forEach((s: ServiceInstance) => {
           expect(s.serviceType).to.eq('VC');
         });
       });
@@ -272,7 +314,7 @@ describe('Service API', { testIsolation: false }, () => {
     it('filters by adapterType', () => {
       cy.request('/api/v1/services?adapterType=VCKIT').then((response) => {
         expect(response.status).to.eq(200);
-        response.body.services.forEach((s: ServiceInstance) => {
+        response.body.data.forEach((s: ServiceInstance) => {
           expect(s.adapterType).to.eq('VCKIT');
         });
       });
@@ -282,7 +324,7 @@ describe('Service API', { testIsolation: false }, () => {
       cy.request('/api/v1/services?serviceType=VC&adapterType=VCKIT').then(
         (response) => {
           expect(response.status).to.eq(200);
-          response.body.services.forEach((s: ServiceInstance) => {
+          response.body.data.forEach((s: ServiceInstance) => {
             expect(s.serviceType).to.eq('VC');
             expect(s.adapterType).to.eq('VCKIT');
           });
@@ -293,22 +335,26 @@ describe('Service API', { testIsolation: false }, () => {
     it('supports pagination with limit', () => {
       cy.request('/api/v1/services?limit=1').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.services.length).to.be.at.most(1);
+        expect(response.body.data.length).to.be.at.most(1);
+        expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.limit).to.eq(1);
       });
     });
 
     it('supports pagination with limit and offset', () => {
       cy.request('/api/v1/services?limit=1&offset=0').then((firstPage) => {
         expect(firstPage.status).to.eq(200);
-        expect(firstPage.body.services.length).to.be.at.most(1);
+        expect(firstPage.body.data.length).to.be.at.most(1);
+        expect(firstPage.body.pagination.offset).to.eq(0);
 
-        if (firstPage.body.services.length === 1) {
-          const firstId = firstPage.body.services[0].id;
+        if (firstPage.body.data.length === 1) {
+          const firstId = firstPage.body.data[0].id;
 
           cy.request('/api/v1/services?limit=1&offset=1').then((secondPage) => {
             expect(secondPage.status).to.eq(200);
-            if (secondPage.body.services.length === 1) {
-              expect(secondPage.body.services[0].id).to.not.eq(firstId);
+            expect(secondPage.body.pagination.offset).to.eq(1);
+            if (secondPage.body.data.length === 1) {
+              expect(secondPage.body.data[0].id).to.not.eq(firstId);
             }
           });
         }
@@ -319,7 +365,8 @@ describe('Service API', { testIsolation: false }, () => {
       cy.request('/api/v1/services').then((response) => {
         expect(response.status).to.eq(200);
         // System defaults are seeded at startup — at least one should exist
-        expect(response.body.services.length).to.be.greaterThan(0);
+        expect(response.body.data.length).to.be.greaterThan(0);
+        expect(response.body.pagination.total).to.be.greaterThan(0);
       });
     });
   });
@@ -333,7 +380,6 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'VCKIT',
           name: 'Test',
           config: { endpoint: 'https://example.com', apiKey: 'key' },
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -349,7 +395,6 @@ describe('Service API', { testIsolation: false }, () => {
           serviceType: 'VC',
           name: 'Test',
           config: { endpoint: 'https://example.com', apiKey: 'key' },
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -365,7 +410,6 @@ describe('Service API', { testIsolation: false }, () => {
           serviceType: 'VC',
           adapterType: 'VCKIT',
           config: { endpoint: 'https://example.com', apiKey: 'key' },
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -381,23 +425,6 @@ describe('Service API', { testIsolation: false }, () => {
           serviceType: 'VC',
           adapterType: 'VCKIT',
           name: 'Test',
-          apiVersion: '1.0.0',
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.status).to.eq(400);
-      });
-    });
-
-    it('returns 400 when apiVersion is missing', () => {
-      cy.request({
-        method: 'POST',
-        url: '/api/v1/services',
-        body: {
-          serviceType: 'VC',
-          adapterType: 'VCKIT',
-          name: 'Test',
-          config: { endpoint: 'https://example.com', apiKey: 'key' },
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -414,7 +441,6 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'VCKIT',
           name: 'Test',
           config: { endpoint: 'https://example.com', apiKey: 'key' },
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -431,7 +457,6 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'PYX_IDR',
           name: 'Test',
           config: {},
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -448,7 +473,6 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'VCKIT',
           name: 'Test',
           config: null,
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -465,7 +489,6 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'VCKIT',
           name: 'Test',
           config: [],
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -482,7 +505,6 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'VCKIT',
           name: 'Test',
           config: 'not an object',
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -499,7 +521,6 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'VCKIT',
           name: 'Test',
           config: { endpoint: 'not-a-url' },
-          apiVersion: '1.0.0',
         },
         failOnStatusCode: false,
       }).then((response) => {
@@ -519,10 +540,9 @@ describe('Service API', { testIsolation: false }, () => {
             endpoint: 'https://temp.example.com',
             apiKey: 'temp-key',
           },
-          apiVersion: '1.0.0',
         },
       }).then((createResponse) => {
-        const tempId = createResponse.body.serviceInstanceId;
+        const tempId = createResponse.body.id;
 
         cy.request({
           method: 'PATCH',
@@ -535,7 +555,7 @@ describe('Service API', { testIsolation: false }, () => {
           // Clean up
           cy.request({
             method: 'DELETE',
-            url: `/api/v1/services/${tempId}?force=true`,
+            url: `/api/v1/services/${tempId}`,
           });
         });
       });
@@ -553,10 +573,9 @@ describe('Service API', { testIsolation: false }, () => {
             endpoint: 'https://temp.example.com',
             apiKey: 'temp-key',
           },
-          apiVersion: '1.0.0',
         },
       }).then((createResponse) => {
-        const tempId = createResponse.body.serviceInstanceId;
+        const tempId = createResponse.body.id;
 
         cy.request({
           method: 'PATCH',
@@ -569,7 +588,7 @@ describe('Service API', { testIsolation: false }, () => {
           // Clean up
           cy.request({
             method: 'DELETE',
-            url: `/api/v1/services/${tempId}?force=true`,
+            url: `/api/v1/services/${tempId}`,
           });
         });
       });
@@ -588,7 +607,7 @@ describe('Service API', { testIsolation: false }, () => {
     it('returns 404 when deleting nonexistent service instance', () => {
       cy.request({
         method: 'DELETE',
-        url: '/api/v1/services/nonexistent-id?force=true',
+        url: '/api/v1/services/nonexistent-id',
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);

--- a/e2e/cypress/e2e/service_api/service-management.cy.ts
+++ b/e2e/cypress/e2e/service_api/service-management.cy.ts
@@ -155,8 +155,8 @@ describe('Service API', { testIsolation: false }, () => {
           adapterType: 'VCKIT',
           name: `E2E Ref Check ${RUN_ID}`,
           config: {
-            endpoint: 'https://ref-check.example.com',
-            apiKey: 'ref-key',
+            endpoint: 'http://vckit-api:3332',
+            apiKey: 'test123',
           },
         },
       }).then((createRes) => {

--- a/e2e/cypress/e2e/service_api/service-management.cy.ts
+++ b/e2e/cypress/e2e/service_api/service-management.cy.ts
@@ -555,7 +555,7 @@ describe('Service API', { testIsolation: false }, () => {
           // Clean up
           cy.request({
             method: 'DELETE',
-            url: `/api/v1/services/${tempId}`,
+            url: `/api/v1/services/${tempId}?force=true`,
           });
         });
       });
@@ -588,7 +588,7 @@ describe('Service API', { testIsolation: false }, () => {
           // Clean up
           cy.request({
             method: 'DELETE',
-            url: `/api/v1/services/${tempId}`,
+            url: `/api/v1/services/${tempId}?force=true`,
           });
         });
       });

--- a/packages/reference-implementation/prisma/migrations/20260304000000_remove_api_version_from_service_instance/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260304000000_remove_api_version_from_service_instance/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ServiceInstance" DROP COLUMN "apiVersion";

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -181,7 +181,6 @@ model ServiceInstance {
   name           String
   description    String?
   config         String       // AES-256-GCM encrypted JSON blob
-  apiVersion     String       @default("1.0.0") // Semver without v prefix, e.g. "1.0.0"
   isPrimary      Boolean      @default(false)
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -261,7 +261,6 @@ async function main() {
           name: 'System Default Pyx IDR',
           description: 'System-wide default Pyx Identity Resolver instance',
           config: encryptedIdrConfig,
-          apiVersion: '2.0.0',
           isPrimary: true,
         },
       });
@@ -303,7 +302,6 @@ async function main() {
           name: 'System Default UNCEFACT Storage',
           description: 'System-wide default UNCEFACT storage instance for credential persistence',
           config: encryptedStorageConfig,
-          apiVersion: '3.0.0',
           isPrimary: true,
         },
       });
@@ -341,7 +339,6 @@ async function main() {
           name: 'System Default VCKit',
           description: 'System-wide default VCKit instance for DID management and verifiable credential operations',
           config: encryptedVcConfig,
-          apiVersion: '1.0.0',
           isPrimary: true,
         },
       });

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.test.ts
@@ -1,0 +1,443 @@
+// Provide a minimal Response constructor for the DELETE handler
+// (jsdom does not expose the Fetch API's Response)
+global.Response = class Response {
+  status: number;
+  body: unknown;
+  constructor(body: unknown, init?: { status?: number }) {
+    this.body = body;
+    this.status = init?.status ?? 200;
+  }
+} as unknown as typeof globalThis.Response;
+
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth to mirror handleRouteError behaviour
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { NotFoundError, ConflictError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
+  const { ValidationError } = jest.requireActual('@/lib/api/validation');
+  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
+
+  function jsonResponse(body: unknown, init?: { status?: number }) {
+    return { status: init?.status ?? 200, json: async () => body };
+  }
+
+  return {
+    withTenantAuth:
+      (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
+        try {
+          return await handler(req, ctx);
+        } catch (e: unknown) {
+          if (e instanceof ValidationError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
+          }
+          if (e instanceof NotFoundError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
+          }
+          if (e instanceof ConflictError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 409 });
+          }
+          if (e instanceof ServiceRegistryError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
+          }
+          if (e instanceof ServiceError) {
+            const serviceErr = e as Error & { code?: string; statusCode?: number };
+            return jsonResponse(
+              { error: serviceErr.message, code: serviceErr.code },
+              { status: serviceErr.statusCode },
+            );
+          }
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        }
+      },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock repositories
+// ---------------------------------------------------------------------------
+
+const mockGetServiceInstanceById = jest.fn();
+const mockUpdateServiceInstance = jest.fn();
+const mockDeleteServiceInstance = jest.fn();
+const mockCountServiceInstanceReferences = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  getServiceInstanceById: (id: string, tenantId: string) => mockGetServiceInstanceById(id, tenantId),
+  updateServiceInstance: (id: string, tenantId: string, input: unknown) =>
+    mockUpdateServiceInstance(id, tenantId, input),
+  deleteServiceInstance: (id: string, tenantId: string) => mockDeleteServiceInstance(id, tenantId),
+  countServiceInstanceReferences: (id: string) => mockCountServiceInstanceReferences(id),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock encryption service
+// ---------------------------------------------------------------------------
+
+const mockEncrypt = jest.fn();
+const mockDecrypt = jest.fn();
+const mockGetEncryptionService = jest.fn();
+
+jest.mock('@/lib/encryption/encryption', () => ({
+  getEncryptionService: () => mockGetEncryptionService(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock maskInstanceConfig
+// ---------------------------------------------------------------------------
+
+const mockMaskInstanceConfig = jest.fn();
+
+jest.mock('@uncefact/untp-ri-services', () => {
+  const actual = jest.requireActual('@uncefact/untp-ri-services');
+  return {
+    ...actual,
+    maskInstanceConfig: (...args: unknown[]) => mockMaskInstanceConfig(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: {
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn().mockReturnThis(),
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import route handlers AFTER all mocks
+// ---------------------------------------------------------------------------
+
+import { GET, PATCH, DELETE } from './route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'GET', body, url = 'http://localhost/api/v1/services/svc-123' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createContext(id: string) {
+  return { tenantId: 'org-1', params: Promise.resolve({ id }) };
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_INSTANCE = {
+  id: 'svc-123',
+  tenantId: 'org-1',
+  serviceType: 'VC',
+  adapterType: 'VCKIT',
+  name: 'Test VC Service',
+  description: null,
+  config: JSON.stringify({ cipherText: 'abc', iv: '123', tag: '456', type: 'aes-256-gcm' }),
+  isPrimary: false,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+const MOCK_MASKED = {
+  ...MOCK_INSTANCE,
+  config: { endpoint: 'https://example.com', apiKey: '***' },
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/services/:id
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/services/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('retrieves a service instance successfully', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockMaskInstanceConfig.mockReturnValue(MOCK_MASKED);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('svc-123') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual(MOCK_MASKED);
+    expect(mockGetServiceInstanceById).toHaveBeenCalledWith('svc-123', 'org-1');
+    expect(mockMaskInstanceConfig).toHaveBeenCalledWith(MOCK_INSTANCE, mockGetEncryptionService(), expect.anything());
+  });
+
+  it('returns 404 when instance not found', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(null);
+
+    const req = createFakeRequest({});
+    const res = await GET(req, createContext('nonexistent') as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe('Service instance not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/services/:id
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/v1/services/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default encryption service mock
+    mockGetEncryptionService.mockReturnValue({ encrypt: mockEncrypt, decrypt: mockDecrypt });
+  });
+
+  it('updates name successfully', async () => {
+    const updated = { ...MOCK_INSTANCE, name: 'New Name' };
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockUpdateServiceInstance.mockResolvedValue(updated);
+    mockMaskInstanceConfig.mockReturnValue({ ...MOCK_MASKED, name: 'New Name' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'New Name' } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.name).toBe('New Name');
+    expect(mockUpdateServiceInstance).toHaveBeenCalledWith('svc-123', 'org-1', { name: 'New Name' });
+  });
+
+  it('updates description', async () => {
+    const updated = { ...MOCK_INSTANCE, description: 'New desc' };
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockUpdateServiceInstance.mockResolvedValue(updated);
+    mockMaskInstanceConfig.mockReturnValue({ ...MOCK_MASKED, description: 'New desc' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { description: 'New desc' } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.description).toBe('New desc');
+    expect(mockUpdateServiceInstance).toHaveBeenCalledWith('svc-123', 'org-1', { description: 'New desc' });
+  });
+
+  it('updates config (merges with existing, validates against schema, encrypts)', async () => {
+    const existingPlainConfig = { endpoint: 'https://old.com', apiKey: 'old-key' };
+    const newConfigPatch = { endpoint: 'https://new.com' };
+    const mergedConfig = { endpoint: 'https://new.com', apiKey: 'old-key' };
+    const encryptedEnvelope = { cipherText: 'new-cipher', iv: 'new-iv', tag: 'new-tag', type: 'aes-256-gcm' };
+
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockDecrypt.mockReturnValue(JSON.stringify(existingPlainConfig));
+    mockEncrypt.mockReturnValue(encryptedEnvelope);
+
+    const updated = { ...MOCK_INSTANCE, config: JSON.stringify(encryptedEnvelope) };
+    mockUpdateServiceInstance.mockResolvedValue(updated);
+    mockMaskInstanceConfig.mockReturnValue({ ...MOCK_MASKED, config: { endpoint: 'https://new.com', apiKey: '***' } });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { config: newConfigPatch } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockDecrypt).toHaveBeenCalled();
+    expect(mockEncrypt).toHaveBeenCalledWith(JSON.stringify(mergedConfig), 'aes-256-gcm');
+    expect(mockUpdateServiceInstance).toHaveBeenCalledWith('svc-123', 'org-1', {
+      config: JSON.stringify(encryptedEnvelope),
+    });
+    expect(json.config.endpoint).toBe('https://new.com');
+  });
+
+  it('updates isPrimary', async () => {
+    const updated = { ...MOCK_INSTANCE, isPrimary: true };
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockUpdateServiceInstance.mockResolvedValue(updated);
+    mockMaskInstanceConfig.mockReturnValue({ ...MOCK_MASKED, isPrimary: true });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { isPrimary: true } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.isPrimary).toBe(true);
+    expect(mockUpdateServiceInstance).toHaveBeenCalledWith('svc-123', 'org-1', { isPrimary: true });
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = createFakeRequest({ method: 'PATCH' }); // no body → json() throws SyntaxError
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 when body is empty (no fields provided)', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: {} });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/at least one of/i);
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/name must be a non-empty string/i);
+  });
+
+  it('returns 400 when config is not an object', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { config: 'not-an-object' } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/config must be an object/i);
+  });
+
+  it('returns 400 when config is an array', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { config: [1, 2, 3] } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/config must be an object/i);
+  });
+
+  it('returns 400 when config schema validation fails after merge', async () => {
+    // Existing config has valid endpoint + apiKey
+    const existingPlainConfig = { endpoint: 'https://old.com', apiKey: 'old-key' };
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockDecrypt.mockReturnValue(JSON.stringify(existingPlainConfig));
+
+    // Patch with invalid endpoint URL — merged config will fail schema validation
+    const req = createFakeRequest({ method: 'PATCH', body: { config: { endpoint: 'not-a-url' } } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/invalid configuration/i);
+  });
+
+  it('returns 404 when instance not found', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(null);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'New Name' } });
+    const res = await PATCH(req, createContext('nonexistent') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe('Service instance not found');
+  });
+
+  it('returns 400 when existing config cannot be decrypted', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockDecrypt.mockImplementation(() => {
+      throw new Error('Decryption failed');
+    });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { config: { endpoint: 'https://new.com' } } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/cannot update configuration/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/services/:id
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/v1/services/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes successfully when no references exist', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockCountServiceInstanceReferences.mockResolvedValue({ dids: 0, registrars: 0, schemes: 0 });
+    mockDeleteServiceInstance.mockResolvedValue(undefined);
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('svc-123') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(204);
+    expect((res as unknown as { body: unknown }).body).toBeNull();
+    expect(mockGetServiceInstanceById).toHaveBeenCalledWith('svc-123', 'org-1');
+    expect(mockCountServiceInstanceReferences).toHaveBeenCalledWith('svc-123');
+    expect(mockDeleteServiceInstance).toHaveBeenCalledWith('svc-123', 'org-1');
+  });
+
+  it('returns 409 when references exist and force is not set', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockCountServiceInstanceReferences.mockResolvedValue({ dids: 2, registrars: 1, schemes: 0 });
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('svc-123') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toMatch(/cannot delete/i);
+    expect(json.error).toMatch(/2 DID\(s\)/);
+    expect(json.error).toMatch(/1 registrar\(s\)/);
+    expect(mockDeleteServiceInstance).not.toHaveBeenCalled();
+  });
+
+  it('deletes with force=true even when references exist', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(MOCK_INSTANCE);
+    mockDeleteServiceInstance.mockResolvedValue(undefined);
+
+    const req = createFakeRequest({
+      method: 'DELETE',
+      url: 'http://localhost/api/v1/services/svc-123?force=true',
+    });
+    const res = await DELETE(req, createContext('svc-123') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(204);
+    // Should not check references when force=true
+    expect(mockCountServiceInstanceReferences).not.toHaveBeenCalled();
+    expect(mockDeleteServiceInstance).toHaveBeenCalledWith('svc-123', 'org-1');
+  });
+
+  it('returns 404 when instance not found', async () => {
+    mockGetServiceInstanceById.mockResolvedValue(null);
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('nonexistent') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe('Service instance not found');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
-import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError } from '@/lib/api/validation';
+import { NotFoundError, ConflictError } from '@/lib/api/errors';
+import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
-import { getServiceInstanceById, updateServiceInstance, deleteServiceInstance } from '@/lib/prisma/repositories';
+import {
+  getServiceInstanceById,
+  updateServiceInstance,
+  deleteServiceInstance,
+  countServiceInstanceReferences,
+} from '@/lib/prisma/repositories';
 import { getEncryptionService } from '@/lib/encryption/encryption';
 import { EncryptionAlgorithm, adapterRegistry, maskInstanceConfig } from '@uncefact/untp-ri-services';
 import type { AdapterRegistryEntry } from '@uncefact/untp-ri-services';
@@ -35,10 +40,7 @@ const logger = apiLogger.child({ route: '/api/v1/services/[id]' });
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 service:
- *                   $ref: '#/components/schemas/ServiceInstance'
+ *               $ref: '#/components/schemas/ServiceInstance'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -60,14 +62,15 @@ const logger = apiLogger.child({ route: '/api/v1/services/[id]' });
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, serviceInstanceId: id }, 'Looking up service instance');
 
+  logger.info({ tenantId, serviceInstanceId: id }, 'Looking up service instance');
   const instance = await getServiceInstanceById(id, tenantId);
   if (!instance) {
     throw new NotFoundError('Service instance not found');
   }
 
-  return NextResponse.json({ service: maskInstanceConfig(instance, getEncryptionService(), logger) });
+  logger.info({ tenantId, serviceInstanceId: id }, 'Service instance retrieved');
+  return NextResponse.json(maskInstanceConfig(instance, getEncryptionService(), logger));
 });
 
 // ---------------------------------------------------------------------------
@@ -115,10 +118,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 service:
- *                   $ref: '#/components/schemas/ServiceInstance'
+ *               $ref: '#/components/schemas/ServiceInstance'
  *       400:
  *         description: Validation error - invalid body or configuration
  *         content:
@@ -147,6 +147,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
+  logger.info({ tenantId, serviceInstanceId: id }, 'Parsing request body');
   let body: { name?: string; description?: string; config?: Record<string, unknown>; isPrimary?: boolean };
   try {
     body = await req.json();
@@ -156,6 +157,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 
   const { name, description, config, isPrimary } = body;
 
+  logger.info({ tenantId, serviceInstanceId: id }, 'Validating fields');
   const hasName = name !== undefined;
   const hasDescription = description !== undefined;
   const hasConfig = config !== undefined;
@@ -165,10 +167,15 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('At least one of name, description, config, or isPrimary is required');
   }
 
+  if (hasName && !isNonEmptyString(name)) {
+    throw new ValidationError('name must be a non-empty string');
+  }
+
   if (hasConfig && (typeof config !== 'object' || Array.isArray(config) || config === null)) {
     throw new ValidationError('config must be an object');
   }
 
+  logger.info({ tenantId, serviceInstanceId: id }, 'Looking up existing service instance');
   const existing = await getServiceInstanceById(id, tenantId);
   if (!existing) {
     throw new NotFoundError('Service instance not found');
@@ -177,7 +184,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   let encryptedConfig: string | undefined;
 
   if (hasConfig) {
-    // Decrypt existing config and merge with user-supplied fields
+    logger.info({ tenantId, serviceInstanceId: id }, 'Decrypting existing config');
     let existingConfig: Record<string, unknown>;
     try {
       existingConfig = JSON.parse(getEncryptionService().decrypt(JSON.parse(existing.config)));
@@ -185,9 +192,11 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
       logger.error({ error, serviceInstanceId: id }, 'Failed to decrypt existing config for merge');
       throw new ValidationError('Cannot update configuration: existing config could not be decrypted.');
     }
+
+    logger.info({ tenantId, serviceInstanceId: id }, 'Merging config');
     const mergedConfig = { ...existingConfig, ...config };
 
-    // Validate the merged config against the adapter schema
+    logger.info({ tenantId, serviceInstanceId: id }, 'Validating merged config against adapter schema');
     const { serviceType, adapterType } = existing;
     const serviceAdapters = (adapterRegistry as Record<string, Record<string, AdapterRegistryEntry> | undefined>)[
       serviceType
@@ -205,6 +214,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
       throw new ValidationError(`Invalid configuration: ${result.error.message}`);
     }
 
+    logger.info({ tenantId, serviceInstanceId: id }, 'Encrypting config');
     encryptedConfig = JSON.stringify(
       getEncryptionService().encrypt(JSON.stringify(mergedConfig), EncryptionAlgorithm.AES_256_GCM),
     );
@@ -222,8 +232,8 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     ...(hasIsPrimary && { isPrimary }),
   });
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Service instance updated');
-  return NextResponse.json({ service: maskInstanceConfig(updated, getEncryptionService(), logger) });
+  logger.info({ tenantId, serviceInstanceId: id }, 'Service instance updated successfully');
+  return NextResponse.json(maskInstanceConfig(updated, getEncryptionService(), logger));
 });
 
 // ---------------------------------------------------------------------------
@@ -235,7 +245,11 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  * /services/{id}:
  *   delete:
  *     summary: Delete a service instance
- *     description: "Deletes a service instance. Requires the `force` query parameter set to `true` to confirm deletion."
+ *     description: >
+ *       Permanently deletes a service instance. If the instance is referenced by
+ *       DIDs, registrars, or identifier schemes, returns 409 Conflict unless the
+ *       `force` query parameter is set to `true`. When forced, Prisma's `onDelete: SetNull`
+ *       behaviour nullifies the foreign keys on related records.
  *     tags:
  *       - Services
  *     parameters:
@@ -247,25 +261,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *         description: The database ID of the service instance
  *       - in: query
  *         name: force
- *         required: false
  *         schema:
- *           type: string
- *           enum:
- *             - 'true'
- *         description: Set to "true" to confirm deletion
+ *           type: boolean
+ *         description: Set to true to delete even when other records reference this instance
  *     responses:
- *       200:
- *         description: Service instance deleted successfully (or warning if force not set)
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 deleted:
- *                   type: boolean
- *                 warning:
- *                   type: string
- *                   description: Present when force is not set to true
+ *       204:
+ *         description: Service instance deleted successfully
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -274,6 +275,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
  *         description: Service instance not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: Conflict - service instance is referenced by other records
  *         content:
  *           application/json:
  *             schema:
@@ -287,25 +294,36 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  */
 export const DELETE = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
+  const url = new URL(req.url);
+  const force = url.searchParams.get('force') === 'true';
 
+  logger.info({ tenantId, serviceInstanceId: id }, 'Looking up service instance for deletion');
   const existing = await getServiceInstanceById(id, tenantId);
   if (!existing) {
     throw new NotFoundError('Service instance not found');
   }
 
-  const url = new URL(req.url);
-  const force = url.searchParams.get('force') === 'true';
-
   if (!force) {
-    logger.warn({ tenantId, serviceInstanceId: id }, 'Delete requested without force flag');
-    return NextResponse.json({
-      deleted: false,
-      warning: 'Use ?force=true to confirm deletion.',
-    });
+    logger.info({ tenantId, serviceInstanceId: id }, 'Checking for referencing records');
+    const refs = await countServiceInstanceReferences(id);
+    const total = refs.dids + refs.registrars + refs.schemes;
+
+    if (total > 0) {
+      const parts: string[] = [];
+      if (refs.dids > 0) parts.push(`${refs.dids} DID(s)`);
+      if (refs.registrars > 0) parts.push(`${refs.registrars} registrar(s)`);
+      if (refs.schemes > 0) parts.push(`${refs.schemes} identifier scheme(s)`);
+
+      throw new ConflictError(
+        `Cannot delete: service instance is referenced by ${parts.join(', ')}. ` +
+          'Use ?force=true to delete anyway (references will be set to null).',
+      );
+    }
   }
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Deleting service instance');
+  logger.info({ tenantId, serviceInstanceId: id, force }, 'Deleting service instance');
   await deleteServiceInstance(id, tenantId);
 
-  return NextResponse.json({ deleted: true });
+  logger.info({ tenantId, serviceInstanceId: id }, 'Service instance deleted');
+  return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
@@ -63,13 +63,13 @@ const logger = apiLogger.child({ route: '/api/v1/services/[id]' });
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Looking up service instance');
+  logger.info({ serviceInstanceId: id }, 'Looking up service instance');
   const instance = await getServiceInstanceById(id, tenantId);
   if (!instance) {
     throw new NotFoundError('Service instance not found');
   }
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Service instance retrieved');
+  logger.info({ serviceInstanceId: id }, 'Service instance retrieved');
   return NextResponse.json(maskInstanceConfig(instance, getEncryptionService(), logger));
 });
 
@@ -147,7 +147,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Parsing request body');
+  logger.info({ serviceInstanceId: id }, 'Parsing request body');
   let body: { name?: string; description?: string; config?: Record<string, unknown>; isPrimary?: boolean };
   try {
     body = await req.json();
@@ -157,7 +157,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 
   const { name, description, config, isPrimary } = body;
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Validating fields');
+  logger.info({ serviceInstanceId: id }, 'Validating fields');
   const hasName = name !== undefined;
   const hasDescription = description !== undefined;
   const hasConfig = config !== undefined;
@@ -175,7 +175,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('config must be an object');
   }
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Looking up existing service instance');
+  logger.info({ serviceInstanceId: id }, 'Looking up existing service instance');
   const existing = await getServiceInstanceById(id, tenantId);
   if (!existing) {
     throw new NotFoundError('Service instance not found');
@@ -184,7 +184,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   let encryptedConfig: string | undefined;
 
   if (hasConfig) {
-    logger.info({ tenantId, serviceInstanceId: id }, 'Decrypting existing config');
+    logger.info({ serviceInstanceId: id }, 'Decrypting existing config');
     let existingConfig: Record<string, unknown>;
     try {
       existingConfig = JSON.parse(getEncryptionService().decrypt(JSON.parse(existing.config)));
@@ -193,10 +193,10 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
       throw new ValidationError('Cannot update configuration: existing config could not be decrypted.');
     }
 
-    logger.info({ tenantId, serviceInstanceId: id }, 'Merging config');
+    logger.info({ serviceInstanceId: id }, 'Merging config');
     const mergedConfig = { ...existingConfig, ...config };
 
-    logger.info({ tenantId, serviceInstanceId: id }, 'Validating merged config against adapter schema');
+    logger.info({ serviceInstanceId: id }, 'Validating merged config against adapter schema');
     const { serviceType, adapterType } = existing;
     const serviceAdapters = (adapterRegistry as Record<string, Record<string, AdapterRegistryEntry> | undefined>)[
       serviceType
@@ -214,14 +214,14 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
       throw new ValidationError(`Invalid configuration: ${result.error.message}`);
     }
 
-    logger.info({ tenantId, serviceInstanceId: id }, 'Encrypting config');
+    logger.info({ serviceInstanceId: id }, 'Encrypting config');
     encryptedConfig = JSON.stringify(
       getEncryptionService().encrypt(JSON.stringify(mergedConfig), EncryptionAlgorithm.AES_256_GCM),
     );
   }
 
   logger.info(
-    { tenantId, serviceInstanceId: id, fields: { hasName, hasDescription, hasConfig, hasIsPrimary } },
+    { serviceInstanceId: id, fields: { hasName, hasDescription, hasConfig, hasIsPrimary } },
     'Updating service instance',
   );
 
@@ -232,7 +232,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     ...(hasIsPrimary && { isPrimary }),
   });
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Service instance updated successfully');
+  logger.info({ serviceInstanceId: id }, 'Service instance updated successfully');
   return NextResponse.json(maskInstanceConfig(updated, getEncryptionService(), logger));
 });
 
@@ -297,14 +297,14 @@ export const DELETE = withTenantAuth(async (req, { tenantId, params }) => {
   const url = new URL(req.url);
   const force = url.searchParams.get('force') === 'true';
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Looking up service instance for deletion');
+  logger.info({ serviceInstanceId: id }, 'Looking up service instance for deletion');
   const existing = await getServiceInstanceById(id, tenantId);
   if (!existing) {
     throw new NotFoundError('Service instance not found');
   }
 
   if (!force) {
-    logger.info({ tenantId, serviceInstanceId: id }, 'Checking for referencing records');
+    logger.info({ serviceInstanceId: id }, 'Checking for referencing records');
     const refs = await countServiceInstanceReferences(id);
     const total = refs.dids + refs.registrars + refs.schemes;
 
@@ -321,9 +321,9 @@ export const DELETE = withTenantAuth(async (req, { tenantId, params }) => {
     }
   }
 
-  logger.info({ tenantId, serviceInstanceId: id, force }, 'Deleting service instance');
+  logger.info({ serviceInstanceId: id, force }, 'Deleting service instance');
   await deleteServiceInstance(id, tenantId);
 
-  logger.info({ tenantId, serviceInstanceId: id }, 'Service instance deleted');
+  logger.info({ serviceInstanceId: id }, 'Service instance deleted');
   return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/services/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/route.test.ts
@@ -1,0 +1,520 @@
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth to mirror handleRouteError behaviour
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
+  const { ValidationError } = jest.requireActual('@/lib/api/validation');
+  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
+
+  function jsonResponse(body: unknown, init?: { status?: number }) {
+    return { status: init?.status ?? 200, json: async () => body };
+  }
+
+  return {
+    withTenantAuth:
+      (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
+        try {
+          return await handler(req, ctx);
+        } catch (e: unknown) {
+          if (e instanceof ValidationError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 400 });
+          }
+          if (e instanceof NotFoundError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 404 });
+          }
+          if (e instanceof ServiceRegistryError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 500 });
+          }
+          if (e instanceof ServiceError) {
+            const serviceErr = e as Error & { code?: string; statusCode?: number };
+            return jsonResponse(
+              { error: serviceErr.message, code: serviceErr.code },
+              { status: serviceErr.statusCode },
+            );
+          }
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        }
+      },
+  };
+});
+
+const mockCreateServiceInstance = jest.fn();
+const mockListServiceInstances = jest.fn();
+
+jest.mock('@/lib/prisma/repositories', () => ({
+  createServiceInstance: (input: unknown) => mockCreateServiceInstance(input),
+  listServiceInstances: (tenantId: string, opts: unknown) => mockListServiceInstances(tenantId, opts),
+}));
+
+const mockEncrypt = jest.fn();
+const mockGetEncryptionService = jest.fn();
+
+jest.mock('@/lib/encryption/encryption', () => ({
+  getEncryptionService: () => mockGetEncryptionService(),
+}));
+
+const mockMaskInstanceConfig = jest.fn();
+
+jest.mock('@uncefact/untp-ri-services', () => {
+  const actual = jest.requireActual('@uncefact/untp-ri-services');
+  return {
+    ...actual,
+    maskInstanceConfig: (...args: unknown[]) => mockMaskInstanceConfig(...args),
+  };
+});
+
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: {
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn().mockReturnThis(),
+    }),
+  },
+}));
+
+import { POST, GET } from './route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
+  const { method = 'POST', body, url = 'http://localhost/api/v1/services' } = options;
+  const bodyString = body !== undefined ? JSON.stringify(body) : undefined;
+  return {
+    method,
+    url,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json:
+      bodyString !== undefined
+        ? async () => JSON.parse(bodyString)
+        : async () => {
+            throw new SyntaxError('Unexpected token');
+          },
+  } as unknown as Request;
+}
+
+function createBadJsonRequest(): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/services',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => {
+      throw new SyntaxError('Unexpected token n in JSON at position 0');
+    },
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_RECORD = {
+  id: 'svc-123',
+  tenantId: 'org-1',
+  serviceType: 'VC',
+  adapterType: 'VCKIT',
+  name: 'Test VC Service',
+  description: null,
+  config: '{"encrypted":"blob"}',
+  isPrimary: false,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+const MOCK_MASKED = {
+  ...MOCK_RECORD,
+  config: { endpoint: 'https://example.com', apiKey: '***' },
+};
+
+const VALID_CONFIG = {
+  endpoint: 'https://vckit.example.com',
+  apiKey: 'test-api-key',
+};
+
+const VALID_BODY = {
+  serviceType: 'VC',
+  adapterType: 'VCKIT',
+  name: 'Test VC Service',
+  config: VALID_CONFIG,
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/services
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/services', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateServiceInstance.mockResolvedValue(MOCK_RECORD);
+    mockMaskInstanceConfig.mockReturnValue(MOCK_MASKED);
+    mockGetEncryptionService.mockReturnValue({
+      encrypt: mockEncrypt.mockReturnValue({ cipher: 'abc', iv: '123', tag: '456' }),
+    });
+  });
+
+  it('creates a service instance successfully and returns 201', async () => {
+    const req = createFakeRequest({ body: VALID_BODY });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json).toEqual(MOCK_MASKED);
+    expect(mockCreateServiceInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'org-1',
+        serviceType: 'VC',
+        adapterType: 'VCKIT',
+        name: 'Test VC Service',
+      }),
+    );
+    expect(mockEncrypt).toHaveBeenCalledWith(JSON.stringify(VALID_CONFIG), 'aes-256-gcm');
+    expect(mockMaskInstanceConfig).toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = createBadJsonRequest();
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 when serviceType is missing', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, serviceType: undefined },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('serviceType is required');
+  });
+
+  it('returns 400 when adapterType is missing', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, adapterType: undefined },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('adapterType is required');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, name: undefined },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('name is required');
+  });
+
+  it('returns 400 when name is an empty string', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, name: '' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('name is required');
+  });
+
+  it('returns 400 when config is missing', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, config: undefined },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('config must be an object');
+  });
+
+  it('returns 400 when config is not an object', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, config: 'not-an-object' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('config must be an object');
+  });
+
+  it('returns 400 when config is an array', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, config: [1, 2, 3] },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('config must be an object');
+  });
+
+  it('returns 400 for invalid serviceType enum value', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, serviceType: 'INVALID' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('serviceType must be one of');
+  });
+
+  it('returns 400 for invalid adapterType enum value', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, adapterType: 'INVALID' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('adapterType must be one of');
+  });
+
+  it('returns 400 when adapter type does not match service type (registry lookup fails)', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, serviceType: 'VC', adapterType: 'PYX_IDR' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Unknown adapter type 'PYX_IDR' for service type 'VC'");
+  });
+
+  it('returns 400 for config schema validation failure', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, config: { endpoint: 'not-a-url' } },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('Invalid config');
+  });
+
+  it('passes description and isPrimary to createServiceInstance when provided', async () => {
+    const req = createFakeRequest({
+      body: { ...VALID_BODY, description: 'My description', isPrimary: true },
+    });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateServiceInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'My description',
+        isPrimary: true,
+      }),
+    );
+  });
+
+  it('encrypts the config before persisting', async () => {
+    const req = createFakeRequest({ body: VALID_BODY });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockEncrypt).toHaveBeenCalledWith(JSON.stringify(VALID_CONFIG), 'aes-256-gcm');
+    expect(mockCreateServiceInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: JSON.stringify({ cipher: 'abc', iv: '123', tag: '456' }),
+      }),
+    );
+  });
+
+  it('returns 500 when createServiceInstance throws', async () => {
+    mockCreateServiceInstance.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ body: VALID_BODY });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toContain('Database error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/services
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/services', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListServiceInstances.mockResolvedValue({ data: [MOCK_RECORD], total: 1 });
+    mockMaskInstanceConfig.mockReturnValue(MOCK_MASKED);
+    mockGetEncryptionService.mockReturnValue({ encrypt: mockEncrypt });
+  });
+
+  it('lists service instances with pagination', async () => {
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/services' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data).toEqual([MOCK_MASKED]);
+    expect(json.pagination).toEqual({
+      total: 1,
+      limit: 20,
+      offset: 0,
+      hasMore: false,
+    });
+  });
+
+  it('masks each service instance config in the response', async () => {
+    const secondRecord = { ...MOCK_RECORD, id: 'svc-456', name: 'Second Service' };
+    const secondMasked = { ...secondRecord, config: { endpoint: 'https://other.com', apiKey: '***' } };
+    mockListServiceInstances.mockResolvedValue({ data: [MOCK_RECORD, secondRecord], total: 2 });
+    mockMaskInstanceConfig.mockReturnValueOnce(MOCK_MASKED).mockReturnValueOnce(secondMasked);
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/services' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(mockMaskInstanceConfig).toHaveBeenCalledTimes(2);
+    expect(json.data).toEqual([MOCK_MASKED, secondMasked]);
+  });
+
+  it('passes filters to the repository', async () => {
+    mockListServiceInstances.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/services?serviceType=VC&adapterType=VCKIT&limit=10&offset=5',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListServiceInstances).toHaveBeenCalledWith('org-1', {
+      serviceType: 'VC',
+      adapterType: 'VCKIT',
+      limit: 10,
+      offset: 5,
+    });
+  });
+
+  it('handles no query parameters', async () => {
+    mockListServiceInstances.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/services' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListServiceInstances).toHaveBeenCalledWith('org-1', {
+      serviceType: undefined,
+      adapterType: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  it('returns hasMore: true when more results exist', async () => {
+    const records = [
+      { ...MOCK_RECORD, id: 'svc-1' },
+      { ...MOCK_RECORD, id: 'svc-2' },
+    ];
+    mockListServiceInstances.mockResolvedValue({ data: records, total: 5 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/services?limit=2&offset=0',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(json.pagination).toEqual({
+      total: 5,
+      limit: 2,
+      offset: 0,
+      hasMore: true,
+    });
+  });
+
+  it('returns 400 for invalid serviceType filter', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/services?serviceType=GARBAGE',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('serviceType must be one of');
+  });
+
+  it('returns 400 for invalid adapterType filter', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/services?adapterType=GARBAGE',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('adapterType must be one of');
+  });
+
+  it('returns 400 for invalid limit (non-numeric)', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/services?limit=abc',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for zero limit', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/services?limit=0',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for negative offset', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/services?offset=-1',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('offset must be a non-negative integer');
+  });
+
+  it('returns 500 when listServiceInstances throws', async () => {
+    mockListServiceInstances.mockRejectedValue(new Error('Database error'));
+
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/services' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toContain('Database error');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/services/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/route.ts
@@ -102,7 +102,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     isPrimary?: boolean;
   };
 
-  logger.info({ tenantId }, 'Parsing request body');
+  logger.info('Parsing request body');
   try {
     body = await req.json();
   } catch {
@@ -112,7 +112,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   // --- Field validation ---------------------------------------------------
 
   logger.info(
-    { tenantId, serviceType: body.serviceType, adapterType: body.adapterType, name: body.name },
+    { serviceType: body.serviceType, adapterType: body.adapterType, name: body.name },
     'Validating input parameters',
   );
 
@@ -132,7 +132,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   // --- Registry look-up & config schema validation ------------------------
 
-  logger.info({ tenantId, serviceType, adapterType }, 'Looking up adapter in registry');
+  logger.info({ serviceType, adapterType }, 'Looking up adapter in registry');
 
   const registryForService = (adapterRegistry as Record<string, Record<string, AdapterRegistryEntry> | undefined>)[
     serviceType
@@ -144,7 +144,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError(`Unknown adapter type '${adapterType}' for service type '${serviceType}'`);
   }
 
-  logger.info({ tenantId, serviceType, adapterType }, 'Validating config against adapter schema');
+  logger.info({ serviceType, adapterType }, 'Validating config against adapter schema');
 
   const parseResult = registryEntry.configSchema.safeParse(body.config);
   if (!parseResult.success) {
@@ -154,7 +154,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   // --- Encrypt & persist --------------------------------------------------
 
-  logger.info({ tenantId, serviceType, adapterType, name: body.name }, 'Encrypting and persisting service instance');
+  logger.info({ serviceType, adapterType, name: body.name }, 'Encrypting and persisting service instance');
 
   const encryptedConfig = JSON.stringify(
     getEncryptionService().encrypt(JSON.stringify(body.config), EncryptionAlgorithm.AES_256_GCM),
@@ -172,7 +172,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   const masked = maskInstanceConfig(record, getEncryptionService(), logger);
 
-  logger.info({ tenantId, serviceInstanceId: record.id }, 'Service instance created');
+  logger.info({ serviceInstanceId: record.id }, 'Service instance created');
   return NextResponse.json(masked, { status: 201 });
 });
 
@@ -249,7 +249,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   const url = new URL(req.url);
 
-  logger.info({ tenantId }, 'Parsing and validating query filters');
+  logger.info('Parsing and validating query filters');
 
   const serviceType = validateEnum(
     url.searchParams.get('serviceType') ?? undefined,
@@ -264,7 +264,7 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
   const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, filters: { serviceType, adapterType, limit, offset } }, 'Querying service instances');
+  logger.info({ filters: { serviceType, adapterType, limit, offset } }, 'Querying service instances');
 
   const { data, total } = await listServiceInstances(tenantId, {
     serviceType,
@@ -273,9 +273,9 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
     offset,
   });
 
-  logger.info({ tenantId }, 'Masking service instance configurations');
+  logger.info('Masking service instance configurations');
   const masked = data.map((i) => maskInstanceConfig(i, getEncryptionService(), logger));
 
-  logger.info({ tenantId, count: masked.length }, 'Service instances listed');
+  logger.info({ count: masked.length }, 'Service instances listed');
   return NextResponse.json(buildPaginatedResponse(masked, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/services/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/route.ts
@@ -1,7 +1,14 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, validateEnum, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import {
+  ValidationError,
+  validateEnum,
+  isNonEmptyString,
+  parsePositiveInt,
+  parseNonNegativeInt,
+} from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { createServiceInstance, listServiceInstances } from '@/lib/prisma/repositories';
 import { getEncryptionService } from '@/lib/encryption/encryption';
 import {
@@ -38,11 +45,10 @@ const logger = apiLogger.child({ route: '/api/v1/services' });
  *               - adapterType
  *               - name
  *               - config
- *               - apiVersion
  *             properties:
  *               serviceType:
  *                 type: string
- *                 enum: [DID, IDR, STORAGE, VC]
+ *                 enum: [IDR, STORAGE, VC]
  *                 description: The service category
  *               adapterType:
  *                 type: string
@@ -57,9 +63,6 @@ const logger = apiLogger.child({ route: '/api/v1/services' });
  *               config:
  *                 type: object
  *                 description: Adapter-specific configuration (validated against the adapter schema)
- *               apiVersion:
- *                 type: string
- *                 description: Semver API version (e.g. "1.1.0")
  *               isPrimary:
  *                 type: boolean
  *                 description: Whether this instance is the primary for its service type
@@ -69,11 +72,7 @@ const logger = apiLogger.child({ route: '/api/v1/services' });
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 serviceInstanceId:
- *                   type: string
- *                   description: Database record ID for the new service instance
+ *               $ref: '#/components/schemas/ServiceInstance'
  *       400:
  *         description: Validation error
  *         content:
@@ -100,10 +99,10 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     name?: string;
     description?: string;
     config?: unknown;
-    apiVersion?: string;
     isPrimary?: boolean;
   };
 
+  logger.info({ tenantId }, 'Parsing request body');
   try {
     body = await req.json();
   } catch {
@@ -112,13 +111,18 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   // --- Field validation ---------------------------------------------------
 
+  logger.info(
+    { tenantId, serviceType: body.serviceType, adapterType: body.adapterType, name: body.name },
+    'Validating input parameters',
+  );
+
   const serviceType = validateEnum(body.serviceType, Object.values(ServiceType), 'serviceType');
   if (!serviceType) throw new ValidationError('serviceType is required');
 
   const adapterType = validateEnum(body.adapterType, Object.values(AdapterType), 'adapterType');
   if (!adapterType) throw new ValidationError('adapterType is required');
 
-  if (!body.name || typeof body.name !== 'string') {
+  if (!isNonEmptyString(body.name)) {
     throw new ValidationError('name is required');
   }
 
@@ -126,11 +130,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('config must be an object');
   }
 
-  if (!body.apiVersion || typeof body.apiVersion !== 'string') {
-    throw new ValidationError('apiVersion is required');
-  }
-
   // --- Registry look-up & config schema validation ------------------------
+
+  logger.info({ tenantId, serviceType, adapterType }, 'Looking up adapter in registry');
 
   const registryForService = (adapterRegistry as Record<string, Record<string, AdapterRegistryEntry> | undefined>)[
     serviceType
@@ -142,6 +144,8 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError(`Unknown adapter type '${adapterType}' for service type '${serviceType}'`);
   }
 
+  logger.info({ tenantId, serviceType, adapterType }, 'Validating config against adapter schema');
+
   const parseResult = registryEntry.configSchema.safeParse(body.config);
   if (!parseResult.success) {
     const messages = parseResult.error.issues.map((i) => i.message).join('; ');
@@ -150,11 +154,11 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   // --- Encrypt & persist --------------------------------------------------
 
+  logger.info({ tenantId, serviceType, adapterType, name: body.name }, 'Encrypting and persisting service instance');
+
   const encryptedConfig = JSON.stringify(
     getEncryptionService().encrypt(JSON.stringify(body.config), EncryptionAlgorithm.AES_256_GCM),
   );
-
-  logger.info({ tenantId, serviceType, adapterType, name: body.name }, 'Creating service instance');
 
   const record = await createServiceInstance({
     tenantId,
@@ -163,13 +167,13 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     name: body.name,
     description: body.description,
     config: encryptedConfig,
-    apiVersion: body.apiVersion,
     isPrimary: body.isPrimary,
   });
 
-  logger.info({ tenantId, serviceId: record.id }, 'Service instance created');
+  const masked = maskInstanceConfig(record, getEncryptionService(), logger);
 
-  return NextResponse.json({ serviceInstanceId: record.id }, { status: 201 });
+  logger.info({ tenantId, serviceInstanceId: record.id }, 'Service instance created');
+  return NextResponse.json(masked, { status: 201 });
 });
 
 // ---------------------------------------------------------------------------
@@ -189,7 +193,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: serviceType
  *         schema:
  *           type: string
- *           enum: [DID, IDR, STORAGE, VC]
+ *           enum: [IDR, STORAGE, VC]
  *         description: Filter by service type
  *       - in: query
  *         name: adapterType
@@ -217,10 +221,12 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               type: object
  *               properties:
- *                 services:
+ *                 data:
  *                   type: array
  *                   items:
  *                     $ref: '#/components/schemas/ServiceInstance'
+ *                 pagination:
+ *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
  *         description: Validation error
  *         content:
@@ -243,6 +249,8 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   const url = new URL(req.url);
 
+  logger.info({ tenantId }, 'Parsing and validating query filters');
+
   const serviceType = validateEnum(
     url.searchParams.get('serviceType') ?? undefined,
     Object.values(ServiceType),
@@ -256,17 +264,18 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
   const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, filters: { serviceType, adapterType, limit, offset } }, 'Listing service instances');
+  logger.info({ tenantId, filters: { serviceType, adapterType, limit, offset } }, 'Querying service instances');
 
-  const instances = await listServiceInstances(tenantId, {
+  const { data, total } = await listServiceInstances(tenantId, {
     serviceType,
     adapterType,
     limit,
     offset,
   });
 
-  const services = instances.map((i) => maskInstanceConfig(i, getEncryptionService(), logger));
+  logger.info({ tenantId }, 'Masking service instance configurations');
+  const masked = data.map((i) => maskInstanceConfig(i, getEncryptionService(), logger));
 
-  logger.info({ tenantId, count: services.length }, 'Service instances listed');
-  return NextResponse.json({ services });
+  logger.info({ tenantId, count: masked.length }, 'Service instances listed');
+  return NextResponse.json(buildPaginatedResponse(masked, total, limit, offset));
 });

--- a/packages/reference-implementation/src/lib/api/errors.ts
+++ b/packages/reference-implementation/src/lib/api/errors.ts
@@ -12,6 +12,13 @@ export class NotFoundError extends Error {
   }
 }
 
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}
+
 export class UnprocessableError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/reference-implementation/src/lib/api/handle-route-error.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { NotFoundError, UnprocessableError, errorMessage, ServiceRegistryError } from '@/lib/api/errors';
+import { NotFoundError, ConflictError, UnprocessableError, errorMessage, ServiceRegistryError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { ServiceError } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
@@ -25,6 +25,10 @@ export function handleRouteError(e: unknown): Response {
   if (e instanceof NotFoundError) {
     logger.warn({ err: e }, 'Not found');
     return NextResponse.json({ error: e.message }, { status: 404 });
+  }
+  if (e instanceof ConflictError) {
+    logger.warn({ err: e }, 'Conflict');
+    return NextResponse.json({ error: e.message }, { status: 409 });
   }
   if (e instanceof UnprocessableError) {
     logger.warn({ err: e }, 'Unprocessable entity');

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
@@ -4,6 +4,7 @@ import {
   listServiceInstances,
   updateServiceInstance,
   deleteServiceInstance,
+  countServiceInstanceReferences,
   getInstanceByResolution,
 } from './service-instance.repository';
 
@@ -12,6 +13,7 @@ const mockServiceInstance = {
   create: jest.fn(),
   findFirst: jest.fn(),
   findMany: jest.fn(),
+  count: jest.fn(),
   update: jest.fn(),
   updateMany: jest.fn(),
   delete: jest.fn(),
@@ -23,10 +25,14 @@ jest.mock('../prisma', () => ({
       create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
+      count: jest.fn(),
       update: jest.fn(),
       updateMany: jest.fn(),
       delete: jest.fn(),
     },
+    did: { count: jest.fn() },
+    registrar: { count: jest.fn() },
+    identifierScheme: { count: jest.fn() },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     $transaction: jest.fn((fn: any) => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -52,7 +58,6 @@ describe('service-instance.repository', () => {
     name: 'Test VCKit Instance',
     description: null,
     config: 'encrypted-config-blob',
-    apiVersion: '1.1.0',
     isPrimary: false,
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-01'),
@@ -72,7 +77,6 @@ describe('service-instance.repository', () => {
         adapterType: 'VCKIT',
         name: 'Test VCKit Instance',
         config: 'encrypted-config-blob',
-        apiVersion: '1.1.0',
       });
 
       expect(mockServiceInstance.create).toHaveBeenCalledWith({
@@ -82,7 +86,6 @@ describe('service-instance.repository', () => {
           adapterType: 'VCKIT',
           name: 'Test VCKit Instance',
           config: 'encrypted-config-blob',
-          apiVersion: '1.1.0',
           isPrimary: false,
         }),
       });
@@ -98,7 +101,6 @@ describe('service-instance.repository', () => {
         adapterType: 'VCKIT',
         name: 'Test',
         config: 'encrypted',
-        apiVersion: '1.1.0',
       });
 
       expect(mockServiceInstance.create).toHaveBeenCalledWith({
@@ -119,7 +121,6 @@ describe('service-instance.repository', () => {
         adapterType: 'VCKIT',
         name: 'Primary Instance',
         config: 'encrypted',
-        apiVersion: '1.1.0',
         isPrimary: true,
       });
 
@@ -174,6 +175,7 @@ describe('service-instance.repository', () => {
   describe('listServiceInstances', () => {
     it('lists for organisation including system defaults', async () => {
       mockServiceInstance.findMany.mockResolvedValue([INSTANCE_RECORD]);
+      mockServiceInstance.count.mockResolvedValue(1);
 
       const result = await listServiceInstances(ORG_ID);
 
@@ -181,47 +183,60 @@ describe('service-instance.repository', () => {
         where: {
           OR: [{ tenantId: ORG_ID }, { tenantId: 'system' }],
         },
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
-      expect(result).toEqual([INSTANCE_RECORD]);
+      expect(mockServiceInstance.count).toHaveBeenCalledWith({
+        where: {
+          OR: [{ tenantId: ORG_ID }, { tenantId: 'system' }],
+        },
+      });
+      expect(result.data).toEqual([INSTANCE_RECORD]);
+      expect(result.total).toBe(1);
     });
 
     it('applies serviceType filter', async () => {
       mockServiceInstance.findMany.mockResolvedValue([]);
+      mockServiceInstance.count.mockResolvedValue(0);
 
-      await listServiceInstances(ORG_ID, { serviceType: 'VC' });
+      const result = await listServiceInstances(ORG_ID, { serviceType: 'VC' });
 
       expect(mockServiceInstance.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
           serviceType: 'VC',
         }),
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
     });
 
     it('applies adapterType filter', async () => {
       mockServiceInstance.findMany.mockResolvedValue([]);
+      mockServiceInstance.count.mockResolvedValue(0);
 
-      await listServiceInstances(ORG_ID, { adapterType: 'VCKIT' });
+      const result = await listServiceInstances(ORG_ID, { adapterType: 'VCKIT' });
 
       expect(mockServiceInstance.findMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
           adapterType: 'VCKIT',
         }),
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
     });
 
     it('applies pagination', async () => {
       mockServiceInstance.findMany.mockResolvedValue([]);
+      mockServiceInstance.count.mockResolvedValue(0);
 
-      await listServiceInstances(ORG_ID, { limit: 10, offset: 20 });
+      const result = await listServiceInstances(ORG_ID, { limit: 10, offset: 20 });
 
       expect(mockServiceInstance.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -229,6 +244,8 @@ describe('service-instance.repository', () => {
           skip: 20,
         }),
       );
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
     });
   });
 
@@ -325,6 +342,31 @@ describe('service-instance.repository', () => {
       await expect(deleteServiceInstance('instance-1', 'other-org')).rejects.toThrow(
         'Service instance not found or access denied',
       );
+    });
+  });
+
+  describe('countServiceInstanceReferences', () => {
+    it('counts references across all related models', async () => {
+      (prisma.did.count as jest.Mock).mockResolvedValue(3);
+      (prisma.registrar.count as jest.Mock).mockResolvedValue(1);
+      (prisma.identifierScheme.count as jest.Mock).mockResolvedValue(2);
+
+      const result = await countServiceInstanceReferences('instance-1');
+
+      expect(prisma.did.count).toHaveBeenCalledWith({ where: { serviceInstanceId: 'instance-1' } });
+      expect(prisma.registrar.count).toHaveBeenCalledWith({ where: { idrServiceInstanceId: 'instance-1' } });
+      expect(prisma.identifierScheme.count).toHaveBeenCalledWith({ where: { idrServiceInstanceId: 'instance-1' } });
+      expect(result).toEqual({ dids: 3, registrars: 1, schemes: 2 });
+    });
+
+    it('returns zeros when no references exist', async () => {
+      (prisma.did.count as jest.Mock).mockResolvedValue(0);
+      (prisma.registrar.count as jest.Mock).mockResolvedValue(0);
+      (prisma.identifierScheme.count as jest.Mock).mockResolvedValue(0);
+
+      const result = await countServiceInstanceReferences('instance-1');
+
+      expect(result).toEqual({ dids: 0, registrars: 0, schemes: 0 });
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -10,7 +10,6 @@ export type CreateServiceInstanceInput = {
   name: string;
   description?: string;
   config: string; // Already encrypted by the caller
-  apiVersion: string; // Semver without v prefix, e.g. "1.1.0"
   isPrimary?: boolean;
 };
 
@@ -53,7 +52,6 @@ export async function createServiceInstance(input: CreateServiceInstanceInput): 
         name: input.name,
         description: input.description,
         config: input.config,
-        apiVersion: input.apiVersion,
         isPrimary: input.isPrimary ?? false,
       },
     });
@@ -79,7 +77,7 @@ export async function getServiceInstanceById(id: string, tenantId: string): Prom
 export async function listServiceInstances(
   tenantId: string,
   options: ListServiceInstancesOptions = {},
-): Promise<ServiceInstance[]> {
+): Promise<{ data: ServiceInstance[]; total: number }> {
   const { serviceType, adapterType, limit, offset } = options;
 
   const where: Prisma.ServiceInstanceWhereInput = {
@@ -94,12 +92,17 @@ export async function listServiceInstances(
     where.adapterType = adapterType as AdapterType;
   }
 
-  return prisma.serviceInstance.findMany({
-    where,
-    take: limit ?? 100,
-    skip: offset,
-    orderBy: { createdAt: 'desc' },
-  });
+  const [data, total] = await Promise.all([
+    prisma.serviceInstance.findMany({
+      where,
+      take: limit ?? 20,
+      skip: offset,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.serviceInstance.count({ where }),
+  ]);
+
+  return { data, total };
 }
 
 /**
@@ -161,6 +164,22 @@ export async function deleteServiceInstance(id: string, tenantId: string): Promi
       where: { id },
     });
   });
+}
+
+/**
+ * Counts records that reference a given service instance.
+ * Used for pre-delete referential integrity checks.
+ */
+export async function countServiceInstanceReferences(
+  id: string,
+): Promise<{ dids: number; registrars: number; schemes: number }> {
+  const [dids, registrars, schemes] = await Promise.all([
+    prisma.did.count({ where: { serviceInstanceId: id } }),
+    prisma.registrar.count({ where: { idrServiceInstanceId: id } }),
+    prisma.identifierScheme.count({ where: { idrServiceInstanceId: id } }),
+  ]);
+
+  return { dids, registrars, schemes };
 }
 
 /**

--- a/packages/reference-implementation/src/lib/services/resolve-did-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-did-service.test.ts
@@ -84,7 +84,6 @@ const MOCK_INSTANCE = {
   adapterType: 'VCKIT',
   name: 'System VCKit',
   config: JSON.stringify(MOCK_ENCRYPTED_ENVELOPE),
-  apiVersion: '1.1.0',
   isPrimary: false,
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/packages/reference-implementation/src/lib/services/resolve-idr-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-idr-service.test.ts
@@ -70,7 +70,6 @@ const MOCK_INSTANCE = {
   adapterType: 'PYX_IDR',
   name: 'System Pyx IDR',
   config: JSON.stringify(MOCK_ENCRYPTED_ENVELOPE),
-  apiVersion: '2.0.0',
   isPrimary: true,
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/packages/reference-implementation/src/lib/services/resolve-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-service.test.ts
@@ -72,7 +72,6 @@ const MOCK_INSTANCE = {
   adapterType: 'UNCEFACT_STORAGE',
   name: 'System UNCEFACT Storage',
   config: JSON.stringify(MOCK_ENCRYPTED_ENVELOPE),
-  apiVersion: '1.0.0',
   isPrimary: true,
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/packages/reference-implementation/src/lib/services/resolve-storage-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-storage-service.test.ts
@@ -70,7 +70,6 @@ const MOCK_INSTANCE = {
   adapterType: 'UNCEFACT_STORAGE',
   name: 'System UNCEFACT Storage',
   config: JSON.stringify(MOCK_ENCRYPTED_ENVELOPE),
-  apiVersion: '3.0.0',
   isPrimary: true,
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/packages/reference-implementation/src/lib/services/resolve-vc-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-vc-service.test.ts
@@ -70,7 +70,6 @@ const MOCK_INSTANCE = {
   adapterType: 'VCKIT_VC',
   name: 'System VCKit VC',
   config: JSON.stringify(MOCK_ENCRYPTED_ENVELOPE),
-  apiVersion: '1.0.0',
   isPrimary: true,
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -20,6 +20,8 @@ import {
   identifierSchemeSchema,
   identifierSchema,
   linkRegistrationSchema,
+  // Service instance schemas
+  serviceInstanceResponseSchema,
   // Shared schemas
   errorResponseSchema,
 } from '@uncefact/untp-ri-services';
@@ -80,6 +82,7 @@ export {
   identifierSchemeSchema,
   identifierSchema,
   linkRegistrationSchema,
+  serviceInstanceResponseSchema,
   errorResponseSchema,
   paginationMetaSchema,
 };
@@ -116,6 +119,7 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     IdentifierScheme: identifierSchemeSchema,
     Identifier: identifierSchema,
     LinkRegistration: linkRegistrationSchema,
+    ServiceInstance: serviceInstanceResponseSchema,
   };
 
   const openAPISchemas: Record<string, OpenAPISchema> = {};

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -57,6 +57,7 @@ export { adapterRegistry } from './registry/registry.js';
 export { getSensitiveFields } from './registry/common/get-sensitive-fields.js';
 export type { AdapterRegistryEntry, AdapterRegistry } from './registry/types.js';
 export { maskInstanceConfig } from './registry/common/mask-instance-config.js';
+export { serviceInstanceResponseSchema } from './registry/schemas.js';
 
 // Config schemas
 export { vckitDidConfigSchema, vckitDidSensitiveFields } from './did-manager/adapters/vckit/vckit-did.schema.js';

--- a/packages/services/src/registry/schemas.ts
+++ b/packages/services/src/registry/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+/**
+ * Service instance record as returned by the REST API.
+ *
+ * The `config` field contains the adapter configuration with sensitive
+ * fields masked (replaced with `'***'`).
+ */
+export const serviceInstanceResponseSchema = z.object({
+  id: z.string().describe('Database ID of the service instance'),
+  tenantId: z.string().describe('ID of the owning tenant'),
+  serviceType: z.enum(['IDR', 'STORAGE', 'VC']).describe('Service category'),
+  adapterType: z.enum(['VCKIT', 'PYX_IDR', 'UNCEFACT_STORAGE']).describe('Adapter implementation'),
+  name: z.string().describe('Human-readable name'),
+  description: z.string().nullable().describe('Description of the instance'),
+  config: z.record(z.unknown()).describe('Adapter configuration (sensitive fields masked)'),
+  isPrimary: z.boolean().describe('Whether this is the primary instance for its service type'),
+  createdAt: z.string().datetime().describe('Timestamp when created'),
+  updatedAt: z.string().datetime().describe('Timestamp when last updated'),
+});


### PR DESCRIPTION
This PR removes the redundant `apiVersion` column from the `ServiceInstance` Prisma model. The field existed in two places: as a top-level database column and inside each adapter's encrypted config (validated by the adapter's Zod schema). The adapter config is the source of truth for which API version to use when calling external services, so the top-level column was pure duplication. Removing it simplifies the data model and eliminates a potential source of drift.

Also included: service route handler tests (`route.test.ts`, `[id]/route.test.ts`), Swagger schema alignment, and `ServiceRegistryError` support in the error handler, which were previously uncommitted from the service management work.

## Test plan
- [x] Repository tests pass (25/25)
- [x] Route handler tests pass (45/45)
- [x] Resolve-service tests pass (46/46 across 5 suites)
- [x] Lint and prettier pass via pre-commit hook
- [x] Adapter config `apiVersion` values preserved in seed and test fixtures (not removed)