### PR TITLE
fix(storage): parameterise hardcoded storage bucket names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,8 @@ DEFAULT_MACHINE_VERIFICATION_URL=http://localhost:3332/agent/routeVerificationCr
 # UNCEFACT Storage Service
 UNCEFACT_STORAGE_URL=http://localhost:3334/api/3.0.0/public
 UNCEFACT_STORAGE_API_KEY=test123
+UNCEFACT_STORAGE_PUBLIC_BUCKET=public-data
+UNCEFACT_STORAGE_PRIVATE_BUCKET=private-data
 
 # Digital Link Resolver
 IDR_API_URL=http://localhost:3000/api/2.0.0

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -43,8 +43,8 @@ services:
       - PROTOCOL=http
       - DOMAIN=localhost
       - PORT=3334
-      - AVAILABLE_BUCKETS=public-data,private-data
-      - DEFAULT_BUCKET=public-data
+      - AVAILABLE_BUCKETS=${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data},${UNCEFACT_STORAGE_PRIVATE_BUCKET:-private-data}
+      - DEFAULT_BUCKET=${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data}
       - STORAGE_TYPE=local
       - API_KEY=${UNCEFACT_STORAGE_API_KEY:-test123}
       - ALLOWED_UPLOAD_TYPES=image/png,image/jpeg,image/webp,application/pdf,text/html
@@ -181,6 +181,8 @@ services:
       - AUTH_OIDC_SERVICE_ACCOUNT_AUDIENCE=ri-api
       - UNCEFACT_STORAGE_URL=http://storage-service:3334/api/3.0.0/public
       - UNCEFACT_STORAGE_API_KEY=test123
+      - UNCEFACT_STORAGE_PUBLIC_BUCKET=${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data}
+      - UNCEFACT_STORAGE_PRIVATE_BUCKET=${UNCEFACT_STORAGE_PRIVATE_BUCKET:-private-data}
       - PYX_IDR_API_URL=http://identity-resolver-service:3000
       - PYX_IDR_API_KEY=test123
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,8 @@ services:
       ISSUER_API_URL: http://vckit-api:3332/v2
       ISSUER_AUTH_TOKEN: ${ISSUER_AUTH_TOKEN}
       UNCEFACT_STORAGE_URL: http://storage-service:3334/api/3.0.0/public
+      UNCEFACT_STORAGE_PUBLIC_BUCKET: ${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data}
+      UNCEFACT_STORAGE_PRIVATE_BUCKET: ${UNCEFACT_STORAGE_PRIVATE_BUCKET:-private-data}
       IDR_API_URL: http://identity-resolver-service:3000/api/2.0.0
       IDR_API_KEY: ${IDR_API_KEY}
     healthcheck:
@@ -158,8 +160,8 @@ services:
       - PROTOCOL=http
       - DOMAIN=localhost
       - PORT=3334
-      - AVAILABLE_BUCKETS=public-data,private-data
-      - DEFAULT_BUCKET=public-data
+      - AVAILABLE_BUCKETS=${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data},${UNCEFACT_STORAGE_PRIVATE_BUCKET:-private-data}
+      - DEFAULT_BUCKET=${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data}
       - STORAGE_TYPE=local
       - API_KEY=${UNCEFACT_STORAGE_API_KEY:-test123}
       - ALLOWED_UPLOAD_TYPES=image/png,image/jpeg,image/webp,application/pdf,text/html

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -288,8 +288,8 @@ async function main() {
         baseUrl: new URL(storageServiceUrl).origin,
         ...(storageApiKey && { apiKey: storageApiKey }),
         apiVersion: '3.0.0',
-        publicBucket: 'public-data',
-        privateBucket: 'private-data',
+        publicBucket: process.env.UNCEFACT_STORAGE_PUBLIC_BUCKET || 'public-data',
+        privateBucket: process.env.UNCEFACT_STORAGE_PRIVATE_BUCKET || 'private-data',
       });
       const encryptedStorageConfig = JSON.stringify(
         encryptionService.encrypt(storageServiceConfig, EncryptionAlgorithm.AES_256_GCM),
@@ -449,7 +449,7 @@ async function main() {
       const { storageServiceUrl } = getStorageConfig();
       const storageApiKey = process.env.UNCEFACT_STORAGE_API_KEY;
       const storageBaseUrl = new URL(storageServiceUrl).origin;
-      const storageBucket = 'public-data';
+      const storageBucket = process.env.UNCEFACT_STORAGE_PUBLIC_BUCKET || 'public-data';
 
       const TEMPLATES_DIR = path.resolve(__dirname, '../src/templates/v0.6.0');
 


### PR DESCRIPTION
This PR parameterises the hardcoded `public-data` and `private-data` storage bucket names, allowing external deployments to configure custom bucket names via environment variables. This fixes seeding failures in environments where the storage service uses different bucket names.

Two new environment variables are introduced:
- `UNCEFACT_STORAGE_PUBLIC_BUCKET` (default: `public-data`)
- `UNCEFACT_STORAGE_PRIVATE_BUCKET` (default: `private-data`)

All existing deployments are unaffected as the defaults match the previously hardcoded values.

## Test plan
- [x] Defaults match original hardcoded values, no behavioural change without env vars set
- [x] All occurrences of hardcoded bucket names parameterised (seed config, template upload, docker-compose storage service, docker-compose RI passthrough)
- [x] Parity between `docker-compose.yml` and `docker-compose.e2e.yml`
- [x] `.env.example` updated with new variables