### PR TITLE
feat(api): add healthcheck endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,12 @@ services:
       UNCEFACT_STORAGE_URL: http://storage-service:3334/api/3.0.0/public
       IDR_API_URL: http://identity-resolver-service:3000/api/2.0.0
       IDR_API_KEY: ${IDR_API_KEY}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3003/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     depends_on:
       keycloak:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       IDR_API_URL: http://identity-resolver-service:3000/api/2.0.0
       IDR_API_KEY: ${IDR_API_KEY}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3003/api/health"]
+      test: ["CMD", "wget", "--quiet", "--spider", "http://localhost:3003/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/packages/reference-implementation/src/app/api/health/route.test.ts
+++ b/packages/reference-implementation/src/app/api/health/route.test.ts
@@ -16,17 +16,19 @@ describe('GET /api/health', () => {
     jest.clearAllMocks();
   });
 
-  it('returns healthy with 200', () => {
-    GET();
-
-    expect(NextResponse.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'healthy' }));
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
-  it('includes a timestamp', () => {
+  it('returns a healthy status and the current timestamp', () => {
+    const mockDate = new Date('2024-01-01T00:00:00.000Z');
+    jest.useFakeTimers().setSystemTime(mockDate);
+
     GET();
 
-    const call = (NextResponse.json as jest.Mock).mock.calls[0][0];
-    expect(call.timestamp).toBeDefined();
-    expect(() => new Date(call.timestamp)).not.toThrow();
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      status: 'healthy',
+      timestamp: '2024-01-01T00:00:00.000Z',
+    });
   });
 });

--- a/packages/reference-implementation/src/app/api/health/route.test.ts
+++ b/packages/reference-implementation/src/app/api/health/route.test.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}));
+
+import { GET } from './route';
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns healthy with 200', () => {
+    GET();
+
+    expect(NextResponse.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'healthy' }));
+  });
+
+  it('includes a timestamp', () => {
+    GET();
+
+    const call = (NextResponse.json as jest.Mock).mock.calls[0][0];
+    expect(call.timestamp).toBeDefined();
+    expect(() => new Date(call.timestamp)).not.toThrow();
+  });
+});

--- a/packages/reference-implementation/src/app/api/health/route.ts
+++ b/packages/reference-implementation/src/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+// Intentionally unauthenticated (outside /api/v1/* middleware matcher)
+// so Docker healthchecks and load balancers can probe without credentials.
+export function GET() {
+  return NextResponse.json({ status: 'healthy', timestamp: new Date().toISOString() });
+}


### PR DESCRIPTION
This PR adds a lightweight healthcheck endpoint at `GET /api/health`, giving Docker and load balancers a way to verify the RI process is alive. The endpoint is intentionally unauthenticated (placed outside the `/api/v1/*` middleware matcher) and returns `{ status, timestamp }` with a 200.

The `ri` service in `docker-compose.yml` now has a `healthcheck` block that probes this endpoint every 30 seconds.

## Test plan
- [x] Unit tests for healthy response and timestamp format
- [x] Verified endpoint sits outside auth middleware matcher