### PR TITLE
feat(api)!: rename RenderTemplate isPrimary to isDefault, upgrade storage, clean up DID verify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,7 @@ DEFAULT_HUMAN_VERIFICATION_URL=http://localhost:3003
 DEFAULT_MACHINE_VERIFICATION_URL=http://localhost:3332/agent/routeVerificationCredential
 
 # UNCEFACT Storage Service
-UNCEFACT_STORAGE_URL=http://localhost:3334/api/3.0.0/public
+UNCEFACT_STORAGE_URL=http://localhost:3334/api/3.1.0/public
 UNCEFACT_STORAGE_API_KEY=test123
 UNCEFACT_STORAGE_PUBLIC_BUCKET=public-data
 UNCEFACT_STORAGE_PRIVATE_BUCKET=private-data

--- a/app-config.json
+++ b/app-config.json
@@ -114,7 +114,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -501,7 +501,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -802,7 +802,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1144,7 +1144,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1272,7 +1272,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1399,7 +1399,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1535,7 +1535,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1667,7 +1667,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1802,7 +1802,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -36,7 +36,7 @@ services:
     restart: always
 
   storage-service:
-    image: ghcr.io/uncefact/project-storage-service:3.1.0
+    image: ghcr.io/uncefact/project-storage-service:3.2.0
     ports:
       - 3334:3334
     environment:
@@ -179,7 +179,7 @@ services:
       - AUTH_OIDC_CLIENT_SECRET=e2e-test-secret
       - AUTH_OIDC_ISSUER=http://localhost:8081/realms/ri-e2e
       - AUTH_OIDC_SERVICE_ACCOUNT_AUDIENCE=ri-api
-      - UNCEFACT_STORAGE_URL=http://storage-service:3334/api/3.0.0/public
+      - UNCEFACT_STORAGE_URL=http://storage-service:3334/api/3.1.0/public
       - UNCEFACT_STORAGE_API_KEY=test123
       - UNCEFACT_STORAGE_PUBLIC_BUCKET=${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data}
       - UNCEFACT_STORAGE_PRIVATE_BUCKET=${UNCEFACT_STORAGE_PRIVATE_BUCKET:-private-data}

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -36,7 +36,7 @@ services:
     restart: always
 
   storage-service:
-    image: ghcr.io/uncefact/project-storage-service:3.2.0
+    image: ghcr.io/uncefact/project-storage-service:3.2.1
     ports:
       - 3334:3334
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
     restart: always
 
   storage-service:
-    image: ghcr.io/uncefact/project-storage-service:3.2.0
+    image: ghcr.io/uncefact/project-storage-service:3.2.1
     ports:
       - 3334:3334
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
       # Service URLs (using docker internal networking)
       ISSUER_API_URL: http://vckit-api:3332/v2
       ISSUER_AUTH_TOKEN: ${ISSUER_AUTH_TOKEN}
-      UNCEFACT_STORAGE_URL: http://storage-service:3334/api/3.0.0/public
+      UNCEFACT_STORAGE_URL: http://storage-service:3334/api/3.1.0/public
       UNCEFACT_STORAGE_PUBLIC_BUCKET: ${UNCEFACT_STORAGE_PUBLIC_BUCKET:-public-data}
       UNCEFACT_STORAGE_PRIVATE_BUCKET: ${UNCEFACT_STORAGE_PRIVATE_BUCKET:-private-data}
       IDR_API_URL: http://identity-resolver-service:3000/api/2.0.0
@@ -153,7 +153,7 @@ services:
     restart: always
 
   storage-service:
-    image: ghcr.io/uncefact/project-storage-service:3.1.0
+    image: ghcr.io/uncefact/project-storage-service:3.2.0
     ports:
       - 3334:3334
     environment:

--- a/e2e/cypress/e2e/credential_api/credential-management.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-management.cy.ts
@@ -63,9 +63,9 @@ describe('Credential API', { testIsolation: false }, () => {
         config: {
           baseUrl: 'http://storage-service:3334',
           apiKey: 'test123',
-          apiVersion: '3.0.0',
+          apiVersion: '3.1.0',
         },
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
         isPrimary: true,
       },
     }).then((res) => {

--- a/e2e/cypress/e2e/credential_api/credential-verify-page.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-verify-page.cy.ts
@@ -71,9 +71,9 @@ describe('Verify Page', { testIsolation: false }, () => {
         config: {
           baseUrl: 'http://storage-service:3334',
           apiKey: 'test123',
-          apiVersion: '3.0.0',
+          apiVersion: '3.1.0',
         },
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
         isPrimary: true,
       },
     }).then((res) => expect(res.status).to.eq(201));

--- a/e2e/cypress/e2e/credential_api/credential-verify.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-verify.cy.ts
@@ -62,9 +62,9 @@ describe('Credential Verify API', { testIsolation: false }, () => {
         config: {
           baseUrl: 'http://storage-service:3334',
           apiKey: 'test123',
-          apiVersion: '3.0.0',
+          apiVersion: '3.1.0',
         },
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
         isPrimary: true,
       },
     }).then((res) => expect(res.status).to.eq(201));

--- a/e2e/cypress/e2e/cvc_api/cvc-credential-validation.cy.ts
+++ b/e2e/cypress/e2e/cvc_api/cvc-credential-validation.cy.ts
@@ -132,9 +132,9 @@ describe('CVC Credential Validation', { testIsolation: false }, () => {
         config: {
           baseUrl: 'http://storage-service:3334',
           apiKey: 'test123',
-          apiVersion: '3.0.0',
+          apiVersion: '3.1.0',
         },
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
         isPrimary: true,
       },
       failOnStatusCode: false,

--- a/e2e/cypress/e2e/render_template_api/render-template-management.cy.ts
+++ b/e2e/cypress/e2e/render_template_api/render-template-management.cy.ts
@@ -81,7 +81,7 @@ describe('Render Template API', { testIsolation: false }, () => {
       });
     });
 
-    it('POST — creates with isPrimary', function () {
+    it('POST — creates with isDefault', function () {
       if (!dataModelId) this.skip();
 
       cy.request({
@@ -92,11 +92,11 @@ describe('Render Template API', { testIsolation: false }, () => {
           dataModelId,
           renderMethodType: 'WebRenderingTemplate2022',
           template: `<html><body><h1>Primary Template ${RUN_ID}</h1></body></html>`,
-          isPrimary: true,
+          isDefault: true,
         },
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.isPrimary).to.be.true;
+        expect(response.body.isDefault).to.be.true;
 
         // Clean up — only keep the other templates for remaining tests
         cy.request({ method: 'DELETE', url: `/api/v1/render-templates/${response.body.id}` });
@@ -179,16 +179,16 @@ describe('Render Template API', { testIsolation: false }, () => {
       });
     });
 
-    it('PATCH — updates isPrimary', function () {
+    it('PATCH — updates isDefault', function () {
       if (!createdTemplateId) this.skip();
 
       cy.request({
         method: 'PATCH',
         url: `/api/v1/render-templates/${createdTemplateId}`,
-        body: { isPrimary: true },
+        body: { isDefault: true },
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.isPrimary).to.be.true;
+        expect(response.body.isDefault).to.be.true;
       });
     });
 
@@ -212,7 +212,7 @@ describe('Render Template API', { testIsolation: false }, () => {
       cy.request(`/api/v1/render-templates/${createdTemplateId}`).then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body.name).to.eq(`Updated E2E Template ${RUN_ID}`);
-        expect(response.body.isPrimary).to.be.true;
+        expect(response.body.isDefault).to.be.true;
       });
     });
 
@@ -394,7 +394,7 @@ describe('Render Template API', { testIsolation: false }, () => {
       });
     });
 
-    it('returns 400 when isPrimary is not a boolean', () => {
+    it('returns 400 when isDefault is not a boolean', () => {
       cy.request({
         method: 'POST',
         url: '/api/v1/render-templates',
@@ -403,12 +403,12 @@ describe('Render Template API', { testIsolation: false }, () => {
           dataModelId: 'dm-1',
           renderMethodType: 'WebRenderingTemplate2022',
           template: '<html>test</html>',
-          isPrimary: 'yes',
+          isDefault: 'yes',
         },
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
-        expect(response.body.error).to.include('isPrimary');
+        expect(response.body.error).to.include('isDefault');
       });
     });
 
@@ -571,17 +571,17 @@ describe('Render Template API', { testIsolation: false }, () => {
       });
     });
 
-    it('returns 400 when isPrimary is not a boolean', function () {
+    it('returns 400 when isDefault is not a boolean', function () {
       if (!tempTemplateId) this.skip();
 
       cy.request({
         method: 'PATCH',
         url: `/api/v1/render-templates/${tempTemplateId}`,
-        body: { isPrimary: 'yes' },
+        body: { isDefault: 'yes' },
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
-        expect(response.body.error).to.include('isPrimary');
+        expect(response.body.error).to.include('isDefault');
       });
     });
 

--- a/e2e/cypress/fixtures/app-config.json
+++ b/e2e/cypress/fixtures/app-config.json
@@ -1398,7 +1398,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1571,7 +1571,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -2854,7 +2854,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -4385,7 +4385,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -4837,7 +4837,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -5293,7 +5293,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -5727,7 +5727,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -6174,7 +6174,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -6617,7 +6617,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",

--- a/packages/components/src/constants/app-config.json
+++ b/packages/components/src/constants/app-config.json
@@ -114,7 +114,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -501,7 +501,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -802,7 +802,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1144,7 +1144,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1272,7 +1272,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1399,7 +1399,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1535,7 +1535,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1667,7 +1667,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1802,7 +1802,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",

--- a/packages/reference-implementation/prisma/migrations/20260306000000_rename_render_template_is_primary_to_is_default/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260306000000_rename_render_template_is_primary_to_is_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: rename isPrimary to isDefault on RenderTemplate
+ALTER TABLE "RenderTemplate" RENAME COLUMN "isPrimary" TO "isDefault";

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -463,7 +463,7 @@ model DataModel {
 
 /**
  * Render template references for credential types.
- * Stores storage URLs and hashes, with an isPrimary flag for tenant default selection.
+ * Stores storage URLs and hashes, with an isDefault flag for tenant default selection.
  */
 model RenderTemplate {
   id                       String                @id @default(cuid())
@@ -476,7 +476,7 @@ model RenderTemplate {
   name                     String
   storageUrl               String
   hash                     String
-  isPrimary                Boolean   @default(false)
+  isDefault                Boolean   @default(false)
   renderMethodType          RenderMethodType
   storageServiceInstanceId  String?
   storageExternalId         String?

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -287,7 +287,7 @@ async function main() {
       const storageServiceConfig = JSON.stringify({
         baseUrl: new URL(storageServiceUrl).origin,
         ...(storageApiKey && { apiKey: storageApiKey }),
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
         publicBucket: process.env.UNCEFACT_STORAGE_PUBLIC_BUCKET || 'public-data',
         privateBucket: process.env.UNCEFACT_STORAGE_PRIVATE_BUCKET || 'private-data',
       });
@@ -487,7 +487,7 @@ async function main() {
           uploadHeaders['X-API-Key'] = storageApiKey;
         }
 
-        const uploadUrl = `${storageBaseUrl}/api/3.0.0/public`;
+        const uploadUrl = `${storageBaseUrl}/api/3.1.0/public`;
         const response = await fetch(uploadUrl, {
           method: 'POST',
           headers: uploadHeaders,
@@ -524,7 +524,7 @@ async function main() {
             name: `${dm.name} Default Template`,
             storageUrl: uri,
             hash: hash ?? crypto.createHash('sha256').update(templateContent).digest('hex'),
-            isPrimary: true,
+            isDefault: true,
             renderMethodType: RenderMethodType.RenderTemplate2024,
             inline: false,
             mediaType: 'text/html',

--- a/packages/reference-implementation/src/__tests__/mocks/app-config.mock.json
+++ b/packages/reference-implementation/src/__tests__/mocks/app-config.mock.json
@@ -725,7 +725,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -913,7 +913,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -1129,7 +1129,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -2323,7 +2323,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -2795,7 +2795,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -3546,7 +3546,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -4028,7 +4028,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -4779,7 +4779,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -5261,7 +5261,7 @@
                     "linkRegisterPath": "/api/resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -118,7 +118,6 @@ describe('POST /api/v1/dids/:id/verify', () => {
     const verification = {
       verified: false,
       checks: [{ name: 'resolve', passed: false }],
-      errors: [{ name: 'resolve', message: 'Resolution failed' }],
     };
     mockDidService.verify.mockResolvedValue(verification);
     mockUpdateDidStatus.mockResolvedValue({ id: 'did-1', status: 'VERIFICATION_FAILED' });

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -10,7 +10,7 @@ jest.mock('next/server', () => ({
 
 // Mock withTenantAuth to mirror handleRouteError behaviour
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
+  const { NotFoundError, ConflictError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
   const { ValidationError } = jest.requireActual('@/lib/api/validation');
   const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
 
@@ -26,6 +26,9 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
             return jsonResponse({ error: (e as Error).message }, { status: 400 });
+          }
+          if (e instanceof ConflictError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 409 });
           }
           if (e instanceof NotFoundError) {
             return jsonResponse({ error: (e as Error).message }, { status: 404 });
@@ -49,6 +52,7 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
 const mockResolveDidService = jest.fn();
 const mockCreateDid = jest.fn();
 const mockListDids = jest.fn();
+const mockFindDidByAliasAndService = jest.fn();
 
 jest.mock('@/lib/services/resolve-did-service', () => ({
   resolveDidService: (...args: unknown[]) => mockResolveDidService(...args),
@@ -57,6 +61,8 @@ jest.mock('@/lib/services/resolve-did-service', () => ({
 jest.mock('@/lib/prisma/repositories', () => ({
   createDid: (input: unknown) => mockCreateDid(input),
   listDids: (orgId: string, opts: unknown) => mockListDids(orgId, opts),
+  findDidByAliasAndService: (alias: string, serviceInstanceId: string) =>
+    mockFindDidByAliasAndService(alias, serviceInstanceId),
 }));
 
 import { ServiceResolutionError } from '@/lib/api/errors';
@@ -103,6 +109,7 @@ describe('POST /api/v1/dids', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockResolveDidService.mockResolvedValue({ service: mockDidService, instanceId: 'inst-1' });
+    mockFindDidByAliasAndService.mockResolvedValue(false);
   });
 
   it('creates a managed DID and returns 201', async () => {
@@ -324,6 +331,23 @@ describe('POST /api/v1/dids', () => {
       DidType.MANAGED,
     );
     expect(mockDidService.create).toHaveBeenCalledWith(expect.objectContaining({ alias: 'my-normalised-alias' }));
+  });
+
+  it('returns 409 when DID with same alias already exists on service instance', async () => {
+    mockDidService.normaliseAlias.mockReturnValue('existing-alias');
+    mockFindDidByAliasAndService.mockResolvedValue(true);
+
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'existing-alias' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBeDefined();
+    expect(mockFindDidByAliasAndService).toHaveBeenCalledWith('existing-alias', 'inst-1');
+    expect(mockDidService.create).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('returns 400 when service does not support the requested method', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { resolveDidService } from '@/lib/services/resolve-did-service';
-import { errorMessage } from '@/lib/api/errors';
+import { errorMessage, ConflictError } from '@/lib/api/errors';
 import { ValidationError, validateEnum, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { createDid, listDids } from '@/lib/prisma/repositories';
+import { createDid, listDids, findDidByAliasAndService } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { CREATABLE_DID_TYPES, DidType, DidMethod, DidStatus } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
@@ -71,6 +71,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: A DID with this alias already exists on the service instance
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
  *         description: Service instance not found
  *         content:
@@ -129,6 +135,12 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     normalisedAlias = didService.normaliseAlias(body.alias, method, type);
   } catch (aliasErr) {
     throw new ValidationError(errorMessage(aliasErr, 'Invalid alias'));
+  }
+
+  logger.info({ alias: normalisedAlias, serviceInstanceId }, 'Checking for duplicate DID');
+  const aliasExists = await findDidByAliasAndService(normalisedAlias, serviceInstanceId);
+  if (aliasExists) {
+    throw new ConflictError(`A DID with alias "${normalisedAlias}" already exists on this service instance`);
   }
 
   logger.info({ type, method, alias: normalisedAlias, serviceInstanceId }, 'Creating DID via provider');

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
@@ -87,7 +87,7 @@ describe('GET /api/v1/render-templates/:id', () => {
       name: 'DPP Default Template',
       storageUrl: 'https://storage.example.com/templates/dpp.html',
       hash: 'abc123',
-      isPrimary: true,
+      isDefault: true,
       dataModel: { id: 'dm-1', name: 'DPP v0.6.0' },
     };
     mockGetRenderTemplateById.mockResolvedValue(renderTemplate);
@@ -135,7 +135,7 @@ describe('PATCH /api/v1/render-templates/:id', () => {
       name: 'Updated Template',
       storageUrl: 'https://storage.example.com/templates/dpp.html',
       hash: 'abc123',
-      isPrimary: false,
+      isDefault: false,
       dataModel: { id: 'dm-1', name: 'DPP v0.6.0' },
     };
     mockUpdateRenderTemplate.mockResolvedValue(updated);
@@ -152,7 +152,7 @@ describe('PATCH /api/v1/render-templates/:id', () => {
       name: 'Updated Template',
       template: undefined,
       storageService: undefined,
-      isPrimary: undefined,
+      isDefault: undefined,
       inline: undefined,
       mediaType: undefined,
       mediaQuery: undefined,
@@ -172,7 +172,7 @@ describe('PATCH /api/v1/render-templates/:id', () => {
       name: 'DPP Template',
       storageUrl: 'https://storage.example.com/templates/new.html',
       hash: 'newhash',
-      isPrimary: false,
+      isDefault: false,
       dataModel: { id: 'dm-1', name: 'DPP v0.6.0' },
     };
     mockUpdateRenderTemplate.mockResolvedValue(updated);
@@ -190,7 +190,7 @@ describe('PATCH /api/v1/render-templates/:id', () => {
       name: undefined,
       template: '<div>new</div>',
       storageService: mockStorageService,
-      isPrimary: undefined,
+      isDefault: undefined,
       inline: undefined,
       mediaType: undefined,
       mediaQuery: undefined,

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
@@ -11,7 +11,7 @@ import { apiLogger } from '@/lib/api/logger';
 const logger = apiLogger.child({ route: '/api/v1/render-templates/[id]' });
 
 const REJECTED_FIELDS = ['storageUrl', 'hash', 'renderMethodType'] as const;
-const PATCHABLE_FIELDS = ['name', 'template', 'isPrimary', 'inline', 'mediaType', 'mediaQuery'] as const;
+const PATCHABLE_FIELDS = ['name', 'template', 'isDefault', 'inline', 'mediaType', 'mediaQuery'] as const;
 
 /**
  * @swagger
@@ -74,7 +74,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *       Updates one or more fields of a tenant-owned render template.
  *       The fields storageUrl, hash, and renderMethodType cannot be set directly — they are managed by the server.
  *       When template content is provided, the server re-uploads it to storage and updates storageUrl/hash automatically.
- *       When setting isPrimary to true, any existing primary template for the same data model will be unset.
+ *       When setting isDefault to true, any existing default template for the same data model will be unset.
  *     tags:
  *       - Render Templates
  *     parameters:
@@ -97,9 +97,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *               template:
  *                 type: string
  *                 description: HTML content to replace the existing template
- *               isPrimary:
+ *               isDefault:
  *                 type: boolean
- *                 description: Whether this is the primary template for its data model
+ *                 description: Whether this is the default template for its data model
  *               inline:
  *                 type: boolean
  *                 description: Whether to inline the template (RenderTemplate2024 only)
@@ -184,8 +184,8 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   if (body.name !== undefined && !isNonEmptyString(body.name)) {
     throw new ValidationError('name must be a non-empty string');
   }
-  if (body.isPrimary !== undefined && typeof body.isPrimary !== 'boolean') {
-    throw new ValidationError('isPrimary must be a boolean');
+  if (body.isDefault !== undefined && typeof body.isDefault !== 'boolean') {
+    throw new ValidationError('isDefault must be a boolean');
   }
   if (body.inline !== undefined && typeof body.inline !== 'boolean') {
     throw new ValidationError('inline must be a boolean');
@@ -198,7 +198,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     name: body.name as string | undefined,
     template: body.template as string | undefined,
     storageService,
-    isPrimary: body.isPrimary,
+    isDefault: body.isDefault,
     inline: body.inline,
     mediaType: body.mediaType as string | undefined,
     mediaQuery: body.mediaQuery as string | undefined,

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
@@ -205,7 +205,7 @@ describe('POST /api/v1/render-templates', () => {
       renderMethodType: 'RenderTemplate2024',
       storageUrl: 'https://example.com/template.html',
       hash: 'sha256-abc123',
-      isPrimary: false,
+      isDefault: false,
     };
     mockCreateRenderTemplate.mockResolvedValue(created);
 
@@ -229,7 +229,7 @@ describe('POST /api/v1/render-templates', () => {
       renderMethodType: 'RenderTemplate2024',
       template: '<div>Hello</div>',
       storageService: defaultStorageService,
-      isPrimary: undefined,
+      isDefault: undefined,
       inline: undefined,
       mediaType: undefined,
       mediaQuery: undefined,

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
@@ -127,9 +127,9 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *               template:
  *                 type: string
  *                 description: HTML content of the render template
- *               isPrimary:
+ *               isDefault:
  *                 type: boolean
- *                 description: Whether this is the primary template for the data model. Setting to true will unset any existing primary template for the same data model.
+ *                 description: Whether this is the default template for the data model. Setting to true will unset any existing default template for the same data model.
  *               inline:
  *                 type: boolean
  *                 description: Whether the template is inline (applicable to RenderTemplate2024)
@@ -198,8 +198,8 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   if (!isNonEmptyString(body.template)) throw new ValidationError('template is required');
 
   // Validate optional field types
-  if (body.isPrimary !== undefined && typeof body.isPrimary !== 'boolean') {
-    throw new ValidationError('isPrimary must be a boolean');
+  if (body.isDefault !== undefined && typeof body.isDefault !== 'boolean') {
+    throw new ValidationError('isDefault must be a boolean');
   }
   if (body.inline !== undefined && typeof body.inline !== 'boolean') {
     throw new ValidationError('inline must be a boolean');
@@ -225,7 +225,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     renderMethodType,
     template: body.template as string,
     storageService,
-    isPrimary: body.isPrimary,
+    isDefault: body.isDefault,
     inline: body.inline,
     mediaType: body.mediaType as string | undefined,
     mediaQuery: body.mediaQuery as string | undefined,

--- a/packages/reference-implementation/src/constants/app-config.example.json
+++ b/packages/reference-implementation/src/constants/app-config.example.json
@@ -713,7 +713,7 @@
                     "dlrAPIKey": "5555555555555"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },
@@ -1193,7 +1193,7 @@
                     "dlrAPIKey": "5555555555555"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {
                       "resultPath": "/uri"
                     },

--- a/packages/reference-implementation/src/constants/app-config.issue.json
+++ b/packages/reference-implementation/src/constants/app-config.issue.json
@@ -325,7 +325,7 @@
             "linkRegisterPath": "resolver"
           },
           "storage": {
-            "url": "http://localhost:3334/api/3.0.0/public",
+            "url": "http://localhost:3334/api/3.1.0/public",
             "params": {},
             "options": {
               "method": "POST",

--- a/packages/reference-implementation/src/constants/app-config.json
+++ b/packages/reference-implementation/src/constants/app-config.json
@@ -114,7 +114,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -502,7 +502,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -804,7 +804,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1147,7 +1147,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1276,7 +1276,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1404,7 +1404,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1541,7 +1541,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1674,7 +1674,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",
@@ -1810,7 +1810,7 @@
                     "linkRegisterPath": "resolver"
                   },
                   "storage": {
-                    "url": "http://localhost:3334/api/3.0.0/public",
+                    "url": "http://localhost:3334/api/3.1.0/public",
                     "params": {},
                     "options": {
                       "method": "POST",

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -7,8 +7,9 @@ import {
   updateDidStatus,
   deleteDid,
   getDefaultDid,
+  findDidByAliasAndService,
 } from './did.repository';
-import type { DidStatus } from '../generated';
+import { DidStatus } from '../generated';
 
 // Transaction mock — functions called via $transaction callback
 const mockTx = {
@@ -507,6 +508,53 @@ describe('did.repository', () => {
 
       await expect(deleteDid('did-record-1', 'other-org')).rejects.toThrow('DID not found or access denied');
       expect(mockTx.did.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findDidByAliasAndService', () => {
+    it('returns true when a matching DID exists on the service instance', async () => {
+      mockDid.findFirst.mockResolvedValue({ id: 'did-record-1' });
+
+      const result = await findDidByAliasAndService('my-alias', 'si-1');
+
+      expect(mockDid.findFirst).toHaveBeenCalledWith({
+        where: {
+          serviceInstanceId: 'si-1',
+          did: { endsWith: ':my-alias' },
+        },
+        select: { id: true },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when no matching DID exists', async () => {
+      mockDid.findFirst.mockResolvedValue(null);
+
+      const result = await findDidByAliasAndService('nonexistent', 'si-1');
+
+      expect(mockDid.findFirst).toHaveBeenCalledWith({
+        where: {
+          serviceInstanceId: 'si-1',
+          did: { endsWith: ':nonexistent' },
+        },
+        select: { id: true },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when matching alias exists on a different service instance', async () => {
+      mockDid.findFirst.mockResolvedValue(null);
+
+      const result = await findDidByAliasAndService('my-alias', 'si-2');
+
+      expect(mockDid.findFirst).toHaveBeenCalledWith({
+        where: {
+          serviceInstanceId: 'si-2',
+          did: { endsWith: ':my-alias' },
+        },
+        select: { id: true },
+      });
+      expect(result).toBe(false);
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -258,6 +258,21 @@ export async function deleteDid(id: string, tenantId: string): Promise<void> {
  * own default DID over the system default. Falls back to the system default
  * if the tenant has no default set.
  */
+/**
+ * Checks whether a DID with the given alias already exists on the specified service instance.
+ * Uses endsWith matching since the normalised alias forms the trailing segment(s) of the DID URI.
+ */
+export async function findDidByAliasAndService(normalisedAlias: string, serviceInstanceId: string): Promise<boolean> {
+  const existing = await prisma.did.findFirst({
+    where: {
+      serviceInstanceId,
+      did: { endsWith: `:${normalisedAlias}` },
+    },
+    select: { id: true },
+  });
+  return existing !== null;
+}
+
 export async function getDefaultDid(tenantId?: string): Promise<Did | null> {
   if (tenantId) {
     const tenantDefault = await prisma.did.findFirst({

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
@@ -4,7 +4,7 @@ import {
   listRenderTemplates,
   updateRenderTemplate,
   deleteRenderTemplate,
-  getPrimaryRenderTemplate,
+  getDefaultRenderTemplate,
 } from './render-template.repository';
 
 // Transaction mock — functions called via $transaction callback
@@ -63,7 +63,7 @@ describe('render-template.repository', () => {
     renderMethodType: 'RenderTemplate2024',
     storageUrl: 'https://storage.example.com/templates/dpp-default.html',
     hash: 'sha256-abc123',
-    isPrimary: false,
+    isDefault: false,
     storageServiceInstanceId: null,
     storageExternalId: null,
     storageBucket: null,
@@ -103,7 +103,7 @@ describe('render-template.repository', () => {
           renderMethodType: 'RenderTemplate2024',
           storageUrl: 'https://storage.example.com/templates/dpp-default.html',
           hash: 'sha256-abc123',
-          isPrimary: false,
+          isDefault: false,
           storageServiceInstanceId: undefined,
           storageExternalId: undefined,
           storageBucket: undefined,
@@ -117,7 +117,7 @@ describe('render-template.repository', () => {
       expect(result).toEqual(TEMPLATE_RECORD);
     });
 
-    it('defaults isPrimary to false', async () => {
+    it('defaults isDefault to false', async () => {
       mockTx.renderTemplate.create.mockResolvedValue(TEMPLATE_RECORD);
 
       await createRenderTemplate(TENANT_ID, {
@@ -130,37 +130,37 @@ describe('render-template.repository', () => {
 
       expect(mockTx.renderTemplate.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
-          isPrimary: false,
+          isDefault: false,
         }),
         include: INCLUDE_SHAPE,
       });
     });
 
-    it('unsets existing primary when isPrimary is true', async () => {
-      const primaryRecord = { ...TEMPLATE_RECORD, isPrimary: true };
+    it('unsets existing default when isDefault is true', async () => {
+      const defaultRecord = { ...TEMPLATE_RECORD, isDefault: true };
       mockTx.renderTemplate.updateMany.mockResolvedValue({ count: 1 });
-      mockTx.renderTemplate.create.mockResolvedValue(primaryRecord);
+      mockTx.renderTemplate.create.mockResolvedValue(defaultRecord);
 
       await createRenderTemplate(TENANT_ID, {
-        name: 'DPP Primary Template',
+        name: 'DPP Default Template',
         dataModelId: CONFIG_ID,
         renderMethodType: 'RenderTemplate2024',
-        storageUrl: 'https://storage.example.com/templates/dpp-primary.html',
+        storageUrl: 'https://storage.example.com/templates/dpp-default.html',
         hash: 'sha256-def456',
-        isPrimary: true,
+        isDefault: true,
       });
 
       expect(mockTx.renderTemplate.updateMany).toHaveBeenCalledWith({
         where: {
           tenantId: TENANT_ID,
           dataModelId: CONFIG_ID,
-          isPrimary: true,
+          isDefault: true,
         },
-        data: { isPrimary: false },
+        data: { isDefault: false },
       });
       expect(mockTx.renderTemplate.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
-          isPrimary: true,
+          isDefault: true,
         }),
         include: INCLUDE_SHAPE,
       });
@@ -203,11 +203,43 @@ describe('render-template.repository', () => {
       const result = await getRenderTemplateById('nonexistent', TENANT_ID);
       expect(result).toBeNull();
     });
+
+    it('overrides isDefault to false for system template when tenant has own default', async () => {
+      const systemTemplate = {
+        ...TEMPLATE_RECORD,
+        id: 'system-template-1',
+        tenantId: 'system',
+        isDefault: true,
+      };
+      mockRenderTemplate.findFirst
+        .mockResolvedValueOnce(systemTemplate) // getRenderTemplateById query
+        .mockResolvedValueOnce({ id: 'tenant-default' }); // applyTenantDefaultOverride check
+
+      const result = await getRenderTemplateById('system-template-1', TENANT_ID);
+
+      expect(result).toEqual({ ...systemTemplate, isDefault: false });
+    });
+
+    it('preserves isDefault for system template when tenant has no own default', async () => {
+      const systemTemplate = {
+        ...TEMPLATE_RECORD,
+        id: 'system-template-1',
+        tenantId: 'system',
+        isDefault: true,
+      };
+      mockRenderTemplate.findFirst.mockResolvedValueOnce(systemTemplate).mockResolvedValueOnce(null);
+
+      const result = await getRenderTemplateById('system-template-1', TENANT_ID);
+
+      expect(result).toEqual(systemTemplate);
+    });
   });
 
   describe('listRenderTemplates', () => {
     it('lists templates for tenant with total count', async () => {
-      mockRenderTemplate.findMany.mockResolvedValue([TEMPLATE_RECORD]);
+      mockRenderTemplate.findMany
+        .mockResolvedValueOnce([TEMPLATE_RECORD]) // main query
+        .mockResolvedValueOnce([]); // tenant defaults query
       mockRenderTemplate.count.mockResolvedValue(1);
 
       const result = await listRenderTemplates(TENANT_ID);
@@ -230,7 +262,9 @@ describe('render-template.repository', () => {
     });
 
     it('filters by dataModelId', async () => {
-      mockRenderTemplate.findMany.mockResolvedValue([TEMPLATE_RECORD]);
+      mockRenderTemplate.findMany
+        .mockResolvedValueOnce([TEMPLATE_RECORD]) // main query
+        .mockResolvedValueOnce([]); // tenant defaults query
       mockRenderTemplate.count.mockResolvedValue(1);
 
       await listRenderTemplates(TENANT_ID, { dataModelId: CONFIG_ID });
@@ -258,7 +292,9 @@ describe('render-template.repository', () => {
         tenantId: 'system',
         name: 'DPP System Default Template',
       };
-      mockRenderTemplate.findMany.mockResolvedValue([TEMPLATE_RECORD, SYSTEM_TEMPLATE_RECORD]);
+      mockRenderTemplate.findMany
+        .mockResolvedValueOnce([TEMPLATE_RECORD, SYSTEM_TEMPLATE_RECORD]) // main query
+        .mockResolvedValueOnce([]); // tenant defaults query
       mockRenderTemplate.count.mockResolvedValue(2);
 
       const result = await listRenderTemplates(TENANT_ID);
@@ -268,7 +304,9 @@ describe('render-template.repository', () => {
     });
 
     it('applies pagination', async () => {
-      mockRenderTemplate.findMany.mockResolvedValue([]);
+      mockRenderTemplate.findMany
+        .mockResolvedValueOnce([]) // main query
+        .mockResolvedValueOnce([]); // tenant defaults query
       mockRenderTemplate.count.mockResolvedValue(0);
 
       await listRenderTemplates(TENANT_ID, { limit: 10, offset: 20 });
@@ -279,6 +317,30 @@ describe('render-template.repository', () => {
           skip: 20,
         }),
       );
+    });
+
+    it('overrides isDefault on system templates when tenant has own default for same dataModelId', async () => {
+      const systemTemplate = {
+        ...TEMPLATE_RECORD,
+        id: 'system-template-1',
+        tenantId: 'system',
+        isDefault: true,
+      };
+      const tenantTemplate = {
+        ...TEMPLATE_RECORD,
+        id: 'tenant-template-1',
+        tenantId: TENANT_ID,
+        isDefault: true,
+      };
+      mockRenderTemplate.findMany
+        .mockResolvedValueOnce([tenantTemplate, systemTemplate]) // main query
+        .mockResolvedValueOnce([{ dataModelId: CONFIG_ID }]); // tenant defaults query
+      mockRenderTemplate.count.mockResolvedValue(2);
+
+      const result = await listRenderTemplates(TENANT_ID);
+
+      expect(result.data[0].isDefault).toBe(true); // tenant's own
+      expect(result.data[1].isDefault).toBe(false); // system overridden
     });
   });
 
@@ -311,28 +373,28 @@ describe('render-template.repository', () => {
       );
     });
 
-    it('unsets existing primary when setting isPrimary (excluding self)', async () => {
+    it('unsets existing default when setting isDefault (excluding self)', async () => {
       mockTx.renderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
       mockTx.renderTemplate.updateMany.mockResolvedValue({ count: 1 });
       mockTx.renderTemplate.update.mockResolvedValue({
         ...TEMPLATE_RECORD,
-        isPrimary: true,
+        isDefault: true,
       });
 
-      await updateRenderTemplate('template-1', TENANT_ID, { isPrimary: true });
+      await updateRenderTemplate('template-1', TENANT_ID, { isDefault: true });
 
       expect(mockTx.renderTemplate.updateMany).toHaveBeenCalledWith({
         where: {
           tenantId: TENANT_ID,
           dataModelId: CONFIG_ID,
-          isPrimary: true,
+          isDefault: true,
           NOT: { id: 'template-1' },
         },
-        data: { isPrimary: false },
+        data: { isDefault: false },
       });
       expect(mockTx.renderTemplate.update).toHaveBeenCalledWith({
         where: { id: 'template-1' },
-        data: { isPrimary: true },
+        data: { isDefault: true },
         include: INCLUDE_SHAPE,
       });
     });
@@ -425,29 +487,56 @@ describe('render-template.repository', () => {
     });
   });
 
-  describe('getPrimaryRenderTemplate', () => {
-    it('returns the primary template for a tenant and config', async () => {
-      const primaryRecord = { ...TEMPLATE_RECORD, isPrimary: true };
-      mockRenderTemplate.findFirst.mockResolvedValue(primaryRecord);
+  describe('getDefaultRenderTemplate', () => {
+    it('returns the default template for a tenant and config', async () => {
+      const defaultRecord = { ...TEMPLATE_RECORD, isDefault: true };
+      mockRenderTemplate.findFirst.mockResolvedValueOnce(defaultRecord);
 
-      const result = await getPrimaryRenderTemplate(TENANT_ID, CONFIG_ID);
+      const result = await getDefaultRenderTemplate(TENANT_ID, CONFIG_ID);
 
       expect(mockRenderTemplate.findFirst).toHaveBeenCalledWith({
         where: {
-          OR: [{ tenantId: TENANT_ID }, { tenantId: 'system' }],
+          tenantId: TENANT_ID,
           dataModelId: CONFIG_ID,
-          isPrimary: true,
+          isDefault: true,
         },
         include: INCLUDE_SHAPE,
       });
-      expect(result).toEqual(primaryRecord);
+      expect(result).toEqual(defaultRecord);
     });
 
-    it('returns null when no primary template exists', async () => {
-      mockRenderTemplate.findFirst.mockResolvedValue(null);
+    it('returns null when no default template exists', async () => {
+      mockRenderTemplate.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
 
-      const result = await getPrimaryRenderTemplate(TENANT_ID, CONFIG_ID);
+      const result = await getDefaultRenderTemplate(TENANT_ID, CONFIG_ID);
       expect(result).toBeNull();
+    });
+
+    it('returns tenant default over system default', async () => {
+      const tenantDefault = { ...TEMPLATE_RECORD, isDefault: true };
+      mockRenderTemplate.findFirst.mockResolvedValueOnce(tenantDefault);
+
+      const result = await getDefaultRenderTemplate(TENANT_ID, CONFIG_ID);
+
+      expect(mockRenderTemplate.findFirst).toHaveBeenCalledWith({
+        where: { tenantId: TENANT_ID, dataModelId: CONFIG_ID, isDefault: true },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(tenantDefault);
+    });
+
+    it('falls back to system default when tenant has none', async () => {
+      const systemDefault = { ...TEMPLATE_RECORD, tenantId: 'system', isDefault: true };
+      mockRenderTemplate.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(systemDefault);
+
+      const result = await getDefaultRenderTemplate(TENANT_ID, CONFIG_ID);
+
+      expect(mockRenderTemplate.findFirst).toHaveBeenCalledTimes(2);
+      expect(mockRenderTemplate.findFirst).toHaveBeenNthCalledWith(2, {
+        where: { tenantId: 'system', dataModelId: CONFIG_ID, isDefault: true },
+        include: INCLUDE_SHAPE,
+      });
+      expect(result).toEqual(systemDefault);
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
@@ -176,7 +176,7 @@ export async function listRenderTemplates(
     }),
     prisma.renderTemplate.count({ where }),
     prisma.renderTemplate.findMany({
-      where: { tenantId, isDefault: true },
+      where: { tenantId, isDefault: true, ...(dataModelId && { dataModelId }) },
       select: { dataModelId: true },
     }),
   ]);

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
@@ -28,7 +28,7 @@ export type CreateRenderTemplateInput = {
   renderMethodType: RenderMethodType;
   storageUrl: string;
   hash: string;
-  isPrimary?: boolean;
+  isDefault?: boolean;
   storageServiceInstanceId?: string;
   storageExternalId?: string;
   storageBucket?: string;
@@ -45,7 +45,7 @@ export type UpdateRenderTemplateInput = {
   name?: string;
   storageUrl?: string;
   hash?: string;
-  isPrimary?: boolean;
+  isDefault?: boolean;
   storageServiceInstanceId?: string;
   storageExternalId?: string;
   storageBucket?: string;
@@ -65,8 +65,31 @@ export type ListRenderTemplatesOptions = {
 };
 
 /**
+ * When a system default render template has isDefault true but the tenant
+ * has set their own default for the same dataModelId, the system template's
+ * isDefault should appear as false for that tenant.
+ */
+async function applyTenantDefaultOverride(
+  template: RenderTemplateWithRelations | null,
+  tenantId: string,
+): Promise<RenderTemplateWithRelations | null> {
+  if (!template || template.tenantId !== SYSTEM_TENANT_ID || !template.isDefault) return template;
+
+  const tenantDefault = await prisma.renderTemplate.findFirst({
+    where: {
+      tenantId,
+      dataModelId: template.dataModelId,
+      isDefault: true,
+    },
+    select: { id: true },
+  });
+
+  return tenantDefault ? { ...template, isDefault: false } : template;
+}
+
+/**
  * Creates a new render template scoped to a tenant.
- * When isPrimary is true, first unsets any existing primary for the same
+ * When isDefault is true, first unsets any existing default for the same
  * tenant + dataModelId combination.
  */
 export async function createRenderTemplate(
@@ -74,14 +97,14 @@ export async function createRenderTemplate(
   input: CreateRenderTemplateInput,
 ): Promise<RenderTemplateWithRelations> {
   return prisma.$transaction(async (tx) => {
-    if (input.isPrimary) {
+    if (input.isDefault) {
       await tx.renderTemplate.updateMany({
         where: {
           tenantId,
           dataModelId: input.dataModelId,
-          isPrimary: true,
+          isDefault: true,
         },
-        data: { isPrimary: false },
+        data: { isDefault: false },
       });
     }
 
@@ -93,7 +116,7 @@ export async function createRenderTemplate(
         renderMethodType: input.renderMethodType,
         storageUrl: input.storageUrl,
         hash: input.hash,
-        isPrimary: input.isPrimary ?? false,
+        isDefault: input.isDefault ?? false,
         storageServiceInstanceId: input.storageServiceInstanceId,
         storageExternalId: input.storageExternalId,
         storageBucket: input.storageBucket,
@@ -110,20 +133,24 @@ export async function createRenderTemplate(
 /**
  * Retrieves a render template by ID.
  * Returns templates visible to the tenant OR system-provisioned.
+ * Applies tenant default override for system templates.
  */
 export async function getRenderTemplateById(id: string, tenantId: string): Promise<RenderTemplateWithRelations | null> {
-  return prisma.renderTemplate.findFirst({
+  const result = await prisma.renderTemplate.findFirst({
     where: {
       id,
       OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
     },
     include: RENDER_TEMPLATE_INCLUDE,
   });
+
+  return applyTenantDefaultOverride(result, tenantId);
 }
 
 /**
  * Lists render templates for a tenant, including system-provisioned templates.
  * Supports filtering by dataModelId and pagination.
+ * Applies tenant default override for system templates.
  */
 export async function listRenderTemplates(
   tenantId: string,
@@ -139,7 +166,7 @@ export async function listRenderTemplates(
     where.dataModelId = dataModelId;
   }
 
-  const [data, total] = await Promise.all([
+  const [data, total, tenantDefaults] = await Promise.all([
     prisma.renderTemplate.findMany({
       where,
       include: RENDER_TEMPLATE_INCLUDE,
@@ -148,14 +175,27 @@ export async function listRenderTemplates(
       orderBy: { createdAt: 'desc' },
     }),
     prisma.renderTemplate.count({ where }),
+    prisma.renderTemplate.findMany({
+      where: { tenantId, isDefault: true },
+      select: { dataModelId: true },
+    }),
   ]);
 
-  return { data, total };
+  const tenantDefaultDataModels = new Set(tenantDefaults.map((t) => t.dataModelId));
+
+  return {
+    data: data.map((t) =>
+      t.tenantId === SYSTEM_TENANT_ID && t.isDefault && tenantDefaultDataModels.has(t.dataModelId)
+        ? { ...t, isDefault: false }
+        : t,
+    ),
+    total,
+  };
 }
 
 /**
  * Updates a render template. Only tenant-owned templates can be updated.
- * When setting isPrimary to true, unsets any existing primary for the same
+ * When setting isDefault to true, unsets any existing default for the same
  * tenant + dataModelId combination (excluding self).
  */
 export async function updateRenderTemplate(
@@ -172,15 +212,15 @@ export async function updateRenderTemplate(
       throw new NotFoundError('Render template not found or access denied');
     }
 
-    if (input.isPrimary) {
+    if (input.isDefault) {
       await tx.renderTemplate.updateMany({
         where: {
           tenantId,
           dataModelId: existing.dataModelId,
-          isPrimary: true,
+          isDefault: true,
           NOT: { id },
         },
-        data: { isPrimary: false },
+        data: { isDefault: false },
       });
     }
 
@@ -190,7 +230,7 @@ export async function updateRenderTemplate(
         ...(input.name !== undefined && { name: input.name }),
         ...(input.storageUrl !== undefined && { storageUrl: input.storageUrl }),
         ...(input.hash !== undefined && { hash: input.hash }),
-        ...(input.isPrimary !== undefined && { isPrimary: input.isPrimary }),
+        ...(input.isDefault !== undefined && { isDefault: input.isDefault }),
         ...(input.storageServiceInstanceId !== undefined && {
           storageServiceInstanceId: input.storageServiceInstanceId,
         }),
@@ -227,20 +267,24 @@ export async function deleteRenderTemplate(id: string, tenantId: string): Promis
 }
 
 /**
- * Returns the primary render template for a tenant + dataModelId
- * combination, including system-provisioned templates.
+ * Returns the default render template for a tenant + dataModelId combination.
+ * Prefers the tenant's own default; falls back to the system default.
  * Returns null if none is set.
  */
-export async function getPrimaryRenderTemplate(
+export async function getDefaultRenderTemplate(
   tenantId: string,
   dataModelId: string,
 ): Promise<RenderTemplateWithRelations | null> {
+  // Tenant's own default first
+  const tenantDefault = await prisma.renderTemplate.findFirst({
+    where: { tenantId, dataModelId, isDefault: true },
+    include: RENDER_TEMPLATE_INCLUDE,
+  });
+  if (tenantDefault) return tenantDefault;
+
+  // Fall back to system default
   return prisma.renderTemplate.findFirst({
-    where: {
-      OR: [{ tenantId }, { tenantId: SYSTEM_TENANT_ID }],
-      dataModelId,
-      isPrimary: true,
-    },
+    where: { tenantId: SYSTEM_TENANT_ID, dataModelId, isDefault: true },
     include: RENDER_TEMPLATE_INCLUDE,
   });
 }

--- a/packages/reference-implementation/src/lib/render-templates/create-render-template.test.ts
+++ b/packages/reference-implementation/src/lib/render-templates/create-render-template.test.ts
@@ -59,7 +59,7 @@ const MOCK_CREATED_RECORD = {
   renderMethodType: 'RenderTemplate2024',
   storageUrl: MOCK_STORAGE_RESULT.uri,
   hash: MOCK_STORAGE_RESULT.hash,
-  isPrimary: false,
+  isDefault: false,
   dataModel: MOCK_DATA_MODEL,
 };
 
@@ -137,7 +137,7 @@ describe('createRenderTemplate', () => {
       renderMethodType: 'RenderTemplate2024',
       storageUrl: MOCK_STORAGE_RESULT.uri,
       hash: MOCK_STORAGE_RESULT.hash,
-      isPrimary: undefined,
+      isDefault: undefined,
       storageServiceInstanceId: 'storage-instance-1',
       storageExternalId: MOCK_STORAGE_RESULT.externalId,
       storageBucket: MOCK_STORAGE_RESULT.bucket,
@@ -152,10 +152,10 @@ describe('createRenderTemplate', () => {
     expect(result).toEqual(MOCK_CREATED_RECORD);
   });
 
-  it('passes isPrimary to repository when provided', async () => {
-    await createRenderTemplate(buildInput({ isPrimary: true }));
+  it('passes isDefault to repository when provided', async () => {
+    await createRenderTemplate(buildInput({ isDefault: true }));
 
-    expect(mockCreateRenderTemplateRepo).toHaveBeenCalledWith(TENANT_ID, expect.objectContaining({ isPrimary: true }));
+    expect(mockCreateRenderTemplateRepo).toHaveBeenCalledWith(TENANT_ID, expect.objectContaining({ isDefault: true }));
   });
 
   it('sanitises template content before upload', async () => {

--- a/packages/reference-implementation/src/lib/render-templates/create-render-template.ts
+++ b/packages/reference-implementation/src/lib/render-templates/create-render-template.ts
@@ -18,11 +18,11 @@ export type CreateRenderTemplateInput = {
   renderMethodType: RenderMethodType;
   template: string;
   storageService: ResolvedService<IStorageService>;
-  isPrimary?: boolean;
+  isDefault?: boolean;
 } & RenderMethodFields;
 
 export async function createRenderTemplate(input: CreateRenderTemplateInput): Promise<RenderTemplateWithRelations> {
-  const { tenantId, name, dataModelId, renderMethodType, template, storageService, isPrimary } = input;
+  const { tenantId, name, dataModelId, renderMethodType, template, storageService, isDefault } = input;
 
   logger.info({ dataModelId }, 'Verifying data model exists');
   const dataModel = await getDataModelById(dataModelId, tenantId);
@@ -51,7 +51,7 @@ export async function createRenderTemplate(input: CreateRenderTemplateInput): Pr
     renderMethodType,
     storageUrl: storageResult.uri,
     hash: storageResult.hash,
-    isPrimary,
+    isDefault,
     storageServiceInstanceId: storageService.instanceId,
     storageExternalId: storageResult.externalId,
     storageBucket: storageResult.bucket,

--- a/packages/reference-implementation/src/lib/render-templates/update-render-template.test.ts
+++ b/packages/reference-implementation/src/lib/render-templates/update-render-template.test.ts
@@ -39,7 +39,7 @@ const MOCK_EXISTING = {
   storageBucket: 'old-bucket',
   storageContentType: 'text/html',
   storageServiceInstanceId: 'old-storage-instance',
-  isPrimary: false,
+  isDefault: false,
   inline: false,
   mediaType: 'text/html',
   mediaQuery: null,
@@ -183,13 +183,13 @@ describe('updateRenderTemplate', () => {
     expect(repoCallArg).not.toHaveProperty('storageExternalId');
   });
 
-  it('passes isPrimary to repository when provided', async () => {
-    await updateRenderTemplate(buildInput({ isPrimary: true }));
+  it('passes isDefault to repository when provided', async () => {
+    await updateRenderTemplate(buildInput({ isDefault: true }));
 
     expect(mockUpdateRenderTemplateRepo).toHaveBeenCalledWith(
       'rt-1',
       'tenant-1',
-      expect.objectContaining({ isPrimary: true }),
+      expect.objectContaining({ isDefault: true }),
     );
   });
 

--- a/packages/reference-implementation/src/lib/render-templates/update-render-template.ts
+++ b/packages/reference-implementation/src/lib/render-templates/update-render-template.ts
@@ -16,11 +16,11 @@ export type UpdateRenderTemplateInput = {
   name?: string;
   template?: string;
   storageService?: ResolvedService<IStorageService>;
-  isPrimary?: boolean;
+  isDefault?: boolean;
 } & RenderMethodFields;
 
 export async function updateRenderTemplate(input: UpdateRenderTemplateInput): Promise<RenderTemplateWithRelations> {
-  const { id, tenantId, name, template, storageService, isPrimary } = input;
+  const { id, tenantId, name, template, storageService, isDefault } = input;
 
   logger.info({ renderTemplateId: id }, 'Looking up existing render template');
   const existing = await getRenderTemplateById(id, tenantId);
@@ -81,7 +81,7 @@ export async function updateRenderTemplate(input: UpdateRenderTemplateInput): Pr
   logger.info({ renderTemplateId: id }, 'Updating render template record');
   return updateRenderTemplateRepo(id, tenantId, {
     ...(name !== undefined && { name }),
-    ...(isPrimary !== undefined && { isPrimary }),
+    ...(isDefault !== undefined && { isDefault }),
     ...storageUpdates,
     ...(input.inline !== undefined && { inline: validatedFields.inline }),
     ...(input.mediaType !== undefined && { mediaType: validatedFields.mediaType }),

--- a/packages/reference-implementation/src/lib/services/resolve-storage-service.test.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-storage-service.test.ts
@@ -77,7 +77,7 @@ const MOCK_INSTANCE = {
 
 const VALID_CONFIG = {
   baseUrl: 'https://storage.example.com',
-  apiVersion: '3.0.0',
+  apiVersion: '3.1.0',
 };
 const VALID_JSON = JSON.stringify(VALID_CONFIG);
 

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -11,7 +11,6 @@ import {
   // DID schemas
   didResponseSchema,
   verificationCheckSchema,
-  verificationErrorSchema,
   verificationResultResponseSchema,
   didDocumentResponseSchema,
   // IDR schemas
@@ -159,7 +158,6 @@ export const criterionSchema = z.object({
 export {
   didResponseSchema,
   verificationCheckSchema,
-  verificationErrorSchema,
   verificationResultResponseSchema,
   didDocumentResponseSchema,
   registrarSchema,
@@ -193,7 +191,6 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     VerificationResult: verificationResultResponseSchema,
     PaginationMeta: paginationMetaSchema,
     VerificationCheck: verificationCheckSchema,
-    VerificationError: verificationErrorSchema,
     DidDocument: didDocumentResponseSchema,
     CredentialIssueRequest: credentialIssueRequestSchema,
     CredentialIssueResponse: credentialIssueResponseSchema,

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
@@ -335,7 +335,7 @@ describe('VCKitDidAdapter', () => {
   // verify() delegation test
   describe('verify', () => {
     it('delegates to verifyDid with provider keys from VCKit', async () => {
-      const mockResult = { verified: true, checks: [], errors: undefined };
+      const mockResult = { verified: true, checks: [] };
       (verifyDid as jest.Mock).mockResolvedValue(mockResult);
       (global.fetch as jest.Mock).mockResolvedValueOnce(
         createMockResponse({ keys: [{ kid: 'key-1' }, { kid: 'key-2' }] }),
@@ -364,8 +364,13 @@ describe('VCKitDidAdapter', () => {
       await expect(service.verify('')).rejects.toThrow(DidInputError);
     });
 
-    it('passes empty providerKeys and adds KEY_MATERIAL error when key fetch throws', async () => {
-      const mockResult = { verified: true, checks: [], errors: undefined };
+    it('replaces KEY_MATERIAL check and recalculates verified when key fetch throws', async () => {
+      const existingKeyCheck = {
+        name: DidVerificationCheckName.KEY_MATERIAL,
+        passed: true,
+        message: 'No provider keys to compare',
+      };
+      const mockResult = { verified: true, checks: [existingKeyCheck] };
       (verifyDid as jest.Mock).mockResolvedValue(mockResult);
       (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
 
@@ -375,16 +380,24 @@ describe('VCKitDidAdapter', () => {
         providerKeys: [],
       });
 
-      expect(result.errors).toEqual([
-        {
-          name: DidVerificationCheckName.KEY_MATERIAL,
-          message: 'Provider key material could not be fetched — key_material check may be incomplete',
-        },
-      ]);
+      // Should replace the existing KEY_MATERIAL check, not append
+      expect(result.checks.filter((c) => c.name === DidVerificationCheckName.KEY_MATERIAL)).toHaveLength(1);
+      expect(result.checks).toContainEqual({
+        name: DidVerificationCheckName.KEY_MATERIAL,
+        passed: false,
+        message: 'Provider key material could not be fetched — key_material check may be incomplete',
+      });
+      // verified should be recalculated to false
+      expect(result.verified).toBe(false);
     });
 
-    it('adds KEY_MATERIAL error when key fetch returns non-OK status', async () => {
-      const mockResult = { verified: true, checks: [], errors: undefined };
+    it('replaces KEY_MATERIAL check when key fetch returns non-OK status', async () => {
+      const existingKeyCheck = {
+        name: DidVerificationCheckName.KEY_MATERIAL,
+        passed: true,
+        message: 'No provider keys to compare',
+      };
+      const mockResult = { verified: true, checks: [existingKeyCheck] };
       (verifyDid as jest.Mock).mockResolvedValue(mockResult);
       (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse({}, false, 500));
 
@@ -394,28 +407,31 @@ describe('VCKitDidAdapter', () => {
         providerKeys: [],
       });
 
-      expect(result.errors).toEqual([
-        {
-          name: DidVerificationCheckName.KEY_MATERIAL,
-          message: 'Provider key material could not be fetched — key_material check may be incomplete',
-        },
-      ]);
+      expect(result.checks.filter((c) => c.name === DidVerificationCheckName.KEY_MATERIAL)).toHaveLength(1);
+      expect(result.checks).toContainEqual({
+        name: DidVerificationCheckName.KEY_MATERIAL,
+        passed: false,
+        message: 'Provider key material could not be fetched — key_material check may be incomplete',
+      });
+      expect(result.verified).toBe(false);
     });
 
-    it('appends KEY_MATERIAL error to existing errors when key fetch fails', async () => {
-      const existingError = { name: DidVerificationCheckName.RESOLVE, message: 'Could not resolve' };
-      const mockResult = { verified: false, checks: [], errors: [existingError] };
+    it('pushes KEY_MATERIAL check when no existing KEY_MATERIAL check and key fetch fails', async () => {
+      const existingCheck = { name: DidVerificationCheckName.RESOLVE, passed: false, message: 'Could not resolve' };
+      const mockResult = { verified: false, checks: [existingCheck] };
       (verifyDid as jest.Mock).mockResolvedValue(mockResult);
       (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
 
       const result = await service.verify('did:web:example.com');
 
-      expect(result.errors).toHaveLength(2);
-      expect(result.errors![0]).toEqual(existingError);
-      expect(result.errors![1]).toEqual({
+      expect(result.checks).toHaveLength(2);
+      expect(result.checks[0]).toEqual(existingCheck);
+      expect(result.checks[1]).toEqual({
         name: DidVerificationCheckName.KEY_MATERIAL,
+        passed: false,
         message: 'Provider key material could not be fetched — key_material check may be incomplete',
       });
+      expect(result.verified).toBe(false);
     });
   });
 

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -222,11 +222,19 @@ export class VCKitDidAdapter implements IDidService {
     const result = await verifyDid(did, { providerKeys });
 
     if (keyFetchFailed) {
-      if (!result.errors) result.errors = [];
-      result.errors.push({
+      // Replace the vacuously-passing KEY_MATERIAL check with a failure
+      const keyCheckIndex = result.checks.findIndex((c) => c.name === DidVerificationCheckName.KEY_MATERIAL);
+      const failedCheck = {
         name: DidVerificationCheckName.KEY_MATERIAL,
+        passed: false,
         message: 'Provider key material could not be fetched — key_material check may be incomplete',
-      });
+      };
+      if (keyCheckIndex >= 0) {
+        result.checks[keyCheckIndex] = failedCheck;
+      } else {
+        result.checks.push(failedCheck);
+      }
+      result.verified = result.checks.every((c) => c.passed);
     }
 
     this.logger.info({ did, verified: result.verified }, 'DID verification completed');

--- a/packages/services/src/did-manager/common/verify.test.ts
+++ b/packages/services/src/did-manager/common/verify.test.ts
@@ -88,7 +88,6 @@ describe('verifyDid', () => {
     expect(result.verified).toBe(true);
     expect(result.checks).toHaveLength(6);
     expect(result.checks.every((c) => c.passed)).toBe(true);
-    expect(result.errors).toBeUndefined();
   });
 
   it('returns structure failure when document is missing required fields', async () => {

--- a/packages/services/src/did-manager/common/verify.ts
+++ b/packages/services/src/did-manager/common/verify.ts
@@ -128,11 +128,9 @@ export async function verifyDid(did: string, options: VerifyDidOptions): Promise
   checks.push({ name: C.JSONLD_VALIDITY, passed: true, message: 'Skipped — JSON-LD expansion disabled' });
 
   const verified = checks.every((c) => c.passed);
-  const errors = checks.filter((c) => !c.passed).map((c) => ({ name: c.name, message: c.message ?? 'Check failed' }));
 
   return {
     verified,
     checks,
-    errors: errors.length > 0 ? errors : undefined,
   };
 }

--- a/packages/services/src/did-manager/schemas.ts
+++ b/packages/services/src/did-manager/schemas.ts
@@ -54,18 +54,12 @@ export const verificationCheckSchema = z.object({
   message: z.string().optional(),
 });
 
-export const verificationErrorSchema = z.object({
-  name: z.enum(VERIFICATION_CHECK_NAMES),
-  message: z.string(),
-});
-
 /**
  * Verification result as returned by the REST API.
  */
 export const verificationResultResponseSchema = z.object({
   verified: z.boolean().describe('Whether the DID was successfully verified'),
   checks: z.array(verificationCheckSchema).describe('Individual verification checks performed'),
-  errors: z.array(verificationErrorSchema).optional().describe('Errors encountered during verification'),
 });
 
 /**

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -102,15 +102,9 @@ export type DidVerificationCheck = {
   message?: string;
 };
 
-export type DidVerificationError = {
-  name: DidVerificationCheckName;
-  message: string;
-};
-
 export type DidVerificationResult = {
   verified: boolean;
   checks: DidVerificationCheck[];
-  errors?: DidVerificationError[];
 };
 
 /** Result returned by a method-specific verifier (e.g. did:web, did:webvh). */

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -30,7 +30,6 @@ export {
   verificationMethodSchema,
   didResponseSchema,
   verificationCheckSchema,
-  verificationErrorSchema,
   verificationResultResponseSchema,
   didDocumentResponseSchema,
 } from './did-manager/schemas.js';

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
@@ -22,7 +22,7 @@ describe('UncefactStorageAdapter', () => {
   const mockConfig: UncefactStorageConfig = {
     baseUrl: 'https://storage.example.com',
     apiKey: 'test-api-key',
-    apiVersion: '3.0.0',
+    apiVersion: '3.1.0',
   };
 
   const mockCredential: EnvelopedVerifiableCredential = {
@@ -90,7 +90,7 @@ describe('UncefactStorageAdapter', () => {
     it('should not include X-API-Key header when apiKey is omitted', async () => {
       const configWithoutKey: UncefactStorageConfig = {
         baseUrl: 'https://storage.example.com',
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
       };
       const adapter = new UncefactStorageAdapter(configWithoutKey, mockLogger);
       await adapter.store(mockCredential);
@@ -114,21 +114,21 @@ describe('UncefactStorageAdapter', () => {
       const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
       await adapter.store(mockCredential);
 
-      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.0.0/public', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.1.0/public', expect.any(Object));
     });
 
     it('should use /public endpoint for unencrypted storage (encrypt = false)', async () => {
       const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
       await adapter.store(mockCredential, false);
 
-      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.0.0/public', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.1.0/public', expect.any(Object));
     });
 
     it('should use /public endpoint when encrypt is not specified (defaults to false)', async () => {
       const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
       await adapter.store(mockCredential);
 
-      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.0.0/public', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.1.0/public', expect.any(Object));
     });
 
     it('should use /private endpoint for encrypted storage (encrypt = true)', async () => {
@@ -145,7 +145,7 @@ describe('UncefactStorageAdapter', () => {
       const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
       await adapter.store(mockCredential, true);
 
-      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.0.0/private', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.1.0/private', expect.any(Object));
     });
 
     it('should send correct payload with data and client-generated id', async () => {
@@ -309,7 +309,7 @@ describe('UncefactStorageAdapter', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockLogger.debug).toHaveBeenCalledWith(
           expect.objectContaining({
-            url: 'https://storage.example.com/api/3.0.0/public',
+            url: 'https://storage.example.com/api/3.1.0/public',
             encrypt: false,
             bucket: undefined,
             externalId: MOCK_UUID,
@@ -639,7 +639,7 @@ describe('UncefactStorageAdapter', () => {
       const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
       await adapter.storeBinary('<html>Hello</html>', 'template.html', 'text/html');
 
-      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.0.0/public', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.1.0/public', expect.any(Object));
     });
 
     it('should use /private endpoint for encrypted upload', async () => {
@@ -656,7 +656,7 @@ describe('UncefactStorageAdapter', () => {
       const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
       await adapter.storeBinary('<html>Secret</html>', 'template.html', 'text/html', true);
 
-      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.0.0/private', expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith('https://storage.example.com/api/3.1.0/private', expect.any(Object));
     });
 
     it('should send FormData body with file field', async () => {
@@ -717,7 +717,7 @@ describe('UncefactStorageAdapter', () => {
     it('should not include X-API-Key header when apiKey is omitted', async () => {
       const configWithoutKey: UncefactStorageConfig = {
         baseUrl: 'https://storage.example.com',
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
       };
       const adapter = new UncefactStorageAdapter(configWithoutKey, mockLogger);
       await adapter.storeBinary('<html>Hello</html>', 'template.html', 'text/html');
@@ -880,7 +880,7 @@ describe('UncefactStorageAdapter', () => {
       await adapter.delete('resource-id-42', 'my-bucket');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://storage.example.com/api/3.0.0/my-bucket/resource-id-42',
+        'https://storage.example.com/api/3.1.0/my-bucket/resource-id-42',
         expect.objectContaining({ method: 'DELETE' }),
       );
     });
@@ -909,7 +909,7 @@ describe('UncefactStorageAdapter', () => {
 
       const configWithoutKey: UncefactStorageConfig = {
         baseUrl: 'https://storage.example.com',
-        apiVersion: '3.0.0',
+        apiVersion: '3.1.0',
       };
       const adapter = new UncefactStorageAdapter(configWithoutKey, mockLogger);
       await adapter.delete('resource-id-42', 'my-bucket');
@@ -1119,12 +1119,12 @@ describe('UncefactStorageAdapter', () => {
       ).toThrow();
     });
 
-    it('should default apiVersion to "3.0.0" when not provided', () => {
+    it('should default apiVersion to "3.1.0" when not provided', () => {
       const config = {
         baseUrl: 'https://storage.example.com',
       };
       const result = uncefactStorageRegistryEntry.configSchema.parse(config);
-      expect(result.apiVersion).toBe('3.0.0');
+      expect(result.apiVersion).toBe('3.1.0');
     });
 
     it('should reject an unsupported apiVersion', () => {

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.schema.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const uncefactStorageConfigSchema = z.object({
   baseUrl: z.string().url().describe('Base URL||The base URL of the UNCEFACT storage service (no path segments)'),
   apiKey: z.string().min(1).optional().describe('API Key||The API key for authenticating with the storage service'),
-  apiVersion: z.enum(['3.0.0']).default('3.0.0').describe('API Version||The storage API version to use'),
+  apiVersion: z.enum(['3.1.0']).default('3.1.0').describe('API Version||The storage API version to use'),
   publicBucket: z
     .string()
     .min(1)

--- a/packages/vc-test-suite/config.ts
+++ b/packages/vc-test-suite/config.ts
@@ -17,8 +17,8 @@ export default {
       method: 'POST',
     },
     Storage: {
-      url: 'http://localhost:3334/api/3.0.0/public',
-      encryptionUrl: 'http://localhost:3334/api/3.0.0/private',
+      url: 'http://localhost:3334/api/3.1.0/public',
+      encryptionUrl: 'http://localhost:3334/api/3.1.0/private',
       headers: {},
       additionalParams: {},
       additionalPayload: {},


### PR DESCRIPTION
This PR standardises the RenderTemplate model by renaming `isPrimary` to `isDefault` (matching the DID and service instance patterns), upgrades the UNCEFACT storage service, removes redundant data from the DID verification response, and prevents duplicate DID creation on the same service instance.

## Changes

- **RenderTemplate `isPrimary` → `isDefault`**: Prisma migration, repository, API routes, Swagger docs, lib helpers, seed data, and tests all updated. Tenant default override logic applied so system defaults appear as `isDefault: false` when a tenant sets their own default for the same data model.
- **Storage service upgrade**: Docker image bumped to 3.2.1, API version updated from 3.0.0 to 3.1.0 across all config files, fixtures, seed data, and E2E tests.
- **DID verification cleanup**: Removed the `errors` array which duplicated information already in `checks`. Key-fetch failures now replace the vacuously-passing KEY_MATERIAL check with a failed one, and `verified` is recalculated accordingly.
- **Duplicate DID prevention**: POST /dids now checks for an existing DID with the same alias on the same service instance before calling VCKit, returning 409 Conflict instead of letting VCKit return a generic 500.

## Test plan

- [x] 24 render template unit tests pass (repository, helpers, routes)
- [x] 43 DID services tests pass (verify, adapter)
- [x] 88 storage adapter tests pass
- [x] 37 DID repository tests pass (including 3 new `findDidByAliasAndService` tests)
- [x] DID route test covers 409 duplicate rejection
- [x] E2E tests updated for `isDefault` rename and storage 3.1.0
- [x] No remaining `isPrimary` references in render template code
- [x] No remaining `3.0.0` references in storage code