### PR TITLE
fix(api): preserve dots and colons in self-managed DID alias normalisation

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -318,7 +318,11 @@ describe('POST /api/v1/dids', () => {
     });
     await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
-    expect(mockDidService.normaliseAlias).toHaveBeenCalledWith('My Normalised Alias', DidMethod.DID_WEB);
+    expect(mockDidService.normaliseAlias).toHaveBeenCalledWith(
+      'My Normalised Alias',
+      DidMethod.DID_WEB,
+      DidType.MANAGED,
+    );
     expect(mockDidService.create).toHaveBeenCalledWith(expect.objectContaining({ alias: 'my-normalised-alias' }));
   });
 

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -126,7 +126,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   logger.info({ alias: body.alias, method }, 'Normalising alias');
   let normalisedAlias: string;
   try {
-    normalisedAlias = didService.normaliseAlias(body.alias, method);
+    normalisedAlias = didService.normaliseAlias(body.alias, method, type);
   } catch (aliasErr) {
     throw new ValidationError(errorMessage(aliasErr, 'Invalid alias'));
   }

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -1,7 +1,7 @@
 import type { IDidService, CreateDidOptions, DidRecord, DidDocument, DidVerificationResult } from '../../types.js';
 import { DidMethod, DidType, DidVerificationCheckName } from '../../types.js';
 import { verifyDid } from '../../common/verify.js';
-import { normaliseDidWebAlias } from '../../common/utils.js';
+import { normaliseDidWebAlias, normaliseSelfManagedAlias } from '../../common/utils.js';
 import type { AdapterRegistryEntry } from '../../../registry/types.js';
 import { vckitDidConfigSchema, vckitDidSensitiveFields } from './vckit-did.schema.js';
 import type { VCKitDidConfig } from './vckit-did.schema.js';
@@ -60,10 +60,10 @@ export class VCKitDidAdapter implements IDidService {
     return url.port && url.port !== '443' && url.port !== '80' ? `${url.hostname}%3A${url.port}` : url.hostname;
   }
 
-  normaliseAlias(alias: string, method: DidMethod): string {
+  normaliseAlias(alias: string, method: DidMethod, type?: DidType): string {
     switch (method) {
       case DidMethod.DID_WEB:
-        return normaliseDidWebAlias(alias);
+        return type === DidType.SELF_MANAGED ? normaliseSelfManagedAlias(alias) : normaliseDidWebAlias(alias);
       case DidMethod.DID_WEB_VH:
         throw new DidMethodNotSupportedError('did:webvh');
       default:

--- a/packages/services/src/did-manager/common/utils.test.ts
+++ b/packages/services/src/did-manager/common/utils.test.ts
@@ -116,6 +116,10 @@ describe('normaliseSelfManagedAlias', () => {
     expect(normaliseSelfManagedAlias('example.com:my_org@123!')).toBe('example.com:myorg123');
   });
 
+  it('handles complex whitespace and invalid characters', () => {
+    expect(normaliseSelfManagedAlias('  my-domain.com : my org  ')).toBe('my-domain.com:my-org');
+  });
+
   it('preserves hyphens', () => {
     expect(normaliseSelfManagedAlias('my-domain.io:my-org')).toBe('my-domain.io:my-org');
   });

--- a/packages/services/src/did-manager/common/utils.test.ts
+++ b/packages/services/src/did-manager/common/utils.test.ts
@@ -1,4 +1,4 @@
-import { didWebToUrl, parseDidMethod, normaliseDidWebAlias } from './utils';
+import { didWebToUrl, parseDidMethod, normaliseDidWebAlias, normaliseSelfManagedAlias } from './utils';
 import { DidParseError, DidMethodNotSupportedError, DidInputError } from '../errors';
 
 describe('didWebToUrl', () => {
@@ -96,5 +96,35 @@ describe('normaliseDidWebAlias', () => {
 
   it('preserves already-valid aliases', () => {
     expect(normaliseDidWebAlias('my-org-123')).toBe('my-org-123');
+  });
+});
+
+describe('normaliseSelfManagedAlias', () => {
+  it('preserves dots and colons in domain aliases', () => {
+    expect(normaliseSelfManagedAlias('vckit.dev3.pyx.io:my-org')).toBe('vckit.dev3.pyx.io:my-org');
+  });
+
+  it('lowercases the input', () => {
+    expect(normaliseSelfManagedAlias('Example.COM:My-Org')).toBe('example.com:my-org');
+  });
+
+  it('trims whitespace', () => {
+    expect(normaliseSelfManagedAlias('  example.com:org  ')).toBe('example.com:org');
+  });
+
+  it('strips invalid characters', () => {
+    expect(normaliseSelfManagedAlias('example.com:my_org@123!')).toBe('example.com:myorg123');
+  });
+
+  it('preserves hyphens', () => {
+    expect(normaliseSelfManagedAlias('my-domain.io:my-org')).toBe('my-domain.io:my-org');
+  });
+
+  it('throws DidInputError for input that normalises to empty', () => {
+    expect(() => normaliseSelfManagedAlias('!!!')).toThrow(DidInputError);
+  });
+
+  it('throws DidInputError for empty string', () => {
+    expect(() => normaliseSelfManagedAlias('')).toThrow(DidInputError);
   });
 });

--- a/packages/services/src/did-manager/common/utils.ts
+++ b/packages/services/src/did-manager/common/utils.ts
@@ -91,14 +91,22 @@ export function normaliseDidWebAlias(alias: string): string {
  *
  * - Lowercases the input
  * - Trims whitespace
+ * - Collapses whitespace around structural characters (dots, colons, hyphens)
+ * - Replaces remaining whitespace with hyphens
  * - Keeps alphanumeric characters, dots, colons, and hyphens
+ * - Collapses consecutive hyphens
+ * - Trims leading/trailing hyphens
  * - Throws if the result is empty
  */
 export function normaliseSelfManagedAlias(alias: string): string {
   const normalised = alias
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9.:-]/g, '');
+    .replace(/\s*([:.-])\s*/g, '$1')
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9.:-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '');
 
   if (!normalised) {
     throw new DidInputError(`alias "${alias}" produces an empty identifier after normalisation`);

--- a/packages/services/src/did-manager/common/utils.ts
+++ b/packages/services/src/did-manager/common/utils.ts
@@ -91,7 +91,7 @@ export function normaliseDidWebAlias(alias: string): string {
  *
  * - Lowercases the input
  * - Trims whitespace
- * - Collapses whitespace around structural characters (dots, colons, hyphens)
+ * - Strips whitespace adjacent to structural characters (dots, colons, hyphens)
  * - Replaces remaining whitespace with hyphens
  * - Keeps alphanumeric characters, dots, colons, and hyphens
  * - Collapses consecutive hyphens
@@ -102,7 +102,8 @@ export function normaliseSelfManagedAlias(alias: string): string {
   const normalised = alias
     .toLowerCase()
     .trim()
-    .replace(/\s*([:.-])\s*/g, '$1')
+    .replace(/\s+(?=[:.-])/g, '')
+    .replace(/(?<=[:.-])\s+/g, '')
     .replace(/\s+/g, '-')
     .replace(/[^a-z0-9.:-]/g, '')
     .replace(/-{2,}/g, '-')

--- a/packages/services/src/did-manager/common/utils.ts
+++ b/packages/services/src/did-manager/common/utils.ts
@@ -99,11 +99,13 @@ export function normaliseDidWebAlias(alias: string): string {
  * - Throws if the result is empty
  */
 export function normaliseSelfManagedAlias(alias: string): string {
-  const normalised = alias
-    .toLowerCase()
-    .trim()
-    .replace(/\s+(?=[:.-])/g, '')
-    .replace(/(?<=[:.-])\s+/g, '')
+  // Split on structural characters, trim each segment, then rejoin.
+  // This avoids polynomial regex when stripping whitespace around delimiters.
+  const trimmed = alias.toLowerCase().trim();
+  const tokens = trimmed.split(/([:.-])/);
+  const rejoined = tokens.map((t) => t.trim()).join('');
+
+  const normalised = rejoined
     .replace(/\s+/g, '-')
     .replace(/[^a-z0-9.:-]/g, '')
     .replace(/-{2,}/g, '-')

--- a/packages/services/src/did-manager/common/utils.ts
+++ b/packages/services/src/did-manager/common/utils.ts
@@ -81,3 +81,28 @@ export function normaliseDidWebAlias(alias: string): string {
 
   return normalised;
 }
+
+/**
+ * Light normalisation for self-managed DID aliases that include a domain.
+ *
+ * Unlike `normaliseDidWebAlias` (which strips dots and colons for single-segment
+ * aliases), this preserves dots and colons because self-managed aliases include
+ * the full domain and DID path.
+ *
+ * - Lowercases the input
+ * - Trims whitespace
+ * - Keeps alphanumeric characters, dots, colons, and hyphens
+ * - Throws if the result is empty
+ */
+export function normaliseSelfManagedAlias(alias: string): string {
+  const normalised = alias
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9.:-]/g, '');
+
+  if (!normalised) {
+    throw new DidInputError(`alias "${alias}" produces an empty identifier after normalisation`);
+  }
+
+  return normalised;
+}

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -122,8 +122,8 @@ export type MethodVerificationResult = {
 // ── Service interface ──────────────────────────────────────────────────────
 
 export interface IDidService {
-  /** Normalise and validate an alias for the given DID method. Throws if invalid. */
-  normaliseAlias(alias: string, method: DidMethod): string;
+  /** Normalise and validate an alias for the given DID method and type. Throws if invalid. */
+  normaliseAlias(alias: string, method: DidMethod, type?: DidType): string;
   /** Create a new DID in the provider */
   create(options: CreateDidOptions): Promise<DidRecord>;
   /** Get the full DID Document */

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -34,7 +34,12 @@ export {
   verificationResultResponseSchema,
   didDocumentResponseSchema,
 } from './did-manager/schemas.js';
-export { didWebToUrl, parseDidMethod, normaliseDidWebAlias } from './did-manager/common/utils.js';
+export {
+  didWebToUrl,
+  parseDidMethod,
+  normaliseDidWebAlias,
+  normaliseSelfManagedAlias,
+} from './did-manager/common/utils.js';
 // Encryption
 export { AesGcmEncryptionAdapter } from './encryption/adapters/aes-gcm/aes-gcm.adapter.js';
 export { EncryptionAlgorithm, assertPermittedAlgorithm } from './encryption/encryption.interface.js';


### PR DESCRIPTION
## Summary

This PR fixes self-managed DID alias normalisation stripping dots and colons from the alias. The existing `normaliseDidWebAlias` was designed for single-segment managed aliases (e.g. `my-org`) and aggressively strips everything except `[a-z0-9-]`. For self-managed DIDs, the alias includes the full domain and DID path (e.g. `vckit.dev3.pyx.io:my-org`), where dots and colons are structural characters.

A new `normaliseSelfManagedAlias` function applies light normalisation that preserves dots and colons. The adapter's `normaliseAlias` method now accepts an optional `type` parameter to select the appropriate normaliser.

## Test plan
- [x] `normaliseSelfManagedAlias` preserves dots and colons in domain aliases
- [x] `normaliseSelfManagedAlias` lowercases, trims, and strips invalid characters
- [x] Existing `normaliseDidWebAlias` tests still pass (managed alias behaviour unchanged)
- [x] All 97 DID manager tests pass