### PR TITLE
refactor(api)!: standardise data-models routes with REST conventions

### DIFF
--- a/e2e/cypress/e2e/data_model_api/data-model-management.cy.ts
+++ b/e2e/cypress/e2e/data_model_api/data-model-management.cy.ts
@@ -9,9 +9,7 @@ describe('Data Model API', { testIsolation: false }, () => {
 
     // Find a core data model to use as parent for extension tests
     cy.request('/api/v1/data-models').then((response) => {
-      const core = response.body.dataModels.find(
-        (dm: any) => !dm.isExtension,
-      );
+      const core = response.body.data.find((dm: any) => !dm.isExtension);
       if (core) {
         parentConfigId = core.id;
       }
@@ -26,15 +24,16 @@ describe('Data Model API', { testIsolation: false }, () => {
     it('GET /api/v1/data-models — lists data models including system defaults', () => {
       cy.request('/api/v1/data-models').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.dataModels).to.be.an('array');
+        expect(response.body.data).to.be.an('array');
+        expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.total).to.be.a('number');
       });
     });
 
     it('GET /api/v1/data-models — filters by credentialType', () => {
       cy.request('/api/v1/data-models?credentialType=DigitalProductPassport').then((response) => {
         expect(response.status).to.eq(200);
-        response.body.dataModels.forEach((dm: any) => {
+        response.body.data.forEach((dm: any) => {
           expect(dm.credentialType).to.eq('DigitalProductPassport');
         });
       });
@@ -43,7 +42,7 @@ describe('Data Model API', { testIsolation: false }, () => {
     it('GET /api/v1/data-models — filters by isExtension=false', () => {
       cy.request('/api/v1/data-models?isExtension=false').then((response) => {
         expect(response.status).to.eq(200);
-        response.body.dataModels.forEach((dm: any) => {
+        response.body.data.forEach((dm: any) => {
           expect(dm.isExtension).to.be.false;
         });
       });
@@ -67,14 +66,12 @@ describe('Data Model API', { testIsolation: false }, () => {
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.dataModel).to.exist;
-        expect(response.body.dataModel.name).to.eq(`E2E DPP Extension ${RUN_ID}`);
-        expect(response.body.dataModel.credentialType).to.eq('DigitalProductPassport');
-        expect(response.body.dataModel.version).to.eq('0.6.1');
-        expect(response.body.dataModel.isExtension).to.be.true;
+        expect(response.body.name).to.eq(`E2E DPP Extension ${RUN_ID}`);
+        expect(response.body.credentialType).to.eq('DigitalProductPassport');
+        expect(response.body.version).to.eq('0.6.1');
+        expect(response.body.isExtension).to.be.true;
 
-        createdDataModelId = response.body.dataModel.id;
+        createdDataModelId = response.body.id;
       });
     });
 
@@ -95,10 +92,10 @@ describe('Data Model API', { testIsolation: false }, () => {
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.dataModel.websiteUrl).to.eq(`https://example.com/e2e-dcc-${RUN_ID}`);
+        expect(response.body.websiteUrl).to.eq(`https://example.com/e2e-dcc-${RUN_ID}`);
 
         // Clean up — only keep the first extension for remaining tests
-        cy.request({ method: 'DELETE', url: `/api/v1/data-models/${response.body.dataModel.id}` });
+        cy.request({ method: 'DELETE', url: `/api/v1/data-models/${response.body.id}` });
       });
     });
 
@@ -107,9 +104,7 @@ describe('Data Model API', { testIsolation: false }, () => {
 
       cy.request('/api/v1/data-models').then((response) => {
         expect(response.status).to.eq(200);
-        const found = response.body.dataModels.find(
-          (dm: any) => dm.id === createdDataModelId,
-        );
+        const found = response.body.data.find((dm: any) => dm.id === createdDataModelId);
         expect(found).to.exist;
       });
     });
@@ -117,7 +112,7 @@ describe('Data Model API', { testIsolation: false }, () => {
     it('GET /api/v1/data-models — filters by isExtension=true', () => {
       cy.request('/api/v1/data-models?isExtension=true').then((response) => {
         expect(response.status).to.eq(200);
-        response.body.dataModels.forEach((dm: any) => {
+        response.body.data.forEach((dm: any) => {
           expect(dm.isExtension).to.be.true;
         });
       });
@@ -128,9 +123,8 @@ describe('Data Model API', { testIsolation: false }, () => {
 
       cy.request(`/api/v1/data-models/${createdDataModelId}`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.dataModel.id).to.eq(createdDataModelId);
-        expect(response.body.dataModel.name).to.eq(`E2E DPP Extension ${RUN_ID}`);
+        expect(response.body.id).to.eq(createdDataModelId);
+        expect(response.body.name).to.eq(`E2E DPP Extension ${RUN_ID}`);
       });
     });
 
@@ -143,8 +137,7 @@ describe('Data Model API', { testIsolation: false }, () => {
         body: { name: `Updated E2E Extension ${RUN_ID}` },
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
-        expect(response.body.dataModel.name).to.eq(`Updated E2E Extension ${RUN_ID}`);
+        expect(response.body.name).to.eq(`Updated E2E Extension ${RUN_ID}`);
       });
     });
 
@@ -160,8 +153,8 @@ describe('Data Model API', { testIsolation: false }, () => {
         },
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.dataModel.schemaUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/schema.json`);
-        expect(response.body.dataModel.contextUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/context.jsonld`);
+        expect(response.body.schemaUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/schema.json`);
+        expect(response.body.contextUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/context.jsonld`);
       });
     });
 
@@ -170,8 +163,8 @@ describe('Data Model API', { testIsolation: false }, () => {
 
       cy.request(`/api/v1/data-models/${createdDataModelId}`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.dataModel.name).to.eq(`Updated E2E Extension ${RUN_ID}`);
-        expect(response.body.dataModel.schemaUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/schema.json`);
+        expect(response.body.name).to.eq(`Updated E2E Extension ${RUN_ID}`);
+        expect(response.body.schemaUrl).to.eq(`https://example.com/e2e-updated-${RUN_ID}/schema.json`);
       });
     });
 
@@ -180,7 +173,6 @@ describe('Data Model API', { testIsolation: false }, () => {
 
       cy.request(`/api/v1/data-models/${createdDataModelId}/form-config`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
         expect(response.body.formConfig).to.exist;
         expect(response.body.formConfig.dataModelId).to.eq(createdDataModelId);
         expect(response.body.formConfig.credentialType).to.eq('DigitalProductPassport');
@@ -196,8 +188,7 @@ describe('Data Model API', { testIsolation: false }, () => {
         method: 'DELETE',
         url: `/api/v1/data-models/${createdDataModelId}`,
       }).then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body.ok).to.be.true;
+        expect(response.status).to.eq(204);
       });
     });
 
@@ -218,7 +209,10 @@ describe('Data Model API', { testIsolation: false }, () => {
     it('supports limit and offset parameters', () => {
       cy.request('/api/v1/data-models?limit=1&offset=0').then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.dataModels.length).to.be.at.most(1);
+        expect(response.body.data.length).to.be.at.most(1);
+        expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
       });
     });
   });
@@ -400,7 +394,7 @@ describe('Data Model API', { testIsolation: false }, () => {
           parentConfigId,
         },
       }).then((createResponse) => {
-        const tempId = createResponse.body.dataModel.id;
+        const tempId = createResponse.body.id;
 
         cy.request({
           method: 'PATCH',

--- a/e2e/cypress/e2e/render_template_api/render-template-management.cy.ts
+++ b/e2e/cypress/e2e/render_template_api/render-template-management.cy.ts
@@ -10,9 +10,7 @@ describe('Render Template API', { testIsolation: false }, () => {
 
     // Find a data model to associate templates with
     cy.request('/api/v1/data-models').then((response) => {
-      const dm = response.body.dataModels.find(
-        (d: any) => !d.isExtension,
-      );
+      const dm = response.body.data.find((d: any) => !d.isExtension);
       if (dm) {
         dataModelId = dm.id;
       }

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.test.ts
@@ -64,7 +64,6 @@ describe('GET /api/v1/data-models/:id/form-config', () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
     expect(json.formConfig).toEqual({
       dataModelId: 'dm-1',
       credentialType: 'DigitalProductPassport',
@@ -94,7 +93,6 @@ describe('GET /api/v1/data-models/:id/form-config', () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
     expect(json.formConfig.sections).toHaveLength(1);
     expect(json.formConfig.sections).toEqual([
       { entityType: 'organisation', label: 'Organisation', endpoint: '/api/v1/organisations', required: true },

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.ts
@@ -58,9 +58,6 @@ const ENTITY_REQUIREMENTS: Record<
  *             schema:
  *               type: object
  *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
  *                 formConfig:
  *                   type: object
  *                   properties:
@@ -121,7 +118,6 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   );
 
   return NextResponse.json({
-    ok: true,
     formConfig: {
       dataModelId: dataModel.id,
       credentialType: dataModel.credentialType,

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
@@ -1,3 +1,17 @@
+// Provide a minimal Response constructor for the DELETE handler
+// (jsdom does not expose the Fetch API's Response)
+global.Response = class Response {
+  status: number;
+  body: unknown;
+  constructor(body: unknown, init?: { status?: number }) {
+    this.body = body;
+    this.status = init?.status ?? 200;
+  }
+  json(): never {
+    throw new Error('Response has no body (e.g. 204 No Content)');
+  }
+} as unknown as typeof globalThis.Response;
+
 // Mock next/server before importing route handlers
 jest.mock('next/server', () => ({
   NextResponse: {
@@ -75,8 +89,7 @@ describe('GET /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
-    expect(json.dataModel).toEqual(dataModel);
+    expect(json).toEqual(dataModel);
     expect(mockGetDataModelById).toHaveBeenCalledWith('dm-1', 'tenant-1');
   });
 
@@ -121,8 +134,7 @@ describe('PATCH /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
-    expect(json.dataModel).toEqual(updated);
+    expect(json).toEqual(updated);
     expect(mockUpdateDataModel).toHaveBeenCalledWith('dm-1', 'tenant-1', {
       name: 'Updated Extension',
     });
@@ -179,6 +191,15 @@ describe('PATCH /api/v1/data-models/:id', () => {
     expect(json.error).toContain('contextUrl must be a non-empty string');
   });
 
+  it('returns 400 when websiteUrl is empty string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { websiteUrl: '' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('websiteUrl must be a non-empty string');
+  });
+
   it('returns 400 for invalid JSON body', async () => {
     const req = {
       method: 'PATCH',
@@ -223,17 +244,13 @@ describe('DELETE /api/v1/data-models/:id', () => {
     jest.clearAllMocks();
   });
 
-  it('deletes the data model and returns it', async () => {
-    const deleted = { id: 'dm-1', name: 'Deleted Extension' };
-    mockDeleteDataModel.mockResolvedValue(deleted);
+  it('deletes the data model and returns 204', async () => {
+    mockDeleteDataModel.mockResolvedValue(undefined);
 
     const req = createFakeRequest({});
     const res = await DELETE(req, createContext('dm-1') as unknown as Parameters<typeof DELETE>[1]);
-    const json = await res.json();
 
-    expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
-    expect(json.dataModel).toEqual(deleted);
+    expect(res.status).toBe(204);
     expect(mockDeleteDataModel).toHaveBeenCalledWith('dm-1', 'tenant-1');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
@@ -30,13 +30,7 @@ const UPDATABLE_FIELDS = ['name', 'schemaUrl', 'contextUrl', 'websiteUrl'] as co
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 dataModel:
- *                   $ref: '#/components/schemas/DataModel'
+ *               $ref: '#/components/schemas/DataModel'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -63,7 +57,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   if (!dataModel) {
     throw new NotFoundError('Data model not found');
   }
-  return NextResponse.json({ ok: true, dataModel });
+  return NextResponse.json(dataModel);
 });
 
 /**
@@ -107,13 +101,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 dataModel:
- *                   $ref: '#/components/schemas/DataModel'
+ *               $ref: '#/components/schemas/DataModel'
  *       400:
  *         description: Validation error
  *         content:
@@ -142,6 +130,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
+  logger.info({ tenantId, dataModelId: id }, 'Parsing request body');
   let body: Record<string, unknown>;
 
   try {
@@ -150,6 +139,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
+  logger.info({ tenantId, dataModelId: id }, 'Validating input parameters');
   const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
   if (!hasUpdatableField) {
     throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
@@ -164,6 +154,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   if (body.contextUrl !== undefined && !isNonEmptyString(body.contextUrl)) {
     throw new ValidationError('contextUrl must be a non-empty string');
   }
+  if (body.websiteUrl !== undefined && !isNonEmptyString(body.websiteUrl)) {
+    throw new ValidationError('websiteUrl must be a non-empty string');
+  }
 
   logger.info({ tenantId, dataModelId: id }, 'Updating data model');
   const dataModel = await updateDataModel(id, tenantId, {
@@ -174,7 +167,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   });
 
   logger.info({ tenantId, dataModelId: id }, 'Data model updated');
-  return NextResponse.json({ ok: true, dataModel });
+  return NextResponse.json(dataModel);
 });
 
 /**
@@ -193,18 +186,8 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *           type: string
  *         description: The database ID of the data model
  *     responses:
- *       200:
+ *       204:
  *         description: Data model deleted successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 dataModel:
- *                   $ref: '#/components/schemas/DataModel'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -228,8 +211,8 @@ export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
   logger.info({ tenantId, dataModelId: id }, 'Deleting data model');
-  const dataModel = await deleteDataModel(id, tenantId);
+  await deleteDataModel(id, tenantId);
 
   logger.info({ tenantId, dataModelId: id }, 'Data model deleted');
-  return NextResponse.json({ ok: true, dataModel });
+  return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
@@ -74,15 +74,15 @@ describe('GET /api/v1/data-models', () => {
       { id: 'cfg-1', name: 'DPP v0.6.0', credentialType: 'DigitalProductPassport' },
       { id: 'cfg-2', name: 'DCC v0.6.0', credentialType: 'DigitalConformityCredential' },
     ];
-    mockListDataModels.mockResolvedValue(dataModels);
+    mockListDataModels.mockResolvedValue({ data: dataModels, total: 2 });
 
     const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/data-models' });
     const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json.ok).toBe(true);
-    expect(json.dataModels).toEqual(dataModels);
+    expect(json.data).toEqual(dataModels);
+    expect(json.pagination).toEqual({ total: 2, limit: 20, offset: 0, hasMore: false });
     expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', {
       isExtension: undefined,
       credentialType: undefined,
@@ -93,7 +93,7 @@ describe('GET /api/v1/data-models', () => {
   });
 
   it('passes isExtension=true filter correctly', async () => {
-    mockListDataModels.mockResolvedValue([]);
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
@@ -111,7 +111,7 @@ describe('GET /api/v1/data-models', () => {
   });
 
   it('passes isExtension=false filter correctly', async () => {
-    mockListDataModels.mockResolvedValue([]);
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
@@ -141,7 +141,7 @@ describe('GET /api/v1/data-models', () => {
   });
 
   it('passes credentialType filter correctly', async () => {
-    mockListDataModels.mockResolvedValue([]);
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
@@ -171,7 +171,7 @@ describe('GET /api/v1/data-models', () => {
   });
 
   it('passes version filter correctly', async () => {
-    mockListDataModels.mockResolvedValue([]);
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
@@ -189,7 +189,7 @@ describe('GET /api/v1/data-models', () => {
   });
 
   it('passes pagination parameters correctly', async () => {
-    mockListDataModels.mockResolvedValue([]);
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
@@ -207,7 +207,7 @@ describe('GET /api/v1/data-models', () => {
   });
 
   it('passes all filters together', async () => {
-    mockListDataModels.mockResolvedValue([]);
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
@@ -292,8 +292,7 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(201);
-    expect(json.ok).toBe(true);
-    expect(json.dataModel).toEqual(created);
+    expect(json).toEqual(created);
   });
 
   it('passes isExtension=true and all fields to the repository', async () => {

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
@@ -224,6 +224,18 @@ describe('GET /api/v1/data-models', () => {
     });
   });
 
+  it('clamps limit to maximum of 100', async () => {
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/data-models?limit=500',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListDataModels).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ limit: 100 }));
+  });
+
   it('returns 400 for non-numeric limit', async () => {
     const req = createFakeRequest({
       method: 'GET',
@@ -459,6 +471,25 @@ describe('POST /api/v1/data-models', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('parentConfigId is required');
+  });
+
+  it('returns 400 when websiteUrl is empty string', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+        websiteUrl: '',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('websiteUrl must be a non-empty string');
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.ts
@@ -14,6 +14,8 @@ import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/data-models' });
 
+const MAX_LIMIT = 100;
+
 /**
  * Parse a boolean string query parameter ("true" or "false").
  * Returns undefined if the raw value is null/undefined.
@@ -57,7 +59,8 @@ function parseBooleanParam(raw: string | null | undefined, paramName: string): b
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Maximum number of results to return
+ *           maximum: 100
+ *         description: Maximum number of results to return (capped at 100)
  *       - in: query
  *         name: offset
  *         schema:
@@ -108,7 +111,8 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
     'credentialType',
   );
   const version = url.searchParams.get('version') ?? undefined;
-  const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_LIMIT) : undefined;
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
   logger.info(
@@ -232,6 +236,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   if (!isNonEmptyString(body.contextUrl)) throw new ValidationError('contextUrl is required');
   if (!isNonEmptyString(body.parentConfigId)) {
     throw new ValidationError('parentConfigId is required');
+  }
+  if (body.websiteUrl !== undefined && !isNonEmptyString(body.websiteUrl)) {
+    throw new ValidationError('websiteUrl must be a non-empty string');
   }
 
   logger.info({ tenantId, credentialType, name: body.name }, 'Creating data model extension');

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.ts
@@ -6,6 +6,7 @@ import {
   parsePositiveInt,
   parseNonNegativeInt,
 } from '@/lib/api/validation';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { listDataModels, createDataModel } from '@/lib/prisma/repositories';
 import { CredentialType } from '@/lib/prisma/generated';
@@ -71,13 +72,12 @@ function parseBooleanParam(raw: string | null | undefined, paramName: string): b
  *             schema:
  *               type: object
  *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 dataModels:
+ *                 data:
  *                   type: array
  *                   items:
  *                     $ref: '#/components/schemas/DataModel'
+ *                 pagination:
+ *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
  *         description: Validation error
  *         content:
@@ -100,6 +100,7 @@ function parseBooleanParam(raw: string | null | undefined, paramName: string): b
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   const url = new URL(req.url);
 
+  logger.info({ tenantId }, 'Parsing query filters');
   const isExtension = parseBooleanParam(url.searchParams.get('isExtension'), 'isExtension');
   const credentialType = validateEnum(
     url.searchParams.get('credentialType') ?? undefined,
@@ -110,8 +111,11 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
   const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, filters: { isExtension, credentialType, version, limit, offset } }, 'Listing data models');
-  const dataModels = await listDataModels(tenantId, {
+  logger.info(
+    { tenantId, filters: { isExtension, credentialType, version, limit, offset } },
+    'Querying data models from database',
+  );
+  const { data, total } = await listDataModels(tenantId, {
     isExtension,
     credentialType,
     version,
@@ -119,8 +123,8 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
     offset,
   });
 
-  logger.info({ tenantId, count: dataModels.length }, 'Data models listed');
-  return NextResponse.json({ ok: true, dataModels });
+  logger.info({ tenantId, count: data.length, total }, 'Data models listed');
+  return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });
 
 /**
@@ -173,13 +177,7 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 ok:
- *                   type: boolean
- *                   example: true
- *                 dataModel:
- *                   $ref: '#/components/schemas/DataModel'
+ *               $ref: '#/components/schemas/DataModel'
  *       400:
  *         description: Validation error
  *         content:
@@ -206,6 +204,7 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
+  logger.info({ tenantId }, 'Parsing request body');
   let body: {
     name?: string;
     credentialType?: string;
@@ -222,6 +221,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
+  logger.info({ tenantId }, 'Validating input parameters');
   if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
 
   const credentialType = validateEnum(body.credentialType, Object.values(CredentialType), 'credentialType');
@@ -247,5 +247,5 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   });
 
   logger.info({ tenantId, dataModelId: dataModel.id }, 'Data model extension created');
-  return NextResponse.json({ ok: true, dataModel }, { status: 201 });
+  return NextResponse.json(dataModel, { status: 201 });
 });

--- a/packages/reference-implementation/src/lib/credentials/resolve-data-model.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/resolve-data-model.test.ts
@@ -66,7 +66,7 @@ describe('resolveDataModel', () => {
   });
 
   it('resolves core data model, mapper, and schema URLs', async () => {
-    mockListDataModels.mockResolvedValue([CORE_DATA_MODEL]);
+    mockListDataModels.mockResolvedValue({ data: [CORE_DATA_MODEL], total: 1 });
     mockGetMapper.mockReturnValue(MOCK_MAPPER);
 
     const result = await resolveDataModel('tenant-1', 'DigitalProductPassport', '0.6.1');
@@ -84,7 +84,7 @@ describe('resolveDataModel', () => {
   });
 
   it('infers mapper from parent config for extension data models', async () => {
-    mockListDataModels.mockResolvedValue([EXTENSION_DATA_MODEL]);
+    mockListDataModels.mockResolvedValue({ data: [EXTENSION_DATA_MODEL], total: 1 });
     mockGetMapper.mockReturnValue(MOCK_MAPPER);
 
     const result = await resolveDataModel('tenant-1', 'DigitalProductPassport', '0.6.1');
@@ -94,7 +94,7 @@ describe('resolveDataModel', () => {
   });
 
   it('returns core + extension schema URLs for extension data models', async () => {
-    mockListDataModels.mockResolvedValue([EXTENSION_DATA_MODEL]);
+    mockListDataModels.mockResolvedValue({ data: [EXTENSION_DATA_MODEL], total: 1 });
     mockGetMapper.mockReturnValue(MOCK_MAPPER);
 
     const result = await resolveDataModel('tenant-1', 'DigitalProductPassport', '0.6.1');
@@ -106,7 +106,7 @@ describe('resolveDataModel', () => {
   });
 
   it('throws ValidationError when no data model found', async () => {
-    mockListDataModels.mockResolvedValue([]);
+    mockListDataModels.mockResolvedValue({ data: [], total: 0 });
 
     await expect(resolveDataModel('tenant-1', 'DigitalProductPassport', '0.6.1')).rejects.toThrow(ValidationError);
 
@@ -116,7 +116,7 @@ describe('resolveDataModel', () => {
   });
 
   it('throws ValidationError when no mapper found', async () => {
-    mockListDataModels.mockResolvedValue([CORE_DATA_MODEL]);
+    mockListDataModels.mockResolvedValue({ data: [CORE_DATA_MODEL], total: 1 });
     mockGetMapper.mockReturnValue(undefined);
 
     await expect(resolveDataModel('tenant-1', 'DigitalProductPassport', '0.6.1')).rejects.toThrow(ValidationError);

--- a/packages/reference-implementation/src/lib/credentials/resolve-data-model.ts
+++ b/packages/reference-implementation/src/lib/credentials/resolve-data-model.ts
@@ -16,7 +16,7 @@ export async function resolveDataModel(
   credentialType: string,
   version: string,
 ): Promise<ResolvedDataModel> {
-  const dataModels = await listDataModels(tenantId, {
+  const { data: dataModels } = await listDataModels(tenantId, {
     credentialType: credentialType as CredentialType,
     version,
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
@@ -26,7 +26,12 @@ jest.mock('../prisma', () => ({
       findMany: jest.fn(),
       count: jest.fn(),
     },
-    $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
+    $transaction: jest.fn((arg: unknown) => {
+      // Batch form: $transaction([promise1, promise2])
+      if (Array.isArray(arg)) return Promise.all(arg);
+      // Interactive form: $transaction(async (tx) => { ... })
+      return (arg as (tx: typeof mockTx) => Promise<unknown>)(mockTx);
+    }),
   },
 }));
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
@@ -24,6 +24,7 @@ jest.mock('../prisma', () => ({
       create: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
+      count: jest.fn(),
     },
     $transaction: jest.fn((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
   },
@@ -37,6 +38,7 @@ const mockDataModel = prisma.dataModel as unknown as {
   create: jest.Mock;
   findFirst: jest.Mock;
   findMany: jest.Mock;
+  count: jest.Mock;
 };
 
 const INCLUDE_SHAPE = {
@@ -226,73 +228,81 @@ describe('data-model.repository', () => {
   describe('listDataModels', () => {
     it('returns system and tenant configs', async () => {
       mockDataModel.findMany.mockResolvedValue([CONFIG_RECORD, EXTENSION_RECORD]);
+      mockDataModel.count.mockResolvedValue(2);
 
       const result = await listDataModels(TENANT_ID);
 
+      const expectedWhere = {
+        OR: [{ tenantId: TENANT_ID }, { tenantId: SYSTEM_TENANT_ID }],
+      };
       expect(mockDataModel.findMany).toHaveBeenCalledWith({
-        where: {
-          OR: [{ tenantId: TENANT_ID }, { tenantId: SYSTEM_TENANT_ID }],
-        },
+        where: expectedWhere,
         include: INCLUDE_SHAPE,
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
-      expect(result).toHaveLength(2);
+      expect(mockDataModel.count).toHaveBeenCalledWith({ where: expectedWhere });
+      expect(result.data).toHaveLength(2);
+      expect(result.total).toBe(2);
     });
 
     it('applies isExtension filter', async () => {
       mockDataModel.findMany.mockResolvedValue([CONFIG_RECORD]);
+      mockDataModel.count.mockResolvedValue(1);
 
       await listDataModels(TENANT_ID, { isExtension: false });
 
+      const expectedWhere = expect.objectContaining({ isExtension: false });
       expect(mockDataModel.findMany).toHaveBeenCalledWith({
-        where: expect.objectContaining({
-          isExtension: false,
-        }),
+        where: expectedWhere,
         include: INCLUDE_SHAPE,
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
+      expect(mockDataModel.count).toHaveBeenCalledWith({ where: expectedWhere });
     });
 
     it('applies credentialType filter', async () => {
       mockDataModel.findMany.mockResolvedValue([]);
+      mockDataModel.count.mockResolvedValue(0);
 
       await listDataModels(TENANT_ID, {
         credentialType: 'DigitalProductPassport' as never,
       });
 
+      const expectedWhere = expect.objectContaining({ credentialType: 'DigitalProductPassport' });
       expect(mockDataModel.findMany).toHaveBeenCalledWith({
-        where: expect.objectContaining({
-          credentialType: 'DigitalProductPassport',
-        }),
+        where: expectedWhere,
         include: INCLUDE_SHAPE,
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
+      expect(mockDataModel.count).toHaveBeenCalledWith({ where: expectedWhere });
     });
 
     it('applies version filter', async () => {
       mockDataModel.findMany.mockResolvedValue([]);
+      mockDataModel.count.mockResolvedValue(0);
 
       await listDataModels(TENANT_ID, { version: '0.6.0' });
 
+      const expectedWhere = expect.objectContaining({ version: '0.6.0' });
       expect(mockDataModel.findMany).toHaveBeenCalledWith({
-        where: expect.objectContaining({
-          version: '0.6.0',
-        }),
+        where: expectedWhere,
         include: INCLUDE_SHAPE,
-        take: 100,
+        take: 20,
         skip: undefined,
         orderBy: { createdAt: 'desc' },
       });
+      expect(mockDataModel.count).toHaveBeenCalledWith({ where: expectedWhere });
     });
 
     it('applies pagination', async () => {
       mockDataModel.findMany.mockResolvedValue([]);
+      mockDataModel.count.mockResolvedValue(0);
 
       await listDataModels(TENANT_ID, { limit: 10, offset: 20 });
 
@@ -364,18 +374,16 @@ describe('data-model.repository', () => {
   describe('deleteDataModel', () => {
     it('deletes a tenant-owned extension config', async () => {
       mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
-      mockTx.dataModel.delete.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.delete.mockResolvedValue(undefined);
 
-      const result = await deleteDataModel('config-ext-1', TENANT_ID);
+      await deleteDataModel('config-ext-1', TENANT_ID);
 
       expect(mockTx.dataModel.findFirst).toHaveBeenCalledWith({
         where: { id: 'config-ext-1', tenantId: TENANT_ID, isExtension: true },
       });
       expect(mockTx.dataModel.delete).toHaveBeenCalledWith({
         where: { id: 'config-ext-1' },
-        include: INCLUDE_SHAPE,
       });
-      expect(result).toEqual(EXTENSION_RECORD);
     });
 
     it('throws when config is not tenant-owned', async () => {

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -142,7 +142,7 @@ export async function listDataModels(
     where.version = version;
   }
 
-  const [data, total] = await Promise.all([
+  const [data, total] = await prisma.$transaction([
     prisma.dataModel.findMany({
       where,
       include: DATA_MODEL_INCLUDE,

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -123,7 +123,7 @@ export async function getDataModelById(id: string, tenantId: string): Promise<Da
 export async function listDataModels(
   tenantId: string,
   options: ListDataModelOptions = {},
-): Promise<DataModelWithRelations[]> {
+): Promise<{ data: DataModelWithRelations[]; total: number }> {
   const { isExtension, credentialType, version, limit, offset } = options;
 
   const where: Prisma.DataModelWhereInput = {
@@ -142,13 +142,18 @@ export async function listDataModels(
     where.version = version;
   }
 
-  return prisma.dataModel.findMany({
-    where,
-    include: DATA_MODEL_INCLUDE,
-    take: limit ?? 100,
-    skip: offset,
-    orderBy: { createdAt: 'desc' },
-  });
+  const [data, total] = await Promise.all([
+    prisma.dataModel.findMany({
+      where,
+      include: DATA_MODEL_INCLUDE,
+      take: limit ?? 20,
+      skip: offset,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.dataModel.count({ where }),
+  ]);
+
+  return { data, total };
 }
 
 /**
@@ -188,8 +193,8 @@ export async function updateDataModel(
  * Only tenant-owned extension configs can be deleted.
  * System-provisioned and core configs cannot be removed by tenants.
  */
-export async function deleteDataModel(id: string, tenantId: string): Promise<DataModelWithRelations> {
-  return prisma.$transaction(async (tx) => {
+export async function deleteDataModel(id: string, tenantId: string): Promise<void> {
+  await prisma.$transaction(async (tx) => {
     const existing = await tx.dataModel.findFirst({
       where: { id, tenantId, isExtension: true },
     });
@@ -198,9 +203,6 @@ export async function deleteDataModel(id: string, tenantId: string): Promise<Dat
       throw new NotFoundError('Data model not found or access denied');
     }
 
-    return tx.dataModel.delete({
-      where: { id },
-      include: DATA_MODEL_INCLUDE,
-    });
+    await tx.dataModel.delete({ where: { id } });
   });
 }


### PR DESCRIPTION
This PR aligns the data-models API routes with the REST conventions established in DIDs (#439) and render-templates (#441), fixing response envelope inconsistencies, missing pagination, incorrect DELETE status codes, and absent request tracing.

## Changes

- **Response envelope**: All routes now return resources directly instead of wrapping in `{ ok: true }`
- **Paginated list**: GET `/data-models` uses `buildPaginatedResponse` with `{ data, pagination: { total, limit, offset, hasMore } }`
- **DELETE 204**: DELETE `/data-models/:id` returns 204 with empty body instead of 200 with resource
- **Step-level logging**: Added structured request tracing to all route handlers per logger-setup conventions
- **PATCH validation**: Added missing `websiteUrl` non-empty string validation
- **Repository**: `listDataModels` returns `{ data, total }` via parallel `findMany` + `count`; `deleteDataModel` returns `Promise<void>`
- **Consumer fix**: Updated `resolve-data-model.ts` to destructure the new `listDataModels` return shape (would have broken credential issuance)
- **Swagger**: Updated all annotations to match new response shapes

## Test plan
- [x] All 1009 tests pass (7 pre-existing suite failures unrelated to changes)
- [x] Repository tests updated for `{ data, total }` return and count mock
- [x] Route tests updated for direct resource returns, paginated list, 204 DELETE
- [x] resolve-data-model tests updated for destructured consumer
- [x] PATCH validation tests cover all four updatable fields