### PR TITLE
fix(api): correct DID default handling, self-managed alias, and verification error shape

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -118,7 +118,7 @@ describe('POST /api/v1/dids/:id/verify', () => {
     const verification = {
       verified: false,
       checks: [{ name: 'resolve', passed: false }],
-      errors: [{ check: 'resolve', message: 'Resolution failed' }],
+      errors: [{ name: 'resolve', message: 'Resolution failed' }],
     };
     mockDidService.verify.mockResolvedValue(verification);
     mockUpdateDidStatus.mockResolvedValue({ id: 'did-1', status: 'VERIFICATION_FAILED' });

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -150,6 +150,31 @@ describe('POST /api/v1/dids', () => {
     );
   });
 
+  it('passes isDefault to createDid when provided', async () => {
+    mockDidService.create.mockResolvedValue({
+      did: 'did:web:example.com:org:789',
+      keyId: 'key-3',
+      document: { '@context': 'https://www.w3.org/ns/did/v1', id: 'did:web:example.com:org:789' },
+    });
+    mockCreateDid.mockResolvedValue({
+      id: 'record-3',
+      did: 'did:web:example.com:org:789',
+      type: DidType.MANAGED,
+      status: DidStatus.ACTIVE,
+      isDefault: true,
+    });
+
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'default-did', isDefault: true },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(mockCreateDid).toHaveBeenCalledWith(expect.objectContaining({ isDefault: true }));
+    expect(json.isDefault).toBe(true);
+  });
+
   it('returns 400 for invalid type', async () => {
     const req = createFakeRequest({
       body: { type: 'INVALID', method: DidMethod.DID_WEB },

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -46,6 +46,9 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *               description:
  *                 type: string
  *                 description: Description of the DID's purpose
+ *               isDefault:
+ *                 type: boolean
+ *                 description: Whether this DID should be the tenant's default
  *               serviceInstanceId:
  *                 type: string
  *                 description: Optional service instance ID to use for DID creation
@@ -88,6 +91,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     alias?: string;
     name?: string;
     description?: string;
+    isDefault?: boolean;
     serviceInstanceId?: string;
   };
 
@@ -147,6 +151,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     keyId: providerResult.keyId,
     name: body.name ?? providerResult.did,
     description: body.description,
+    isDefault: body.isDefault,
     status,
     serviceInstanceId,
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -14,6 +14,7 @@ import type { DidStatus } from '../generated';
 const mockTx = {
   did: {
     findFirst: jest.fn(),
+    create: jest.fn(),
     update: jest.fn(),
     updateMany: jest.fn(),
     delete: jest.fn(),
@@ -144,6 +145,36 @@ describe('did.repository', () => {
       });
     });
 
+    it('clears existing tenant defaults when isDefault is true', async () => {
+      const createdRecord = { ...DID_RECORD, isDefault: true };
+      mockTx.did.updateMany.mockResolvedValue({ count: 1 });
+      mockTx.did.create.mockResolvedValue(createdRecord);
+
+      const result = await createDid({
+        tenantId: ORG_ID,
+        did: 'did:web:example.com:org:123',
+        type: 'MANAGED',
+        keyId: 'key-1',
+        isDefault: true,
+      });
+
+      expect(mockTx.did.updateMany).toHaveBeenCalledWith({
+        where: {
+          tenantId: ORG_ID,
+          isDefault: true,
+          type: { not: 'DEFAULT' },
+        },
+        data: { isDefault: false },
+      });
+      expect(mockTx.did.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          tenantId: ORG_ID,
+          isDefault: true,
+        }),
+      });
+      expect(result).toEqual(createdRecord);
+    });
+
     it('passes undefined serviceInstanceId when not provided', async () => {
       mockDid.create.mockResolvedValue(DID_RECORD);
 
@@ -183,6 +214,29 @@ describe('did.repository', () => {
       const result = await getDidById('did-record-1', 'other-org');
       expect(result).toBeNull();
     });
+
+    it('returns system DEFAULT DID with isDefault false when tenant has own default', async () => {
+      const systemDid = { ...DID_RECORD, id: 'sys-did', type: 'DEFAULT', isDefault: true, tenantId: 'system' };
+      const tenantDid = { ...DID_RECORD, id: 'tenant-did', isDefault: true };
+
+      // First call returns the system DID, second call finds tenant default
+      mockDid.findFirst.mockResolvedValueOnce(systemDid).mockResolvedValueOnce(tenantDid);
+
+      const result = await getDidById('sys-did', ORG_ID);
+
+      expect(result).toEqual({ ...systemDid, isDefault: false });
+    });
+
+    it('returns system DEFAULT DID with isDefault true when tenant has no default', async () => {
+      const systemDid = { ...DID_RECORD, id: 'sys-did', type: 'DEFAULT', isDefault: true, tenantId: 'system' };
+
+      // First call returns the system DID, second call finds no tenant default
+      mockDid.findFirst.mockResolvedValueOnce(systemDid).mockResolvedValueOnce(null);
+
+      const result = await getDidById('sys-did', ORG_ID);
+
+      expect(result).toEqual(systemDid);
+    });
   });
 
   describe('getDidByDid', () => {
@@ -220,6 +274,17 @@ describe('did.repository', () => {
 
       const result = await getDidByDid('did:web:nonexistent', ORG_ID);
       expect(result).toBeNull();
+    });
+
+    it('returns system DEFAULT DID with isDefault false when tenant has own default', async () => {
+      const systemDid = { ...DID_RECORD, type: 'DEFAULT', isDefault: true, tenantId: 'system' };
+      const tenantDid = { ...DID_RECORD, id: 'tenant-did', isDefault: true };
+
+      mockDid.findFirst.mockResolvedValueOnce(systemDid).mockResolvedValueOnce(tenantDid);
+
+      const result = await getDidByDid('did:web:example.com:org:123', ORG_ID);
+
+      expect(result).toEqual({ ...systemDid, isDefault: false });
     });
   });
 
@@ -291,6 +356,31 @@ describe('did.repository', () => {
           skip: 20,
         }),
       );
+    });
+
+    it('returns system DEFAULT DID with isDefault false when tenant has own default', async () => {
+      const systemDid = { ...DID_RECORD, id: 'sys-did', type: 'DEFAULT', isDefault: true, tenantId: 'system' };
+      const tenantDid = { ...DID_RECORD, id: 'tenant-did', type: 'MANAGED', isDefault: true };
+
+      mockDid.findMany.mockResolvedValue([systemDid, tenantDid]);
+      mockDid.count.mockResolvedValue(2);
+
+      const result = await listDids(ORG_ID);
+
+      expect(result.data[0]).toEqual(expect.objectContaining({ id: 'sys-did', isDefault: false }));
+      expect(result.data[1]).toEqual(expect.objectContaining({ id: 'tenant-did', isDefault: true }));
+    });
+
+    it('keeps system DEFAULT DID with isDefault true when tenant has no default', async () => {
+      const systemDid = { ...DID_RECORD, id: 'sys-did', type: 'DEFAULT', isDefault: true, tenantId: 'system' };
+      const tenantDid = { ...DID_RECORD, id: 'tenant-did', type: 'MANAGED', isDefault: false };
+
+      mockDid.findMany.mockResolvedValue([systemDid, tenantDid]);
+      mockDid.count.mockResolvedValue(2);
+
+      const result = await listDids(ORG_ID);
+
+      expect(result.data[0]).toEqual(expect.objectContaining({ id: 'sys-did', isDefault: true }));
     });
   });
 
@@ -421,14 +511,14 @@ describe('did.repository', () => {
   });
 
   describe('getDefaultDid', () => {
-    it('returns the default DID', async () => {
+    it('returns the system default DID when no tenantId is provided', async () => {
       const defaultDid = { ...DID_RECORD, isDefault: true, type: 'DEFAULT' };
       mockDid.findFirst.mockResolvedValue(defaultDid);
 
       const result = await getDefaultDid();
 
       expect(mockDid.findFirst).toHaveBeenCalledWith({
-        where: { isDefault: true },
+        where: { isDefault: true, type: 'DEFAULT' },
       });
       expect(result).toEqual(defaultDid);
     });
@@ -438,6 +528,34 @@ describe('did.repository', () => {
 
       const result = await getDefaultDid();
       expect(result).toBeNull();
+    });
+
+    it('returns tenant default DID when tenant has one set', async () => {
+      const tenantDid = { ...DID_RECORD, isDefault: true, type: 'MANAGED' };
+      mockDid.findFirst.mockResolvedValueOnce(tenantDid);
+
+      const result = await getDefaultDid(ORG_ID);
+
+      expect(mockDid.findFirst).toHaveBeenCalledWith({
+        where: { tenantId: ORG_ID, isDefault: true, type: { not: 'DEFAULT' } },
+      });
+      expect(result).toEqual(tenantDid);
+    });
+
+    it('falls back to system default when tenant has no default', async () => {
+      const systemDid = { ...DID_RECORD, isDefault: true, type: 'DEFAULT' };
+      mockDid.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(systemDid);
+
+      const result = await getDefaultDid(ORG_ID);
+
+      expect(mockDid.findFirst).toHaveBeenCalledTimes(2);
+      expect(mockDid.findFirst).toHaveBeenNthCalledWith(1, {
+        where: { tenantId: ORG_ID, isDefault: true, type: { not: 'DEFAULT' } },
+      });
+      expect(mockDid.findFirst).toHaveBeenNthCalledWith(2, {
+        where: { isDefault: true, type: 'DEFAULT' },
+      });
+      expect(result).toEqual(systemDid);
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -40,50 +40,92 @@ export type ListDidsOptions = {
 };
 
 /**
- * Creates a new DID record scoped to an organisation
+ * Creates a new DID record scoped to an organisation.
+ * When isDefault is true, clears any existing tenant default
+ * (excluding system DEFAULT type DIDs) within a transaction.
  */
 export async function createDid(input: CreateDidInput): Promise<Did> {
-  return prisma.did.create({
-    data: {
-      tenantId: input.tenantId,
-      did: input.did,
-      type: input.type,
-      method: input.method ?? 'DID_WEB',
-      keyId: input.keyId,
-      name: input.name ?? input.did,
-      description: input.description,
-      isDefault: input.isDefault ?? false,
-      status: input.status ?? 'UNVERIFIED',
-      serviceInstanceId: input.serviceInstanceId,
-    },
-  });
+  const data = {
+    tenantId: input.tenantId,
+    did: input.did,
+    type: input.type,
+    method: input.method ?? 'DID_WEB',
+    keyId: input.keyId,
+    name: input.name ?? input.did,
+    description: input.description,
+    isDefault: input.isDefault ?? false,
+    status: input.status ?? 'UNVERIFIED',
+    serviceInstanceId: input.serviceInstanceId,
+  };
+
+  if (input.isDefault) {
+    return prisma.$transaction(async (tx) => {
+      await tx.did.updateMany({
+        where: {
+          tenantId: input.tenantId,
+          isDefault: true,
+          type: { not: 'DEFAULT' },
+        },
+        data: { isDefault: false },
+      });
+      return tx.did.create({ data });
+    });
+  }
+
+  return prisma.did.create({ data });
 }
 
 /**
  * Retrieves a DID by ID, scoped to an organisation.
  * Returns null if the DID does not exist or belongs to a different organisation.
+ * If the fetched DID is a system DEFAULT with isDefault true, checks whether the
+ * tenant has their own default set and overrides isDefault to false if so.
  */
 export async function getDidById(id: string, tenantId: string): Promise<Did | null> {
-  return prisma.did.findFirst({
+  const did = await prisma.did.findFirst({
     where: {
       id,
       OR: [{ tenantId }, { isDefault: true, type: 'DEFAULT' }],
     },
   });
+
+  if (did?.type === 'DEFAULT' && did.isDefault) {
+    const tenantDefault = await prisma.did.findFirst({
+      where: { tenantId, isDefault: true, type: { not: 'DEFAULT' } },
+    });
+    if (tenantDefault) {
+      return { ...did, isDefault: false };
+    }
+  }
+
+  return did;
 }
 
 /**
  * Retrieves a DID by its DID string (e.g. "did:web:example.com"), scoped to an organisation.
  * Also returns system default DIDs regardless of tenant. Returns null if the DID
  * does not exist or belongs to a different non-default organisation.
+ * If the fetched DID is a system DEFAULT with isDefault true, checks whether the
+ * tenant has their own default set and overrides isDefault to false if so.
  */
-export async function getDidByDid(did: string, tenantId: string): Promise<Did | null> {
-  return prisma.did.findFirst({
+export async function getDidByDid(didString: string, tenantId: string): Promise<Did | null> {
+  const did = await prisma.did.findFirst({
     where: {
-      did,
+      did: didString,
       OR: [{ tenantId }, { isDefault: true, type: 'DEFAULT' }],
     },
   });
+
+  if (did?.type === 'DEFAULT' && did.isDefault) {
+    const tenantDefault = await prisma.did.findFirst({
+      where: { tenantId, isDefault: true, type: { not: 'DEFAULT' } },
+    });
+    if (tenantDefault) {
+      return { ...did, isDefault: false };
+    }
+  }
+
+  return did;
 }
 
 /**
@@ -121,6 +163,16 @@ export async function listDids(
     }),
     prisma.did.count({ where }),
   ]);
+
+  // If the tenant has set their own default, override the system DID's isDefault
+  const tenantHasDefault = data.some((d) => d.isDefault && d.type !== 'DEFAULT');
+  if (tenantHasDefault) {
+    for (const d of data) {
+      if (d.type === 'DEFAULT' && d.isDefault) {
+        d.isDefault = false;
+      }
+    }
+  }
 
   return { data, total };
 }
@@ -210,10 +262,18 @@ export async function deleteDid(id: string, tenantId: string): Promise<void> {
 }
 
 /**
- * Returns the system default DID (if seeded).
+ * Returns the default DID. When a tenantId is provided, prefers the tenant's
+ * own default DID over the system default. Falls back to the system default
+ * if the tenant has no default set.
  */
-export async function getDefaultDid(): Promise<Did | null> {
+export async function getDefaultDid(tenantId?: string): Promise<Did | null> {
+  if (tenantId) {
+    const tenantDefault = await prisma.did.findFirst({
+      where: { tenantId, isDefault: true, type: { not: 'DEFAULT' } },
+    });
+    if (tenantDefault) return tenantDefault;
+  }
   return prisma.did.findFirst({
-    where: { isDefault: true },
+    where: { isDefault: true, type: 'DEFAULT' },
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -166,15 +166,11 @@ export async function listDids(
 
   // If the tenant has set their own default, override the system DID's isDefault
   const tenantHasDefault = data.some((d) => d.isDefault && d.type !== 'DEFAULT');
-  if (tenantHasDefault) {
-    for (const d of data) {
-      if (d.type === 'DEFAULT' && d.isDefault) {
-        d.isDefault = false;
-      }
-    }
-  }
+  const adjusted = tenantHasDefault
+    ? data.map((d) => (d.type === 'DEFAULT' && d.isDefault ? { ...d, isDefault: false } : d))
+    : data;
 
-  return { data, total };
+  return { data: adjusted, total };
 }
 
 /**

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -76,10 +76,23 @@ export async function createDid(input: CreateDidInput): Promise<Did> {
 }
 
 /**
+ * When a system DEFAULT DID has isDefault true but the tenant has set their own
+ * default, the system DID's isDefault should appear as false for that tenant.
+ */
+async function applyTenantDefaultOverride(did: Did | null, tenantId: string): Promise<Did | null> {
+  if (!did || did.type !== 'DEFAULT' || !did.isDefault) return did;
+
+  const tenantDefault = await prisma.did.findFirst({
+    where: { tenantId, isDefault: true, type: { not: 'DEFAULT' } },
+  });
+
+  return tenantDefault ? { ...did, isDefault: false } : did;
+}
+
+/**
  * Retrieves a DID by ID, scoped to an organisation.
  * Returns null if the DID does not exist or belongs to a different organisation.
- * If the fetched DID is a system DEFAULT with isDefault true, checks whether the
- * tenant has their own default set and overrides isDefault to false if so.
+ * If the fetched DID is a system DEFAULT, applies tenant default override.
  */
 export async function getDidById(id: string, tenantId: string): Promise<Did | null> {
   const did = await prisma.did.findFirst({
@@ -89,24 +102,14 @@ export async function getDidById(id: string, tenantId: string): Promise<Did | nu
     },
   });
 
-  if (did?.type === 'DEFAULT' && did.isDefault) {
-    const tenantDefault = await prisma.did.findFirst({
-      where: { tenantId, isDefault: true, type: { not: 'DEFAULT' } },
-    });
-    if (tenantDefault) {
-      return { ...did, isDefault: false };
-    }
-  }
-
-  return did;
+  return applyTenantDefaultOverride(did, tenantId);
 }
 
 /**
  * Retrieves a DID by its DID string (e.g. "did:web:example.com"), scoped to an organisation.
  * Also returns system default DIDs regardless of tenant. Returns null if the DID
  * does not exist or belongs to a different non-default organisation.
- * If the fetched DID is a system DEFAULT with isDefault true, checks whether the
- * tenant has their own default set and overrides isDefault to false if so.
+ * If the fetched DID is a system DEFAULT, applies tenant default override.
  */
 export async function getDidByDid(didString: string, tenantId: string): Promise<Did | null> {
   const did = await prisma.did.findFirst({
@@ -116,16 +119,7 @@ export async function getDidByDid(didString: string, tenantId: string): Promise<
     },
   });
 
-  if (did?.type === 'DEFAULT' && did.isDefault) {
-    const tenantDefault = await prisma.did.findFirst({
-      where: { tenantId, isDefault: true, type: { not: 'DEFAULT' } },
-    });
-    if (tenantDefault) {
-      return { ...did, isDefault: false };
-    }
-  }
-
-  return did;
+  return applyTenantDefaultOverride(did, tenantId);
 }
 
 /**
@@ -164,13 +158,15 @@ export async function listDids(
     prisma.did.count({ where }),
   ]);
 
-  // If the tenant has set their own default, override the system DID's isDefault
   const tenantHasDefault = data.some((d) => d.isDefault && d.type !== 'DEFAULT');
-  const adjusted = tenantHasDefault
-    ? data.map((d) => (d.type === 'DEFAULT' && d.isDefault ? { ...d, isDefault: false } : d))
-    : data;
+  if (tenantHasDefault) {
+    return {
+      data: data.map((d) => (d.type === 'DEFAULT' && d.isDefault ? { ...d, isDefault: false } : d)),
+      total,
+    };
+  }
 
-  return { data: adjusted, total };
+  return { data, total };
 }
 
 /**

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
@@ -226,6 +226,29 @@ describe('VCKitDidAdapter', () => {
       const payload = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
       expect(payload.alias).toBe('vckit.dev3.pyx.io:acme-corp');
     });
+
+    it('does NOT prepend host prefix for SELF_MANAGED type', async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(createMockResponse({ did: 'did:web:my-domain.com:my-org', controllerKeyId: 'key-1' }))
+        .mockResolvedValueOnce(
+          createMockResponse({
+            didDocument: {
+              '@context': ['https://www.w3.org/ns/did/v1'],
+              id: 'did:web:my-domain.com:my-org',
+              verificationMethod: [],
+            },
+          }),
+        );
+
+      await service.create({
+        type: DidType.SELF_MANAGED,
+        method: DidMethod.DID_WEB,
+        alias: 'my-domain.com:my-org',
+      });
+
+      const payload = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(payload.alias).toBe('my-domain.com:my-org');
+    });
   });
 
   // delete() tests

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
@@ -354,7 +354,7 @@ describe('VCKitDidAdapter', () => {
 
       expect(result.errors).toEqual([
         {
-          check: DidVerificationCheckName.KEY_MATERIAL,
+          name: DidVerificationCheckName.KEY_MATERIAL,
           message: 'Provider key material could not be fetched — key_material check may be incomplete',
         },
       ]);
@@ -373,14 +373,14 @@ describe('VCKitDidAdapter', () => {
 
       expect(result.errors).toEqual([
         {
-          check: DidVerificationCheckName.KEY_MATERIAL,
+          name: DidVerificationCheckName.KEY_MATERIAL,
           message: 'Provider key material could not be fetched — key_material check may be incomplete',
         },
       ]);
     });
 
     it('appends KEY_MATERIAL error to existing errors when key fetch fails', async () => {
-      const existingError = { check: DidVerificationCheckName.RESOLVE, message: 'Could not resolve' };
+      const existingError = { name: DidVerificationCheckName.RESOLVE, message: 'Could not resolve' };
       const mockResult = { verified: false, checks: [], errors: [existingError] };
       (verifyDid as jest.Mock).mockResolvedValue(mockResult);
       (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
@@ -390,7 +390,7 @@ describe('VCKitDidAdapter', () => {
       expect(result.errors).toHaveLength(2);
       expect(result.errors![0]).toEqual(existingError);
       expect(result.errors![1]).toEqual({
-        check: DidVerificationCheckName.KEY_MATERIAL,
+        name: DidVerificationCheckName.KEY_MATERIAL,
         message: 'Provider key material could not be fetched — key_material check may be incomplete',
       });
     });

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -55,6 +55,11 @@ export class VCKitDidAdapter implements IDidService {
     this.logger = logger || createLogger().child({ service: 'DID - VCKitDid' });
   }
 
+  private getHostPrefix(): string {
+    const url = new URL(this.baseURL);
+    return url.port && url.port !== '443' && url.port !== '80' ? `${url.hostname}%3A${url.port}` : url.hostname;
+  }
+
   normaliseAlias(alias: string, method: DidMethod): string {
     switch (method) {
       case DidMethod.DID_WEB:
@@ -69,17 +74,10 @@ export class VCKitDidAdapter implements IDidService {
   async create(options: CreateDidOptions): Promise<DidRecord> {
     const provider = toProviderString(options.method);
 
-    // For MANAGED DIDs, prefix the alias with the VCKit host (VCKit hosts the
-    // DID document). For SELF_MANAGED DIDs, use the alias as-is because the
-    // user hosts their own DID document at their own domain.
-    let resolvedAlias: string;
-    if (options.type === DidType.SELF_MANAGED) {
-      resolvedAlias = options.alias;
-    } else {
-      const url = new URL(this.baseURL);
-      const host = url.port && url.port !== '443' && url.port !== '80' ? `${url.hostname}%3A${url.port}` : url.hostname;
-      resolvedAlias = `${host}:${options.alias}`;
-    }
+    // MANAGED DIDs are hosted by VCKit, so prefix the alias with the VCKit host.
+    // SELF_MANAGED DIDs are hosted at the user's own domain — use the alias as-is.
+    const resolvedAlias =
+      options.type === DidType.SELF_MANAGED ? options.alias : `${this.getHostPrefix()}:${options.alias}`;
 
     const payload = {
       alias: resolvedAlias,

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -219,7 +219,7 @@ export class VCKitDidAdapter implements IDidService {
     if (keyFetchFailed) {
       if (!result.errors) result.errors = [];
       result.errors.push({
-        check: DidVerificationCheckName.KEY_MATERIAL,
+        name: DidVerificationCheckName.KEY_MATERIAL,
         message: 'Provider key material could not be fetched — key_material check may be incomplete',
       });
     }

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -69,13 +69,20 @@ export class VCKitDidAdapter implements IDidService {
   async create(options: CreateDidOptions): Promise<DidRecord> {
     const provider = toProviderString(options.method);
 
-    // Extract host from baseURL for did:web alias prefixing
-    const url = new URL(this.baseURL);
-    const host = url.port && url.port !== '443' && url.port !== '80' ? `${url.hostname}%3A${url.port}` : url.hostname;
-    const prefixedAlias = `${host}:${options.alias}`;
+    // For MANAGED DIDs, prefix the alias with the VCKit host (VCKit hosts the
+    // DID document). For SELF_MANAGED DIDs, use the alias as-is because the
+    // user hosts their own DID document at their own domain.
+    let resolvedAlias: string;
+    if (options.type === DidType.SELF_MANAGED) {
+      resolvedAlias = options.alias;
+    } else {
+      const url = new URL(this.baseURL);
+      const host = url.port && url.port !== '443' && url.port !== '80' ? `${url.hostname}%3A${url.port}` : url.hostname;
+      resolvedAlias = `${host}:${options.alias}`;
+    }
 
     const payload = {
-      alias: prefixedAlias,
+      alias: resolvedAlias,
       provider,
       kms: 'local',
       options: { keyType: this.keyType },

--- a/packages/services/src/did-manager/common/verify.ts
+++ b/packages/services/src/did-manager/common/verify.ts
@@ -128,7 +128,7 @@ export async function verifyDid(did: string, options: VerifyDidOptions): Promise
   checks.push({ name: C.JSONLD_VALIDITY, passed: true, message: 'Skipped — JSON-LD expansion disabled' });
 
   const verified = checks.every((c) => c.passed);
-  const errors = checks.filter((c) => !c.passed).map((c) => ({ check: c.name, message: c.message ?? 'Check failed' }));
+  const errors = checks.filter((c) => !c.passed).map((c) => ({ name: c.name, message: c.message ?? 'Check failed' }));
 
   return {
     verified,

--- a/packages/services/src/did-manager/schemas.ts
+++ b/packages/services/src/did-manager/schemas.ts
@@ -55,7 +55,7 @@ export const verificationCheckSchema = z.object({
 });
 
 export const verificationErrorSchema = z.object({
-  check: z.enum(VERIFICATION_CHECK_NAMES),
+  name: z.enum(VERIFICATION_CHECK_NAMES),
   message: z.string(),
 });
 

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -103,7 +103,7 @@ export type DidVerificationCheck = {
 };
 
 export type DidVerificationError = {
-  check: DidVerificationCheckName;
+  name: DidVerificationCheckName;
   message: string;
 };
 


### PR DESCRIPTION
## Summary

This PR fixes four issues in the DID management API routes:

- **Self-managed alias prefix**: Self-managed DIDs no longer get the VCKit host prefixed to their alias, since the user hosts their own DID document at their own domain
- **isDefault on create**: The POST `/dids` endpoint now accepts `isDefault`, clearing existing tenant defaults in a transaction when set to true
- **Tenant-aware defaults**: When a tenant has set their own default DID, the system DID appears with `isDefault: false` in list and get responses. `getDefaultDid(tenantId)` prefers the tenant's default, falling back to the system DID. Unsetting a tenant's default (`isDefault: false`) reverts to the system default automatically
- **Verification error consistency**: Renamed `DidVerificationError.check` to `.name` to match the `DidVerificationCheck` type, including the Zod schema and Swagger docs

## Test plan
- [x] Services DID manager tests pass (90 tests)
- [x] Reference-implementation DID repository tests pass (34 tests)
- [x] Self-managed DID create does not prefix alias with VCKit host
- [x] Creating a DID with `isDefault: true` clears existing tenant defaults
- [x] System DID shows `isDefault: false` when tenant has own default set
- [x] `getDefaultDid(tenantId)` returns tenant default, falls back to system
- [x] Verification errors use consistent `name` field across type, schema, and runtime