### PR TITLE
fix(api): align master data routes with skills and add documentation

### DIFF
--- a/documentation/docs/reference-implementation/api/_category_.json
+++ b/documentation/docs/reference-implementation/api/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "API",
-  "position": 7,
+  "position": 8,
   "collapsed": true
 }

--- a/documentation/docs/reference-implementation/api/facilities.md
+++ b/documentation/docs/reference-implementation/api/facilities.md
@@ -121,7 +121,7 @@ Updates one or more fields of an existing facility. At least one updatable field
 DELETE /api/v1/facilities/{id}
 ```
 
-Permanently deletes a facility. Returns `204 No Content` with an empty body.
+Permanently deletes a facility. If the facility is referenced as the manufacturing facility for any products, those references are cleared (set to `null`) — the product records are not deleted.
 
 ```mermaid
 sequenceDiagram

--- a/documentation/docs/reference-implementation/api/facilities.md
+++ b/documentation/docs/reference-implementation/api/facilities.md
@@ -1,0 +1,140 @@
+---
+sidebar_position: 6
+title: Facilities
+---
+
+# Facilities API
+
+The Facilities API manages **facilities** — the physical locations (factories, warehouses, farms, processing plants) where products are manufactured, stored, or processed. Facilities are one of the core [master data](../master-data/) entities referenced when issuing UNTP credentials.
+
+:::tip[Interactive API documentation]
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+:::
+
+## Concepts
+
+### What is a facility?
+
+A facility represents a physical site involved in the production or handling of goods. In the context of UNTP, facilities can be referenced by multiple credential types. The Reference Implementation stores facility records as tenant-scoped master data that can be linked to products and credentials.
+
+### Operating Organisation
+
+Each facility can optionally be linked to an **operating organisation** via `operatingOrganisationId`. This references an [organisation](./organisations) record that represents the business entity responsible for running the facility. The operating organisation must belong to the same tenant.
+
+### Identifiers
+
+Facilities support the same identifier model as [organisations](./organisations#identifiers):
+
+- **Primary identifier** — a single main identifier for the facility. Set via `primaryIdentifierId`.
+- **Secondary identifiers** — additional identifiers. Set via `secondaryIdentifierIds`.
+
+Identifiers are managed through the [Identifiers API](./identifiers) and linked to facilities by their database IDs. The primary identifier cannot also appear in the secondary identifiers list.
+
+### Location
+
+The optional `location` field stores a structured JSON object describing the geographical position of the facility. See [Location](../master-data/#location) for the field structure.
+
+### Tenant Scoping
+
+Facilities are scoped to the authenticated tenant. Each tenant manages its own set of facilities independently.
+
+## Endpoints
+
+### Create facilities
+
+```
+POST /api/v1/facilities
+```
+
+Creates one or more facilities in bulk. The request body is an array of facility objects — each must include a `name`. Optional fields include `description`, `location`, `operatingOrganisationId`, `primaryIdentifierId`, and `secondaryIdentifierIds`.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: POST /api/v1/facilities [{ name, ... }]
+    RI->>RI: Validate each item (name required)
+    alt optional IDs provided
+        RI->>DB: Verify referenced records exist and belong to tenant
+        alt referenced record not found
+            RI-->>Client: 404 Not Found
+        end
+    end
+    RI->>DB: Insert facility records
+    DB-->>RI: Created records
+    RI-->>Client: 201 Created (array of facilities)
+```
+
+---
+
+### List facilities
+
+```
+GET /api/v1/facilities
+```
+
+Returns facilities for the authenticated tenant with optional filtering. Results are paginated.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `search` | string | — | Search by facility name or identifier value |
+| `organisationId` | string | — | Filter by operating organisation ID |
+| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `offset` | integer | `0` | Number of results to skip |
+
+---
+
+### Get a facility
+
+```
+GET /api/v1/facilities/{id}
+```
+
+Retrieves a specific facility by its database ID. The response includes the full primary identifier (with scheme and registrar details), secondary identifiers, and the operating organisation.
+
+---
+
+### Update a facility
+
+```
+PATCH /api/v1/facilities/{id}
+```
+
+Updates one or more fields of an existing facility. At least one updatable field must be provided.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `name` | Facility name (must be non-empty if provided) |
+| `description` | Free-text description |
+| `location` | UNTP location object (set to `null` to clear) |
+| `operatingOrganisationId` | ID of the operating organisation (set to `null` to clear) |
+| `primaryIdentifierId` | ID of the primary identifier (set to `null` to clear) |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing) |
+
+---
+
+### Delete a facility
+
+```
+DELETE /api/v1/facilities/{id}
+```
+
+Permanently deletes a facility. Returns `204 No Content` with an empty body.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: DELETE /api/v1/facilities/{id}
+    RI->>DB: Fetch facility (tenant-scoped)
+    alt not found
+        RI-->>Client: 404 Not Found
+    end
+    RI->>DB: Delete facility
+    DB-->>RI: Deleted
+    RI-->>Client: 204 No Content
+```

--- a/documentation/docs/reference-implementation/api/identifiers.md
+++ b/documentation/docs/reference-implementation/api/identifiers.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 9
+title: Identifiers
+---
+
+# Identifiers API
+
+The Identifiers API manages **identifiers** and **identifier schemes** — the structured values that connect [master data](../master-data/) entities to real-world identification systems. Identifiers are created under schemes, which are registered under registrars.
+
+:::tip[Interactive API documentation]
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+:::
+
+:::info[Documentation in progress]
+Detailed endpoint documentation for identifiers, schemes, and their link management is planned. Refer to the Swagger UI for current endpoint details.
+:::

--- a/documentation/docs/reference-implementation/api/organisations.md
+++ b/documentation/docs/reference-implementation/api/organisations.md
@@ -115,7 +115,7 @@ Updates one or more fields of an existing organisation. At least one updatable f
 DELETE /api/v1/organisations/{id}
 ```
 
-Permanently deletes an organisation. Returns `204 No Content` with an empty body.
+Permanently deletes an organisation. If the organisation is referenced by products or facilities, those references are cleared (set to `null`) — the related records are not deleted.
 
 ```mermaid
 sequenceDiagram

--- a/documentation/docs/reference-implementation/api/organisations.md
+++ b/documentation/docs/reference-implementation/api/organisations.md
@@ -1,0 +1,134 @@
+---
+sidebar_position: 5
+title: Organisations
+---
+
+# Organisations API
+
+The Organisations API manages **organisations** — the business entities that produce products and operate facilities within the Reference Implementation. Organisations are one of the core [master data](../master-data/) entities referenced across all UNTP credential types.
+
+:::tip[Interactive API documentation]
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+:::
+
+## Concepts
+
+### What is an organisation?
+
+An organisation represents a legal entity or business that participates in the supply chain. In the context of UNTP, organisations are referenced by credentials as the product brand owner, the operating entity, or the party being assessed for conformity. The Reference Implementation stores organisation records as tenant-scoped master data that can be linked to credentials.
+
+### Identifiers
+
+Organisations can be associated with **identifiers** — structured values that follow an [identifier scheme](./identifiers). Each organisation supports:
+
+- **Primary identifier** — a single identifier that serves as the main business identifier for the organisation. Set via `primaryIdentifierId`.
+- **Secondary identifiers** — additional identifiers. Set via `secondaryIdentifierIds`.
+
+Identifiers are managed through the [Identifiers API](./identifiers) and linked to organisations by their database IDs. The primary identifier cannot also appear in the secondary identifiers list.
+
+### Location
+
+The optional `location` field stores a structured JSON object describing the geographical location of the organisation. See [Location](../master-data/#location) for the field structure.
+
+### Tenant Scoping
+
+Organisations are scoped to the authenticated tenant. Each tenant manages its own set of organisations — they cannot see or modify organisations belonging to other tenants.
+
+## Endpoints
+
+### Create organisations
+
+```
+POST /api/v1/organisations
+```
+
+Creates one or more organisations in bulk. The request body is an array of organisation objects — each must include a `name`. Optional fields include `description`, `location`, `primaryIdentifierId`, and `secondaryIdentifierIds`.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: POST /api/v1/organisations [{ name, ... }]
+    RI->>RI: Validate each item (name required)
+    alt optional IDs provided
+        RI->>DB: Verify referenced records exist and belong to tenant
+        alt referenced record not found
+            RI-->>Client: 404 Not Found
+        end
+    end
+    RI->>DB: Insert organisation records
+    DB-->>RI: Created records
+    RI-->>Client: 201 Created (array of organisations)
+```
+
+---
+
+### List organisations
+
+```
+GET /api/v1/organisations
+```
+
+Returns organisations for the authenticated tenant with optional filtering. Results are paginated.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `search` | string | — | Search by organisation name or identifier value |
+| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `offset` | integer | `0` | Number of results to skip |
+
+---
+
+### Get an organisation
+
+```
+GET /api/v1/organisations/{id}
+```
+
+Retrieves a specific organisation by its database ID. The response includes the full primary identifier (with scheme and registrar details) and secondary identifiers.
+
+---
+
+### Update an organisation
+
+```
+PATCH /api/v1/organisations/{id}
+```
+
+Updates one or more fields of an existing organisation. At least one updatable field must be provided.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `name` | Organisation name (must be non-empty if provided) |
+| `description` | Free-text description |
+| `location` | UNTP location object (set to `null` to clear) |
+| `primaryIdentifierId` | ID of the primary identifier (set to `null` to clear) |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing) |
+
+---
+
+### Delete an organisation
+
+```
+DELETE /api/v1/organisations/{id}
+```
+
+Permanently deletes an organisation. Returns `204 No Content` with an empty body.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: DELETE /api/v1/organisations/{id}
+    RI->>DB: Fetch organisation (tenant-scoped)
+    alt not found
+        RI-->>Client: 404 Not Found
+    end
+    RI->>DB: Delete organisation
+    DB-->>RI: Deleted
+    RI-->>Client: 204 No Content
+```

--- a/documentation/docs/reference-implementation/api/products.md
+++ b/documentation/docs/reference-implementation/api/products.md
@@ -1,0 +1,202 @@
+---
+sidebar_position: 7
+title: Products
+---
+
+# Products API
+
+The Products API manages **products** — the goods, materials, and items that move through the supply chain. The Reference Implementation stores product records as tenant-scoped [master data](../master-data/) that can be referenced by UNTP credentials.
+
+:::tip[Interactive API documentation]
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+:::
+
+## Concepts
+
+### Product Levels
+
+Every product has a **level** that represents its position in the product hierarchy. The level is set at creation and is immutable — it cannot be changed after the product is created.
+
+| Level | Description | Parent Requirement |
+|-------|-------------|-------------------|
+| `MODEL` | A product definition or SKU — the abstract design of a product | Must not have a parent |
+| `BATCH` | A specific production run of a model — a group of items manufactured together | Must have a `MODEL` parent |
+| `ITEM` | An individual serialised unit from a batch or standalone | May optionally have a `BATCH` parent |
+
+This three-tier hierarchy mirrors how products are identified in supply chains: a model defines *what* a product is, a batch identifies *when and where* a group was produced, and an item identifies a *specific unit*.
+
+### Product Hierarchy
+
+Products form a tree structure through `parentId` references:
+
+```
+MODEL (e.g., "Organic Coffee Beans 1kg")
+├── BATCH (e.g., "Batch 2024-Q1-001")
+│   ├── ITEM (e.g., "Serial #A001")
+│   └── ITEM (e.g., "Serial #A002")
+└── BATCH (e.g., "Batch 2024-Q2-001")
+    └── ITEM (e.g., "Serial #B001")
+```
+
+**Hierarchy rules:**
+- A `MODEL` cannot have a parent
+- A `BATCH` must reference a `MODEL` as its parent
+- An `ITEM` may optionally reference a `BATCH` as its parent (standalone items are permitted)
+- Hierarchy depth is limited to three levels — nesting beyond MODEL → BATCH → ITEM is not permitted
+
+These constraints are enforced during creation and update.
+
+### Organisation and Facility Links
+
+Each product can optionally be linked to:
+
+- **Producing organisation** (`producedByOrganisationId`) — the [organisation](./organisations) that brands or produces the product
+- **Manufacturing facility** (`manufacturingFacilityId`) — the [facility](./facilities) where the product is manufactured
+
+These links connect the product to other master data entities and are used during [extraction](../data-models/index.md#extraction) to link credentials back to the relevant organisation and facility records.
+
+### Identifiers
+
+Products support the same identifier model as [organisations](./organisations#identifiers) and [facilities](./facilities#identifiers):
+
+- **Primary identifier** — a single main identifier for the product. Set via `primaryIdentifierId`.
+- **Secondary identifiers** — additional identifiers. Set via `secondaryIdentifierIds`.
+
+Identifiers are managed through the [Identifiers API](./identifiers) and linked to products by their database IDs. The primary identifier cannot also appear in the secondary identifiers list.
+
+### Deletion Behaviour
+
+Deleting a product has cascading effects that depend on the product's level and its children:
+
+| Scenario | Behaviour |
+|----------|-----------|
+| `MODEL` with `BATCH` children | **Blocked** — the batches must be deleted first |
+| `BATCH` with `ITEM` children | **Permitted** — item children are detached (their `parentId` is set to `null`) |
+| Product with no children | **Permitted** |
+
+### Tenant Scoping
+
+Products are scoped to the authenticated tenant. Each tenant manages its own product catalogue independently.
+
+## Endpoints
+
+### Create products
+
+```
+POST /api/v1/products
+```
+
+Creates one or more products in bulk. The request body is an array of product objects — each must include a `name` and a `level`. Optional fields include `description`, `parentId`, `producedByOrganisationId`, `manufacturingFacilityId`, `primaryIdentifierId`, and `secondaryIdentifierIds`.
+
+The [hierarchy rules](#product-hierarchy) are enforced for each item. If any item violates the rules, the entire request is rejected.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: POST /api/v1/products [{ name, level, ... }]
+    RI->>RI: Validate each item (name, level required)
+    RI->>RI: Validate level enum (MODEL, BATCH, ITEM)
+    alt parentId provided
+        RI->>DB: Verify parent exists and hierarchy is valid
+        alt parent not found
+            RI-->>Client: 404 Not Found
+        end
+        alt hierarchy violation
+            RI-->>Client: 400 Bad Request
+        end
+    end
+    alt optional IDs provided
+        RI->>DB: Verify referenced records exist and belong to tenant
+        alt referenced record not found
+            RI-->>Client: 404 Not Found
+        end
+    end
+    RI->>DB: Insert product records
+    DB-->>RI: Created records
+    RI-->>Client: 201 Created (array of products)
+```
+
+---
+
+### List products
+
+```
+GET /api/v1/products
+```
+
+Returns products for the authenticated tenant with optional filtering. Results are paginated.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `search` | string | — | Search by product name or identifier value |
+| `level` | string | — | Filter by product level (`MODEL`, `BATCH`, or `ITEM`) |
+| `parentId` | string | — | Filter by parent product ID |
+| `organisationId` | string | — | Filter by producing organisation ID |
+| `facilityId` | string | — | Filter by manufacturing facility ID |
+| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `offset` | integer | `0` | Number of results to skip |
+
+---
+
+### Get a product
+
+```
+GET /api/v1/products/{id}
+```
+
+Retrieves a specific product by its database ID. The response includes the full primary identifier (with scheme and registrar details), secondary identifiers, the producing organisation, the manufacturing facility, and the parent product (if any).
+
+---
+
+### Update a product
+
+```
+PATCH /api/v1/products/{id}
+```
+
+Updates one or more fields of an existing product. The product `level` is **immutable** — if provided in the request body, it is silently stripped. At least one updatable field must be provided.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `name` | Product name (must be non-empty if provided) |
+| `description` | Free-text description |
+| `parentId` | Parent product ID (subject to [hierarchy rules](#product-hierarchy)) |
+| `producedByOrganisationId` | ID of the producing organisation (set to `null` to clear) |
+| `manufacturingFacilityId` | ID of the manufacturing facility (set to `null` to clear) |
+| `primaryIdentifierId` | ID of the primary identifier (set to `null` to clear) |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing) |
+
+---
+
+### Delete a product
+
+```
+DELETE /api/v1/products/{id}
+```
+
+Deletes a product from the database. See [deletion behaviour](#deletion-behaviour) for how children are handled.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: DELETE /api/v1/products/{id}
+    RI->>DB: Fetch product + children (tenant-scoped)
+    alt not found
+        RI-->>Client: 404 Not Found
+    end
+    alt has BATCH children
+        RI-->>Client: 400 Bad Request
+    end
+    alt has ITEM children
+        RI->>DB: Detach items (set parentId to null)
+    end
+    RI->>DB: Delete product
+    DB-->>RI: Deleted
+    RI-->>Client: 204 No Content
+```

--- a/documentation/docs/reference-implementation/api/registrars.md
+++ b/documentation/docs/reference-implementation/api/registrars.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 10
+title: Registrars
+---
+
+# Registrars API
+
+The Registrars API manages **registrars** — the organisations that maintain [identifier schemes](./identifiers). Each registrar can have multiple schemes registered under it.
+
+:::tip[Interactive API documentation]
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+:::
+
+:::info[Documentation in progress]
+Detailed endpoint documentation for registrars is planned. Refer to the Swagger UI for current endpoint details.
+:::

--- a/documentation/docs/reference-implementation/master-data/_category_.json
+++ b/documentation/docs/reference-implementation/master-data/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Master Data",
+  "position": 7,
+  "collapsed": true
+}

--- a/documentation/docs/reference-implementation/master-data/index.md
+++ b/documentation/docs/reference-implementation/master-data/index.md
@@ -116,7 +116,7 @@ The [population](../data-models/index.md#population) direction — where entity 
 
 ## Tenant Scoping
 
-All master data is scoped to the authenticated tenant. Each tenant maintains its own set of organisations, facilities, and products — they cannot see or modify entities belonging to other tenants. Unlike [data models](../data-models/index.md#untp-core-data-models-and-extensions) and [service instances](../services/service-architecture#system-services-vs-tenant-services), there are no system-level master data records — every entity is tenant-owned.
+All master data is scoped to the authenticated tenant. Each tenant maintains its own set of organisations, facilities, and products — they cannot see or modify entities belonging to other tenants. Unlike [data models](../api/data-models#untp-core-data-models-and-extensions) and [service instances](../services/service-architecture#system-services-vs-tenant-services), there are no system-level master data records — every entity is tenant-owned.
 
 ## Further Reading
 

--- a/documentation/docs/reference-implementation/master-data/index.md
+++ b/documentation/docs/reference-implementation/master-data/index.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 1
+title: Overview
+---
+
+# Master Data
+
+The Reference Implementation stores **master data** — the stable records that describe the real-world things credentials are issued about. UNTP credentials reference organisations, facilities, and products — these are not created fresh for each credential but maintained as persistent, reusable records that predate and outlive any individual credential.
+
+Master data serves two purposes in the Reference Implementation:
+
+1. **Credential population** — the [data model bridge](../data-models/index.md#population) can read entity records and map their data into the correct positions within the credential subject, so tenants define their entity data once rather than re-entering it for each credential. Population is UI-driven — see the [bridge documentation](../data-models/index.md#population) for the current status.
+
+2. **Credential linking** — after a credential is issued, the [extraction](../data-models/index.md#extraction) process pulls entity identifiers out of the credential subject and links the credential record back to the entities it describes. This enables querying credentials by the entities they reference.
+
+## Entity Types
+
+The Reference Implementation defines three master data entity types. Together they model the core supply chain relationships that UNTP credentials describe.
+
+```mermaid
+erDiagram
+    Organisation |o--o{ Facility : "operates"
+    Organisation |o--o{ Product : "produces"
+    Facility |o--o{ Product : "manufactures"
+    Product |o--o{ Product : "parent (hierarchy)"
+    Organisation |o--o| Identifier : "primary"
+    Organisation }o--o{ Identifier : "secondary"
+    Facility |o--o| Identifier : "primary"
+    Facility }o--o{ Identifier : "secondary"
+    Product |o--o| Identifier : "primary"
+    Product }o--o{ Identifier : "secondary"
+```
+
+### Organisations
+
+An organisation represents a legal entity or business — the brand owner, producer, or any party that the tenant needs to reference when issuing credentials. Organisations can be linked to facilities they operate and products they produce.
+
+See the [Organisations API](../api/organisations) for endpoint documentation.
+
+### Facilities
+
+A facility represents a physical location — a factory, warehouse, farm, or processing plant. Each facility can optionally be linked to the organisation that operates it. Facilities can be referenced by multiple UNTP credential types.
+
+See the [Facilities API](../api/facilities) for endpoint documentation.
+
+### Products
+
+A product represents a good, material, or item in the supply chain. Products have a three-tier hierarchy that mirrors how goods are identified in practice:
+
+| Level | Description | Example |
+|-------|-------------|---------|
+| `MODEL` | A product definition or SKU | "Organic Coffee Beans 1kg" |
+| `BATCH` | A production run of a model | "Batch 2024-Q1-001" |
+| `ITEM` | An individual serialised unit | "Serial #A001" |
+
+Each product can be linked to the organisation that produces it and the facility where it is manufactured.
+
+See the [Products API](../api/products) for endpoint documentation.
+
+## Identifiers
+
+All three entity types support **identifiers** — structured values that follow an [identifier scheme](../api/identifiers) registered with a [registrar](../api/registrars). Identifiers connect master data records to the identification systems used in the tenant's industry or jurisdiction.
+
+Each entity supports:
+
+- **Primary identifier** — a single main identifier that serves as the entity's principal business identifier
+- **Secondary identifiers** — additional identifiers that provide supplementary identification. These can be from any scheme, including the same scheme as the primary identifier — the only constraint is that the same identifier record cannot appear as both primary and secondary
+
+Identifiers are optional — entities can be created without them and have identifiers assigned later via the update endpoint. This supports a progressive setup workflow where tenants build their master data incrementally, adding the [registrar → scheme → identifier](../api/identifiers) chain when ready.
+
+However, identifiers are central to how credentials reference entities. After a credential is issued, the [extraction](../data-models/index.md#extraction) process uses entity identifiers to match the credential back to entity records in the database. **Entities without identifiers will not be linked to credentials during extraction.** Assigning identifiers before issuing credentials that reference the entity is recommended.
+
+## Location
+
+Organisations and facilities support an optional `location` field — a structured JSON object matching the [UNTP core vocabulary](https://untp.unece.org/) location model. All fields are optional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address.streetAddress` | string | Street address |
+| `address.postalCode` | string | Postal or ZIP code |
+| `address.addressLocality` | string | City or town |
+| `address.addressRegion` | string | State, province, or region |
+| `address.addressCountry` | string | Country (ISO 3166 alpha-2) |
+| `plusCode` | string | [Plus Code](https://maps.google.com/pluscodes/) (Open Location Code) |
+| `geoLocation` | GeoJSON Point | `{ "type": "Point", "coordinates": [longitude, latitude] }` |
+| `geoBoundary` | GeoJSON Polygon | `{ "type": "Polygon", "coordinates": [[[lon, lat], ...]] }` |
+
+A location can contain any combination of these fields. For entities with only a free-text address, use `address.streetAddress`.
+
+## How Master Data Connects to Credentials
+
+Master data entities are linked to credentials through the [extraction](../data-models/index.md#extraction) process that runs automatically during credential issuance. After a credential is signed and stored, the data model bridge extracts entity identifier references from the credential subject and uses them to create links between the credential record and the entities it describes.
+
+```mermaid
+sequenceDiagram
+    participant Tenant
+    participant RI as Reference Implementation
+    participant DB as Database
+    participant Bridge as Data Model Bridge
+
+    Note over Tenant,DB: Master data maintained over time
+    Tenant->>RI: Create/update organisations, facilities, products
+    RI->>DB: Store entity records
+
+    Note over Tenant,Bridge: Credential issuance
+    Tenant->>RI: Issue credential (credentialPayload)
+    RI->>RI: Sign, store, and publish credential
+
+    Note over RI,Bridge: Post-issuance extraction
+    RI->>Bridge: extractRefs(credential subject)
+    Bridge-->>RI: Entity identifier references
+    RI->>DB: Link credential to entity records
+```
+
+The [population](../data-models/index.md#population) direction — where entity data is mapped into a credential subject before issuance — is UI-driven and planned for a future iteration of the web interface. See the [bridge documentation](../data-models/index.md#population) for details.
+
+## Tenant Scoping
+
+All master data is scoped to the authenticated tenant. Each tenant maintains its own set of organisations, facilities, and products — they cannot see or modify entities belonging to other tenants. Unlike [data models](../data-models/index.md#untp-core-data-models-and-extensions) and [service instances](../services/service-architecture#system-services-vs-tenant-services), there are no system-level master data records — every entity is tenant-owned.
+
+## Further Reading
+
+- [Organisations API](../api/organisations) — create, list, update, and delete organisations
+- [Facilities API](../api/facilities) — create, list, update, and delete facilities
+- [Products API](../api/products) — create, list, update, and delete products
+- [Data Model Bridges](../data-models/index.md) — how bridges map entity data into credential structures
+- [Identifiers API](../api/identifiers) — manage identifiers and their schemes

--- a/documentation/docs/reference-implementation/operations/_category_.json
+++ b/documentation/docs/reference-implementation/operations/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Operations",
-  "position": 9,
+  "position": 10,
   "collapsed": true
 }

--- a/documentation/docs/reference-implementation/verify-page.md
+++ b/documentation/docs/reference-implementation/verify-page.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: Verify Page
 ---
 

--- a/e2e/cypress/e2e/api/facility_api/facility-management.cy.ts
+++ b/e2e/cypress/e2e/api/facility_api/facility-management.cy.ts
@@ -113,6 +113,7 @@ describe('Facility API', { testIsolation: false }, () => {
     it('GET /api/v1/facilities — lists facilities', () => {
       cy.request('/api/v1/facilities').then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.data).to.be.an('array');
         expect(response.body.pagination).to.exist;
 
@@ -233,6 +234,7 @@ describe('Facility API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -246,6 +248,7 @@ describe('Facility API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -257,6 +260,7 @@ describe('Facility API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -268,6 +272,20 @@ describe('Facility API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid JSON body', function () {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/facilities',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -278,6 +296,7 @@ describe('Facility API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -288,6 +307,7 @@ describe('Facility API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -298,6 +318,71 @@ describe('Facility API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 404 for nonexistent operatingOrganisationId', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/facilities',
+        body: [
+          {
+            name: `Facility Bad Org ${RUN_ID}`,
+            operatingOrganisationId: 'nonexistent-org-id',
+          },
+        ],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 400 for empty body (no updatable fields)', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/facilities/nonexistent-id',
+        body: {},
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 400 for invalid name (empty string)', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/facilities/nonexistent-id',
+        body: { name: '' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 404 for nonexistent facility', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/facilities/nonexistent-id',
+        body: { name: `Nonexistent Facility ${RUN_ID}` },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE returns 404 for nonexistent facility', () => {
+      cy.request({
+        method: 'DELETE',
+        url: '/api/v1/facilities/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -307,6 +392,10 @@ describe('Facility API', { testIsolation: false }, () => {
       cy.request('/api/v1/facilities?limit=1&offset=0').then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body.data.length).to.be.at.most(1);
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
+        expect(response.body.pagination.total).to.be.a('number');
       });
     });
   });

--- a/e2e/cypress/e2e/api/organisation_api/organisation-management.cy.ts
+++ b/e2e/cypress/e2e/api/organisation_api/organisation-management.cy.ts
@@ -101,6 +101,7 @@ describe('Organisation API', { testIsolation: false }, () => {
     it('GET /api/v1/organisations — lists organisations', () => {
       cy.request('/api/v1/organisations').then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.data).to.be.an('array');
         expect(response.body.pagination).to.exist;
 
@@ -220,6 +221,7 @@ describe('Organisation API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -233,6 +235,7 @@ describe('Organisation API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -244,6 +247,7 @@ describe('Organisation API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -255,6 +259,20 @@ describe('Organisation API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid JSON body', function () {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/organisations',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -265,6 +283,7 @@ describe('Organisation API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -275,6 +294,7 @@ describe('Organisation API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -285,6 +305,71 @@ describe('Organisation API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 404 for nonexistent primaryIdentifierId', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/organisations',
+        body: [
+          {
+            name: `Org Bad Identifier ${RUN_ID}`,
+            primaryIdentifierId: 'nonexistent-identifier-id',
+          },
+        ],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 400 for empty body (no updatable fields)', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/organisations/nonexistent-id',
+        body: {},
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 400 for invalid name (empty string)', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/organisations/nonexistent-id',
+        body: { name: '' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 404 for nonexistent organisation', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/organisations/nonexistent-id',
+        body: { name: `Nonexistent Organisation ${RUN_ID}` },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE returns 404 for nonexistent organisation', () => {
+      cy.request({
+        method: 'DELETE',
+        url: '/api/v1/organisations/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -294,6 +379,10 @@ describe('Organisation API', { testIsolation: false }, () => {
       cy.request('/api/v1/organisations?limit=1&offset=0').then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body.data.length).to.be.at.most(1);
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
+        expect(response.body.pagination.total).to.be.a('number');
       });
     });
   });

--- a/e2e/cypress/e2e/api/product_api/product-management.cy.ts
+++ b/e2e/cypress/e2e/api/product_api/product-management.cy.ts
@@ -203,6 +203,7 @@ describe('Product API', { testIsolation: false }, () => {
     it('GET /api/v1/products — lists products', () => {
       cy.request('/api/v1/products').then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.data).to.be.an('array');
         expect(response.body.pagination).to.exist;
 
@@ -354,6 +355,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -370,6 +372,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -387,6 +390,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -399,6 +403,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -452,6 +457,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -465,6 +471,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -476,6 +483,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -487,6 +495,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -498,6 +507,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -509,6 +519,20 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid JSON body', function () {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -519,6 +543,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -529,6 +554,7 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -539,6 +565,72 @@ describe('Product API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 404 for nonexistent parentId', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/products',
+        body: [
+          {
+            name: `Orphan Batch ${RUN_ID}`,
+            level: 'BATCH',
+            parentId: 'nonexistent-parent-id',
+          },
+        ],
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 400 for empty body (no updatable fields)', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/products/nonexistent-id',
+        body: {},
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 400 for invalid name (empty string)', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/products/nonexistent-id',
+        body: { name: '' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH returns 404 for nonexistent product', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/products/nonexistent-id',
+        body: { name: `Nonexistent Product ${RUN_ID}` },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE returns 404 for nonexistent product', () => {
+      cy.request({
+        method: 'DELETE',
+        url: '/api/v1/products/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -548,6 +640,10 @@ describe('Product API', { testIsolation: false }, () => {
       cy.request('/api/v1/products?limit=1&offset=0').then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body.data.length).to.be.at.most(1);
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
+        expect(response.body.pagination.total).to.be.a('number');
       });
     });
   });

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
@@ -1,12 +1,21 @@
 // Mock next/server before importing route handlers
-jest.mock('next/server', () => ({
-  NextResponse: {
-    json: (body: unknown, init?: { status?: number }) => ({
-      status: init?.status ?? 200,
-      json: async () => body,
-    }),
-  },
-}));
+jest.mock('next/server', () => {
+  class MockNextResponse {
+    status: number;
+    body: unknown;
+    constructor(body: unknown, init?: { status?: number }) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+    async json() {
+      return this.body;
+    }
+    static json(body: unknown, init?: { status?: number }) {
+      return new MockNextResponse(body, init);
+    }
+  }
+  return { NextResponse: MockNextResponse };
+});
 
 // Mock withTenantAuth — skips auth but mirrors handleRouteError behaviour inline
 jest.mock('@/lib/api/with-tenant-auth', () => {

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
@@ -17,29 +17,17 @@ jest.mock('next/server', () => {
   return { NextResponse: MockNextResponse };
 });
 
-// Mock withTenantAuth — skips auth but mirrors handleRouteError behaviour inline
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError } = jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
       (handler: (...args: unknown[]) => unknown) =>
       async (...args: unknown[]) => {
         try {
           return await handler(...args);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          return jsonResponse({ error: (e as Error).message }, { status: 500 });
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -60,12 +60,12 @@ const UPDATABLE_FIELDS = [
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, facilityId: id }, 'Looking up facility');
+  logger.info({ facilityId: id }, 'Looking up facility');
   const facility = await getFacilityById(id, tenantId);
   if (!facility) {
     throw new NotFoundError('Facility not found');
   }
-  logger.info({ tenantId, facilityId: id }, 'Facility retrieved');
+  logger.info({ facilityId: id }, 'Facility retrieved');
   return NextResponse.json(facility);
 });
 
@@ -149,7 +149,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, facilityId: id }, 'Parsing request body');
+  logger.info({ facilityId: id }, 'Parsing request body');
   let body: Record<string, unknown>;
 
   try {
@@ -158,7 +158,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, facilityId: id }, 'Validating update fields');
+  logger.info({ facilityId: id }, 'Validating update fields');
   // Ensure at least one updatable field is present
   const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
   if (!hasUpdatableField) {
@@ -170,10 +170,10 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('name must be a non-empty string');
   }
 
-  logger.info({ tenantId, facilityId: id }, 'Updating facility');
+  logger.info({ facilityId: id }, 'Updating facility');
   const updated = await updateFacility(id, tenantId, body);
 
-  logger.info({ tenantId, facilityId: id }, 'Facility updated');
+  logger.info({ facilityId: id }, 'Facility updated');
   return NextResponse.json(updated);
 });
 
@@ -217,9 +217,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, facilityId: id }, 'Deleting facility');
+  logger.info({ facilityId: id }, 'Deleting facility');
   await deleteFacility(id, tenantId);
 
-  logger.info({ tenantId, facilityId: id }, 'Facility deleted');
-  return new Response(null, { status: 204 });
+  logger.info({ facilityId: id }, 'Facility deleted');
+  return new NextResponse(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -170,8 +170,15 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('name must be a non-empty string');
   }
 
+  const updateData: Record<string, unknown> = {};
+  for (const field of UPDATABLE_FIELDS) {
+    if (field in body) {
+      updateData[field] = body[field];
+    }
+  }
+
   logger.info({ facilityId: id }, 'Updating facility');
-  const updated = await updateFacility(id, tenantId, body);
+  const updated = await updateFacility(id, tenantId, updateData);
 
   logger.info({ facilityId: id }, 'Facility updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { getFacilityById, updateFacility, deleteFacility } from '@/lib/prisma/repositories';
+import { getFacilityById, updateFacility, deleteFacility, UpdateFacilityInput } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/facilities/[id]' });
@@ -178,7 +178,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   }
 
   logger.info({ facilityId: id }, 'Updating facility');
-  const updated = await updateFacility(id, tenantId, updateData);
+  const updated = await updateFacility(id, tenantId, updateData as UpdateFacilityInput);
 
   logger.info({ facilityId: id }, 'Facility updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -81,7 +81,7 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing request body');
+  logger.info('Parsing request body');
   let body: unknown;
 
   try {
@@ -90,7 +90,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId }, 'Validating input parameters');
+  logger.info('Validating input parameters');
   if (!Array.isArray(body)) {
     throw new ValidationError('Request body must be an array');
   }
@@ -105,10 +105,10 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     }
   }
 
-  logger.info({ tenantId, count: body.length }, 'Creating facilities');
+  logger.info({ count: body.length }, 'Creating facilities');
   const facilities = await createFacilities(tenantId, body);
 
-  logger.info({ tenantId, count: facilities.length }, 'Facilities created');
+  logger.info({ count: facilities.length }, 'Facilities created');
   return NextResponse.json(facilities, { status: 201 });
 });
 
@@ -177,7 +177,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing query parameters');
+  logger.info('Parsing query filters');
   const url = new URL(req.url);
   const search = url.searchParams.get('search') ?? undefined;
   const organisationId = url.searchParams.get('organisationId') ?? undefined;
@@ -185,9 +185,9 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
   const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, search, organisationId, limit, offset }, 'Listing facilities');
+  logger.info({ filters: { search, organisationId, limit, offset } }, 'Querying facilities');
   const { data, total } = await listFacilities(tenantId, { search, organisationId, limit, offset });
 
-  logger.info({ tenantId, count: data.length }, 'Facilities listed');
+  logger.info({ count: data.length, total }, 'Facilities listed');
   return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
@@ -1,12 +1,21 @@
 // Mock next/server before importing route handlers
-jest.mock('next/server', () => ({
-  NextResponse: {
-    json: (body: unknown, init?: { status?: number }) => ({
-      status: init?.status ?? 200,
-      json: async () => body,
-    }),
-  },
-}));
+jest.mock('next/server', () => {
+  class MockNextResponse {
+    status: number;
+    body: unknown;
+    constructor(body: unknown, init?: { status?: number }) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+    async json() {
+      return this.body;
+    }
+    static json(body: unknown, init?: { status?: number }) {
+      return new MockNextResponse(body, init);
+    }
+  }
+  return { NextResponse: MockNextResponse };
+});
 
 // Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
 jest.mock('@/lib/api/with-tenant-auth', () => {

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -57,12 +57,12 @@ const UPDATABLE_FIELDS = ['name', 'description', 'location', 'primaryIdentifierI
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, organisationId: id }, 'Looking up organisation');
+  logger.info({ organisationId: id }, 'Looking up organisation');
   const organisation = await getOrganisationById(id, tenantId);
   if (!organisation) {
     throw new NotFoundError('Organisation not found');
   }
-  logger.info({ tenantId, organisationId: id }, 'Organisation retrieved');
+  logger.info({ organisationId: id }, 'Organisation retrieved');
   return NextResponse.json(organisation);
 });
 
@@ -95,8 +95,8 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                 type: string
  *                 description: Updated description
  *               location:
- *                 type: string
- *                 description: Updated location
+ *                 type: object
+ *                 description: Updated UNTP location object
  *               primaryIdentifierId:
  *                 type: string
  *                 description: ID of the primary identifier
@@ -141,7 +141,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, organisationId: id }, 'Parsing request body');
+  logger.info({ organisationId: id }, 'Parsing request body');
   let body: Record<string, unknown>;
 
   try {
@@ -150,7 +150,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, organisationId: id }, 'Validating update fields');
+  logger.info({ organisationId: id }, 'Validating update fields');
   const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
   if (!hasUpdatableField) {
     throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
@@ -160,10 +160,10 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('name must be a non-empty string');
   }
 
-  logger.info({ tenantId, organisationId: id }, 'Updating organisation');
+  logger.info({ organisationId: id }, 'Updating organisation');
   const updated = await updateOrganisation(id, tenantId, body as UpdateOrganisationInput);
 
-  logger.info({ tenantId, organisationId: id }, 'Organisation updated');
+  logger.info({ organisationId: id }, 'Organisation updated');
   return NextResponse.json(updated);
 });
 
@@ -207,9 +207,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, organisationId: id }, 'Deleting organisation');
+  logger.info({ organisationId: id }, 'Deleting organisation');
   await deleteOrganisation(id, tenantId);
 
-  logger.info({ tenantId, organisationId: id }, 'Organisation deleted');
-  return new Response(null, { status: 204 });
+  logger.info({ organisationId: id }, 'Organisation deleted');
+  return new NextResponse(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -160,8 +160,15 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('name must be a non-empty string');
   }
 
+  const updateData: Record<string, unknown> = {};
+  for (const field of UPDATABLE_FIELDS) {
+    if (field in body) {
+      updateData[field] = body[field];
+    }
+  }
+
   logger.info({ organisationId: id }, 'Updating organisation');
-  const updated = await updateOrganisation(id, tenantId, body as UpdateOrganisationInput);
+  const updated = await updateOrganisation(id, tenantId, updateData as UpdateOrganisationInput);
 
   logger.info({ organisationId: id }, 'Organisation updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -35,6 +35,14 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *                 location:
  *                   type: object
  *                   description: Optional UNTP location object
+ *                 primaryIdentifierId:
+ *                   type: string
+ *                   description: ID of the primary identifier
+ *                 secondaryIdentifierIds:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   description: IDs of secondary identifiers
  *     responses:
  *       201:
  *         description: Organisations created successfully
@@ -56,6 +64,12 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Referenced entity not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:
@@ -64,7 +78,7 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing request body');
+  logger.info('Parsing request body');
   let body: unknown;
 
   try {
@@ -73,7 +87,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId }, 'Validating input parameters');
+  logger.info('Validating input parameters');
   if (!Array.isArray(body)) {
     throw new ValidationError('Request body must be an array');
   }
@@ -88,10 +102,10 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     }
   }
 
-  logger.info({ tenantId, count: body.length }, 'Creating organisations');
+  logger.info({ count: body.length }, 'Creating organisations');
   const organisations = await createOrganisations(tenantId, body);
 
-  logger.info({ tenantId, count: organisations.length }, 'Organisations created');
+  logger.info({ count: organisations.length }, 'Organisations created');
   return NextResponse.json(organisations, { status: 201 });
 });
 
@@ -155,16 +169,16 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing query parameters');
+  logger.info('Parsing query filters');
   const url = new URL(req.url);
   const search = url.searchParams.get('search') ?? undefined;
   const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, search, limit, offset }, 'Listing organisations');
+  logger.info({ filters: { search, limit, offset } }, 'Querying organisations');
   const { data, total } = await listOrganisations(tenantId, { search, limit, offset });
 
-  logger.info({ tenantId, count: data.length }, 'Organisations listed');
+  logger.info({ count: data.length, total }, 'Organisations listed');
   return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -122,7 +122,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: search
  *         schema:
  *           type: string
- *         description: Search term to filter organisations
+ *         description: Search by organisation name or identifier value
  *       - in: query
  *         name: limit
  *         schema:

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
@@ -1,12 +1,21 @@
 // Mock next/server before importing route handlers
-jest.mock('next/server', () => ({
-  NextResponse: {
-    json: (body: unknown, init?: { status?: number }) => ({
-      status: init?.status ?? 200,
-      json: async () => body,
-    }),
-  },
-}));
+jest.mock('next/server', () => {
+  class MockNextResponse {
+    status: number;
+    body: unknown;
+    constructor(body: unknown, init?: { status?: number }) {
+      this.body = body;
+      this.status = init?.status ?? 200;
+    }
+    async json() {
+      return this.body;
+    }
+    static json(body: unknown, init?: { status?: number }) {
+      return new MockNextResponse(body, init);
+    }
+  }
+  return { NextResponse: MockNextResponse };
+});
 
 // Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
 jest.mock('@/lib/api/with-tenant-auth', () => {

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -105,7 +105,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                 description: Updated parent product ID
  *               producedByOrganisationId:
  *                 type: string
- *                 description: Updated brand organisation ID
+ *                 description: Updated producing organisation ID
  *               manufacturingFacilityId:
  *                 type: string
  *                 description: Updated manufacturing facility ID
@@ -163,20 +163,25 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   }
 
   logger.info({ productId: id }, 'Validating update fields');
-  // Strip the immutable level field if provided
-  const { level: _level, ...updateFields } = body;
-
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in updateFields);
+  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
   if (!hasUpdatableField) {
     throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
   }
 
-  if (updateFields.name !== undefined && !isNonEmptyString(updateFields.name)) {
+  if (body.name !== undefined && !isNonEmptyString(body.name)) {
     throw new ValidationError('name must be a non-empty string');
   }
 
+  // Pick only known updatable fields (level is immutable and silently excluded)
+  const updateData: Record<string, unknown> = {};
+  for (const field of UPDATABLE_FIELDS) {
+    if (field in body) {
+      updateData[field] = body[field];
+    }
+  }
+
   logger.info({ productId: id }, 'Updating product');
-  const updated = await updateProduct(id, tenantId, updateFields);
+  const updated = await updateProduct(id, tenantId, updateData);
 
   logger.info({ productId: id }, 'Product updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -61,12 +61,12 @@ const UPDATABLE_FIELDS = [
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, productId: id }, 'Looking up product');
+  logger.info({ productId: id }, 'Looking up product');
   const product = await getProductById(id, tenantId);
   if (!product) {
     throw new NotFoundError('Product not found');
   }
-  logger.info({ tenantId, productId: id }, 'Product retrieved');
+  logger.info({ productId: id }, 'Product retrieved');
   return NextResponse.json(product);
 });
 
@@ -153,7 +153,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, productId: id }, 'Parsing request body');
+  logger.info({ productId: id }, 'Parsing request body');
   let body: Record<string, unknown>;
 
   try {
@@ -162,7 +162,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, productId: id }, 'Validating update fields');
+  logger.info({ productId: id }, 'Validating update fields');
   // Strip the immutable level field if provided
   const { level: _level, ...updateFields } = body;
 
@@ -175,10 +175,10 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('name must be a non-empty string');
   }
 
-  logger.info({ tenantId, productId: id }, 'Updating product');
+  logger.info({ productId: id }, 'Updating product');
   const updated = await updateProduct(id, tenantId, updateFields);
 
-  logger.info({ tenantId, productId: id }, 'Product updated');
+  logger.info({ productId: id }, 'Product updated');
   return NextResponse.json(updated);
 });
 
@@ -200,6 +200,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *     responses:
  *       204:
  *         description: Product deleted successfully
+ *       400:
+ *         description: Validation error — cannot delete product with dependent children
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -222,9 +228,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, productId: id }, 'Deleting product');
+  logger.info({ productId: id }, 'Deleting product');
   await deleteProduct(id, tenantId);
 
-  logger.info({ tenantId, productId: id }, 'Product deleted');
-  return new Response(null, { status: 204 });
+  logger.info({ productId: id }, 'Product deleted');
+  return new NextResponse(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { getProductById, updateProduct, deleteProduct } from '@/lib/prisma/repositories';
+import { getProductById, updateProduct, deleteProduct, UpdateProductInput } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/products/[id]' });
@@ -181,7 +181,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   }
 
   logger.info({ productId: id }, 'Updating product');
-  const updated = await updateProduct(id, tenantId, updateData);
+  const updated = await updateProduct(id, tenantId, updateData as UpdateProductInput);
 
   logger.info({ productId: id }, 'Product updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/products/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.ts
@@ -150,7 +150,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: search
  *         schema:
  *           type: string
- *         description: Search products by name
+ *         description: Search by product name or identifier value
  *       - in: query
  *         name: level
  *         schema:
@@ -166,7 +166,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: organisationId
  *         schema:
  *           type: string
- *         description: Filter by brand organisation ID
+ *         description: Filter by producing organisation ID
  *       - in: query
  *         name: facilityId
  *         schema:

--- a/packages/reference-implementation/src/app/api/v1/products/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.ts
@@ -48,6 +48,20 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *                 parentId:
  *                   type: string
  *                   description: Optional parent product ID
+ *                 producedByOrganisationId:
+ *                   type: string
+ *                   description: ID of the producing organisation
+ *                 manufacturingFacilityId:
+ *                   type: string
+ *                   description: ID of the manufacturing facility
+ *                 primaryIdentifierId:
+ *                   type: string
+ *                   description: ID of the primary identifier
+ *                 secondaryIdentifierIds:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   description: IDs of secondary identifiers
  *     responses:
  *       201:
  *         description: Products created successfully
@@ -83,7 +97,7 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing request body');
+  logger.info('Parsing request body');
   let body: Array<{
     name?: string;
     level?: string;
@@ -97,7 +111,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId }, 'Validating input parameters');
+  logger.info('Validating input parameters');
   if (!Array.isArray(body)) {
     throw new ValidationError('Request body must be an array');
   }
@@ -116,10 +130,10 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     validateEnum(item.level, PRODUCT_LEVELS, 'level');
   }
 
-  logger.info({ tenantId, count: body.length }, 'Creating products');
+  logger.info({ count: body.length }, 'Creating products');
   const products = await createProducts(tenantId, body as CreateProductInput[]);
 
-  logger.info({ tenantId, count: products.length }, 'Products created');
+  logger.info({ count: products.length }, 'Products created');
   return NextResponse.json(products, { status: 201 });
 });
 
@@ -204,7 +218,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing query parameters');
+  logger.info('Parsing query filters');
   const url = new URL(req.url);
   const search = url.searchParams.get('search') ?? undefined;
   const level = validateEnum(url.searchParams.get('level') ?? undefined, PRODUCT_LEVELS, 'level');
@@ -215,7 +229,7 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
   const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, search, level, parentId, organisationId, facilityId, limit, offset }, 'Listing products');
+  logger.info({ filters: { search, level, parentId, organisationId, facilityId, limit, offset } }, 'Querying products');
   const { data, total } = await listProducts(tenantId, {
     search,
     level,
@@ -226,6 +240,6 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
     offset,
   });
 
-  logger.info({ tenantId, count: data.length }, 'Products listed');
+  logger.info({ count: data.length, total }, 'Products listed');
   return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -207,6 +207,7 @@ export const productSchema = z.object({
   producedByOrganisationId: z.string().nullable(),
   manufacturingFacilityId: z.string().nullable(),
   primaryIdentifierId: z.string().nullable(),
+  secondaryIdentifierIds: z.array(z.string()).describe('IDs of secondary identifiers'),
   createdAt: z.string().describe('ISO 8601 timestamp'),
   updatedAt: z.string().describe('ISO 8601 timestamp'),
 });
@@ -218,6 +219,7 @@ export const organisationSchema = z.object({
   description: z.string().nullable(),
   location: z.record(z.unknown()).nullable().describe('UNTP location object'),
   primaryIdentifierId: z.string().nullable(),
+  secondaryIdentifierIds: z.array(z.string()).describe('IDs of secondary identifiers'),
   createdAt: z.string().describe('ISO 8601 timestamp'),
   updatedAt: z.string().describe('ISO 8601 timestamp'),
 });
@@ -230,6 +232,7 @@ export const facilitySchema = z.object({
   location: z.record(z.unknown()).nullable().describe('UNTP location object'),
   operatingOrganisationId: z.string().nullable(),
   primaryIdentifierId: z.string().nullable(),
+  secondaryIdentifierIds: z.array(z.string()).describe('IDs of secondary identifiers'),
   createdAt: z.string().describe('ISO 8601 timestamp'),
   updatedAt: z.string().describe('ISO 8601 timestamp'),
 });

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -192,6 +192,49 @@ export const renderTemplateSchema = z.object({
 });
 
 // ============================================================================
+// Master Data Schemas
+// ============================================================================
+
+export const productSchema = z.object({
+  id: z.string(),
+  tenantId: z.string(),
+  name: z.string(),
+  level: z.enum(['MODEL', 'BATCH', 'ITEM']),
+  description: z.string().nullable(),
+  batchNumber: z.string().nullable(),
+  serialNumber: z.string().nullable(),
+  parentId: z.string().nullable(),
+  producedByOrganisationId: z.string().nullable(),
+  manufacturingFacilityId: z.string().nullable(),
+  primaryIdentifierId: z.string().nullable(),
+  createdAt: z.string().describe('ISO 8601 timestamp'),
+  updatedAt: z.string().describe('ISO 8601 timestamp'),
+});
+
+export const organisationSchema = z.object({
+  id: z.string(),
+  tenantId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  location: z.record(z.unknown()).nullable().describe('UNTP location object'),
+  primaryIdentifierId: z.string().nullable(),
+  createdAt: z.string().describe('ISO 8601 timestamp'),
+  updatedAt: z.string().describe('ISO 8601 timestamp'),
+});
+
+export const facilitySchema = z.object({
+  id: z.string(),
+  tenantId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  location: z.record(z.unknown()).nullable().describe('UNTP location object'),
+  operatingOrganisationId: z.string().nullable(),
+  primaryIdentifierId: z.string().nullable(),
+  createdAt: z.string().describe('ISO 8601 timestamp'),
+  updatedAt: z.string().describe('ISO 8601 timestamp'),
+});
+
+// ============================================================================
 // Re-export imported schemas so existing consumers continue to work
 // ============================================================================
 
@@ -249,6 +292,9 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     Criterion: criterionSchema,
     DataModel: dataModelSchema,
     RenderTemplate: renderTemplateSchema,
+    Product: productSchema,
+    Organisation: organisationSchema,
+    Facility: facilitySchema,
   };
 
   const openAPISchemas: Record<string, OpenAPISchema> = {};


### PR DESCRIPTION
This PR audits the master data API routes (organisations, facilities, products), fixes all gaps found, and adds documentation to the documentation site.

## Changes

**Route fixes (6 route files, 3 test files, 1 schema file):**
- Remove `tenantId` from all log metadata (auto-injected by `withTenantAuth` via `AsyncLocalStorage`)
- Align log message phrasing with established routes (query filters, nested filter metadata, count + total on list success)
- Register `Product`, `Organisation`, and `Facility` Zod schemas in `generateOpenAPISchemas()` with `secondaryIdentifierIds`
- Add missing Swagger fields: POST request body optional properties, DELETE 400 for products, POST 404 for organisations, fix organisation PATCH location type from `string` to `object`
- Fix Swagger search descriptions to reflect actual behaviour (name + identifier value)
- Correct "brand organisation" to "producing organisation" terminology
- Update DELETE handlers to use `new NextResponse(null, { status: 204 })` with `MockNextResponse` class in test mocks
- Strip unknown fields in all three PATCH handlers to only pass known updatable fields to the repository
- Align facilities test mock to use `handleRouteError` (matching products and organisations pattern)

**E2E tests (3 test files):**
- Add `no ok property` assertions on list endpoints
- Enhance pagination tests with `hasMore`, `limit`, `offset`, `total` assertions
- Add PATCH validation tests (empty body, invalid name, nonexistent ID)
- Add DELETE nonexistent ID tests
- Add invalid JSON body tests
- Add nonexistent foreign key reference tests (parentId, primaryIdentifierId, operatingOrganisationId)
- Add `response.body.error` assertions to all error paths

**Documentation (5 new files, 3 sidebar position bumps):**
- Add master data conceptual overview with entity relationship diagram, identifier model, location structure, and credential linking flow
- Add API reference pages for organisations, facilities, and products
- Document SetNull cascade behaviour on organisation and facility deletion
- Bump sidebar positions for API, Verify Page, and Operations sections

## Test plan
- [x] All 876 unit tests pass (`yarn jest --maxWorkers=1` from RI directory)
- [x] All 6 master data route test suites pass
- [x] Documentation site builds and renders correctly on localhost:3030