### PR TITLE
fix(api): apply tenant primary override to service instance defaults

### DIFF
--- a/e2e/cypress/e2e/service_api/service-management.cy.ts
+++ b/e2e/cypress/e2e/service_api/service-management.cy.ts
@@ -301,6 +301,132 @@ describe('Service API', { testIsolation: false }, () => {
     });
   });
 
+  describe('System default override', () => {
+    let tenantPrimaryId: string;
+
+    it('system defaults show isPrimary when tenant has no primary', () => {
+      cy.request('/api/v1/services?serviceType=VC').then((response) => {
+        expect(response.status).to.eq(200);
+        const systemVc = response.body.data.find(
+          (s: ServiceInstance) => s.id === 'system-vc-vckit',
+        );
+        // No tenant primary exists yet — system default should be primary
+        expect(systemVc).to.exist;
+        expect(systemVc.isPrimary).to.be.true;
+      });
+    });
+
+    it('creates a tenant primary VC service', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/services',
+        body: {
+          serviceType: 'VC',
+          adapterType: 'VCKIT',
+          name: `E2E Override Test ${RUN_ID}`,
+          config: {
+            endpoint: 'https://override-test.example.com',
+            apiKey: 'override-key',
+          },
+          isPrimary: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        tenantPrimaryId = response.body.id;
+      });
+    });
+
+    it('system VC default shows isPrimary false when tenant has own primary', () => {
+      cy.request('/api/v1/services?serviceType=VC').then((response) => {
+        expect(response.status).to.eq(200);
+        const systemVc = response.body.data.find(
+          (s: ServiceInstance) => s.id === 'system-vc-vckit',
+        );
+        const tenantVc = response.body.data.find(
+          (s: ServiceInstance) => s.id === tenantPrimaryId,
+        );
+        expect(systemVc).to.exist;
+        expect(systemVc.isPrimary).to.be.false;
+        expect(tenantVc).to.exist;
+        expect(tenantVc.isPrimary).to.be.true;
+      });
+    });
+
+    it('system default for other serviceType is unaffected', () => {
+      cy.request('/api/v1/services?serviceType=STORAGE').then((response) => {
+        expect(response.status).to.eq(200);
+        const systemStorage = response.body.data.find(
+          (s: ServiceInstance) => s.id === 'system-storage-uncefact',
+        );
+        // Tenant has no STORAGE primary — system default stays primary
+        expect(systemStorage).to.exist;
+        expect(systemStorage.isPrimary).to.be.true;
+      });
+    });
+
+    it('GET by ID also applies override for system VC default', () => {
+      cy.request('/api/v1/services/system-vc-vckit').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.isPrimary).to.be.false;
+      });
+    });
+
+    it('system default restores isPrimary when tenant un-sets their primary via PATCH', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/services/${tenantPrimaryId}`,
+        body: { isPrimary: false },
+      }).then((patchRes) => {
+        expect(patchRes.status).to.eq(200);
+        expect(patchRes.body.isPrimary).to.be.false;
+      });
+
+      cy.request('/api/v1/services?serviceType=VC').then((response) => {
+        const systemVc = response.body.data.find(
+          (s: ServiceInstance) => s.id === 'system-vc-vckit',
+        );
+        expect(systemVc).to.exist;
+        expect(systemVc.isPrimary).to.be.true;
+      });
+    });
+
+    it('system default overrides again when tenant re-sets primary via PATCH', () => {
+      cy.request({
+        method: 'PATCH',
+        url: `/api/v1/services/${tenantPrimaryId}`,
+        body: { isPrimary: true },
+      }).then((patchRes) => {
+        expect(patchRes.status).to.eq(200);
+        expect(patchRes.body.isPrimary).to.be.true;
+      });
+
+      cy.request('/api/v1/services?serviceType=VC').then((response) => {
+        const systemVc = response.body.data.find(
+          (s: ServiceInstance) => s.id === 'system-vc-vckit',
+        );
+        expect(systemVc).to.exist;
+        expect(systemVc.isPrimary).to.be.false;
+      });
+    });
+
+    it('system default restores isPrimary after tenant primary is deleted', () => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v1/services/${tenantPrimaryId}?force=true`,
+      }).then((deleteRes) => {
+        expect(deleteRes.status).to.eq(204);
+      });
+
+      cy.request('/api/v1/services?serviceType=VC').then((response) => {
+        const systemVc = response.body.data.find(
+          (s: ServiceInstance) => s.id === 'system-vc-vckit',
+        );
+        expect(systemVc).to.exist;
+        expect(systemVc.isPrimary).to.be.true;
+      });
+    });
+  });
+
   describe('Filtering and pagination', () => {
     it('filters by serviceType', () => {
       cy.request('/api/v1/services?serviceType=VC').then((response) => {

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
@@ -170,11 +170,38 @@ describe('service-instance.repository', () => {
       const result = await getServiceInstanceById('instance-1', 'other-org');
       expect(result).toBeNull();
     });
+
+    it('overrides system default isPrimary when tenant has own primary for same serviceType', async () => {
+      const systemRecord = { ...INSTANCE_RECORD, tenantId: 'system', isPrimary: true, serviceType: 'VC' };
+      const tenantPrimary = { ...INSTANCE_RECORD, id: 'tenant-vc', tenantId: ORG_ID, isPrimary: true };
+      // First call: getServiceInstanceById lookup
+      mockServiceInstance.findFirst.mockResolvedValueOnce(systemRecord);
+      // Second call: applyTenantPrimaryOverride lookup
+      mockServiceInstance.findFirst.mockResolvedValueOnce(tenantPrimary);
+
+      const result = await getServiceInstanceById('instance-1', ORG_ID);
+
+      expect(result).toEqual({ ...systemRecord, isPrimary: false });
+    });
+
+    it('keeps system default isPrimary when tenant has no primary for same serviceType', async () => {
+      const systemRecord = { ...INSTANCE_RECORD, tenantId: 'system', isPrimary: true, serviceType: 'VC' };
+      // First call: getServiceInstanceById lookup
+      mockServiceInstance.findFirst.mockResolvedValueOnce(systemRecord);
+      // Second call: applyTenantPrimaryOverride lookup — no tenant primary
+      mockServiceInstance.findFirst.mockResolvedValueOnce(null);
+
+      const result = await getServiceInstanceById('instance-1', ORG_ID);
+
+      expect(result).toEqual(systemRecord);
+    });
   });
 
   describe('listServiceInstances', () => {
     it('lists for organisation including system defaults', async () => {
-      mockServiceInstance.findMany.mockResolvedValue([INSTANCE_RECORD]);
+      // First findMany: data query; second findMany: tenant primaries query
+      mockServiceInstance.findMany.mockResolvedValueOnce([INSTANCE_RECORD]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
       mockServiceInstance.count.mockResolvedValue(1);
 
       const result = await listServiceInstances(ORG_ID);
@@ -197,7 +224,8 @@ describe('service-instance.repository', () => {
     });
 
     it('applies serviceType filter', async () => {
-      mockServiceInstance.findMany.mockResolvedValue([]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
       mockServiceInstance.count.mockResolvedValue(0);
 
       const result = await listServiceInstances(ORG_ID, { serviceType: 'VC' });
@@ -215,7 +243,8 @@ describe('service-instance.repository', () => {
     });
 
     it('applies adapterType filter', async () => {
-      mockServiceInstance.findMany.mockResolvedValue([]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
       mockServiceInstance.count.mockResolvedValue(0);
 
       const result = await listServiceInstances(ORG_ID, { adapterType: 'VCKIT' });
@@ -233,7 +262,8 @@ describe('service-instance.repository', () => {
     });
 
     it('applies pagination', async () => {
-      mockServiceInstance.findMany.mockResolvedValue([]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
       mockServiceInstance.count.mockResolvedValue(0);
 
       const result = await listServiceInstances(ORG_ID, { limit: 10, offset: 20 });
@@ -246,6 +276,50 @@ describe('service-instance.repository', () => {
       );
       expect(result.data).toEqual([]);
       expect(result.total).toBe(0);
+    });
+
+    it('overrides system default isPrimary when tenant has own primary for same serviceType', async () => {
+      const systemVc = { ...INSTANCE_RECORD, id: 'sys-vc', tenantId: 'system', serviceType: 'VC', isPrimary: true };
+      const systemIdr = { ...INSTANCE_RECORD, id: 'sys-idr', tenantId: 'system', serviceType: 'IDR', isPrimary: true };
+      const tenantVc = { ...INSTANCE_RECORD, id: 'tenant-vc', tenantId: ORG_ID, serviceType: 'VC', isPrimary: true };
+
+      // First findMany: data query; second findMany: tenant primaries query
+      mockServiceInstance.findMany.mockResolvedValueOnce([tenantVc, systemVc, systemIdr]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([{ serviceType: 'VC' }]);
+      mockServiceInstance.count.mockResolvedValue(3);
+
+      const result = await listServiceInstances(ORG_ID);
+
+      // System VC should be overridden (tenant has VC primary), system IDR should stay primary
+      expect(result.data[0]).toEqual(tenantVc);
+      expect(result.data[1]).toEqual({ ...systemVc, isPrimary: false });
+      expect(result.data[2]).toEqual(systemIdr);
+    });
+
+    it('overrides correctly even when tenant primary is on a different page', async () => {
+      const systemVc = { ...INSTANCE_RECORD, id: 'sys-vc', tenantId: 'system', serviceType: 'VC', isPrimary: true };
+
+      // Data query returns only system default (tenant primary on another page)
+      mockServiceInstance.findMany.mockResolvedValueOnce([systemVc]);
+      // Tenant primaries query finds the primary across all pages
+      mockServiceInstance.findMany.mockResolvedValueOnce([{ serviceType: 'VC' }]);
+      mockServiceInstance.count.mockResolvedValue(2);
+
+      const result = await listServiceInstances(ORG_ID, { limit: 1, offset: 0 });
+
+      expect(result.data[0]).toEqual({ ...systemVc, isPrimary: false });
+    });
+
+    it('keeps system default isPrimary when tenant has no primary', async () => {
+      const systemVc = { ...INSTANCE_RECORD, id: 'sys-vc', tenantId: 'system', serviceType: 'VC', isPrimary: true };
+
+      mockServiceInstance.findMany.mockResolvedValueOnce([systemVc]);
+      mockServiceInstance.findMany.mockResolvedValueOnce([]);
+      mockServiceInstance.count.mockResolvedValue(1);
+
+      const result = await listServiceInstances(ORG_ID);
+
+      expect(result.data[0]).toEqual(systemVc);
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -59,16 +59,41 @@ export async function createServiceInstance(input: CreateServiceInstanceInput): 
 }
 
 /**
+ * When a system default service instance has isPrimary true but the tenant
+ * has set their own primary for the same serviceType, the system instance's
+ * isPrimary should appear as false for that tenant.
+ */
+async function applyTenantPrimaryOverride(
+  instance: ServiceInstance | null,
+  tenantId: string,
+): Promise<ServiceInstance | null> {
+  if (!instance || instance.tenantId !== SYSTEM_TENANT_ID || !instance.isPrimary) return instance;
+
+  const tenantPrimary = await prisma.serviceInstance.findFirst({
+    where: {
+      tenantId,
+      serviceType: instance.serviceType,
+      isPrimary: true,
+    },
+  });
+
+  return tenantPrimary ? { ...instance, isPrimary: false } : instance;
+}
+
+/**
  * Gets a service instance by ID. Returns it if owned by the specified
  * org or if it's a system default.
+ * If the fetched instance is a system default, applies tenant primary override.
  */
 export async function getServiceInstanceById(id: string, tenantId: string): Promise<ServiceInstance | null> {
-  return prisma.serviceInstance.findFirst({
+  const instance = await prisma.serviceInstance.findFirst({
     where: {
       id,
       OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
     },
   });
+
+  return applyTenantPrimaryOverride(instance, tenantId);
 }
 
 /**
@@ -92,7 +117,7 @@ export async function listServiceInstances(
     where.adapterType = adapterType as AdapterType;
   }
 
-  const [data, total] = await Promise.all([
+  const [data, total, tenantPrimaries] = await Promise.all([
     prisma.serviceInstance.findMany({
       where,
       take: limit ?? 20,
@@ -100,7 +125,24 @@ export async function listServiceInstances(
       orderBy: { createdAt: 'desc' },
     }),
     prisma.serviceInstance.count({ where }),
+    prisma.serviceInstance.findMany({
+      where: { tenantId, isPrimary: true },
+      select: { serviceType: true },
+    }),
   ]);
+
+  const tenantPrimaryTypes = new Set(tenantPrimaries.map((p) => p.serviceType));
+
+  if (tenantPrimaryTypes.size > 0) {
+    return {
+      data: data.map((i) =>
+        i.tenantId === SYSTEM_TENANT_ID && i.isPrimary && tenantPrimaryTypes.has(i.serviceType)
+          ? { ...i, isPrimary: false }
+          : i,
+      ),
+      total,
+    };
+  }
 
   return { data, total };
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -75,6 +75,7 @@ async function applyTenantPrimaryOverride(
       serviceType: instance.serviceType,
       isPrimary: true,
     },
+    select: { id: true },
   });
 
   return tenantPrimary ? { ...instance, isPrimary: false } : instance;
@@ -133,18 +134,14 @@ export async function listServiceInstances(
 
   const tenantPrimaryTypes = new Set(tenantPrimaries.map((p) => p.serviceType));
 
-  if (tenantPrimaryTypes.size > 0) {
-    return {
-      data: data.map((i) =>
-        i.tenantId === SYSTEM_TENANT_ID && i.isPrimary && tenantPrimaryTypes.has(i.serviceType)
-          ? { ...i, isPrimary: false }
-          : i,
-      ),
-      total,
-    };
-  }
-
-  return { data, total };
+  return {
+    data: data.map((i) =>
+      i.tenantId === SYSTEM_TENANT_ID && i.isPrimary && tenantPrimaryTypes.has(i.serviceType)
+        ? { ...i, isPrimary: false }
+        : i,
+    ),
+    total,
+  };
 }
 
 /**


### PR DESCRIPTION
This PR fixes service instance listing so that system defaults show `isPrimary: false` when the requesting tenant has their own primary for the same serviceType. Previously, system defaults always displayed `isPrimary: true` regardless of whether a tenant had set their own primary, making it appear that two services of the same type were both primary. This mirrors the existing DID default override pattern already in use for the `/dids` endpoints.

The override is applied at read time in both `getServiceInstanceById` (single fetch) and `listServiceInstances` (list fetch). The tenant primaries query runs alongside the main data query in `Promise.all`, so it adds no sequential latency. The resolution chain (`getInstanceByResolution`) was already correct and is unchanged.

## Test plan
- [x] Unit tests: override applied in `getServiceInstanceById` when tenant has own primary
- [x] Unit tests: override skipped when tenant has no primary for same serviceType
- [x] Unit tests: `listServiceInstances` overrides per-serviceType (VC overridden, IDR kept)
- [x] Unit tests: pagination edge case, tenant primary on different page still triggers override
- [x] E2E tests: system default shows primary when no tenant primary exists
- [x] E2E tests: system default overridden after tenant creates their own primary
- [x] E2E tests: other serviceTypes unaffected
- [x] E2E tests: `GET /services/:id` applies override
- [x] E2E tests: PATCH `isPrimary: false` restores system default
- [x] E2E tests: PATCH `isPrimary: true` re-overrides system default
- [x] E2E tests: DELETE tenant primary restores system default
- [x] All 30 repository unit tests passing