### PR TITLE
feat(playground): make footer URLs configurable via runtime env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ SERVICE_ENCRYPTION_KEY=000000000000000000000000000000000000000000000000000000000
 # SITE_DESCRIPTION=A playground for UNTP
 # HEADER_TITLE=UNTP Playground
 # FAVICON_URL=
+# SPEC_URL=https://untp.unece.org
+# TEST_SUITE_URL=https://github.com/uncefact/tests-untp
 
 # Playground Verification Service (required for credential verification)
 VERIFICATION_SERVICE_URL=https://vckit.untp.showthething.com/agent/routeVerificationCredential

--- a/packages/untp-playground/__tests__/components/Footer.test.tsx
+++ b/packages/untp-playground/__tests__/components/Footer.test.tsx
@@ -5,12 +5,20 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Footer } from '@/components/Footer';
+import { RuntimeConfigProvider, defaultConfig } from '@/contexts/RuntimeConfigContext';
+
+function renderFooter(config = defaultConfig) {
+  return render(
+    <RuntimeConfigProvider config={config}>
+      <Footer />
+    </RuntimeConfigProvider>,
+  );
+}
 
 describe('Footer', () => {
   it('renders correctly', () => {
-    render(<Footer />);
+    renderFooter();
 
-    // Test container classes
     const footer = screen.getByRole('contentinfo');
     expect(footer).toHaveClass('border-t');
 
@@ -18,33 +26,45 @@ describe('Footer', () => {
     expect(container).toHaveClass('container', 'mx-auto', 'p-8', 'max-w-7xl');
   });
 
-  it('renders all links with correct attributes', () => {
-    render(<Footer />);
+  it('renders all links with default URLs', () => {
+    renderFooter();
 
-    // Test UNTP Specification link
     const specLink = screen.getByRole('link', { name: /untp specification/i });
-    expect(specLink).toHaveAttribute('href', 'https://uncefact.github.io/spec-untp/');
+    expect(specLink).toHaveAttribute('href', 'https://untp.unece.org');
     expect(specLink).toHaveAttribute('target', '_blank');
     expect(specLink).toHaveAttribute('rel', 'noopener noreferrer');
     expect(specLink).toHaveClass('hover:text-foreground', 'transition-colors');
 
-    // Test UNTP Test Suite link
     const testSuiteLink = screen.getByRole('link', { name: /untp test suite/i });
-    expect(testSuiteLink).toHaveAttribute('href', 'https://uncefact.github.io/tests-untp/');
+    expect(testSuiteLink).toHaveAttribute('href', 'https://github.com/uncefact/tests-untp');
     expect(testSuiteLink).toHaveAttribute('target', '_blank');
     expect(testSuiteLink).toHaveAttribute('rel', 'noopener noreferrer');
     expect(testSuiteLink).toHaveClass('hover:text-foreground', 'transition-colors');
   });
 
+  it('renders custom URLs from runtime config', () => {
+    renderFooter({
+      ...defaultConfig,
+      specUrl: 'https://custom-spec.example.com',
+      testSuiteUrl: 'https://custom-tests.example.com',
+    });
+
+    const specLink = screen.getByRole('link', { name: /untp specification/i });
+    expect(specLink).toHaveAttribute('href', 'https://custom-spec.example.com');
+
+    const testSuiteLink = screen.getByRole('link', { name: /untp test suite/i });
+    expect(testSuiteLink).toHaveAttribute('href', 'https://custom-tests.example.com');
+  });
+
   it('renders separator dot with correct visibility classes', () => {
-    render(<Footer />);
+    renderFooter();
 
     const separator = screen.getByText('•');
     expect(separator).toHaveClass('hidden', 'md:inline');
   });
 
   it('has correct responsive layout classes', () => {
-    render(<Footer />);
+    renderFooter();
 
     const linksContainer = screen.getByText('•').parentElement;
     expect(linksContainer).toHaveClass(
@@ -60,7 +80,7 @@ describe('Footer', () => {
   });
 
   it('renders links in correct order', () => {
-    render(<Footer />);
+    renderFooter();
 
     const links = screen.getAllByRole('link');
     expect(links).toHaveLength(2);

--- a/packages/untp-playground/__tests__/contexts/RuntimeConfigContext.test.tsx
+++ b/packages/untp-playground/__tests__/contexts/RuntimeConfigContext.test.tsx
@@ -7,7 +7,13 @@ import { RuntimeConfigProvider, useRuntimeConfig, defaultConfig } from '@/contex
 
 function ConfigConsumer() {
   const config = useRuntimeConfig();
-  return <span data-testid='headerTitle'>{config.headerTitle}</span>;
+  return (
+    <>
+      <span data-testid='headerTitle'>{config.headerTitle}</span>
+      <span data-testid='specUrl'>{config.specUrl}</span>
+      <span data-testid='testSuiteUrl'>{config.testSuiteUrl}</span>
+    </>
+  );
 }
 
 describe('RuntimeConfigContext', () => {
@@ -18,14 +24,24 @@ describe('RuntimeConfigContext', () => {
       </RuntimeConfigProvider>,
     );
     expect(screen.getByTestId('headerTitle')).toHaveTextContent('UNTP Playground');
+    expect(screen.getByTestId('specUrl')).toHaveTextContent('https://untp.unece.org');
+    expect(screen.getByTestId('testSuiteUrl')).toHaveTextContent('https://github.com/uncefact/tests-untp');
   });
 
   it('provides custom config values', () => {
     render(
-      <RuntimeConfigProvider config={{ headerTitle: 'Custom App' }}>
+      <RuntimeConfigProvider
+        config={{
+          headerTitle: 'Custom App',
+          specUrl: 'https://custom-spec.example.com',
+          testSuiteUrl: 'https://custom-tests.example.com',
+        }}
+      >
         <ConfigConsumer />
       </RuntimeConfigProvider>,
     );
     expect(screen.getByTestId('headerTitle')).toHaveTextContent('Custom App');
+    expect(screen.getByTestId('specUrl')).toHaveTextContent('https://custom-spec.example.com');
+    expect(screen.getByTestId('testSuiteUrl')).toHaveTextContent('https://custom-tests.example.com');
   });
 });

--- a/packages/untp-playground/src/app/layout.tsx
+++ b/packages/untp-playground/src/app/layout.tsx
@@ -32,6 +32,8 @@ export async function generateMetadata(): Promise<Metadata> {
 function getRuntimeConfig(): RuntimeConfig {
   return {
     headerTitle: process.env.HEADER_TITLE || 'UNTP Playground',
+    specUrl: process.env.SPEC_URL || 'https://untp.unece.org',
+    testSuiteUrl: process.env.TEST_SUITE_URL || 'https://github.com/uncefact/tests-untp',
   };
 }
 

--- a/packages/untp-playground/src/components/Footer.tsx
+++ b/packages/untp-playground/src/components/Footer.tsx
@@ -1,12 +1,16 @@
 'use client';
 
+import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
+
 export function Footer() {
+  const { specUrl, testSuiteUrl } = useRuntimeConfig();
+
   return (
     <footer className='border-t mt-8'>
       <div className='container mx-auto p-8 max-w-7xl'>
         <div className='flex flex-col md:flex-row justify-center items-center gap-4 text-sm text-muted-foreground'>
           <a
-            href='https://uncefact.github.io/spec-untp/'
+            href={specUrl}
             target='_blank'
             rel='noopener noreferrer'
             className='hover:text-foreground transition-colors'
@@ -15,7 +19,7 @@ export function Footer() {
           </a>
           <span className='hidden md:inline'>•</span>
           <a
-            href='https://uncefact.github.io/tests-untp/'
+            href={testSuiteUrl}
             target='_blank'
             rel='noopener noreferrer'
             className='hover:text-foreground transition-colors'

--- a/packages/untp-playground/src/contexts/RuntimeConfigContext.tsx
+++ b/packages/untp-playground/src/contexts/RuntimeConfigContext.tsx
@@ -4,10 +4,14 @@ import { createContext, useContext } from 'react';
 
 export interface RuntimeConfig {
   headerTitle: string;
+  specUrl: string;
+  testSuiteUrl: string;
 }
 
 const defaultConfig: RuntimeConfig = {
   headerTitle: 'UNTP Playground',
+  specUrl: 'https://untp.unece.org',
+  testSuiteUrl: 'https://github.com/uncefact/tests-untp',
 };
 
 const RuntimeConfigContext = createContext<RuntimeConfig>(defaultConfig);


### PR DESCRIPTION
## Summary

This PR makes the footer spec and test suite URLs configurable via runtime environment variables (`SPEC_URL` and `TEST_SUITE_URL`), fixing the incorrect spec URL that was previously hardcoded to `https://uncefact.github.io/spec-untp/`. The defaults are now `https://untp.unece.org` and `https://github.com/uncefact/tests-untp`.

## Test plan
- [x] Footer renders default URLs when env vars are not set
- [x] Footer renders custom URLs when env vars are provided
- [x] RuntimeConfigContext provides new fields to consumers
- [x] Existing footer layout and styling tests updated