### PR TITLE
feat(api): add client-side DID API service layer

### DIFF
--- a/packages/reference-implementation/src/lib/api/client.test.ts
+++ b/packages/reference-implementation/src/lib/api/client.test.ts
@@ -1,0 +1,122 @@
+import { ApiError, throwApiError, handleResponse } from './client';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function fakeResponse(overrides: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  json?: () => Promise<unknown>;
+}): Response {
+  return {
+    ok: overrides.ok ?? true,
+    status: overrides.status ?? 200,
+    statusText: overrides.statusText ?? 'OK',
+    json: overrides.json ?? jest.fn().mockResolvedValue({}),
+  } as unknown as Response;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ApiError', () => {
+  it('should extend Error with name, status, and optional code', () => {
+    const err = new ApiError('Bad request', 400, 'VALIDATION');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('ApiError');
+    expect(err.message).toBe('Bad request');
+    expect(err.status).toBe(400);
+    expect(err.code).toBe('VALIDATION');
+  });
+
+  it('should allow code to be omitted', () => {
+    const err = new ApiError('Not found', 404);
+
+    expect(err.code).toBeUndefined();
+  });
+});
+
+describe('throwApiError', () => {
+  it('should throw an ApiError with message and code from the response body', async () => {
+    const response = fakeResponse({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      json: jest.fn().mockResolvedValue({ error: 'Invalid input', code: 'INVALID' }),
+    });
+
+    try {
+      await throwApiError(response);
+      fail('Expected throwApiError to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({ message: 'Invalid input', status: 422, code: 'INVALID' });
+    }
+  });
+
+  it('should fall back to statusText when response body is not valid JSON', async () => {
+    const response = fakeResponse({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: jest.fn().mockRejectedValue(new SyntaxError('Unexpected token')),
+    });
+
+    try {
+      await throwApiError(response);
+      fail('Expected throwApiError to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({ message: 'Internal Server Error', status: 500, code: undefined });
+    }
+  });
+
+  it('should fall back to statusText when body has no error field', async () => {
+    const response = fakeResponse({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: jest.fn().mockResolvedValue({ detail: 'No access' }),
+    });
+
+    try {
+      await throwApiError(response);
+      fail('Expected throwApiError to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({ message: 'Forbidden', status: 403 });
+    }
+  });
+});
+
+describe('handleResponse', () => {
+  it('should return parsed JSON for successful responses', async () => {
+    const data = { id: '123', name: 'Test' };
+    const response = fakeResponse({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue(data),
+    });
+
+    const result = await handleResponse<typeof data>(response);
+
+    expect(result).toEqual(data);
+  });
+
+  it('should throw ApiError for non-ok responses', async () => {
+    const response = fakeResponse({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: jest.fn().mockResolvedValue({ error: 'Resource not found' }),
+    });
+
+    try {
+      await handleResponse(response);
+      fail('Expected handleResponse to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({ message: 'Resource not found', status: 404 });
+    }
+  });
+});

--- a/packages/reference-implementation/src/lib/api/client.ts
+++ b/packages/reference-implementation/src/lib/api/client.ts
@@ -1,0 +1,34 @@
+// ── Error type ───────────────────────────────────────────────────────────────
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+// ── Response helpers ─────────────────────────────────────────────────────────
+
+export async function throwApiError(response: Response): Promise<never> {
+  let error = response.statusText;
+  let code: string | undefined;
+  try {
+    const body = await response.json();
+    if (body.error) error = body.error;
+    if (body.code) code = body.code;
+  } catch {
+    // Use statusText as fallback
+  }
+  throw new ApiError(error, response.status, code);
+}
+
+export async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    await throwApiError(response);
+  }
+  return response.json() as Promise<T>;
+}

--- a/packages/reference-implementation/src/lib/api/services/did.service.test.ts
+++ b/packages/reference-implementation/src/lib/api/services/did.service.test.ts
@@ -1,0 +1,427 @@
+import type { Did } from '@/lib/prisma/generated';
+import { ApiError, listDids, getDid, createDid, updateDid, deleteDid, getDidDocument, verifyDid } from './did.service';
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const mockDid: Did = {
+  id: 'clx1abc000001',
+  tenantId: 'tenant-001',
+  did: 'did:web:example.com:org:abc',
+  type: 'ISSUER' as Did['type'],
+  method: 'DID_WEB' as Did['method'],
+  name: 'Test DID',
+  description: 'A test DID for unit tests',
+  keyId: 'key-001',
+  status: 'VERIFIED' as Did['status'],
+  isDefault: true,
+  createdAt: new Date('2026-01-15T10:00:00Z'),
+  updatedAt: new Date('2026-02-20T14:30:00Z'),
+  serviceInstanceId: 'svc-inst-001',
+};
+
+const mockDid2: Did = {
+  id: 'clx1abc000002',
+  tenantId: 'tenant-001',
+  did: 'did:web:example.com:org:def',
+  type: 'VERIFIER' as Did['type'],
+  method: 'DID_WEB' as Did['method'],
+  name: 'Secondary DID',
+  description: null,
+  keyId: 'key-002',
+  status: 'UNVERIFIED' as Did['status'],
+  isDefault: false,
+  createdAt: new Date('2026-02-01T08:00:00Z'),
+  updatedAt: new Date('2026-02-01T08:00:00Z'),
+  serviceInstanceId: null,
+};
+
+const mockDidDocument = {
+  '@context': ['https://www.w3.org/ns/did/v1'],
+  id: 'did:web:example.com:org:abc',
+  verificationMethod: [
+    {
+      id: 'did:web:example.com:org:abc#key-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:web:example.com:org:abc',
+    },
+  ],
+  authentication: ['did:web:example.com:org:abc#key-1'],
+};
+
+const mockVerifyResponse = {
+  verification: {
+    verified: true,
+    document: mockDidDocument,
+  },
+  did: mockDid,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockFetchResponse(body: unknown, init?: { status?: number; statusText?: string; ok?: boolean }) {
+  const status = init?.status ?? 200;
+  const ok = init?.ok ?? (status >= 200 && status < 300);
+  const statusText = init?.statusText ?? 'OK';
+
+  return jest.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText,
+    json: jest.fn().mockResolvedValue(body),
+  });
+}
+
+function mockFetchNoContent() {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 204,
+    statusText: 'No Content',
+  });
+}
+
+function mockFetchErrorNonJson(status: number, statusText: string) {
+  return jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText,
+    json: jest.fn().mockRejectedValue(new SyntaxError('Unexpected token')),
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DID API Service', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // ── listDids ─────────────────────────────────────────────────────────────
+
+  describe('listDids', () => {
+    const paginatedResponse = {
+      data: [mockDid, mockDid2],
+      pagination: { total: 2, limit: 10, offset: 0, hasMore: false },
+    };
+
+    it('should call the endpoint without query string when no params are provided', async () => {
+      global.fetch = mockFetchResponse(paginatedResponse);
+
+      const result = await listDids();
+
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost/api/v1/dids');
+      expect(result).toEqual(paginatedResponse);
+    });
+
+    it('should include only provided params in the query string', async () => {
+      global.fetch = mockFetchResponse(paginatedResponse);
+
+      await listDids({ type: 'ISSUER' as Did['type'], limit: 5 });
+
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get('type')).toBe('ISSUER');
+      expect(url.searchParams.get('limit')).toBe('5');
+      expect(url.searchParams.has('status')).toBe(false);
+      expect(url.searchParams.has('offset')).toBe(false);
+      expect(url.searchParams.has('serviceInstanceId')).toBe(false);
+    });
+
+    it('should include all params in the query string when all are provided', async () => {
+      global.fetch = mockFetchResponse(paginatedResponse);
+
+      await listDids({
+        type: 'ISSUER' as Did['type'],
+        status: 'VERIFIED' as Did['status'],
+        serviceInstanceId: 'svc-inst-001',
+        limit: 20,
+        offset: 10,
+      });
+
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.get('type')).toBe('ISSUER');
+      expect(url.searchParams.get('status')).toBe('VERIFIED');
+      expect(url.searchParams.get('serviceInstanceId')).toBe('svc-inst-001');
+      expect(url.searchParams.get('limit')).toBe('20');
+      expect(url.searchParams.get('offset')).toBe('10');
+    });
+
+    it('should exclude undefined values from the query string', async () => {
+      global.fetch = mockFetchResponse(paginatedResponse);
+
+      await listDids({ type: undefined, status: 'UNVERIFIED' as Did['status'], limit: undefined });
+
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      const url = new URL(calledUrl);
+      expect(url.searchParams.has('type')).toBe(false);
+      expect(url.searchParams.get('status')).toBe('UNVERIFIED');
+      expect(url.searchParams.has('limit')).toBe(false);
+    });
+
+    it('should throw ApiError when the response is not ok', async () => {
+      global.fetch = mockFetchResponse(
+        { error: 'Unauthorised', code: 'UNAUTHORISED' },
+        { status: 401, statusText: 'Unauthorized', ok: false },
+      );
+
+      await expect(listDids()).rejects.toThrow(ApiError);
+      await expect(listDids()).rejects.toMatchObject({
+        message: 'Unauthorised',
+        status: 401,
+        code: 'UNAUTHORISED',
+      });
+    });
+  });
+
+  // ── getDid ───────────────────────────────────────────────────────────────
+
+  describe('getDid', () => {
+    it('should fetch a single DID by id', async () => {
+      global.fetch = mockFetchResponse(mockDid);
+
+      const result = await getDid('clx1abc000001');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/dids/clx1abc000001');
+      expect(result).toEqual(mockDid);
+    });
+
+    it('should throw ApiError with 404 when the DID is not found', async () => {
+      global.fetch = mockFetchResponse({ error: 'DID not found' }, { status: 404, statusText: 'Not Found', ok: false });
+
+      await expect(getDid('nonexistent')).rejects.toThrow(ApiError);
+      await expect(getDid('nonexistent')).rejects.toMatchObject({
+        message: 'DID not found',
+        status: 404,
+      });
+    });
+  });
+
+  // ── createDid ────────────────────────────────────────────────────────────
+
+  describe('createDid', () => {
+    const createInput = {
+      type: 'ISSUER' as const,
+      method: 'DID_WEB' as const,
+      alias: 'my-did',
+      name: 'My New DID',
+      description: 'Created in tests',
+      isDefault: false,
+      serviceInstanceId: 'svc-inst-001',
+    };
+
+    it('should send a POST request with the correct method, headers, and body', async () => {
+      global.fetch = mockFetchResponse(mockDid, { status: 201 });
+
+      const result = await createDid(createInput);
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/dids', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(createInput),
+      });
+      expect(result).toEqual(mockDid);
+    });
+
+    it('should throw ApiError on 409 conflict', async () => {
+      global.fetch = mockFetchResponse(
+        { error: 'DID already exists', code: 'CONFLICT' },
+        { status: 409, statusText: 'Conflict', ok: false },
+      );
+
+      await expect(createDid(createInput)).rejects.toThrow(ApiError);
+      await expect(createDid(createInput)).rejects.toMatchObject({
+        message: 'DID already exists',
+        status: 409,
+        code: 'CONFLICT',
+      });
+    });
+  });
+
+  // ── updateDid ────────────────────────────────────────────────────────────
+
+  describe('updateDid', () => {
+    const updateInput = {
+      name: 'Updated DID Name',
+      description: 'Updated description',
+      isDefault: true,
+    };
+
+    it('should send a PATCH request with the correct method, headers, and body', async () => {
+      const updatedDid = { ...mockDid, ...updateInput };
+      global.fetch = mockFetchResponse(updatedDid);
+
+      const result = await updateDid('clx1abc000001', updateInput);
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/dids/clx1abc000001', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updateInput),
+      });
+      expect(result).toEqual(updatedDid);
+    });
+
+    it('should throw ApiError when the response is not ok', async () => {
+      global.fetch = mockFetchResponse(
+        { error: 'Validation failed', code: 'VALIDATION_ERROR' },
+        { status: 422, statusText: 'Unprocessable Entity', ok: false },
+      );
+
+      await expect(updateDid('clx1abc000001', updateInput)).rejects.toThrow(ApiError);
+      await expect(updateDid('clx1abc000001', updateInput)).rejects.toMatchObject({
+        message: 'Validation failed',
+        status: 422,
+        code: 'VALIDATION_ERROR',
+      });
+    });
+  });
+
+  // ── deleteDid ────────────────────────────────────────────────────────────
+
+  describe('deleteDid', () => {
+    it('should send a DELETE request and return void without parsing JSON', async () => {
+      global.fetch = mockFetchNoContent();
+
+      const result = await deleteDid('clx1abc000001');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/dids/clx1abc000001', { method: 'DELETE' });
+      expect(result).toBeUndefined();
+    });
+
+    it('should throw ApiError when the response is not ok', async () => {
+      global.fetch = mockFetchResponse(
+        { error: 'Cannot delete default DID', code: 'DELETE_FORBIDDEN' },
+        { status: 403, statusText: 'Forbidden', ok: false },
+      );
+
+      await expect(deleteDid('clx1abc000001')).rejects.toThrow(ApiError);
+      await expect(deleteDid('clx1abc000001')).rejects.toMatchObject({
+        message: 'Cannot delete default DID',
+        status: 403,
+        code: 'DELETE_FORBIDDEN',
+      });
+    });
+  });
+
+  // ── getDidDocument ───────────────────────────────────────────────────────
+
+  describe('getDidDocument', () => {
+    it('should fetch the DID document for a given id', async () => {
+      global.fetch = mockFetchResponse(mockDidDocument);
+
+      const result = await getDidDocument('clx1abc000001');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/dids/clx1abc000001/document');
+      expect(result).toEqual(mockDidDocument);
+    });
+
+    it('should throw ApiError when the response is not ok', async () => {
+      global.fetch = mockFetchResponse(
+        { error: 'Document resolution failed' },
+        { status: 502, statusText: 'Bad Gateway', ok: false },
+      );
+
+      await expect(getDidDocument('clx1abc000001')).rejects.toThrow(ApiError);
+      await expect(getDidDocument('clx1abc000001')).rejects.toMatchObject({
+        message: 'Document resolution failed',
+        status: 502,
+      });
+    });
+  });
+
+  // ── verifyDid ────────────────────────────────────────────────────────────
+
+  describe('verifyDid', () => {
+    it('should send a POST request and return the verification result', async () => {
+      global.fetch = mockFetchResponse(mockVerifyResponse);
+
+      const result = await verifyDid('clx1abc000001');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/dids/clx1abc000001/verify', { method: 'POST' });
+      expect(result).toEqual(mockVerifyResponse);
+    });
+
+    it('should throw ApiError when the response is not ok', async () => {
+      global.fetch = mockFetchResponse(
+        { error: 'Verification service unavailable' },
+        { status: 503, statusText: 'Service Unavailable', ok: false },
+      );
+
+      await expect(verifyDid('clx1abc000001')).rejects.toThrow(ApiError);
+      await expect(verifyDid('clx1abc000001')).rejects.toMatchObject({
+        message: 'Verification service unavailable',
+        status: 503,
+      });
+    });
+  });
+
+  // ── ApiError ─────────────────────────────────────────────────────────────
+
+  describe('ApiError', () => {
+    it('should have the correct name, message, status, and code properties', () => {
+      const err = new ApiError('Something went wrong', 500, 'INTERNAL');
+
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err.name).toBe('ApiError');
+      expect(err.message).toBe('Something went wrong');
+      expect(err.status).toBe(500);
+      expect(err.code).toBe('INTERNAL');
+    });
+
+    it('should allow code to be undefined', () => {
+      const err = new ApiError('Not found', 404);
+
+      expect(err.code).toBeUndefined();
+    });
+
+    it('should include the error code from the response body when present', async () => {
+      global.fetch = mockFetchResponse(
+        { error: 'Resource locked', code: 'RESOURCE_LOCKED' },
+        { status: 423, statusText: 'Locked', ok: false },
+      );
+
+      try {
+        await getDid('locked-id');
+        fail('Expected ApiError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.code).toBe('RESOURCE_LOCKED');
+        expect(apiErr.message).toBe('Resource locked');
+        expect(apiErr.status).toBe(423);
+      }
+    });
+
+    it('should fall back to statusText when the error response body is not valid JSON', async () => {
+      global.fetch = mockFetchErrorNonJson(500, 'Internal Server Error');
+
+      try {
+        await getDid('bad-response');
+        fail('Expected ApiError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.message).toBe('Internal Server Error');
+        expect(apiErr.status).toBe(500);
+        expect(apiErr.code).toBeUndefined();
+      }
+    });
+
+    it('should fall back to statusText for non-JSON error on deleteDid', async () => {
+      global.fetch = mockFetchErrorNonJson(500, 'Internal Server Error');
+
+      try {
+        await deleteDid('bad-response');
+        fail('Expected ApiError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const apiErr = err as ApiError;
+        expect(apiErr.message).toBe('Internal Server Error');
+        expect(apiErr.status).toBe(500);
+        expect(apiErr.code).toBeUndefined();
+      }
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/api/services/did.service.test.ts
+++ b/packages/reference-implementation/src/lib/api/services/did.service.test.ts
@@ -1,6 +1,7 @@
 import type { Did } from '@/lib/prisma/generated';
 import { DidType, DidMethod, DidStatus } from '@uncefact/untp-ri-services';
-import { ApiError, listDids, getDid, createDid, updateDid, deleteDid, getDidDocument, verifyDid } from './did.service';
+import { ApiError } from '@/lib/api/client';
+import { listDids, getDid, createDid, updateDid, deleteDid, getDidDocument, verifyDid } from './did.service';
 
 // ── Mock data ────────────────────────────────────────────────────────────────
 
@@ -89,6 +90,19 @@ function mockFetchErrorNonJson(status: number, statusText: string) {
   });
 }
 
+async function expectApiError(
+  fn: () => Promise<unknown>,
+  expected: { message: string; status: number; code?: string },
+) {
+  try {
+    await fn();
+    fail('Expected function to throw an ApiError');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject(expected);
+  }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('DID API Service', () => {
@@ -156,8 +170,7 @@ describe('DID API Service', () => {
         { status: 401, statusText: 'Unauthorized', ok: false },
       );
 
-      await expect(listDids()).rejects.toThrow(ApiError);
-      await expect(listDids()).rejects.toMatchObject({
+      await expectApiError(() => listDids(), {
         message: 'Unauthorised',
         status: 401,
         code: 'UNAUTHORISED',
@@ -180,8 +193,7 @@ describe('DID API Service', () => {
     it('should throw ApiError with 404 when the DID is not found', async () => {
       global.fetch = mockFetchResponse({ error: 'DID not found' }, { status: 404, statusText: 'Not Found', ok: false });
 
-      await expect(getDid('nonexistent')).rejects.toThrow(ApiError);
-      await expect(getDid('nonexistent')).rejects.toMatchObject({
+      await expectApiError(() => getDid('nonexistent'), {
         message: 'DID not found',
         status: 404,
       });
@@ -220,8 +232,7 @@ describe('DID API Service', () => {
         { status: 409, statusText: 'Conflict', ok: false },
       );
 
-      await expect(createDid(createInput)).rejects.toThrow(ApiError);
-      await expect(createDid(createInput)).rejects.toMatchObject({
+      await expectApiError(() => createDid(createInput), {
         message: 'DID already exists',
         status: 409,
         code: 'CONFLICT',
@@ -258,8 +269,7 @@ describe('DID API Service', () => {
         { status: 422, statusText: 'Unprocessable Entity', ok: false },
       );
 
-      await expect(updateDid('clx1abc000001', updateInput)).rejects.toThrow(ApiError);
-      await expect(updateDid('clx1abc000001', updateInput)).rejects.toMatchObject({
+      await expectApiError(() => updateDid('clx1abc000001', updateInput), {
         message: 'Validation failed',
         status: 422,
         code: 'VALIDATION_ERROR',
@@ -285,8 +295,7 @@ describe('DID API Service', () => {
         { status: 403, statusText: 'Forbidden', ok: false },
       );
 
-      await expect(deleteDid('clx1abc000001')).rejects.toThrow(ApiError);
-      await expect(deleteDid('clx1abc000001')).rejects.toMatchObject({
+      await expectApiError(() => deleteDid('clx1abc000001'), {
         message: 'Cannot delete default DID',
         status: 403,
         code: 'DELETE_FORBIDDEN',
@@ -312,8 +321,7 @@ describe('DID API Service', () => {
         { status: 502, statusText: 'Bad Gateway', ok: false },
       );
 
-      await expect(getDidDocument('clx1abc000001')).rejects.toThrow(ApiError);
-      await expect(getDidDocument('clx1abc000001')).rejects.toMatchObject({
+      await expectApiError(() => getDidDocument('clx1abc000001'), {
         message: 'Document resolution failed',
         status: 502,
       });
@@ -338,8 +346,7 @@ describe('DID API Service', () => {
         { status: 503, statusText: 'Service Unavailable', ok: false },
       );
 
-      await expect(verifyDid('clx1abc000001')).rejects.toThrow(ApiError);
-      await expect(verifyDid('clx1abc000001')).rejects.toMatchObject({
+      await expectApiError(() => verifyDid('clx1abc000001'), {
         message: 'Verification service unavailable',
         status: 503,
       });
@@ -372,8 +379,7 @@ describe('DID API Service', () => {
         { status: 423, statusText: 'Locked', ok: false },
       );
 
-      await expect(getDid('locked-id')).rejects.toThrow(ApiError);
-      await expect(getDid('locked-id')).rejects.toMatchObject({
+      await expectApiError(() => getDid('locked-id'), {
         message: 'Resource locked',
         status: 423,
         code: 'RESOURCE_LOCKED',
@@ -383,8 +389,7 @@ describe('DID API Service', () => {
     it('should fall back to statusText when the error response body is not valid JSON', async () => {
       global.fetch = mockFetchErrorNonJson(500, 'Internal Server Error');
 
-      await expect(getDid('bad-response')).rejects.toThrow(ApiError);
-      await expect(getDid('bad-response')).rejects.toMatchObject({
+      await expectApiError(() => getDid('bad-response'), {
         message: 'Internal Server Error',
         status: 500,
         code: undefined,
@@ -394,8 +399,7 @@ describe('DID API Service', () => {
     it('should fall back to statusText for non-JSON error on deleteDid', async () => {
       global.fetch = mockFetchErrorNonJson(500, 'Internal Server Error');
 
-      await expect(deleteDid('bad-response')).rejects.toThrow(ApiError);
-      await expect(deleteDid('bad-response')).rejects.toMatchObject({
+      await expectApiError(() => deleteDid('bad-response'), {
         message: 'Internal Server Error',
         status: 500,
         code: undefined,

--- a/packages/reference-implementation/src/lib/api/services/did.service.test.ts
+++ b/packages/reference-implementation/src/lib/api/services/did.service.test.ts
@@ -1,4 +1,5 @@
 import type { Did } from '@/lib/prisma/generated';
+import { DidType, DidMethod, DidStatus } from '@uncefact/untp-ri-services';
 import { ApiError, listDids, getDid, createDid, updateDid, deleteDid, getDidDocument, verifyDid } from './did.service';
 
 // ── Mock data ────────────────────────────────────────────────────────────────
@@ -7,7 +8,7 @@ const mockDid: Did = {
   id: 'clx1abc000001',
   tenantId: 'tenant-001',
   did: 'did:web:example.com:org:abc',
-  type: 'ISSUER' as Did['type'],
+  type: 'MANAGED' as Did['type'],
   method: 'DID_WEB' as Did['method'],
   name: 'Test DID',
   description: 'A test DID for unit tests',
@@ -23,7 +24,7 @@ const mockDid2: Did = {
   id: 'clx1abc000002',
   tenantId: 'tenant-001',
   did: 'did:web:example.com:org:def',
-  type: 'VERIFIER' as Did['type'],
+  type: 'SELF_MANAGED' as Did['type'],
   method: 'DID_WEB' as Did['method'],
   name: 'Secondary DID',
   description: null,
@@ -110,54 +111,43 @@ describe('DID API Service', () => {
 
       const result = await listDids();
 
-      expect(global.fetch).toHaveBeenCalledWith('http://localhost/api/v1/dids');
+      expect(global.fetch).toHaveBeenCalledWith('/api/v1/dids');
       expect(result).toEqual(paginatedResponse);
     });
 
     it('should include only provided params in the query string', async () => {
       global.fetch = mockFetchResponse(paginatedResponse);
 
-      await listDids({ type: 'ISSUER' as Did['type'], limit: 5 });
+      await listDids({ type: DidType.MANAGED, limit: 5 });
 
       const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-      const url = new URL(calledUrl);
-      expect(url.searchParams.get('type')).toBe('ISSUER');
-      expect(url.searchParams.get('limit')).toBe('5');
-      expect(url.searchParams.has('status')).toBe(false);
-      expect(url.searchParams.has('offset')).toBe(false);
-      expect(url.searchParams.has('serviceInstanceId')).toBe(false);
+      expect(calledUrl).toBe('/api/v1/dids?type=MANAGED&limit=5');
     });
 
     it('should include all params in the query string when all are provided', async () => {
       global.fetch = mockFetchResponse(paginatedResponse);
 
       await listDids({
-        type: 'ISSUER' as Did['type'],
-        status: 'VERIFIED' as Did['status'],
+        type: DidType.MANAGED,
+        status: DidStatus.VERIFIED,
         serviceInstanceId: 'svc-inst-001',
         limit: 20,
         offset: 10,
       });
 
       const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-      const url = new URL(calledUrl);
-      expect(url.searchParams.get('type')).toBe('ISSUER');
-      expect(url.searchParams.get('status')).toBe('VERIFIED');
-      expect(url.searchParams.get('serviceInstanceId')).toBe('svc-inst-001');
-      expect(url.searchParams.get('limit')).toBe('20');
-      expect(url.searchParams.get('offset')).toBe('10');
+      expect(calledUrl).toBe(
+        '/api/v1/dids?type=MANAGED&status=VERIFIED&serviceInstanceId=svc-inst-001&limit=20&offset=10',
+      );
     });
 
     it('should exclude undefined values from the query string', async () => {
       global.fetch = mockFetchResponse(paginatedResponse);
 
-      await listDids({ type: undefined, status: 'UNVERIFIED' as Did['status'], limit: undefined });
+      await listDids({ type: undefined, status: DidStatus.UNVERIFIED, limit: undefined });
 
       const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-      const url = new URL(calledUrl);
-      expect(url.searchParams.has('type')).toBe(false);
-      expect(url.searchParams.get('status')).toBe('UNVERIFIED');
-      expect(url.searchParams.has('limit')).toBe(false);
+      expect(calledUrl).toBe('/api/v1/dids?status=UNVERIFIED');
     });
 
     it('should throw ApiError when the response is not ok', async () => {
@@ -202,8 +192,8 @@ describe('DID API Service', () => {
 
   describe('createDid', () => {
     const createInput = {
-      type: 'ISSUER' as const,
-      method: 'DID_WEB' as const,
+      type: DidType.MANAGED as const,
+      method: DidMethod.DID_WEB as const,
       alias: 'my-did',
       name: 'My New DID',
       description: 'Created in tests',

--- a/packages/reference-implementation/src/lib/api/services/did.service.test.ts
+++ b/packages/reference-implementation/src/lib/api/services/did.service.test.ts
@@ -372,46 +372,34 @@ describe('DID API Service', () => {
         { status: 423, statusText: 'Locked', ok: false },
       );
 
-      try {
-        await getDid('locked-id');
-        fail('Expected ApiError to be thrown');
-      } catch (err) {
-        expect(err).toBeInstanceOf(ApiError);
-        const apiErr = err as ApiError;
-        expect(apiErr.code).toBe('RESOURCE_LOCKED');
-        expect(apiErr.message).toBe('Resource locked');
-        expect(apiErr.status).toBe(423);
-      }
+      await expect(getDid('locked-id')).rejects.toThrow(ApiError);
+      await expect(getDid('locked-id')).rejects.toMatchObject({
+        message: 'Resource locked',
+        status: 423,
+        code: 'RESOURCE_LOCKED',
+      });
     });
 
     it('should fall back to statusText when the error response body is not valid JSON', async () => {
       global.fetch = mockFetchErrorNonJson(500, 'Internal Server Error');
 
-      try {
-        await getDid('bad-response');
-        fail('Expected ApiError to be thrown');
-      } catch (err) {
-        expect(err).toBeInstanceOf(ApiError);
-        const apiErr = err as ApiError;
-        expect(apiErr.message).toBe('Internal Server Error');
-        expect(apiErr.status).toBe(500);
-        expect(apiErr.code).toBeUndefined();
-      }
+      await expect(getDid('bad-response')).rejects.toThrow(ApiError);
+      await expect(getDid('bad-response')).rejects.toMatchObject({
+        message: 'Internal Server Error',
+        status: 500,
+        code: undefined,
+      });
     });
 
     it('should fall back to statusText for non-JSON error on deleteDid', async () => {
       global.fetch = mockFetchErrorNonJson(500, 'Internal Server Error');
 
-      try {
-        await deleteDid('bad-response');
-        fail('Expected ApiError to be thrown');
-      } catch (err) {
-        expect(err).toBeInstanceOf(ApiError);
-        const apiErr = err as ApiError;
-        expect(apiErr.message).toBe('Internal Server Error');
-        expect(apiErr.status).toBe(500);
-        expect(apiErr.code).toBeUndefined();
-      }
+      await expect(deleteDid('bad-response')).rejects.toThrow(ApiError);
+      await expect(deleteDid('bad-response')).rejects.toMatchObject({
+        message: 'Internal Server Error',
+        status: 500,
+        code: undefined,
+      });
     });
   });
 });

--- a/packages/reference-implementation/src/lib/api/services/did.service.ts
+++ b/packages/reference-implementation/src/lib/api/services/did.service.ts
@@ -1,0 +1,129 @@
+import type { Did } from '@/lib/prisma/generated';
+import type { PaginatedResponse } from '@/lib/api/pagination';
+import type { DidType, DidMethod, DidStatus, DidDocument, DidVerificationResult } from '@uncefact/untp-ri-services';
+
+// ── Error type ───────────────────────────────────────────────────────────────
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+// ── Request / response types ─────────────────────────────────────────────────
+
+export interface ListDidsParams {
+  type?: DidType;
+  status?: DidStatus;
+  serviceInstanceId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateDidInput {
+  type: DidType;
+  method: DidMethod;
+  alias: string;
+  name?: string;
+  description?: string;
+  isDefault?: boolean;
+  serviceInstanceId?: string;
+}
+
+export interface UpdateDidInput {
+  name?: string;
+  description?: string;
+  isDefault?: boolean;
+}
+
+export interface VerifyDidResponse {
+  verification: DidVerificationResult;
+  did: Did;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const BASE_PATH = '/api/v1/dids';
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let error = response.statusText;
+    let code: string | undefined;
+    try {
+      const body = await response.json();
+      if (body.error) error = body.error;
+      if (body.code) code = body.code;
+    } catch {
+      // Use statusText as fallback
+    }
+    throw new ApiError(error, response.status, code);
+  }
+  return response.json() as Promise<T>;
+}
+
+// ── Service functions ────────────────────────────────────────────────────────
+
+export async function listDids(params?: ListDidsParams): Promise<PaginatedResponse<Did>> {
+  const url = new URL(BASE_PATH, window.location.origin);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+  }
+  const response = await fetch(url.toString());
+  return handleResponse<PaginatedResponse<Did>>(response);
+}
+
+export async function getDid(id: string): Promise<Did> {
+  const response = await fetch(`${BASE_PATH}/${id}`);
+  return handleResponse<Did>(response);
+}
+
+export async function createDid(input: CreateDidInput): Promise<Did> {
+  const response = await fetch(BASE_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  return handleResponse<Did>(response);
+}
+
+export async function updateDid(id: string, input: UpdateDidInput): Promise<Did> {
+  const response = await fetch(`${BASE_PATH}/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  return handleResponse<Did>(response);
+}
+
+export async function deleteDid(id: string): Promise<void> {
+  const response = await fetch(`${BASE_PATH}/${id}`, { method: 'DELETE' });
+  if (!response.ok) {
+    let error = response.statusText;
+    let code: string | undefined;
+    try {
+      const body = await response.json();
+      if (body.error) error = body.error;
+      if (body.code) code = body.code;
+    } catch {
+      // Use statusText as fallback
+    }
+    throw new ApiError(error, response.status, code);
+  }
+}
+
+export async function getDidDocument(id: string): Promise<DidDocument> {
+  const response = await fetch(`${BASE_PATH}/${id}/document`);
+  return handleResponse<DidDocument>(response);
+}
+
+export async function verifyDid(id: string): Promise<VerifyDidResponse> {
+  const response = await fetch(`${BASE_PATH}/${id}/verify`, { method: 'POST' });
+  return handleResponse<VerifyDidResponse>(response);
+}

--- a/packages/reference-implementation/src/lib/api/services/did.service.ts
+++ b/packages/reference-implementation/src/lib/api/services/did.service.ts
@@ -1,85 +1,12 @@
 import type { Did } from '@/lib/prisma/generated';
 import type { PaginatedResponse } from '@/lib/api/pagination';
-import type {
-  DidType,
-  DidMethod,
-  DidStatus,
-  DidDocument,
-  DidVerificationResult,
-  CREATABLE_DID_TYPES,
-} from '@uncefact/untp-ri-services';
-
-type CreatableDidType = (typeof CREATABLE_DID_TYPES)[number];
-
-// ── Error type ───────────────────────────────────────────────────────────────
-
-export class ApiError extends Error {
-  constructor(
-    message: string,
-    public readonly status: number,
-    public readonly code?: string,
-  ) {
-    super(message);
-    this.name = 'ApiError';
-  }
-}
-
-// ── Request / response types ─────────────────────────────────────────────────
-
-export interface ListDidsParams {
-  type?: DidType;
-  status?: DidStatus;
-  serviceInstanceId?: string;
-  limit?: number;
-  offset?: number;
-}
-
-export interface CreateDidInput {
-  type: CreatableDidType;
-  method: DidMethod;
-  alias: string;
-  name?: string;
-  description?: string;
-  isDefault?: boolean;
-  serviceInstanceId?: string;
-}
-
-export interface UpdateDidInput {
-  name?: string;
-  description?: string;
-  isDefault?: boolean;
-}
-
-export interface VerifyDidResponse {
-  verification: DidVerificationResult;
-  did: Did;
-}
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-const BASE_PATH = '/api/v1/dids';
-
-async function throwApiError(response: Response): Promise<never> {
-  let error = response.statusText;
-  let code: string | undefined;
-  try {
-    const body = await response.json();
-    if (body.error) error = body.error;
-    if (body.code) code = body.code;
-  } catch {
-    // Use statusText as fallback
-  }
-  throw new ApiError(error, response.status, code);
-}
-
-async function handleResponse<T>(response: Response): Promise<T> {
-  if (!response.ok) {
-    await throwApiError(response);
-  }
-  return response.json() as Promise<T>;
-}
+import type { DidDocument } from '@uncefact/untp-ri-services';
+import type { ListDidsParams, CreateDidInput, UpdateDidInput, VerifyDidResponse } from '@/lib/api/types/did.types';
+import { handleResponse, throwApiError } from '@/lib/api/client';
 
 // ── Service functions ────────────────────────────────────────────────────────
+
+const BASE_PATH = '/api/v1/dids';
 
 export async function listDids(params?: ListDidsParams): Promise<PaginatedResponse<Did>> {
   const searchParams = new URLSearchParams();

--- a/packages/reference-implementation/src/lib/api/services/did.service.ts
+++ b/packages/reference-implementation/src/lib/api/services/did.service.ts
@@ -1,6 +1,15 @@
 import type { Did } from '@/lib/prisma/generated';
 import type { PaginatedResponse } from '@/lib/api/pagination';
-import type { DidType, DidMethod, DidStatus, DidDocument, DidVerificationResult } from '@uncefact/untp-ri-services';
+import type {
+  DidType,
+  DidMethod,
+  DidStatus,
+  DidDocument,
+  DidVerificationResult,
+  CREATABLE_DID_TYPES,
+} from '@uncefact/untp-ri-services';
+
+type CreatableDidType = (typeof CREATABLE_DID_TYPES)[number];
 
 // ── Error type ───────────────────────────────────────────────────────────────
 
@@ -26,7 +35,7 @@ export interface ListDidsParams {
 }
 
 export interface CreateDidInput {
-  type: DidType;
+  type: CreatableDidType;
   method: DidMethod;
   alias: string;
   name?: string;
@@ -50,18 +59,22 @@ export interface VerifyDidResponse {
 
 const BASE_PATH = '/api/v1/dids';
 
+async function throwApiError(response: Response): Promise<never> {
+  let error = response.statusText;
+  let code: string | undefined;
+  try {
+    const body = await response.json();
+    if (body.error) error = body.error;
+    if (body.code) code = body.code;
+  } catch {
+    // Use statusText as fallback
+  }
+  throw new ApiError(error, response.status, code);
+}
+
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
-    let error = response.statusText;
-    let code: string | undefined;
-    try {
-      const body = await response.json();
-      if (body.error) error = body.error;
-      if (body.code) code = body.code;
-    } catch {
-      // Use statusText as fallback
-    }
-    throw new ApiError(error, response.status, code);
+    await throwApiError(response);
   }
   return response.json() as Promise<T>;
 }
@@ -69,13 +82,15 @@ async function handleResponse<T>(response: Response): Promise<T> {
 // ── Service functions ────────────────────────────────────────────────────────
 
 export async function listDids(params?: ListDidsParams): Promise<PaginatedResponse<Did>> {
-  const url = new URL(BASE_PATH, window.location.origin);
+  const searchParams = new URLSearchParams();
   if (params) {
     for (const [key, value] of Object.entries(params)) {
-      if (value !== undefined) url.searchParams.set(key, String(value));
+      if (value !== undefined) searchParams.set(key, String(value));
     }
   }
-  const response = await fetch(url.toString());
+  const query = searchParams.toString();
+  const url = query ? `${BASE_PATH}?${query}` : BASE_PATH;
+  const response = await fetch(url);
   return handleResponse<PaginatedResponse<Did>>(response);
 }
 
@@ -105,16 +120,7 @@ export async function updateDid(id: string, input: UpdateDidInput): Promise<Did>
 export async function deleteDid(id: string): Promise<void> {
   const response = await fetch(`${BASE_PATH}/${id}`, { method: 'DELETE' });
   if (!response.ok) {
-    let error = response.statusText;
-    let code: string | undefined;
-    try {
-      const body = await response.json();
-      if (body.error) error = body.error;
-      if (body.code) code = body.code;
-    } catch {
-      // Use statusText as fallback
-    }
-    throw new ApiError(error, response.status, code);
+    await throwApiError(response);
   }
 }
 

--- a/packages/reference-implementation/src/lib/api/types/did.types.ts
+++ b/packages/reference-implementation/src/lib/api/types/did.types.ts
@@ -1,0 +1,43 @@
+import type { Did } from '@/lib/prisma/generated';
+import type {
+  DidType,
+  DidMethod,
+  DidStatus,
+  DidVerificationResult,
+  CREATABLE_DID_TYPES,
+} from '@uncefact/untp-ri-services';
+
+export type CreatableDidType = (typeof CREATABLE_DID_TYPES)[number];
+
+// ── Request types ──────────────────────────────────────────────────────────
+
+export interface ListDidsParams {
+  type?: DidType;
+  status?: DidStatus;
+  serviceInstanceId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateDidInput {
+  type: CreatableDidType;
+  method: DidMethod;
+  alias: string;
+  name?: string;
+  description?: string;
+  isDefault?: boolean;
+  serviceInstanceId?: string;
+}
+
+export interface UpdateDidInput {
+  name?: string;
+  description?: string;
+  isDefault?: boolean;
+}
+
+// ── Response types ─────────────────────────────────────────────────────────
+
+export interface VerifyDidResponse {
+  verification: DidVerificationResult;
+  did: Did;
+}


### PR DESCRIPTION
This PR adds a typed client-side service layer for the DID API at `src/lib/api/services/did.service.ts`, providing fetch wrappers for all seven `/api/v1/dids` endpoints. This establishes the convention for client-side API consumption, enabling UI components to call DID endpoints with full type safety and structured error handling via the `ApiError` class.

## Changes

- **`did.service.ts`**: Seven exported functions (`listDids`, `getDid`, `createDid`, `updateDid`, `deleteDid`, `getDidDocument`, `verifyDid`) with typed request/response interfaces, a shared `throwApiError` helper, and `CreatableDidType` narrowing to prevent creating `DEFAULT` DIDs
- **`did.service.test.ts`**: 22 unit tests covering happy paths, error responses (JSON and non-JSON), query parameter serialisation, and `ApiError` construction

## Test plan

- [x] All 22 unit tests pass (`npx jest --maxWorkers=1 src/lib/api/services/did.service.test.ts`)
- [x] TypeScript compiles without errors (verified via `ts-jest`)
- [x] Lint and prettier pass (enforced by pre-commit hooks)
- [x] PR review toolkit run: code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, code-simplifier