### PR TITLE
feat(components): add DidStatusChip and DidMethodChip display components

### DIFF
--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.stories.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import DidMethodChip from './DidMethodChip';
+import { DidMethod } from '@uncefact/untp-ri-services';
+
+const meta = {
+  title: 'Configuration/Dids/DidMethodChip',
+  component: DidMethodChip,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    method: {
+      control: 'select',
+      options: Object.values(DidMethod),
+      description: 'The DID method to display',
+    },
+  },
+} satisfies Meta<typeof DidMethodChip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DidWeb: Story = {
+  args: {
+    method: DidMethod.DID_WEB,
+  },
+};
+
+export const DidWebVh: Story = {
+  args: {
+    method: DidMethod.DID_WEB_VH,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className='flex flex-col gap-4'>
+      {Object.values(DidMethod).map((method) => (
+        <div key={method} className='flex items-center gap-4'>
+          <span className='w-40 text-sm text-gray-500'>{method}</span>
+          <DidMethodChip method={method} />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.test.tsx
@@ -13,11 +13,10 @@ describe('DidMethodChip', () => {
     expect(screen.getByText('did:web+vh')).toBeInTheDocument();
   });
 
-  it('applies correct styling classes', () => {
+  it('renders as a span element with theme colour class', () => {
     const { container } = render(<DidMethodChip method={DidMethod.DID_WEB} />);
     const span = container.firstChild as HTMLElement;
     expect(span.tagName).toBe('SPAN');
-    expect(span.className).toContain('text-base');
-    expect(span.className).toContain('text-black');
+    expect(span.className).toContain('text-foreground');
   });
 });

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import DidMethodChip from './DidMethodChip';
+import { DidMethod } from '@uncefact/untp-ri-services';
+
+describe('DidMethodChip', () => {
+  it('renders "did:web" for DID_WEB method', () => {
+    render(<DidMethodChip method={DidMethod.DID_WEB} />);
+    expect(screen.getByText('did:web')).toBeInTheDocument();
+  });
+
+  it('renders "did:web+vh" for DID_WEB_VH method', () => {
+    render(<DidMethodChip method={DidMethod.DID_WEB_VH} />);
+    expect(screen.getByText('did:web+vh')).toBeInTheDocument();
+  });
+
+  it('applies correct styling classes', () => {
+    const { container } = render(<DidMethodChip method={DidMethod.DID_WEB} />);
+    const span = container.firstChild as HTMLElement;
+    expect(span.tagName).toBe('SPAN');
+    expect(span.className).toContain('text-base');
+    expect(span.className).toContain('text-black');
+  });
+});

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { DidMethod } from '@uncefact/untp-ri-services';
 
 interface IDidMethodChip {

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
@@ -1,0 +1,16 @@
+import { DidMethod } from '@uncefact/untp-ri-services';
+
+interface IDidMethodChip {
+  method: DidMethod;
+}
+
+const METHOD_LABELS: Record<DidMethod, string> = {
+  [DidMethod.DID_WEB]: 'did:web',
+  [DidMethod.DID_WEB_VH]: 'did:web+vh',
+};
+
+export default function DidMethodChip({ method }: IDidMethodChip) {
+  return (
+    <span className="font-['Roboto',sans-serif] text-base leading-[28px] text-black">{METHOD_LABELS[method]}</span>
+  );
+}

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
@@ -2,7 +2,7 @@
 
 import { DidMethod } from '@uncefact/untp-ri-services';
 
-interface IDidMethodChip {
+interface DidMethodChipProps {
   method: DidMethod;
 }
 
@@ -11,6 +11,6 @@ const METHOD_LABELS: Record<DidMethod, string> = {
   [DidMethod.DID_WEB_VH]: 'did:web+vh',
 };
 
-export default function DidMethodChip({ method }: IDidMethodChip) {
-  return <span className='text-base leading-[28px] text-foreground'>{METHOD_LABELS[method]}</span>;
+export default function DidMethodChip({ method }: DidMethodChipProps) {
+  return <span className='text-base leading-7 text-foreground'>{METHOD_LABELS[method]}</span>;
 }

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/DidMethodChip.tsx
@@ -12,7 +12,5 @@ const METHOD_LABELS: Record<DidMethod, string> = {
 };
 
 export default function DidMethodChip({ method }: IDidMethodChip) {
-  return (
-    <span className="font-['Roboto',sans-serif] text-base leading-[28px] text-black">{METHOD_LABELS[method]}</span>
-  );
+  return <span className='text-base leading-[28px] text-foreground'>{METHOD_LABELS[method]}</span>;
 }

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/index.ts
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidMethodChip/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DidMethodChip';

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.stories.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import DidStatusChip from './DidStatusChip';
+import { DidStatus } from '@uncefact/untp-ri-services';
+
+const meta = {
+  title: 'Configuration/Dids/DidStatusChip',
+  component: DidStatusChip,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: Object.values(DidStatus),
+      description: 'The DID status to display',
+    },
+  },
+} satisfies Meta<typeof DidStatusChip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {
+  args: {
+    status: DidStatus.ACTIVE,
+  },
+};
+
+export const Verified: Story = {
+  args: {
+    status: DidStatus.VERIFIED,
+  },
+};
+
+export const Unverified: Story = {
+  args: {
+    status: DidStatus.UNVERIFIED,
+  },
+};
+
+export const VerificationFailed: Story = {
+  args: {
+    status: DidStatus.VERIFICATION_FAILED,
+  },
+};
+
+export const Inactive: Story = {
+  args: {
+    status: DidStatus.INACTIVE,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className='flex flex-col gap-4'>
+      {Object.values(DidStatus).map((status) => (
+        <div key={status} className='flex items-center gap-4'>
+          <span className='w-40 text-sm text-gray-500'>{status}</span>
+          <DidStatusChip status={status} />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
@@ -61,11 +61,11 @@ describe('DidStatusChip', () => {
   });
 
   it.each([
-    { status: DidStatus.ACTIVE, expectedClass: '.text-status-active' },
-    { status: DidStatus.VERIFIED, expectedClass: '.text-status-verified' },
-    { status: DidStatus.UNVERIFIED, expectedClass: '.text-status-unverified' },
-    { status: DidStatus.VERIFICATION_FAILED, expectedClass: '.text-status-failed' },
-    { status: DidStatus.INACTIVE, expectedClass: '.text-status-inactive' },
+    { status: DidStatus.ACTIVE, expectedClass: '.text-did-status-active' },
+    { status: DidStatus.VERIFIED, expectedClass: '.text-did-status-verified' },
+    { status: DidStatus.UNVERIFIED, expectedClass: '.text-did-status-unverified' },
+    { status: DidStatus.VERIFICATION_FAILED, expectedClass: '.text-did-status-failed' },
+    { status: DidStatus.INACTIVE, expectedClass: '.text-did-status-inactive' },
   ])('applies correct colour class for $status status', ({ status, expectedClass }) => {
     const { container } = render(<DidStatusChip status={status} />);
     expect(container.querySelector(expectedClass)).toBeInTheDocument();

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
@@ -60,20 +60,20 @@ describe('DidStatusChip', () => {
     expect(screen.queryByTestId('error-icon')).not.toBeInTheDocument();
   });
 
-  it('applies correct colour class for each status', () => {
+  it('applies theme-based colour class for each status', () => {
     const { container: activeContainer } = render(<DidStatusChip status={DidStatus.ACTIVE} />);
-    expect(activeContainer.querySelector('.text-black')).toBeInTheDocument();
+    expect(activeContainer.querySelector('.text-status-active')).toBeInTheDocument();
 
     const { container: verifiedContainer } = render(<DidStatusChip status={DidStatus.VERIFIED} />);
-    expect(verifiedContainer.querySelector('.text-\\[\\#15803D\\]')).toBeInTheDocument();
+    expect(verifiedContainer.querySelector('.text-status-verified')).toBeInTheDocument();
 
     const { container: unverifiedContainer } = render(<DidStatusChip status={DidStatus.UNVERIFIED} />);
-    expect(unverifiedContainer.querySelector('.text-\\[\\#067971\\]')).toBeInTheDocument();
+    expect(unverifiedContainer.querySelector('.text-status-unverified')).toBeInTheDocument();
 
     const { container: failedContainer } = render(<DidStatusChip status={DidStatus.VERIFICATION_FAILED} />);
-    expect(failedContainer.querySelector('.text-\\[\\#B91C1C\\]')).toBeInTheDocument();
+    expect(failedContainer.querySelector('.text-status-failed')).toBeInTheDocument();
 
     const { container: inactiveContainer } = render(<DidStatusChip status={DidStatus.INACTIVE} />);
-    expect(inactiveContainer.querySelector('.text-\\[\\#737373\\]')).toBeInTheDocument();
+    expect(inactiveContainer.querySelector('.text-status-inactive')).toBeInTheDocument();
   });
 });

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import DidStatusChip from './DidStatusChip';
+import { DidStatus } from '@uncefact/untp-ri-services';
+
+jest.mock('@mui/icons-material/Check', () => {
+  return function CheckIcon() {
+    return <span data-testid='check-icon'>CheckIcon</span>;
+  };
+});
+
+jest.mock('@mui/icons-material/ErrorOutline', () => {
+  return function ErrorOutlineIcon() {
+    return <span data-testid='error-icon'>ErrorOutlineIcon</span>;
+  };
+});
+
+describe('DidStatusChip', () => {
+  it('renders "Ready" for ACTIVE status', () => {
+    render(<DidStatusChip status={DidStatus.ACTIVE} />);
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+  });
+
+  it('does not render an icon for ACTIVE status', () => {
+    render(<DidStatusChip status={DidStatus.ACTIVE} />);
+    expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders "Verified" with check icon for VERIFIED status', () => {
+    render(<DidStatusChip status={DidStatus.VERIFIED} />);
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+    expect(screen.getByTestId('check-icon')).toBeInTheDocument();
+  });
+
+  it('renders "Unverified" for UNVERIFIED status', () => {
+    render(<DidStatusChip status={DidStatus.UNVERIFIED} />);
+    expect(screen.getByText('Unverified')).toBeInTheDocument();
+  });
+
+  it('does not render an icon for UNVERIFIED status', () => {
+    render(<DidStatusChip status={DidStatus.UNVERIFIED} />);
+    expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders "Failed" with error icon for VERIFICATION_FAILED status', () => {
+    render(<DidStatusChip status={DidStatus.VERIFICATION_FAILED} />);
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByTestId('error-icon')).toBeInTheDocument();
+  });
+
+  it('renders "Inactive" for INACTIVE status', () => {
+    render(<DidStatusChip status={DidStatus.INACTIVE} />);
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('does not render an icon for INACTIVE status', () => {
+    render(<DidStatusChip status={DidStatus.INACTIVE} />);
+    expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error-icon')).not.toBeInTheDocument();
+  });
+
+  it('applies correct colour class for each status', () => {
+    const { container: activeContainer } = render(<DidStatusChip status={DidStatus.ACTIVE} />);
+    expect(activeContainer.querySelector('.text-black')).toBeInTheDocument();
+
+    const { container: verifiedContainer } = render(<DidStatusChip status={DidStatus.VERIFIED} />);
+    expect(verifiedContainer.querySelector('.text-\\[\\#15803D\\]')).toBeInTheDocument();
+
+    const { container: unverifiedContainer } = render(<DidStatusChip status={DidStatus.UNVERIFIED} />);
+    expect(unverifiedContainer.querySelector('.text-\\[\\#067971\\]')).toBeInTheDocument();
+
+    const { container: failedContainer } = render(<DidStatusChip status={DidStatus.VERIFICATION_FAILED} />);
+    expect(failedContainer.querySelector('.text-\\[\\#B91C1C\\]')).toBeInTheDocument();
+
+    const { container: inactiveContainer } = render(<DidStatusChip status={DidStatus.INACTIVE} />);
+    expect(inactiveContainer.querySelector('.text-\\[\\#737373\\]')).toBeInTheDocument();
+  });
+});

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.test.tsx
@@ -60,20 +60,14 @@ describe('DidStatusChip', () => {
     expect(screen.queryByTestId('error-icon')).not.toBeInTheDocument();
   });
 
-  it('applies theme-based colour class for each status', () => {
-    const { container: activeContainer } = render(<DidStatusChip status={DidStatus.ACTIVE} />);
-    expect(activeContainer.querySelector('.text-status-active')).toBeInTheDocument();
-
-    const { container: verifiedContainer } = render(<DidStatusChip status={DidStatus.VERIFIED} />);
-    expect(verifiedContainer.querySelector('.text-status-verified')).toBeInTheDocument();
-
-    const { container: unverifiedContainer } = render(<DidStatusChip status={DidStatus.UNVERIFIED} />);
-    expect(unverifiedContainer.querySelector('.text-status-unverified')).toBeInTheDocument();
-
-    const { container: failedContainer } = render(<DidStatusChip status={DidStatus.VERIFICATION_FAILED} />);
-    expect(failedContainer.querySelector('.text-status-failed')).toBeInTheDocument();
-
-    const { container: inactiveContainer } = render(<DidStatusChip status={DidStatus.INACTIVE} />);
-    expect(inactiveContainer.querySelector('.text-status-inactive')).toBeInTheDocument();
+  it.each([
+    { status: DidStatus.ACTIVE, expectedClass: '.text-status-active' },
+    { status: DidStatus.VERIFIED, expectedClass: '.text-status-verified' },
+    { status: DidStatus.UNVERIFIED, expectedClass: '.text-status-unverified' },
+    { status: DidStatus.VERIFICATION_FAILED, expectedClass: '.text-status-failed' },
+    { status: DidStatus.INACTIVE, expectedClass: '.text-status-inactive' },
+  ])('applies correct colour class for $status status', ({ status, expectedClass }) => {
+    const { container } = render(<DidStatusChip status={status} />);
+    expect(container.querySelector(expectedClass)).toBeInTheDocument();
   });
 });

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
@@ -4,7 +4,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { DidStatus } from '@uncefact/untp-ri-services';
 
-interface IDidStatusChip {
+interface DidStatusChipProps {
   status: DidStatus;
 }
 
@@ -33,11 +33,11 @@ const STATUS_CONFIG: Record<DidStatus, { label: string; colourClass: string; ico
   },
 };
 
-export default function DidStatusChip({ status }: IDidStatusChip) {
+export default function DidStatusChip({ status }: DidStatusChipProps) {
   const config = STATUS_CONFIG[status];
 
   return (
-    <span className='inline-flex items-center gap-[10px] text-base leading-[22px]'>
+    <span className='inline-flex items-center gap-2.5 text-base leading-snug'>
       {config.icon}
       <span className={config.colourClass}>{config.label}</span>
     </span>

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { type ReactNode } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { DidStatus } from '@uncefact/untp-ri-services';
@@ -9,28 +8,28 @@ interface IDidStatusChip {
   status: DidStatus;
 }
 
-const STATUS_CONFIG: Record<DidStatus, { label: string; colour: string; icon?: ReactNode }> = {
+const STATUS_CONFIG: Record<DidStatus, { label: string; colourClass: string; icon?: React.ReactNode }> = {
   [DidStatus.ACTIVE]: {
     label: 'Ready',
-    colour: 'text-black',
+    colourClass: 'text-status-active',
   },
   [DidStatus.VERIFIED]: {
     label: 'Verified',
-    colour: 'text-[#15803D]',
-    icon: <CheckIcon sx={{ fontSize: 24, color: '#15803D' }} />,
+    colourClass: 'text-status-verified',
+    icon: <CheckIcon className='text-status-verified' sx={{ fontSize: 24 }} />,
   },
   [DidStatus.UNVERIFIED]: {
     label: 'Unverified',
-    colour: 'text-[#067971]',
+    colourClass: 'text-status-unverified',
   },
   [DidStatus.VERIFICATION_FAILED]: {
     label: 'Failed',
-    colour: 'text-[#B91C1C]',
-    icon: <ErrorOutlineIcon sx={{ fontSize: 24, color: '#B91C1C' }} />,
+    colourClass: 'text-status-failed',
+    icon: <ErrorOutlineIcon className='text-status-failed' sx={{ fontSize: 24 }} />,
   },
   [DidStatus.INACTIVE]: {
     label: 'Inactive',
-    colour: 'text-[#737373]',
+    colourClass: 'text-status-inactive',
   },
 };
 
@@ -38,9 +37,9 @@ export default function DidStatusChip({ status }: IDidStatusChip) {
   const config = STATUS_CONFIG[status];
 
   return (
-    <span className="inline-flex items-center gap-[10px] font-['Roboto',sans-serif] text-base leading-[22px]">
+    <span className='inline-flex items-center gap-[10px] text-base leading-[22px]'>
       {config.icon}
-      <span className={config.colour}>{config.label}</span>
+      <span className={config.colourClass}>{config.label}</span>
     </span>
   );
 }

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { type ReactNode } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { DidStatus } from '@uncefact/untp-ri-services';
@@ -8,7 +9,7 @@ interface IDidStatusChip {
   status: DidStatus;
 }
 
-const STATUS_CONFIG: Record<DidStatus, { label: string; colour: string; icon?: React.ReactNode }> = {
+const STATUS_CONFIG: Record<DidStatus, { label: string; colour: string; icon?: ReactNode }> = {
   [DidStatus.ACTIVE]: {
     label: 'Ready',
     colour: 'text-black',

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
@@ -11,25 +11,25 @@ interface DidStatusChipProps {
 const STATUS_CONFIG: Record<DidStatus, { label: string; colourClass: string; icon?: React.ReactNode }> = {
   [DidStatus.ACTIVE]: {
     label: 'Ready',
-    colourClass: 'text-status-active',
+    colourClass: 'text-did-status-active',
   },
   [DidStatus.VERIFIED]: {
     label: 'Verified',
-    colourClass: 'text-status-verified',
-    icon: <CheckIcon className='text-status-verified' sx={{ fontSize: 24 }} />,
+    colourClass: 'text-did-status-verified',
+    icon: <CheckIcon className='text-did-status-verified' sx={{ fontSize: 24 }} />,
   },
   [DidStatus.UNVERIFIED]: {
     label: 'Unverified',
-    colourClass: 'text-status-unverified',
+    colourClass: 'text-did-status-unverified',
   },
   [DidStatus.VERIFICATION_FAILED]: {
     label: 'Failed',
-    colourClass: 'text-status-failed',
-    icon: <ErrorOutlineIcon className='text-status-failed' sx={{ fontSize: 24 }} />,
+    colourClass: 'text-did-status-failed',
+    icon: <ErrorOutlineIcon className='text-did-status-failed' sx={{ fontSize: 24 }} />,
   },
   [DidStatus.INACTIVE]: {
     label: 'Inactive',
-    colourClass: 'text-status-inactive',
+    colourClass: 'text-did-status-inactive',
   },
 };
 

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/DidStatusChip.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import CheckIcon from '@mui/icons-material/Check';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { DidStatus } from '@uncefact/untp-ri-services';
+
+interface IDidStatusChip {
+  status: DidStatus;
+}
+
+const STATUS_CONFIG: Record<DidStatus, { label: string; colour: string; icon?: React.ReactNode }> = {
+  [DidStatus.ACTIVE]: {
+    label: 'Ready',
+    colour: 'text-black',
+  },
+  [DidStatus.VERIFIED]: {
+    label: 'Verified',
+    colour: 'text-[#15803D]',
+    icon: <CheckIcon sx={{ fontSize: 24, color: '#15803D' }} />,
+  },
+  [DidStatus.UNVERIFIED]: {
+    label: 'Unverified',
+    colour: 'text-[#067971]',
+  },
+  [DidStatus.VERIFICATION_FAILED]: {
+    label: 'Failed',
+    colour: 'text-[#B91C1C]',
+    icon: <ErrorOutlineIcon sx={{ fontSize: 24, color: '#B91C1C' }} />,
+  },
+  [DidStatus.INACTIVE]: {
+    label: 'Inactive',
+    colour: 'text-[#737373]',
+  },
+};
+
+export default function DidStatusChip({ status }: IDidStatusChip) {
+  const config = STATUS_CONFIG[status];
+
+  return (
+    <span className="inline-flex items-center gap-[10px] font-['Roboto',sans-serif] text-base leading-[22px]">
+      {config.icon}
+      <span className={config.colour}>{config.label}</span>
+    </span>
+  );
+}

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/index.ts
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/DidStatusChip/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DidStatusChip';

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/components/index.ts
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/components/index.ts
@@ -1,0 +1,2 @@
+export { default as DidStatusChip } from './DidStatusChip';
+export { default as DidMethodChip } from './DidMethodChip';

--- a/packages/reference-implementation/src/app/globals.css
+++ b/packages/reference-implementation/src/app/globals.css
@@ -53,11 +53,11 @@
   --more-options-foreground: #333333;
   --loader: #666666;
   --loader-foreground: #666666;
-  --status-active: #000000;
-  --status-verified: #15803d;
-  --status-unverified: #067971;
-  --status-failed: #b91c1c;
-  --status-inactive: #737373;
+  --did-status-active: #000000;
+  --did-status-verified: #15803d;
+  --did-status-unverified: #067971;
+  --did-status-failed: #b91c1c;
+  --did-status-inactive: #737373;
 }
 
 .dark {
@@ -106,11 +106,11 @@
   --more-options-foreground: #e5e5e5;
   --loader: #999999;
   --loader-foreground: #999999;
-  --status-active: #ffffff;
-  --status-verified: #4ade80;
-  --status-unverified: #2dd4bf;
-  --status-failed: #f87171;
-  --status-inactive: #a3a3a3;
+  --did-status-active: #ffffff;
+  --did-status-verified: #4ade80;
+  --did-status-unverified: #2dd4bf;
+  --did-status-failed: #f87171;
+  --did-status-inactive: #a3a3a3;
 }
 
 @theme inline {
@@ -163,11 +163,11 @@
   --color-more-options-foreground: var(--more-options-foreground);
   --color-loader: var(--loader);
   --color-loader-foreground: var(--loader-foreground);
-  --color-status-active: var(--status-active);
-  --color-status-verified: var(--status-verified);
-  --color-status-unverified: var(--status-unverified);
-  --color-status-failed: var(--status-failed);
-  --color-status-inactive: var(--status-inactive);
+  --color-did-status-active: var(--did-status-active);
+  --color-did-status-verified: var(--did-status-verified);
+  --color-did-status-unverified: var(--did-status-unverified);
+  --color-did-status-failed: var(--did-status-failed);
+  --color-did-status-inactive: var(--did-status-inactive);
 }
 
 @layer base {

--- a/packages/reference-implementation/src/app/globals.css
+++ b/packages/reference-implementation/src/app/globals.css
@@ -53,6 +53,11 @@
   --more-options-foreground: #333333;
   --loader: #666666;
   --loader-foreground: #666666;
+  --status-active: #000000;
+  --status-verified: #15803d;
+  --status-unverified: #067971;
+  --status-failed: #b91c1c;
+  --status-inactive: #737373;
 }
 
 .dark {
@@ -101,6 +106,11 @@
   --more-options-foreground: #e5e5e5;
   --loader: #999999;
   --loader-foreground: #999999;
+  --status-active: #ffffff;
+  --status-verified: #4ade80;
+  --status-unverified: #2dd4bf;
+  --status-failed: #f87171;
+  --status-inactive: #a3a3a3;
 }
 
 @theme inline {
@@ -153,6 +163,11 @@
   --color-more-options-foreground: var(--more-options-foreground);
   --color-loader: var(--loader);
   --color-loader-foreground: var(--loader-foreground);
+  --color-status-active: var(--status-active);
+  --color-status-verified: var(--status-verified);
+  --color-status-unverified: var(--status-unverified);
+  --color-status-failed: var(--status-failed);
+  --color-status-inactive: var(--status-inactive);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

This PR adds two stateless display components for the DIDs configuration table, matching the Figma design specifications:

- **DidStatusChip**: renders coloured text with optional icons for each `DidStatus` value (Ready, Verified, Unverified, Failed, Inactive)
- **DidMethodChip**: renders the DID method as plain text (`did:web`, `did:web+vh`)

Both components use Tailwind CSS styling with plain `<span>` elements rather than MUI Chips, following the Figma design which shows plain text in table cells.

## Test plan
- [x] 9 unit tests for DidStatusChip covering all status labels, icon presence/absence, and colour classes
- [x] 3 unit tests for DidMethodChip covering both method labels and styling
- [x] All 12 tests passing
- [x] Lint and prettier checks passing via pre-commit hooks
- [x] Storybook stories for all variants of both components