### PR TITLE
feat(api): add GET /api/v1/credentials list endpoint

### DIFF
--- a/e2e/cypress/e2e/credential_api/credential-management.cy.ts
+++ b/e2e/cypress/e2e/credential_api/credential-management.cy.ts
@@ -341,6 +341,132 @@ describe('Credential API', { testIsolation: false }, () => {
   });
 
   // -----------------------------------------------------------------------
+  // List credentials
+  // -----------------------------------------------------------------------
+  describe('List credentials', () => {
+    it('GET /api/v1/credentials — lists credentials with pagination metadata', () => {
+      cy.request('/api/v1/credentials').then((response) => {
+        expect(response.status).to.eq(200);
+
+        // Paginated response shape
+        expect(response.body.data).to.be.an('array');
+        expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.total).to.be.a('number');
+        expect(response.body.pagination.limit).to.eq(100);
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination).to.have.property('hasMore');
+
+        // Should contain at least the credentials issued earlier in the suite
+        expect(response.body.data.length).to.be.at.least(2);
+
+        // Verify credential shape
+        const cred = response.body.data[0];
+        expect(cred.id).to.be.a('string');
+        expect(cred.storageUri).to.be.a('string');
+        expect(cred.hash).to.be.a('string');
+        expect(cred.credentialType).to.be.a('string');
+        expect(cred).to.have.property('isPublished');
+        expect(cred).to.have.property('createdAt');
+        expect(cred).to.have.property('updatedAt');
+      });
+    });
+
+    it('GET /api/v1/credentials?credentialType=DigitalProductPassport — filters by type', () => {
+      cy.request('/api/v1/credentials?credentialType=DigitalProductPassport').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.data).to.be.an('array');
+        expect(response.body.data.length).to.be.at.least(1);
+
+        // All returned credentials should be DPP type
+        response.body.data.forEach((cred: any) => {
+          expect(cred.credentialType).to.eq('DigitalProductPassport');
+        });
+      });
+    });
+
+    it('GET /api/v1/credentials?isPublished=true — filters by published status', () => {
+      cy.request('/api/v1/credentials?isPublished=true').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.data).to.be.an('array');
+
+        // All returned credentials should be published
+        response.body.data.forEach((cred: any) => {
+          expect(cred.isPublished).to.be.true;
+        });
+      });
+    });
+
+    it('GET /api/v1/credentials?isPublished=false — filters by unpublished', () => {
+      cy.request('/api/v1/credentials?isPublished=false').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.data).to.be.an('array');
+
+        response.body.data.forEach((cred: any) => {
+          expect(cred.isPublished).to.be.false;
+        });
+      });
+    });
+
+    it('GET /api/v1/credentials?limit=1 — respects limit', () => {
+      cy.request('/api/v1/credentials?limit=1').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.data).to.have.length(1);
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.hasMore).to.be.true;
+      });
+    });
+
+    it('GET /api/v1/credentials?limit=1&offset=1 — respects offset', () => {
+      cy.request('/api/v1/credentials?limit=1&offset=1').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.data).to.have.length(1);
+        expect(response.body.pagination.offset).to.eq(1);
+      });
+    });
+
+    it('GET /api/v1/credentials?credentialType=NonExistent — returns empty for unknown type', () => {
+      cy.request('/api/v1/credentials?credentialType=NonExistentType').then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.data).to.be.an('array').and.have.length(0);
+        expect(response.body.pagination.total).to.eq(0);
+      });
+    });
+
+    it('GET /api/v1/credentials?isPublished=yes — returns 400 for invalid boolean', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/credentials?isPublished=yes',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('GET /api/v1/credentials?limit=0 — returns 400 for invalid limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/credentials?limit=0',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('GET /api/v1/credentials?offset=-1 — returns 400 for invalid offset', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/credentials?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Error handling
   // -----------------------------------------------------------------------
   describe('Error handling', () => {

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -101,8 +101,10 @@ jest.mock('@uncefact/untp-ri-services', () => ({
 
 // Repository mocks
 const mockUpdateCredentialPublished = jest.fn();
+const mockListCredentials = jest.fn();
 jest.mock('@/lib/prisma/repositories', () => ({
   updateCredentialPublished: (...args: unknown[]) => mockUpdateCredentialPublished(...args),
+  listCredentials: (...args: unknown[]) => mockListCredentials(...args),
 }));
 
 const mockValidateCvcCompliance = jest.fn();
@@ -110,7 +112,7 @@ jest.mock('@/lib/services/cvc-validation.service', () => ({
   validateCvcCompliance: (...args: unknown[]) => mockValidateCvcCompliance(...args),
 }));
 
-import { POST } from './route';
+import { POST, GET } from './route';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -139,6 +141,20 @@ function createBadJsonRequest(): Request {
     json: async () => {
       throw new SyntaxError('Unexpected token n in JSON at position 0');
     },
+  } as unknown as Request;
+}
+
+function createFakeGetRequest(queryParams?: Record<string, string>): Request {
+  const url = new URL('http://localhost/api/v1/credentials');
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+  }
+  return {
+    method: 'GET',
+    url: url.toString(),
+    headers: new Headers(),
   } as unknown as Request;
 }
 
@@ -689,5 +705,147 @@ describe('POST /api/v1/credentials', () => {
       expect(res.status).toBe(500);
       expect(json.error).toContain('Signing service unavailable');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/credentials
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/credentials', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListCredentials.mockResolvedValue({ data: [], total: 0 });
+  });
+
+  it('returns 200 with default pagination when no params provided', async () => {
+    const req = createFakeGetRequest();
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(mockListCredentials).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      credentialType: undefined,
+      isPublished: undefined,
+      limit: 100,
+      offset: undefined,
+    });
+    expect(res.status).toBe(200);
+    expect(json).toHaveProperty('data');
+    expect(json).toHaveProperty('pagination');
+    expect(Array.isArray(json.data)).toBe(true);
+  });
+
+  it('passes credentialType filter to repository', async () => {
+    const req = createFakeGetRequest({ credentialType: 'DPP' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListCredentials).toHaveBeenCalledWith(expect.objectContaining({ credentialType: 'DPP' }));
+  });
+
+  it('passes isPublished=true filter to repository', async () => {
+    const req = createFakeGetRequest({ isPublished: 'true' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListCredentials).toHaveBeenCalledWith(expect.objectContaining({ isPublished: true }));
+  });
+
+  it('passes isPublished=false filter to repository', async () => {
+    const req = createFakeGetRequest({ isPublished: 'false' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListCredentials).toHaveBeenCalledWith(expect.objectContaining({ isPublished: false }));
+  });
+
+  it('passes limit and offset to repository', async () => {
+    const req = createFakeGetRequest({ limit: '10', offset: '20' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListCredentials).toHaveBeenCalledWith(expect.objectContaining({ limit: 10, offset: 20 }));
+  });
+
+  it('returns 400 for invalid limit', async () => {
+    const req = createFakeGetRequest({ limit: 'abc' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit');
+  });
+
+  it('returns 400 for limit=0', async () => {
+    const req = createFakeGetRequest({ limit: '0' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid offset', async () => {
+    const req = createFakeGetRequest({ offset: '-1' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset');
+  });
+
+  it('returns 400 for invalid isPublished value', async () => {
+    const req = createFakeGetRequest({ isPublished: 'yes' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('isPublished');
+  });
+
+  it('returns empty results for unknown credentialType (not 400)', async () => {
+    mockListCredentials.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeGetRequest({ credentialType: 'UnknownType' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data).toEqual([]);
+  });
+
+  it('returns correct pagination metadata', async () => {
+    mockListCredentials.mockResolvedValue({ data: [{ id: 'c1' }, { id: 'c2' }], total: 5 });
+
+    const req = createFakeGetRequest({ limit: '2', offset: '0' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(json.pagination).toEqual({ total: 5, limit: 2, offset: 0, hasMore: true });
+  });
+
+  it('returns hasMore=false on last page', async () => {
+    mockListCredentials.mockResolvedValue({ data: [{ id: 'c1' }], total: 3 });
+
+    const req = createFakeGetRequest({ limit: '2', offset: '2' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(json.pagination).toEqual({ total: 3, limit: 2, offset: 2, hasMore: false });
+  });
+
+  it('passes combined credentialType and isPublished filters to repository', async () => {
+    const req = createFakeGetRequest({ credentialType: 'DPP', isPublished: 'true' });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ credentialType: 'DPP', isPublished: true }),
+    );
+  });
+
+  it('returns 500 when repository throws', async () => {
+    mockListCredentials.mockRejectedValue(new Error('Database connection lost'));
+
+    const req = createFakeGetRequest();
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database connection lost');
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import {
+  ValidationError,
+  isNonEmptyString,
+  parsePositiveInt,
+  parseNonNegativeInt,
+  parseBooleanString,
+} from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
 import { resolveDataModel, isDccDataModel } from '@/lib/credentials/resolve-data-model';
 import { validateCredentialPayload } from '@/lib/credentials/validate-credential-payload';
 import { issueCredential } from '@/lib/credentials/issue-credential';
-import { updateCredentialPublished } from '@/lib/prisma/repositories';
+import { updateCredentialPublished, listCredentials } from '@/lib/prisma/repositories';
+import { buildPaginatedResponse, DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
 import { resolveStorageService } from '@/lib/services/resolve-storage-service';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
@@ -225,4 +232,107 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   const response: Record<string, unknown> = { credentialId };
   if (cvcWarnings.length > 0) response.warnings = cvcWarnings;
   return NextResponse.json(response, { status: 201 });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/credentials
+// ---------------------------------------------------------------------------
+
+/**
+ * @swagger
+ * /credentials:
+ *   get:
+ *     summary: List credentials
+ *     description: |
+ *       Returns a paginated, filterable list of credentials scoped to
+ *       the authenticated tenant.
+ *     tags:
+ *       - Credentials
+ *     parameters:
+ *       - in: query
+ *         name: credentialType
+ *         schema:
+ *           type: string
+ *         description: Filter by credential type (case-sensitive exact match)
+ *       - in: query
+ *         name: isPublished
+ *         schema:
+ *           type: string
+ *           enum: ["true", "false"]
+ *         description: Filter by published status
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 100
+ *         description: Maximum number of results
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *           default: 0
+ *         description: Number of results to skip
+ *     responses:
+ *       200:
+ *         description: Paginated list of credentials
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *                 - pagination
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Credential'
+ *                 pagination:
+ *                   $ref: '#/components/schemas/PaginationMeta'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorised
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+export const GET = withTenantAuth(async (req, { tenantId }) => {
+  const url = new URL(req.url);
+
+  logger.info('Parsing query filters');
+  const credentialType = url.searchParams.get('credentialType') ?? undefined;
+  const isPublished = parseBooleanString(url.searchParams.get('isPublished'), 'isPublished');
+  const limit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
+  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+
+  const effectiveLimit = limit ?? DEFAULT_PAGE_LIMIT;
+
+  logger.info(
+    { filters: { credentialType, isPublished, limit: effectiveLimit, offset } },
+    'Querying credentials from database',
+  );
+  const { data, total } = await listCredentials({
+    tenantId,
+    credentialType,
+    isPublished,
+    limit: effectiveLimit,
+    offset,
+  });
+
+  logger.info({ count: data.length }, 'Credentials listed');
+  return NextResponse.json(buildPaginatedResponse(data, total, effectiveLimit, offset));
 });

--- a/packages/reference-implementation/src/lib/api/validation.test.ts
+++ b/packages/reference-implementation/src/lib/api/validation.test.ts
@@ -1,4 +1,11 @@
-import { ValidationError, isNonEmptyString, validateEnum, parsePositiveInt, parseNonNegativeInt } from './validation';
+import {
+  ValidationError,
+  isNonEmptyString,
+  validateEnum,
+  parsePositiveInt,
+  parseNonNegativeInt,
+  parseBooleanString,
+} from './validation';
 
 describe('isNonEmptyString', () => {
   it('returns true for a non-empty string', () => {
@@ -86,5 +93,40 @@ describe('parseNonNegativeInt', () => {
 
   it('throws for non-numeric strings', () => {
     expect(() => parseNonNegativeInt('abc', 'offset')).toThrow(ValidationError);
+  });
+});
+
+describe('parseBooleanString', () => {
+  it('returns undefined for null', () => {
+    expect(parseBooleanString(null, 'active')).toBeUndefined();
+  });
+
+  it('returns undefined for undefined', () => {
+    expect(parseBooleanString(undefined, 'active')).toBeUndefined();
+  });
+
+  it('returns true for "true"', () => {
+    expect(parseBooleanString('true', 'active')).toBe(true);
+  });
+
+  it('returns false for "false"', () => {
+    expect(parseBooleanString('false', 'active')).toBe(false);
+  });
+
+  it('throws for "TRUE" (case-sensitive)', () => {
+    expect(() => parseBooleanString('TRUE', 'active')).toThrow(ValidationError);
+    expect(() => parseBooleanString('TRUE', 'active')).toThrow('active must be "true" or "false"');
+  });
+
+  it('throws for "1"', () => {
+    expect(() => parseBooleanString('1', 'active')).toThrow(ValidationError);
+  });
+
+  it('throws for "yes"', () => {
+    expect(() => parseBooleanString('yes', 'active')).toThrow(ValidationError);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => parseBooleanString('', 'active')).toThrow(ValidationError);
   });
 });

--- a/packages/reference-implementation/src/lib/api/validation.ts
+++ b/packages/reference-implementation/src/lib/api/validation.ts
@@ -61,3 +61,14 @@ export function parseNonNegativeInt(raw: string | null | undefined, paramName: s
   }
   return parsed;
 }
+
+/**
+ * Parse a string as a boolean ("true" or "false").
+ * Returns undefined if the raw value is null/undefined.
+ */
+export function parseBooleanString(raw: string | null | undefined, paramName: string): boolean | undefined {
+  if (raw == null) return undefined;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  throw new ValidationError(`${paramName} must be "true" or "false"`);
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/credential.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/credential.repository.ts
@@ -56,9 +56,11 @@ export async function getCredentialById(id: string, tenantId: string): Promise<C
 }
 
 /**
- * Lists credentials with optional filtering and pagination
+ * Lists credentials with optional filtering and pagination.
+ * Returns matching records alongside the total count for the filter
+ * criteria (via a parallel count query).
  */
-export async function listCredentials(options: ListCredentialsOptions): Promise<Credential[]> {
+export async function listCredentials(options: ListCredentialsOptions): Promise<{ data: Credential[]; total: number }> {
   const { tenantId, credentialType, isPublished, limit, offset } = options;
 
   const where: Prisma.CredentialWhereInput = { tenantId };
@@ -71,12 +73,17 @@ export async function listCredentials(options: ListCredentialsOptions): Promise<
     where.isPublished = isPublished;
   }
 
-  return prisma.credential.findMany({
-    where,
-    take: limit,
-    skip: offset,
-    orderBy: { createdAt: 'desc' },
-  });
+  const [data, total] = await Promise.all([
+    prisma.credential.findMany({
+      where,
+      take: limit,
+      skip: offset,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.credential.count({ where }),
+  ]);
+
+  return { data, total };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds a paginated, filterable list endpoint for credentials at `GET /api/v1/credentials`, completing the CRUD surface for the credentials resource. The endpoint supports `credentialType` and `isPublished` query filters with standard `limit`/`offset` pagination, matching the established DIDs list endpoint pattern.

- Add `parseBooleanString` reusable validation helper for boolean query parameters
- Update `listCredentials` repository to return `{ data, total }` with parallel count query
- Add GET handler with Swagger/OpenAPI documentation and structured logging
- Add 22 unit tests (8 validation, 14 route handler) and 10 E2E tests (7 happy path, 3 unhappy path)

## Test plan

- [x] `parseBooleanString` helper: 8 unit tests covering null, undefined, valid, and invalid inputs
- [x] GET route handler: 14 unit tests covering default pagination, all filters (individual and combined), validation errors (limit, offset, isPublished), unknown types, empty results, pagination metadata, and 500 error propagation
- [x] E2E happy path: list with pagination, filter by type, filter by published status, limit/offset, empty results for unknown type
- [x] E2E unhappy path: invalid boolean, invalid limit, invalid offset
- [x] Full test suite passes (1216 tests, 0 failures from changes)
- [x] TypeScript compilation passes with zero errors