### PR TITLE
feat(api): add POST /api/v1/credentials/verify endpoint

### DIFF
--- a/e2e/cypress/e2e/credential_api/credential-verify.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-verify.cy.ts
@@ -1,0 +1,275 @@
+describe('Credential Verify API', { testIsolation: false }, () => {
+  const TEST_ORG_ID = 'e2e-test-org';
+  const RUN_ID = Date.now();
+  let defaultDidValue: string;
+  let unencryptedUri: string;
+  let unencryptedHash: string;
+  let encryptedUri: string;
+  let encryptedHash: string;
+  let encryptedKey: string;
+
+  function buildCredentialPayload(issuerDid: string) {
+    return {
+      '@context': [
+        'https://www.w3.org/ns/credentials/v2',
+        'https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/',
+      ],
+      id: `urn:uuid:verify-e2e-${RUN_ID}`,
+      type: ['DigitalProductPassport', 'VerifiableCredential'],
+      issuer: {
+        type: ['CredentialIssuer'],
+        id: issuerDid,
+        name: `Verify E2E Issuer ${RUN_ID}`,
+      },
+      credentialSubject: {
+        type: ['ProductPassport'],
+        id: `https://example.com/products/verify-e2e-${RUN_ID}`,
+      },
+    };
+  }
+
+  // ── Setup ──────────────────────────────────────────────────────────
+
+  before(() => {
+    cy.apiLogin();
+    cy.task('seedTestOrg', { userEmail: 'e2e-admin@test.local' });
+
+    // VC service instance
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/services',
+      body: {
+        serviceType: 'VC',
+        adapterType: 'VCKIT',
+        name: 'Verify E2E VCKit',
+        config: {
+          endpoint: 'http://vckit-api:3332/v2',
+          apiKey: 'test123',
+        },
+        apiVersion: '1.0.0',
+        isPrimary: true,
+      },
+    }).then((res) => expect(res.status).to.eq(201));
+
+    // Storage service instance
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/services',
+      body: {
+        serviceType: 'STORAGE',
+        adapterType: 'UNCEFACT_STORAGE',
+        name: 'Verify E2E Storage',
+        config: {
+          baseUrl: 'http://storage-service:3334',
+          apiKey: 'test123',
+          apiVersion: '3.0.0',
+        },
+        apiVersion: '3.0.0',
+        isPrimary: true,
+      },
+    }).then((res) => expect(res.status).to.eq(201));
+
+    // Look up system default DID
+    cy.request('/api/v1/dids').then((response) => {
+      const defaultDid = response.body.data.find(
+        (d: any) => d.isDefault === true,
+      );
+      expect(defaultDid).to.exist;
+      defaultDidValue = defaultDid.did;
+    });
+  });
+
+  after(() => {
+    cy.task('cleanupTestData', { tenantId: TEST_ORG_ID });
+  });
+
+  // ── Issue credentials for verification ─────────────────────────────
+
+  describe('Setup: issue credentials', () => {
+    it('issues an unencrypted credential', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+          storageOptions: { encrypt: false },
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        const credId = response.body.credentialId;
+
+        cy.request(`/api/v1/credentials/${credId}`).then((res) => {
+          const cred = res.body.credential;
+          unencryptedUri = cred.storageUri;
+          unencryptedHash = cred.hash;
+        });
+      });
+    });
+
+    it('issues an encrypted credential', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        const credId = response.body.credentialId;
+
+        cy.request(`/api/v1/credentials/${credId}`).then((res) => {
+          const cred = res.body.credential;
+          encryptedUri = cred.storageUri;
+          encryptedHash = cred.hash;
+          encryptedKey = cred.decryptionKey;
+        });
+      });
+    });
+  });
+
+  // ── Verification: happy paths ──────────────────────────────────────
+
+  describe('POST /api/v1/credentials/verify', () => {
+    it('verifies an unencrypted credential', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: unencryptedUri, hash: unencryptedHash },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.verified).to.be.true;
+        expect(response.body.credential).to.exist;
+        expect(response.body.credential.type).to.satisfy(
+          (t: string | string[]) =>
+            t === 'EnvelopedVerifiableCredential' ||
+            (Array.isArray(t) && t.includes('EnvelopedVerifiableCredential')),
+        );
+        expect(response.body.decodedCredential).to.exist;
+      });
+    });
+
+    it('verifies an encrypted credential with decryptionKey', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: {
+          uri: encryptedUri,
+          hash: encryptedHash,
+          decryptionKey: encryptedKey,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.verified).to.be.true;
+        expect(response.body.credential).to.exist;
+        expect(response.body.decodedCredential).to.exist;
+      });
+    });
+
+    it('does not require authentication', () => {
+      // Make request without session cookies
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: unencryptedUri },
+        headers: { cookie: '' },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.verified).to.be.a('boolean');
+      });
+    });
+  });
+
+  // ── Validation errors ──────────────────────────────────────────────
+
+  describe('Validation errors', () => {
+    it('returns 400 when uri is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: {},
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid URI format', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: 'not-a-url' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for non-HTTP scheme', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: 'ftp://example.com/file' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for invalid hash format', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: unencryptedUri, hash: 'too-short' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
+    });
+  });
+
+  // ── Processing errors ──────────────────────────────────────────────
+
+  describe('Processing errors', () => {
+    it('returns 422 when encrypted credential has no decryptionKey', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: encryptedUri },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(422);
+        expect(response.body.code).to.eq('DECRYPTION_REQUIRED');
+      });
+    });
+
+    it('returns 422 when hash does not match', () => {
+      const wrongHash = 'f'.repeat(64);
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: unencryptedUri, hash: wrongHash },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(422);
+        expect(response.body.code).to.eq('HASH_MISMATCH');
+      });
+    });
+
+    it('returns 502 when storage URI is unreachable', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: 'https://nonexistent.invalid/credential' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(502);
+        expect(response.body.code).to.eq('UPSTREAM_ERROR');
+      });
+    });
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -1,0 +1,394 @@
+// Polyfill AbortSignal.timeout for jsdom (not available in jsdom)
+if (typeof AbortSignal.timeout !== 'function') {
+  (AbortSignal as any).timeout = (ms: number) => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), ms);
+    return controller.signal;
+  };
+}
+
+// Mock next/server before importing route handlers
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withPublicRoute to mirror handleRouteError behaviour
+jest.mock('@/lib/api/with-public-route', () => {
+  const { errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
+  const { ValidationError } = jest.requireActual('@/lib/api/validation');
+
+  function jsonResponse(body: unknown, init?: { status?: number }) {
+    return { status: init?.status ?? 200, json: async () => body };
+  }
+
+  return {
+    withPublicRoute: (handler: (req: unknown) => Promise<unknown>) => async (req: unknown) => {
+      try {
+        return await handler(req);
+      } catch (e: unknown) {
+        if (e instanceof ValidationError) return jsonResponse({ error: (e as Error).message }, { status: 400 });
+        if (e instanceof ServiceRegistryError) return jsonResponse({ error: (e as Error).message }, { status: 500 });
+        return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+      }
+    },
+  };
+});
+
+const mockResolveVcService = jest.fn();
+const mockComputeHash = jest.fn();
+const mockDecryptCredential = jest.fn();
+const mockDecodeJwt = jest.fn();
+
+jest.mock('@/lib/services/resolve-vc-service', () => ({
+  resolveVcService: (...args: unknown[]) => mockResolveVcService(...args),
+}));
+
+jest.mock('@uncefact/untp-ri-services', () => ({
+  computeHash: (...args: unknown[]) => mockComputeHash(...args),
+  decryptCredential: (...args: unknown[]) => mockDecryptCredential(...args),
+}));
+
+jest.mock('jose', () => ({
+  decodeJwt: (...args: unknown[]) => mockDecodeJwt(...args),
+}));
+
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: { child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }) },
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+import { ServiceResolutionError } from '@/lib/api/errors';
+import { POST } from './route';
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const VALID_URI = 'https://storage.example.com/credentials/abc123';
+const VALID_HASH = 'a'.repeat(64);
+const VALID_KEY = 'b'.repeat(64);
+
+const ENVELOPED_CREDENTIAL = {
+  '@context': ['https://www.w3.org/ns/credentials/v2'],
+  id: 'data:application/vc+jwt,eyJhbGciOiJFZDI1NTE5In0.eyJpc3MiOiJkaWQ6d2ViOmV4YW1wbGUuY29tIn0.signature',
+  type: 'EnvelopedVerifiableCredential',
+};
+
+const ENCRYPTED_DATA = {
+  cipherText: 'encrypted-data',
+  iv: 'init-vector',
+  tag: 'auth-tag',
+  type: 'aes-256-gcm',
+};
+
+const DECODED_JWT = { iss: 'did:web:example.com', type: ['VerifiableCredential'] };
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function createFakeRequest(body: Record<string, unknown>): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/credentials/verify',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => body,
+  } as unknown as Request;
+}
+
+function createBadJsonRequest(): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/credentials/verify',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => {
+      throw new SyntaxError('Unexpected token');
+    },
+  } as unknown as Request;
+}
+
+function createFetchResponse(body: unknown, opts?: { ok?: boolean; status?: number; textThrows?: boolean }) {
+  const ok = opts?.ok ?? true;
+  const status = opts?.status ?? (ok ? 200 : 500);
+  return {
+    ok,
+    status,
+    text: opts?.textThrows
+      ? async () => {
+          throw new Error('read error');
+        }
+      : async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/credentials/verify', () => {
+  const mockVcService = { verify: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveVcService.mockResolvedValue({ service: mockVcService, instanceId: 'inst-1' });
+    mockDecodeJwt.mockReturnValue(DECODED_JWT);
+    mockComputeHash.mockReturnValue(VALID_HASH);
+  });
+
+  // ── Input Validation (400s) ───────────────────────────────────────
+
+  it('returns 400 for malformed JSON body', async () => {
+    const res = await POST(createBadJsonRequest());
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 when uri is missing', async () => {
+    const res = await POST(createFakeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('uri is required');
+  });
+
+  it('returns 400 when uri is not a string', async () => {
+    const res = await POST(createFakeRequest({ uri: 123 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('uri is required');
+  });
+
+  it('returns 400 for invalid URI format', async () => {
+    const res = await POST(createFakeRequest({ uri: 'not-a-url' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('uri must be a valid URL');
+  });
+
+  it('returns 400 for non-HTTP(S) URI scheme (ftp://)', async () => {
+    const res = await POST(createFakeRequest({ uri: 'ftp://example.com/file' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('uri must be a valid HTTP(S) URL');
+  });
+
+  it('returns 400 for invalid hash format (too short)', async () => {
+    const res = await POST(createFakeRequest({ uri: VALID_URI, hash: 'abc123' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('hash must be a 64-character hex string (SHA-256)');
+  });
+
+  it('returns 400 for invalid decryptionKey format', async () => {
+    const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: 'short' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('decryptionKey must be a 64-character hex string');
+  });
+
+  // ── Upstream Errors (502) ─────────────────────────────────────────
+
+  it('returns 502 when fetch times out', async () => {
+    const timeoutError = Object.assign(new Error('Timeout'), { name: 'TimeoutError' });
+    mockFetch.mockImplementation(() => Promise.reject(timeoutError));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toBe('Failed to fetch credential: request timed out');
+    expect(json.code).toBe('UPSTREAM_ERROR');
+  });
+
+  it('returns 502 when fetch fails with network error', async () => {
+    mockFetch.mockRejectedValue(new Error('fetch failed'));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toBe('Failed to fetch credential: network error');
+    expect(json.code).toBe('UPSTREAM_ERROR');
+  });
+
+  it('returns 502 when storage returns non-2xx', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(null, { ok: false, status: 404 }));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toBe('Failed to fetch credential: storage returned 404');
+    expect(json.code).toBe('UPSTREAM_ERROR');
+  });
+
+  it('returns 502 when response exceeds size limit', async () => {
+    const hugeText = 'x'.repeat(10_485_761); // 10 MB + 1 byte
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => hugeText,
+    });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toContain('exceeds maximum size');
+    expect(json.code).toBe('UPSTREAM_ERROR');
+  });
+
+  // ── Credential Processing (422) ───────────────────────────────────
+
+  it('returns 422 when response is not valid JSON', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'not-json{{{',
+    });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Response from storage URI is not valid JSON');
+    expect(json.code).toBe('INVALID_RESPONSE');
+  });
+
+  it('returns 422 when credential is encrypted but no decryption key provided', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Credential is encrypted but no decryptionKey was provided');
+    expect(json.code).toBe('DECRYPTION_REQUIRED');
+  });
+
+  it('returns 422 when decryption fails', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+    mockDecryptCredential.mockImplementation(() => {
+      throw new Error('decryption failure');
+    });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Failed to decrypt credential');
+    expect(json.code).toBe('DECRYPTION_FAILED');
+  });
+
+  it('returns 422 when hash does not match', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockComputeHash.mockReturnValue('c'.repeat(64));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI, hash: VALID_HASH }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Credential hash does not match the expected hash');
+    expect(json.code).toBe('HASH_MISMATCH');
+  });
+
+  it('returns 422 when credential is not an EnvelopedVerifiableCredential', async () => {
+    const plainCredential = { type: 'SomeOtherType', id: 'urn:uuid:123' };
+    mockFetch.mockResolvedValue(createFetchResponse(plainCredential));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Only EnvelopedVerifiableCredential is supported');
+    expect(json.code).toBe('UNSUPPORTED_CREDENTIAL_TYPE');
+  });
+
+  // ── Verification Outcomes (200) ───────────────────────────────────
+
+  it('returns verified: true for successful verification', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.verified).toBe(true);
+    expect(json.credential).toEqual(ENVELOPED_CREDENTIAL);
+    expect(json.decodedCredential).toEqual(DECODED_JWT);
+    expect(json.error).toBeUndefined();
+  });
+
+  it('returns verified: false with error details when verification fails', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    const verificationError = { type: 'status', message: 'Credential revoked' };
+    mockVcService.verify.mockResolvedValue({ verified: false, error: verificationError });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.verified).toBe(false);
+    expect(json.error).toEqual(verificationError);
+    expect(json.credential).toEqual(ENVELOPED_CREDENTIAL);
+    expect(json.decodedCredential).toEqual(DECODED_JWT);
+  });
+
+  // ── Edge Cases ────────────────────────────────────────────────────
+
+  it('skips decryption for unencrypted credentials', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    expect(mockDecryptCredential).not.toHaveBeenCalled();
+  });
+
+  it('skips hash check when hash not provided', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    expect(mockComputeHash).not.toHaveBeenCalled();
+  });
+
+  it('omits decodedCredential when JWT decode fails', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+    mockDecodeJwt.mockImplementation(() => {
+      throw new Error('invalid JWT');
+    });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.verified).toBe(true);
+    expect(json.decodedCredential).toBeUndefined();
+  });
+
+  it('resolves VC service with SYSTEM_TENANT_ID', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    await POST(createFakeRequest({ uri: VALID_URI }));
+
+    expect(mockResolveVcService).toHaveBeenCalledWith('system');
+  });
+
+  it('includes decodedCredential for enveloped credentials', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    const json = await res.json();
+    expect(json.decodedCredential).toEqual(DECODED_JWT);
+    expect(mockDecodeJwt).toHaveBeenCalledWith(
+      'eyJhbGciOiJFZDI1NTE5In0.eyJpc3MiOiJkaWQ6d2ViOmV4YW1wbGUuY29tIn0.signature',
+    );
+  });
+
+  // ── Service Errors ────────────────────────────────────────────────
+
+  it('returns 500 when VC service resolution fails', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockResolveVcService.mockRejectedValue(new ServiceResolutionError('VC', 'system'));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toContain('No service instance available');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -1,5 +1,6 @@
 // Polyfill AbortSignal.timeout for jsdom (not available in jsdom)
 if (typeof AbortSignal.timeout !== 'function') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (AbortSignal as any).timeout = (ms: number) => {
     const controller = new AbortController();
     setTimeout(() => controller.abort(), ms);

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -50,11 +50,15 @@ jest.mock('@/lib/services/resolve-vc-service', () => ({
   resolveVcService: (...args: unknown[]) => mockResolveVcService(...args),
 }));
 
-jest.mock('@uncefact/untp-ri-services', () => ({
-  computeHash: (...args: unknown[]) => mockComputeHash(...args),
-  decryptCredential: (...args: unknown[]) => mockDecryptCredential(...args),
-  isEncryptedEnvelope: (...args: unknown[]) => mockIsEncryptedEnvelope(...args),
-}));
+jest.mock('@uncefact/untp-ri-services', () => {
+  const actual = jest.requireActual('@uncefact/untp-ri-services');
+  return {
+    computeHash: (...args: unknown[]) => mockComputeHash(...args),
+    decryptCredential: (...args: unknown[]) => mockDecryptCredential(...args),
+    isEncryptedEnvelope: (...args: unknown[]) => mockIsEncryptedEnvelope(...args),
+    VcVerifyError: actual.VcVerifyError,
+  };
+});
 
 jest.mock('jose', () => ({
   decodeJwt: (...args: unknown[]) => mockDecodeJwt(...args),
@@ -463,6 +467,18 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toContain('No service instance available');
+  });
+
+  it('returns 502 when VC service returns an error during verification', async () => {
+    const { VcVerifyError } = jest.requireActual('@uncefact/untp-ri-services');
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockRejectedValue(new VcVerifyError('HTTP 404: Not Found', 404));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toBe('Credential verification service failed');
+    expect(json.code).toBe('VC_SERVICE_ERROR');
   });
 
   it('returns 500 when vcService.verify() throws unexpectedly', async () => {

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -235,6 +235,22 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.code).toBe('UPSTREAM_ERROR');
   });
 
+  it('returns 502 when response.text() throws', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => {
+        throw new Error('stream error');
+      },
+    });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toBe('Failed to read credential response');
+    expect(json.code).toBe('UPSTREAM_ERROR');
+  });
+
   // ── Credential Processing (422) ───────────────────────────────────
 
   it('returns 422 when response is not valid JSON', async () => {

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -397,6 +397,20 @@ describe('POST /api/v1/credentials/verify', () => {
     );
   });
 
+  it('accepts credential.type as an array (W3C VC Data Model)', async () => {
+    const arrayTypeCredential = {
+      ...ENVELOPED_CREDENTIAL,
+      type: ['VerifiableCredential', 'EnvelopedVerifiableCredential'],
+    };
+    mockFetch.mockResolvedValue(createFetchResponse(arrayTypeCredential));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.verified).toBe(true);
+  });
+
   // ── Service Errors ────────────────────────────────────────────────
 
   it('returns 500 when VC service resolution fails', async () => {

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -291,6 +291,16 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.code).toBe('DECRYPTION_FAILED');
   });
 
+  it('returns 422 when decrypted output is not valid JSON', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+    mockDecryptCredential.mockReturnValue('not-valid-json{{{');
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.code).toBe('DECRYPTION_FAILED');
+  });
+
   it('returns 422 when hash does not match', async () => {
     mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
     mockComputeHash.mockReturnValue('c'.repeat(64));
@@ -421,5 +431,15 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toContain('No service instance available');
+  });
+
+  it('returns 500 when vcService.verify() throws unexpectedly', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockRejectedValue(new Error('VCKit connection refused'));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe('VCKit connection refused');
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -43,6 +43,7 @@ jest.mock('@/lib/api/with-public-route', () => {
 const mockResolveVcService = jest.fn();
 const mockComputeHash = jest.fn();
 const mockDecryptCredential = jest.fn();
+const mockIsEncryptedEnvelope = jest.fn();
 const mockDecodeJwt = jest.fn();
 
 jest.mock('@/lib/services/resolve-vc-service', () => ({
@@ -52,6 +53,7 @@ jest.mock('@/lib/services/resolve-vc-service', () => ({
 jest.mock('@uncefact/untp-ri-services', () => ({
   computeHash: (...args: unknown[]) => mockComputeHash(...args),
   decryptCredential: (...args: unknown[]) => mockDecryptCredential(...args),
+  isEncryptedEnvelope: (...args: unknown[]) => mockIsEncryptedEnvelope(...args),
 }));
 
 jest.mock('jose', () => ({
@@ -135,6 +137,7 @@ describe('POST /api/v1/credentials/verify', () => {
     mockResolveVcService.mockResolvedValue({ service: mockVcService, instanceId: 'inst-1' });
     mockDecodeJwt.mockReturnValue(DECODED_JWT);
     mockComputeHash.mockReturnValue(VALID_HASH);
+    mockIsEncryptedEnvelope.mockReturnValue(false);
   });
 
   // ── Input Validation (400s) ───────────────────────────────────────
@@ -270,6 +273,7 @@ describe('POST /api/v1/credentials/verify', () => {
 
   it('returns 422 when credential is encrypted but no decryption key provided', async () => {
     mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+    mockIsEncryptedEnvelope.mockReturnValue(true);
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(422);
@@ -280,6 +284,7 @@ describe('POST /api/v1/credentials/verify', () => {
 
   it('returns 422 when decryption fails', async () => {
     mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+    mockIsEncryptedEnvelope.mockReturnValue(true);
     mockDecryptCredential.mockImplementation(() => {
       throw new Error('decryption failure');
     });
@@ -293,6 +298,7 @@ describe('POST /api/v1/credentials/verify', () => {
 
   it('returns 422 when decrypted output is not valid JSON', async () => {
     mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+    mockIsEncryptedEnvelope.mockReturnValue(true);
     mockDecryptCredential.mockReturnValue('not-valid-json{{{');
 
     const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY }));
@@ -336,6 +342,7 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.credential).toEqual(ENVELOPED_CREDENTIAL);
     expect(json.decodedCredential).toEqual(DECODED_JWT);
     expect(json.error).toBeUndefined();
+    expect(json.warnings).toBeUndefined();
   });
 
   it('returns verified: false with error details when verification fails', async () => {
@@ -372,7 +379,7 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(mockComputeHash).not.toHaveBeenCalled();
   });
 
-  it('omits decodedCredential when JWT decode fails', async () => {
+  it('omits decodedCredential and adds warning when JWT decode fails', async () => {
     mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
     mockVcService.verify.mockResolvedValue({ verified: true });
     mockDecodeJwt.mockImplementation(() => {
@@ -383,6 +390,31 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.verified).toBe(true);
+    expect(json.decodedCredential).toBeUndefined();
+    expect(json.warnings).toEqual(['Failed to decode JWT from enveloped credential']);
+  });
+
+  it('adds warning when credential.id is not a string', async () => {
+    const credNoId = { ...ENVELOPED_CREDENTIAL, id: 42 };
+    mockFetch.mockResolvedValue(createFetchResponse(credNoId));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.warnings).toEqual(['Credential id is not a string; unable to decode JWT']);
+    expect(json.decodedCredential).toBeUndefined();
+  });
+
+  it('adds warning when credential.id does not start with data:application/vc+jwt,', async () => {
+    const credBadId = { ...ENVELOPED_CREDENTIAL, id: 'urn:uuid:123' };
+    mockFetch.mockResolvedValue(createFetchResponse(credBadId));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.warnings).toEqual(['Credential id does not use the expected data:application/vc+jwt media type']);
     expect(json.decodedCredential).toBeUndefined();
   });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -188,7 +188,8 @@ export const POST = withPublicRoute(async (req) => {
   let responseText: string;
   try {
     responseText = await fetchResponse.text();
-  } catch {
+  } catch (e: unknown) {
+    logger.warn({ uri: body.uri, err: e }, 'Failed to read credential response body');
     return NextResponse.json({ error: 'Failed to read credential response', code: 'UPSTREAM_ERROR' }, { status: 502 });
   }
 
@@ -203,7 +204,8 @@ export const POST = withPublicRoute(async (req) => {
   let fetchedData: unknown;
   try {
     fetchedData = JSON.parse(responseText);
-  } catch {
+  } catch (e: unknown) {
+    logger.warn({ uri: body.uri }, 'Storage URI returned non-JSON response');
     return NextResponse.json(
       { error: 'Response from storage URI is not valid JSON', code: 'INVALID_RESPONSE' },
       { status: 422 },
@@ -241,8 +243,8 @@ export const POST = withPublicRoute(async (req) => {
         type: encrypted.type as EncryptionAlgorithm,
       });
       credential = JSON.parse(decryptedString);
-    } catch {
-      logger.warn('Credential decryption failed');
+    } catch (e: unknown) {
+      logger.warn({ uri: body.uri, err: e }, 'Credential decryption failed');
       return NextResponse.json({ error: 'Failed to decrypt credential', code: 'DECRYPTION_FAILED' }, { status: 422 });
     }
   } else {
@@ -266,6 +268,7 @@ export const POST = withPublicRoute(async (req) => {
   // ── Step 5: Validate credential type ───────────────────────────────
   const types = Array.isArray(credential.type) ? credential.type : [credential.type];
   if (!types.includes('EnvelopedVerifiableCredential')) {
+    logger.warn({ uri: body.uri, credentialType: credential.type }, 'Unsupported credential type');
     return NextResponse.json(
       { error: 'Only EnvelopedVerifiableCredential is supported', code: 'UNSUPPORTED_CREDENTIAL_TYPE' },
       { status: 422 },
@@ -284,8 +287,8 @@ export const POST = withPublicRoute(async (req) => {
   try {
     const jwt = (credential.id as string).replace('data:application/vc+jwt,', '');
     decodedCredential = decodeJwt(jwt) as unknown as Record<string, unknown>;
-  } catch {
-    logger.warn('Failed to decode JWT from enveloped credential');
+  } catch (e: unknown) {
+    logger.warn({ err: e }, 'Failed to decode JWT from enveloped credential');
   }
 
   // ── Step 8: Return result ──────────────────────────────────────────

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -5,6 +5,7 @@ import { withPublicRoute } from '@/lib/api/with-public-route';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
 import { computeHash, decryptCredential } from '@uncefact/untp-ri-services';
+import type { EncryptionAlgorithm, EnvelopedVerifiableCredential } from '@uncefact/untp-ri-services';
 import { decodeJwt } from 'jose';
 
 const logger = apiLogger.child({ route: '/api/v1/credentials/verify' });
@@ -237,7 +238,7 @@ export const POST = withPublicRoute(async (req) => {
         key: body.decryptionKey,
         iv: encrypted.iv,
         tag: encrypted.tag,
-        type: encrypted.type as any,
+        type: encrypted.type as EncryptionAlgorithm,
       });
       credential = JSON.parse(decryptedString);
     } catch {
@@ -275,7 +276,7 @@ export const POST = withPublicRoute(async (req) => {
   const { service: vcService } = await resolveVcService(SYSTEM_TENANT_ID);
 
   logger.info('Verifying credential');
-  const result = await vcService.verify(credential as any);
+  const result = await vcService.verify(credential as unknown as EnvelopedVerifiableCredential);
 
   // ── Step 7: Decode JWT from enveloped credential ───────────────────
   let decodedCredential: Record<string, unknown> | undefined;

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -1,0 +1,304 @@
+import { NextResponse } from 'next/server';
+import { apiLogger } from '@/lib/api/logger';
+import { ValidationError } from '@/lib/api/validation';
+import { UnprocessableError } from '@/lib/api/errors';
+import { withPublicRoute } from '@/lib/api/with-public-route';
+import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
+import { resolveVcService } from '@/lib/services/resolve-vc-service';
+import { computeHash, decryptCredential } from '@uncefact/untp-ri-services';
+import { decodeJwt } from 'jose';
+
+const logger = apiLogger.child({ route: '/api/v1/credentials/verify' });
+
+const HEX_64 = /^[a-f0-9]{64}$/i;
+const DEFAULT_MAX_CREDENTIAL_SIZE = 10_485_760; // 10 MB
+
+function getMaxCredentialSize(): number {
+  const envVal = process.env.VERIFY_MAX_CREDENTIAL_SIZE;
+  if (!envVal) return DEFAULT_MAX_CREDENTIAL_SIZE;
+  const parsed = parseInt(envVal, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_CREDENTIAL_SIZE;
+}
+
+/**
+ * @swagger
+ * /api/v1/credentials/verify:
+ *   post:
+ *     summary: Verify a credential
+ *     description: |
+ *       Fetches a verifiable credential from the given storage URI, optionally
+ *       decrypts it, checks its integrity hash, and verifies the credential
+ *       signature via the system VC service.
+ *
+ *       This is an unauthenticated endpoint — no bearer token is required.
+ *     tags:
+ *       - Credentials
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - uri
+ *             properties:
+ *               uri:
+ *                 type: string
+ *                 format: uri
+ *                 description: Storage URI where the credential is stored
+ *                 example: https://storage.example.com/credentials/abc123
+ *               hash:
+ *                 type: string
+ *                 pattern: '^[a-fA-F0-9]{64}$'
+ *                 description: Expected SHA-256 hash (64-character hex string)
+ *               decryptionKey:
+ *                 type: string
+ *                 pattern: '^[a-fA-F0-9]{64}$'
+ *                 description: AES-256-GCM decryption key (64-character hex string)
+ *     responses:
+ *       200:
+ *         description: Verification completed (check `verified` field for outcome)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 verified:
+ *                   type: boolean
+ *                 credential:
+ *                   type: object
+ *                   description: The enveloped credential object
+ *                 decodedCredential:
+ *                   type: object
+ *                   description: Decoded JWT payload (omitted if decoding fails)
+ *                 error:
+ *                   type: object
+ *                   description: Present only when verified is false
+ *                   properties:
+ *                     type:
+ *                       type: string
+ *                       enum: [status, integrity, temporal]
+ *                     message:
+ *                       type: string
+ *       400:
+ *         description: Validation error (missing or malformed input)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       422:
+ *         description: Credential processing error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 code:
+ *                   type: string
+ *                   enum:
+ *                     - INVALID_RESPONSE
+ *                     - DECRYPTION_REQUIRED
+ *                     - DECRYPTION_FAILED
+ *                     - HASH_MISMATCH
+ *                     - UNSUPPORTED_CREDENTIAL_TYPE
+ *       502:
+ *         description: Upstream storage error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                 code:
+ *                   type: string
+ *                   enum: [UPSTREAM_ERROR]
+ *       500:
+ *         description: Server error (e.g. system VC service not configured)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const POST = withPublicRoute(async (req) => {
+  // TODO: Production deployments should implement rate limiting at the infrastructure level
+  // (reverse proxy, API gateway, CDN). In-memory rate limiting in a Next.js API route
+  // is fragile across serverless instances.
+
+  // ── Step 1: Parse and validate input ────────────────────────────────
+  let body: { uri?: string; hash?: string; decryptionKey?: string };
+  try {
+    body = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+
+  if (!body.uri || typeof body.uri !== 'string') {
+    throw new ValidationError('uri is required');
+  }
+
+  let parsedUri: URL;
+  try {
+    parsedUri = new URL(body.uri);
+  } catch {
+    throw new ValidationError('uri must be a valid URL');
+  }
+
+  if (parsedUri.protocol !== 'http:' && parsedUri.protocol !== 'https:') {
+    throw new ValidationError('uri must be a valid HTTP(S) URL');
+  }
+
+  if (body.hash !== undefined && (typeof body.hash !== 'string' || !HEX_64.test(body.hash))) {
+    throw new ValidationError('hash must be a 64-character hex string (SHA-256)');
+  }
+
+  if (
+    body.decryptionKey !== undefined &&
+    (typeof body.decryptionKey !== 'string' || !HEX_64.test(body.decryptionKey))
+  ) {
+    throw new ValidationError('decryptionKey must be a 64-character hex string');
+  }
+
+  // ── Step 2: Fetch credential from storage URI ──────────────────────
+  // NOTE: Production deployments should consider SSRF protection (e.g., blocking private IP
+  // ranges at the infrastructure/reverse-proxy level).
+  logger.info({ uri: body.uri }, 'Fetching credential from storage');
+
+  let fetchResponse: Response;
+  try {
+    fetchResponse = await fetch(body.uri, { signal: AbortSignal.timeout(10_000) });
+  } catch (e: unknown) {
+    const message =
+      e instanceof Error && e.name === 'TimeoutError'
+        ? 'Failed to fetch credential: request timed out'
+        : 'Failed to fetch credential: network error';
+    logger.warn({ uri: body.uri, error: message }, 'Credential fetch failed');
+    return NextResponse.json({ error: message, code: 'UPSTREAM_ERROR' }, { status: 502 });
+  }
+
+  if (!fetchResponse.ok) {
+    const message = `Failed to fetch credential: storage returned ${fetchResponse.status}`;
+    logger.warn({ uri: body.uri, status: fetchResponse.status }, 'Credential fetch failed');
+    return NextResponse.json({ error: message, code: 'UPSTREAM_ERROR' }, { status: 502 });
+  }
+
+  let responseText: string;
+  try {
+    responseText = await fetchResponse.text();
+  } catch {
+    return NextResponse.json({ error: 'Failed to read credential response', code: 'UPSTREAM_ERROR' }, { status: 502 });
+  }
+
+  const maxSize = getMaxCredentialSize();
+  if (responseText.length > maxSize) {
+    return NextResponse.json(
+      { error: `Credential response exceeds maximum size of ${maxSize} bytes`, code: 'UPSTREAM_ERROR' },
+      { status: 502 },
+    );
+  }
+
+  let fetchedData: unknown;
+  try {
+    fetchedData = JSON.parse(responseText);
+  } catch {
+    throw new UnprocessableError('Response from storage URI is not valid JSON');
+  }
+
+  // ── Step 3: Detect and handle encryption ───────────────────────────
+  const isEncrypted =
+    typeof fetchedData === 'object' &&
+    fetchedData !== null &&
+    'cipherText' in fetchedData &&
+    'iv' in fetchedData &&
+    'tag' in fetchedData &&
+    'type' in fetchedData;
+
+  let credential: Record<string, unknown>;
+
+  if (isEncrypted) {
+    if (!body.decryptionKey) {
+      logger.info('Encrypted credential but no decryption key provided');
+      return NextResponse.json(
+        { error: 'Credential is encrypted but no decryptionKey was provided', code: 'DECRYPTION_REQUIRED' },
+        { status: 422 },
+      );
+    }
+
+    logger.info('Decrypting credential');
+    const encrypted = fetchedData as { cipherText: string; iv: string; tag: string; type: string };
+    try {
+      const decryptedString = decryptCredential({
+        cipherText: encrypted.cipherText,
+        key: body.decryptionKey,
+        iv: encrypted.iv,
+        tag: encrypted.tag,
+        type: encrypted.type as any,
+      });
+      credential = JSON.parse(decryptedString);
+    } catch {
+      logger.warn('Credential decryption failed');
+      return NextResponse.json({ error: 'Failed to decrypt credential', code: 'DECRYPTION_FAILED' }, { status: 422 });
+    }
+  } else {
+    credential = fetchedData as Record<string, unknown>;
+  }
+
+  // ── Step 4: Hash verification ──────────────────────────────────────
+  if (body.hash) {
+    logger.info('Verifying credential hash');
+    const computed = computeHash(credential);
+    if (computed !== body.hash) {
+      logger.warn({ expected: body.hash, computed }, 'Hash mismatch');
+      return NextResponse.json(
+        { error: 'Credential hash does not match the expected hash', code: 'HASH_MISMATCH' },
+        { status: 422 },
+      );
+    }
+    logger.info('Hash verification passed');
+  }
+
+  // ── Step 5: Validate credential type ───────────────────────────────
+  if (credential.type !== 'EnvelopedVerifiableCredential') {
+    return NextResponse.json(
+      { error: 'Only EnvelopedVerifiableCredential is supported', code: 'UNSUPPORTED_CREDENTIAL_TYPE' },
+      { status: 422 },
+    );
+  }
+
+  // ── Step 6: Verify credential via VC service ───────────────────────
+  logger.info('Resolving system default VC service');
+  const { service: vcService } = await resolveVcService(SYSTEM_TENANT_ID);
+
+  logger.info('Verifying credential');
+  const result = await vcService.verify(credential as any);
+
+  // ── Step 7: Decode JWT from enveloped credential ───────────────────
+  let decodedCredential: Record<string, unknown> | undefined;
+  try {
+    const jwt = (credential.id as string).replace('data:application/vc+jwt,', '');
+    decodedCredential = decodeJwt(jwt) as unknown as Record<string, unknown>;
+  } catch {
+    logger.warn('Failed to decode JWT from enveloped credential');
+  }
+
+  // ── Step 8: Return result ──────────────────────────────────────────
+  if (result.verified) {
+    logger.info('Credential verification passed');
+    return NextResponse.json({
+      verified: true,
+      credential,
+      ...(decodedCredential && { decodedCredential }),
+    });
+  }
+
+  logger.info({ errorType: result.error?.type }, 'Credential verification failed');
+  return NextResponse.json({
+    verified: false,
+    error: result.error,
+    credential,
+    ...(decodedCredential && { decodedCredential }),
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -4,13 +4,14 @@ import { ValidationError } from '@/lib/api/validation';
 import { withPublicRoute } from '@/lib/api/with-public-route';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
-import { computeHash, decryptCredential, isEncryptedEnvelope } from '@uncefact/untp-ri-services';
-import type { EncryptionAlgorithm, EnvelopedVerifiableCredential } from '@uncefact/untp-ri-services';
+import { computeHash, decryptCredential, isEncryptedEnvelope, VcVerifyError } from '@uncefact/untp-ri-services';
+import type { EnvelopedVerifiableCredential, VerifyResult } from '@uncefact/untp-ri-services';
 import { decodeJwt } from 'jose';
 
 const logger = apiLogger.child({ route: '/api/v1/credentials/verify' });
 
 const HEX_64 = /^[a-f0-9]{64}$/i;
+const JWT_PREFIX = 'data:application/vc+jwt,';
 const DEFAULT_MAX_CREDENTIAL_SIZE = 10_485_760; // 10 MB
 
 function getMaxCredentialSize(): number {
@@ -110,7 +111,7 @@ function getMaxCredentialSize(): number {
  *                     - HASH_MISMATCH
  *                     - UNSUPPORTED_CREDENTIAL_TYPE
  *       502:
- *         description: Upstream storage error
+ *         description: Upstream service error
  *         content:
  *           application/json:
  *             schema:
@@ -120,7 +121,7 @@ function getMaxCredentialSize(): number {
  *                   type: string
  *                 code:
  *                   type: string
- *                   enum: [UPSTREAM_ERROR]
+ *                   enum: [UPSTREAM_ERROR, VC_SERVICE_ERROR]
  *       500:
  *         description: Server error (e.g. system VC service not configured)
  *         content:
@@ -220,11 +221,10 @@ export const POST = withPublicRoute(async (req) => {
 
   // ── Step 3: Detect and handle encryption ───────────────────────────
   logger.info('Detecting credential encryption');
-  const isEncrypted = isEncryptedEnvelope(fetchedData);
 
   let credential: Record<string, unknown>;
 
-  if (isEncrypted) {
+  if (isEncryptedEnvelope(fetchedData)) {
     if (!body.decryptionKey) {
       logger.info('Encrypted credential but no decryption key provided');
       return NextResponse.json(
@@ -234,14 +234,13 @@ export const POST = withPublicRoute(async (req) => {
     }
 
     logger.info('Decrypting credential');
-    const encrypted = fetchedData as { cipherText: string; iv: string; tag: string; type: string };
     try {
       const decryptedString = decryptCredential({
-        cipherText: encrypted.cipherText,
+        cipherText: fetchedData.cipherText,
         key: body.decryptionKey,
-        iv: encrypted.iv,
-        tag: encrypted.tag,
-        type: encrypted.type as EncryptionAlgorithm,
+        iv: fetchedData.iv,
+        tag: fetchedData.tag,
+        type: fetchedData.type,
       });
       credential = JSON.parse(decryptedString);
     } catch (e: unknown) {
@@ -282,7 +281,19 @@ export const POST = withPublicRoute(async (req) => {
   const { service: vcService } = await resolveVcService(SYSTEM_TENANT_ID);
 
   logger.info('Verifying credential');
-  const result = await vcService.verify(credential as unknown as EnvelopedVerifiableCredential);
+  let result: VerifyResult;
+  try {
+    result = await vcService.verify(credential as unknown as EnvelopedVerifiableCredential);
+  } catch (e: unknown) {
+    if (e instanceof VcVerifyError) {
+      logger.error({ err: e }, 'VC service verification failed');
+      return NextResponse.json(
+        { error: 'Credential verification service failed', code: 'VC_SERVICE_ERROR' },
+        { status: 502 },
+      );
+    }
+    throw e;
+  }
 
   // ── Step 7: Decode JWT from enveloped credential ───────────────────
   const warnings: string[] = [];
@@ -293,12 +304,12 @@ export const POST = withPublicRoute(async (req) => {
   if (typeof credentialId !== 'string') {
     logger.warn({ credentialIdType: typeof credentialId }, 'Credential id is not a string');
     warnings.push('Credential id is not a string; unable to decode JWT');
-  } else if (!credentialId.startsWith('data:application/vc+jwt,')) {
+  } else if (!credentialId.startsWith(JWT_PREFIX)) {
     logger.warn('Credential id does not use the expected data:application/vc+jwt media type');
     warnings.push('Credential id does not use the expected data:application/vc+jwt media type');
   } else {
     try {
-      const jwt = credentialId.replace('data:application/vc+jwt,', '');
+      const jwt = credentialId.substring(JWT_PREFIX.length);
       decodedCredential = decodeJwt(jwt) as unknown as Record<string, unknown>;
     } catch (e: unknown) {
       logger.warn({ err: e }, 'Failed to decode JWT from enveloped credential');

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -4,7 +4,7 @@ import { ValidationError } from '@/lib/api/validation';
 import { withPublicRoute } from '@/lib/api/with-public-route';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
-import { computeHash, decryptCredential } from '@uncefact/untp-ri-services';
+import { computeHash, decryptCredential, isEncryptedEnvelope } from '@uncefact/untp-ri-services';
 import type { EncryptionAlgorithm, EnvelopedVerifiableCredential } from '@uncefact/untp-ri-services';
 import { decodeJwt } from 'jose';
 
@@ -72,6 +72,11 @@ function getMaxCredentialSize(): number {
  *                 decodedCredential:
  *                   type: object
  *                   description: Decoded JWT payload (omitted if decoding fails)
+ *                 warnings:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   description: Non-fatal issues (e.g. JWT decode failure)
  *                 error:
  *                   type: object
  *                   description: Present only when verified is false
@@ -129,12 +134,15 @@ export const POST = withPublicRoute(async (req) => {
   // is fragile across serverless instances.
 
   // ── Step 1: Parse and validate input ────────────────────────────────
+  logger.info('Parsing request body');
   let body: { uri?: string; hash?: string; decryptionKey?: string };
   try {
     body = await req.json();
   } catch {
     throw new ValidationError('Invalid JSON body');
   }
+
+  logger.info({ uri: body.uri }, 'Validating input parameters');
 
   if (!body.uri || typeof body.uri !== 'string') {
     throw new ValidationError('uri is required');
@@ -163,8 +171,6 @@ export const POST = withPublicRoute(async (req) => {
   }
 
   // ── Step 2: Fetch credential from storage URI ──────────────────────
-  // NOTE: Production deployments should consider SSRF protection (e.g., blocking private IP
-  // ranges at the infrastructure/reverse-proxy level).
   logger.info({ uri: body.uri }, 'Fetching credential from storage');
 
   let fetchResponse: Response;
@@ -204,7 +210,7 @@ export const POST = withPublicRoute(async (req) => {
   let fetchedData: unknown;
   try {
     fetchedData = JSON.parse(responseText);
-  } catch (e: unknown) {
+  } catch {
     logger.warn({ uri: body.uri }, 'Storage URI returned non-JSON response');
     return NextResponse.json(
       { error: 'Response from storage URI is not valid JSON', code: 'INVALID_RESPONSE' },
@@ -213,13 +219,8 @@ export const POST = withPublicRoute(async (req) => {
   }
 
   // ── Step 3: Detect and handle encryption ───────────────────────────
-  const isEncrypted =
-    typeof fetchedData === 'object' &&
-    fetchedData !== null &&
-    'cipherText' in fetchedData &&
-    'iv' in fetchedData &&
-    'tag' in fetchedData &&
-    'type' in fetchedData;
+  logger.info('Detecting credential encryption');
+  const isEncrypted = isEncryptedEnvelope(fetchedData);
 
   let credential: Record<string, unknown>;
 
@@ -266,6 +267,7 @@ export const POST = withPublicRoute(async (req) => {
   }
 
   // ── Step 5: Validate credential type ───────────────────────────────
+  logger.info({ credentialType: credential.type }, 'Validating credential type');
   const types = Array.isArray(credential.type) ? credential.type : [credential.type];
   if (!types.includes('EnvelopedVerifiableCredential')) {
     logger.warn({ uri: body.uri, credentialType: credential.type }, 'Unsupported credential type');
@@ -283,29 +285,40 @@ export const POST = withPublicRoute(async (req) => {
   const result = await vcService.verify(credential as unknown as EnvelopedVerifiableCredential);
 
   // ── Step 7: Decode JWT from enveloped credential ───────────────────
+  const warnings: string[] = [];
   let decodedCredential: Record<string, unknown> | undefined;
-  try {
-    const jwt = (credential.id as string).replace('data:application/vc+jwt,', '');
-    decodedCredential = decodeJwt(jwt) as unknown as Record<string, unknown>;
-  } catch (e: unknown) {
-    logger.warn({ err: e }, 'Failed to decode JWT from enveloped credential');
+
+  logger.info('Decoding JWT from enveloped credential');
+  const credentialId = credential.id;
+  if (typeof credentialId !== 'string') {
+    logger.warn({ credentialIdType: typeof credentialId }, 'Credential id is not a string');
+    warnings.push('Credential id is not a string; unable to decode JWT');
+  } else if (!credentialId.startsWith('data:application/vc+jwt,')) {
+    logger.warn('Credential id does not use the expected data:application/vc+jwt media type');
+    warnings.push('Credential id does not use the expected data:application/vc+jwt media type');
+  } else {
+    try {
+      const jwt = credentialId.replace('data:application/vc+jwt,', '');
+      decodedCredential = decodeJwt(jwt) as unknown as Record<string, unknown>;
+    } catch (e: unknown) {
+      logger.warn({ err: e }, 'Failed to decode JWT from enveloped credential');
+      warnings.push('Failed to decode JWT from enveloped credential');
+    }
   }
 
   // ── Step 8: Return result ──────────────────────────────────────────
-  if (result.verified) {
-    logger.info('Credential verification passed');
-    return NextResponse.json({
-      verified: true,
-      credential,
-      ...(decodedCredential && { decodedCredential }),
-    });
-  }
+  logger.info({ verified: result.verified }, 'Credential verification complete');
 
-  logger.info({ errorType: result.error?.type }, 'Credential verification failed');
-  return NextResponse.json({
-    verified: false,
-    error: result.error,
+  const responseBody: Record<string, unknown> = {
+    verified: result.verified,
     credential,
     ...(decodedCredential && { decodedCredential }),
-  });
+    ...(warnings.length > 0 && { warnings }),
+  };
+
+  if (!result.verified) {
+    responseBody.error = result.error;
+  }
+
+  return NextResponse.json(responseBody, { status: 200 });
 });

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { apiLogger } from '@/lib/api/logger';
 import { ValidationError } from '@/lib/api/validation';
-import { UnprocessableError } from '@/lib/api/errors';
 import { withPublicRoute } from '@/lib/api/with-public-route';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
@@ -204,7 +203,10 @@ export const POST = withPublicRoute(async (req) => {
   try {
     fetchedData = JSON.parse(responseText);
   } catch {
-    throw new UnprocessableError('Response from storage URI is not valid JSON');
+    return NextResponse.json(
+      { error: 'Response from storage URI is not valid JSON', code: 'INVALID_RESPONSE' },
+      { status: 422 },
+    );
   }
 
   // ── Step 3: Detect and handle encryption ───────────────────────────

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -264,7 +264,8 @@ export const POST = withPublicRoute(async (req) => {
   }
 
   // ── Step 5: Validate credential type ───────────────────────────────
-  if (credential.type !== 'EnvelopedVerifiableCredential') {
+  const types = Array.isArray(credential.type) ? credential.type : [credential.type];
+  if (!types.includes('EnvelopedVerifiableCredential')) {
     return NextResponse.json(
       { error: 'Only EnvelopedVerifiableCredential is supported', code: 'UNSUPPORTED_CREDENTIAL_TYPE' },
       { status: 422 },

--- a/packages/reference-implementation/src/lib/api/with-public-route.test.ts
+++ b/packages/reference-implementation/src/lib/api/with-public-route.test.ts
@@ -1,0 +1,199 @@
+// Polyfill crypto.randomUUID for the test environment
+if (!globalThis.crypto?.randomUUID) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { randomUUID } = require('crypto');
+  Object.defineProperty(globalThis, 'crypto', {
+    value: { ...globalThis.crypto, randomUUID },
+  });
+}
+
+const mockRunWithRequestContext = jest.fn((_correlationId: string, callback: () => unknown) => callback());
+
+const mockLogger: Record<string, jest.Mock> = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
+
+jest.mock('@uncefact/untp-ri-services/logging', () => ({
+  runWithRequestContext: (correlationId: string, callback: () => unknown) =>
+    mockRunWithRequestContext(correlationId, callback),
+  createLogger: () => mockLogger,
+}));
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+const mockHandleRouteError = jest.fn();
+jest.mock('@/lib/api/handle-route-error', () => ({
+  handleRouteError: (e: unknown) => mockHandleRouteError(e),
+}));
+
+import { withPublicRoute } from './with-public-route';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRunWithRequestContext.mockImplementation((_correlationId: string, callback: () => unknown) => callback());
+});
+
+function fakeRequest(method = 'GET', headers: Record<string, string> = {}): Request {
+  const headersMap = new Map(Object.entries(headers));
+  return {
+    method,
+    url: 'http://localhost/api/v1/credentials/verify',
+    headers: {
+      get: (key: string) => headersMap.get(key) ?? null,
+    },
+  } as unknown as Request;
+}
+
+describe('withPublicRoute', () => {
+  it('calls handler and returns its response', async () => {
+    const handlerResponse = { status: 200, json: async () => ({ valid: true }) };
+    const handler = jest.fn().mockResolvedValue(handlerResponse);
+    const wrapped = withPublicRoute(handler);
+
+    const req = fakeRequest('POST');
+    const res = await wrapped(req);
+
+    expect(handler).toHaveBeenCalledWith(req);
+    expect(res).toBe(handlerResponse);
+  });
+
+  it('extracts correlation ID from x-correlation-id header', async () => {
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withPublicRoute(handler);
+
+    await wrapped(fakeRequest('POST', { 'x-correlation-id': 'my-corr-id' }));
+
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith('my-corr-id', expect.any(Function));
+  });
+
+  it('generates UUID when no correlation ID header is present', async () => {
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withPublicRoute(handler);
+
+    await wrapped(fakeRequest());
+
+    expect(mockRunWithRequestContext).toHaveBeenCalledTimes(1);
+    const correlationId = mockRunWithRequestContext.mock.calls[0][0];
+    expect(correlationId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('ignores correlation IDs longer than 128 characters', async () => {
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withPublicRoute(handler);
+
+    const oversizedId = 'x'.repeat(200);
+    await wrapped(fakeRequest('GET', { 'x-correlation-id': oversizedId }));
+
+    const correlationId = mockRunWithRequestContext.mock.calls[0][0];
+    expect(correlationId).not.toBe(oversizedId);
+    expect(correlationId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('accepts correlation ID of exactly 128 characters', async () => {
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withPublicRoute(handler);
+
+    const exactId = 'a'.repeat(128);
+    await wrapped(fakeRequest('GET', { 'x-correlation-id': exactId }));
+
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith(exactId, expect.any(Function));
+  });
+
+  it('calls runWithRequestContext with the correlation ID', async () => {
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withPublicRoute(handler);
+
+    await wrapped(fakeRequest('POST', { 'x-correlation-id': 'test-123' }));
+
+    expect(mockRunWithRequestContext).toHaveBeenCalledTimes(1);
+    expect(mockRunWithRequestContext).toHaveBeenCalledWith('test-123', expect.any(Function));
+  });
+
+  it('logs request received and request completed on success', async () => {
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withPublicRoute(handler);
+
+    await wrapped(fakeRequest('POST'));
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { method: 'POST', path: '/api/v1/credentials/verify' },
+      'Request received',
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        path: '/api/v1/credentials/verify',
+        status: 200,
+        durationMs: expect.any(Number),
+      }),
+      'Request completed',
+    );
+  });
+
+  it('catches handler errors and delegates to handleRouteError', async () => {
+    const error = new Error('boom');
+    const errorResponse = { status: 500, json: async () => ({ error: 'boom' }) };
+    mockHandleRouteError.mockReturnValue(errorResponse);
+
+    const handler = jest.fn().mockRejectedValue(error);
+    const wrapped = withPublicRoute(handler);
+
+    const res = await wrapped(fakeRequest('POST'));
+
+    expect(mockHandleRouteError).toHaveBeenCalledWith(error);
+    expect(res).toBe(errorResponse);
+  });
+
+  it('logs 4xx errors at warn level', async () => {
+    const errorResponse = { status: 400, json: async () => ({ error: 'bad input' }) };
+    mockHandleRouteError.mockReturnValue(errorResponse);
+
+    const handler = jest.fn().mockRejectedValue(new Error('bad input'));
+    const wrapped = withPublicRoute(handler);
+
+    await wrapped(fakeRequest('POST'));
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        path: '/api/v1/credentials/verify',
+        status: 400,
+        durationMs: expect.any(Number),
+      }),
+      'Request completed with error',
+    );
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs 5xx errors at error level', async () => {
+    const errorResponse = { status: 500, json: async () => ({ error: 'internal' }) };
+    mockHandleRouteError.mockReturnValue(errorResponse);
+
+    const handler = jest.fn().mockRejectedValue(new Error('internal'));
+    const wrapped = withPublicRoute(handler);
+
+    await wrapped(fakeRequest('POST'));
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        path: '/api/v1/credentials/verify',
+        status: 500,
+        durationMs: expect.any(Number),
+      }),
+      'Request completed with error',
+    );
+  });
+});

--- a/packages/reference-implementation/src/lib/api/with-public-route.ts
+++ b/packages/reference-implementation/src/lib/api/with-public-route.ts
@@ -27,7 +27,7 @@ export function withPublicRoute(handler: PublicRouteHandler) {
         const errorResponse = handleRouteError(e);
         const logLevel = errorResponse.status >= 500 ? 'error' : 'warn';
         logger[logLevel](
-          { method, path, status: errorResponse.status, durationMs: Date.now() - start },
+          { method, path, status: errorResponse.status, durationMs: Date.now() - start, err: e },
           'Request completed with error',
         );
         return errorResponse;

--- a/packages/reference-implementation/src/lib/api/with-public-route.ts
+++ b/packages/reference-implementation/src/lib/api/with-public-route.ts
@@ -1,0 +1,37 @@
+import { handleRouteError } from '@/lib/api/handle-route-error';
+import { apiLogger } from '@/lib/api/logger';
+import { runWithRequestContext } from '@uncefact/untp-ri-services/logging';
+
+type PublicRouteHandler = (req: Request) => Promise<Response>;
+
+const logger = apiLogger.child({ handler: 'public-route' });
+
+export function withPublicRoute(handler: PublicRouteHandler) {
+  return async (req: Request) => {
+    const raw = req.headers.get('x-correlation-id');
+    const correlationId = raw && raw.length <= 128 ? raw : crypto.randomUUID();
+
+    return runWithRequestContext(correlationId, async () => {
+      const method = req.method;
+      const url = new URL(req.url);
+      const path = url.pathname;
+      const start = Date.now();
+
+      logger.info({ method, path }, 'Request received');
+
+      try {
+        const response = await handler(req);
+        logger.info({ method, path, status: response.status, durationMs: Date.now() - start }, 'Request completed');
+        return response;
+      } catch (e: unknown) {
+        const errorResponse = handleRouteError(e);
+        const logLevel = errorResponse.status >= 500 ? 'error' : 'warn';
+        logger[logLevel](
+          { method, path, status: errorResponse.status, durationMs: Date.now() - start },
+          'Request completed with error',
+        );
+        return errorResponse;
+      }
+    });
+  };
+}

--- a/packages/reference-implementation/src/middleware.test.ts
+++ b/packages/reference-implementation/src/middleware.test.ts
@@ -1,0 +1,207 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Polyfill crypto.randomUUID for jsdom (not available by default)
+if (!globalThis.crypto?.randomUUID) {
+  Object.defineProperty(globalThis.crypto, 'randomUUID', {
+    value: () => '00000000-0000-0000-0000-000000000000',
+  });
+}
+
+// --- Mocks (must be declared before imports) ---
+
+const mockValidateServiceAccountToken = jest.fn();
+const mockExtractBearerToken = jest.fn();
+
+jest.mock('@/lib/auth/token-validator', () => ({
+  validateServiceAccountToken: (...args: unknown[]) => mockValidateServiceAccountToken(...args),
+  extractBearerToken: (...args: unknown[]) => mockExtractBearerToken(...args),
+}));
+
+jest.mock('@uncefact/untp-ri-services/logging', () => ({
+  runWithRequestContext: (_id: string, fn: () => unknown) => fn(),
+}));
+
+jest.mock('@/lib/auth/auth.config', () => ({
+  authConfig: {},
+}));
+
+// Mock NextAuth — the middleware calls `auth(handler)` which returns a
+// function.  We make `auth` simply return the handler itself so we can
+// invoke it directly with a fake request.
+jest.mock('next-auth', () => {
+  return {
+    __esModule: true,
+    default: () => ({
+      auth: (handler: (...args: any[]) => any) => handler,
+    }),
+  };
+});
+
+// Provide a minimal NextResponse mock that behaves like the real one.
+const mockNextResponseNext = jest.fn();
+const mockNextResponseJson = jest.fn();
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    next: (...args: unknown[]) => mockNextResponseNext(...args),
+    json: (...args: unknown[]) => mockNextResponseJson(...args),
+  },
+}));
+
+// --- Imports (after mocks) ---
+import middleware from './middleware';
+
+// --- Helpers ---
+
+/** Build a fake NextRequest-like object. */
+function fakeRequest(
+  pathname: string,
+  options?: {
+    headers?: Record<string, string>;
+    auth?: { user?: Record<string, string> } | null;
+  },
+): any {
+  const headers = new Headers(options?.headers ?? {});
+  return {
+    headers,
+    nextUrl: { pathname },
+    auth: options?.auth ?? null,
+  };
+}
+
+/** Fake NextResponse returned by NextResponse.next(). */
+function fakeNextResponse() {
+  const responseHeaders = new Headers();
+  return {
+    headers: responseHeaders,
+    request: {},
+  };
+}
+
+// --- Tests ---
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockNextResponseNext.mockImplementation(() => fakeNextResponse());
+
+  mockNextResponseJson.mockImplementation((body: unknown, init?: any) => ({
+    status: init?.status ?? 200,
+    headers: new Headers(init?.headers ?? {}),
+    json: async () => body,
+  }));
+
+  mockExtractBearerToken.mockReturnValue(null);
+  mockValidateServiceAccountToken.mockResolvedValue({ valid: false });
+});
+
+describe('middleware', () => {
+  describe('public API routes', () => {
+    it('bypasses auth and returns NextResponse.next() for /api/v1/credentials/verify', async () => {
+      const req = fakeRequest('/api/v1/credentials/verify');
+      await (middleware as any)(req);
+
+      expect(mockNextResponseNext).toHaveBeenCalledTimes(1);
+      // Should NOT attempt bearer token validation
+      expect(mockValidateServiceAccountToken).not.toHaveBeenCalled();
+    });
+
+    it('sets x-correlation-id header on the response', async () => {
+      const correlationId = 'test-correlation-id';
+      const req = fakeRequest('/api/v1/credentials/verify', {
+        headers: { 'x-correlation-id': correlationId },
+      });
+
+      const response = fakeNextResponse();
+      mockNextResponseNext.mockReturnValueOnce(response);
+
+      await (middleware as any)(req);
+
+      expect(response.headers.get('x-correlation-id')).toBe(correlationId);
+    });
+
+    it('strips x-auth-* headers from the request', async () => {
+      const req = fakeRequest('/api/v1/credentials/verify', {
+        headers: {
+          'x-auth-sub': 'spoofed-sub',
+          'x-auth-azp': 'spoofed-azp',
+          'content-type': 'application/json',
+        },
+      });
+
+      let capturedHeaders: Headers | undefined;
+      mockNextResponseNext.mockImplementationOnce((opts?: any) => {
+        capturedHeaders = opts?.request?.headers;
+        return fakeNextResponse();
+      });
+
+      await (middleware as any)(req);
+
+      expect(capturedHeaders).toBeDefined();
+      expect(capturedHeaders!.has('x-auth-sub')).toBe(false);
+      expect(capturedHeaders!.has('x-auth-azp')).toBe(false);
+      expect(capturedHeaders!.get('content-type')).toBe('application/json');
+    });
+
+    it('does not require session auth for public routes', async () => {
+      // No session (auth = null), no bearer token — should still succeed
+      const req = fakeRequest('/api/v1/credentials/verify', { auth: null });
+
+      await (middleware as any)(req);
+
+      expect(mockNextResponseNext).toHaveBeenCalledTimes(1);
+      expect(mockNextResponseJson).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-public API routes', () => {
+    it('returns 401 for unauthenticated requests', async () => {
+      const req = fakeRequest('/api/v1/dids');
+
+      await (middleware as any)(req);
+
+      expect(mockNextResponseJson).toHaveBeenCalledWith(
+        { error: 'Unauthorized', message: 'Authentication required' },
+        expect.objectContaining({ status: 401 }),
+      );
+    });
+
+    it('allows session-authenticated requests through', async () => {
+      const req = fakeRequest('/api/v1/dids', {
+        auth: { user: { id: 'user-1' } },
+      });
+
+      await (middleware as any)(req);
+
+      expect(mockNextResponseNext).toHaveBeenCalledTimes(1);
+      expect(mockNextResponseJson).not.toHaveBeenCalled();
+    });
+
+    it('allows valid bearer token requests through', async () => {
+      const req = fakeRequest('/api/v1/dids', {
+        headers: { authorization: 'Bearer valid-token' },
+      });
+
+      mockExtractBearerToken.mockReturnValueOnce('valid-token');
+      mockValidateServiceAccountToken.mockResolvedValueOnce({
+        valid: true,
+        payload: { sub: 'service-account-1', azp: 'client-id' },
+      });
+
+      await (middleware as any)(req);
+
+      expect(mockNextResponseNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('non-API routes', () => {
+    it('passes through without auth checks', async () => {
+      const req = fakeRequest('/dashboard');
+
+      await (middleware as any)(req);
+
+      expect(mockNextResponseNext).toHaveBeenCalledTimes(1);
+      expect(mockValidateServiceAccountToken).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/reference-implementation/src/middleware.ts
+++ b/packages/reference-implementation/src/middleware.ts
@@ -25,6 +25,9 @@ import type { JWTPayload } from 'jose';
 
 const { auth } = NextAuth(authConfig);
 
+/** Routes under /api/v1/ that do not require authentication. */
+const PUBLIC_API_ROUTES = new Set(['/api/v1/credentials/verify']);
+
 /**
  * Strips all x-auth-* headers from the incoming request to prevent spoofing.
  */
@@ -63,6 +66,14 @@ export default auth(async (req) => {
 
     // For API routes, check authentication
     if (pathname.startsWith('/api/v1/')) {
+      // Allow public API routes through without authentication
+      if (PUBLIC_API_ROUTES.has(pathname)) {
+        const requestHeaders = stripAuthHeaders(req.headers);
+        const response = NextResponse.next({ request: { headers: requestHeaders } });
+        response.headers.set('x-correlation-id', correlationId);
+        return response;
+      }
+
       // Strip x-auth-* headers from incoming request to prevent spoofing
       const requestHeaders = stripAuthHeaders(req.headers);
 

--- a/packages/services/src/encryption/index.ts
+++ b/packages/services/src/encryption/index.ts
@@ -8,3 +8,4 @@ export type { EncryptedEnvelope, IEncryptionService } from './encryption.interfa
 export { computeHash, HashAlgorithm } from './compute-hash.js';
 export { decryptCredential } from './decrypt-credential.js';
 export type { DecryptionParams } from './decrypt-credential.js';
+export { isEncryptedEnvelope } from './is-encrypted-envelope.js';

--- a/packages/services/src/encryption/is-encrypted-envelope.test.ts
+++ b/packages/services/src/encryption/is-encrypted-envelope.test.ts
@@ -1,0 +1,23 @@
+import { isEncryptedEnvelope } from './is-encrypted-envelope.js';
+
+describe('isEncryptedEnvelope', () => {
+  it('returns true for an object with all required fields', () => {
+    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isEncryptedEnvelope(null)).toBe(false);
+  });
+
+  it('returns false for a string', () => {
+    expect(isEncryptedEnvelope('hello')).toBe(false);
+  });
+
+  it('returns false when cipherText is missing', () => {
+    expect(isEncryptedEnvelope({ iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(false);
+  });
+
+  it('returns false for an empty object', () => {
+    expect(isEncryptedEnvelope({})).toBe(false);
+  });
+});

--- a/packages/services/src/encryption/is-encrypted-envelope.ts
+++ b/packages/services/src/encryption/is-encrypted-envelope.ts
@@ -1,0 +1,11 @@
+import type { EncryptedEnvelope } from './encryption.interface.js';
+
+/**
+ * Checks whether the given value looks like an encrypted envelope
+ * (has cipherText, iv, tag, and type fields).
+ */
+export function isEncryptedEnvelope(data: unknown): data is EncryptedEnvelope {
+  return (
+    typeof data === 'object' && data !== null && 'cipherText' in data && 'iv' in data && 'tag' in data && 'type' in data
+  );
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -42,6 +42,7 @@ export type { EncryptedEnvelope, IEncryptionService } from './encryption/encrypt
 export { computeHash, HashAlgorithm } from './encryption/compute-hash.js';
 export { decryptCredential } from './encryption/decrypt-credential.js';
 export type { DecryptionParams } from './encryption/decrypt-credential.js';
+export { isEncryptedEnvelope } from './encryption/is-encrypted-envelope.js';
 export type { IKeyGenerator, IKeyStore } from './key-provider/key-provider.interface.js';
 export { LocalKeyGenerator } from './key-provider/adapters/local/local.adapter.js';
 

--- a/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.test.ts
+++ b/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.test.ts
@@ -258,9 +258,9 @@ describe('VCKitVerifiableCredentialService', () => {
 
       expect(result).toEqual({ verified: true });
 
-      // Verify the correct request was made
+      // Verify the correct request was made (agent endpoint, not v2 API)
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://vckit.example.com/credentials/verify',
+        'https://vckit.example.com/agent/routeVerificationCredential',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({

--- a/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.ts
+++ b/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.ts
@@ -94,7 +94,8 @@ export class VCKitVerifiableCredentialService extends BaseServiceAdapter impleme
     };
 
     this.logger.debug('Verifying credential');
-    const response = await fetch(`${this.baseURL}/credentials/verify`, {
+    const host = new URL(this.baseURL).origin;
+    const response = await fetch(`${host}/agent/routeVerificationCredential`, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify(verifyParams),


### PR DESCRIPTION
This PR adds an unauthenticated credential verification API route that fetches a verifiable credential from a storage URI, optionally decrypts it, checks its integrity hash, and verifies the credential signature via the system VC service. This extracts server-side verification logic from the client-side verify page, preparing for a follow-up PR that refactors the page to consume this API.

## Changes

- **`withPublicRoute` wrapper** (`src/lib/api/with-public-route.ts`): lightweight route wrapper mirroring `withTenantAuth` without auth; provides correlation IDs, request context, duration logging, and error handling
- **Middleware update** (`src/middleware.ts`): `PUBLIC_API_ROUTES` allowlist so the verify endpoint bypasses auth while still receiving correlation IDs and header stripping
- **Route handler** (`src/app/api/v1/credentials/verify/route.ts`): 8-step pipeline with step-level logging, encryption detection via `isEncryptedEnvelope`, hash verification, credential type validation (array and string), VC service verification, JWT decoding with shape validation, and a `warnings` array for non-fatal issues
- **`isEncryptedEnvelope` utility** (`packages/services/src/encryption/is-encrypted-envelope.ts`): reusable encrypted envelope detection extracted to the services package
- **E2E tests** (`e2e/cypress/e2e/credential_api/credential-verify.cy.ts`): full integration tests covering happy paths (encrypted and unencrypted), validation errors, processing errors, and unauthenticated access

## Test plan
- [x] 30 route handler unit tests (input validation, upstream errors, credential processing, verification outcomes, edge cases, warnings)
- [x] 10 withPublicRoute wrapper tests
- [x] 8 middleware tests (public route bypass, auth enforcement, header stripping)
- [x] 5 isEncryptedEnvelope utility tests
- [x] E2E tests: verify unencrypted credential, verify encrypted credential, unauthenticated access, validation errors (missing uri, invalid format, bad scheme, bad hash), processing errors (missing key, hash mismatch, unreachable URI)
- [x] Lint clean on all new files