### PR TITLE
refactor(api)!: IDR scheme registration cleanup, identifier route audit, and documentation

### DIFF
--- a/documentation/docs/reference-implementation/api/identifiers.md
+++ b/documentation/docs/reference-implementation/api/identifiers.md
@@ -5,12 +5,413 @@ title: Identifiers
 
 # Identifiers API
 
-The Identifiers API manages **identifiers** and **identifier schemes** — the structured values that connect [master data](../master-data/) entities to real-world identification systems. Identifiers are created under schemes, which are registered under registrars.
+The Identifiers API manages **identifier schemes**, **identifiers**, and **links** — the building blocks that connect physical or logical entities (products, facilities, organisations) to their digital credentials via an Identity Resolver (IDR). Identifier schemes define the rules for a class of identifiers (e.g. GTIN, ABN), identifiers are specific values under those schemes, and links are published references from an identifier to credential resources on an upstream IDR service.
 
 :::tip[Interactive API documentation]
-The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
 :::
 
-:::info[Documentation in progress]
-Detailed endpoint documentation for identifiers, schemes, and their link management is planned. Refer to the Swagger UI for current endpoint details.
-:::
+## Concepts
+
+### What is an identifier scheme?
+
+An identifier scheme is a **type definition** for a class of identifiers — for example, GTIN (Global Trade Item Number), ABN (Australian Business Number), or SSCC (Serial Shipping Container Code). A scheme defines:
+
+- **`name`** — a human-readable label (e.g. "GTIN-14").
+- **`primaryKey`** — the key used in URI construction (e.g. `"gtin"`, `"abn"`).
+- **`validationPattern`** — a regular expression that every identifier value under this scheme must match.
+- **`linkTemplate`** — an ISO 18975 template for constructing resolver URIs (e.g. `"/{primaryKey}/{value}"`).
+
+Schemes are scoped to a tenant, but system-default schemes (created by the platform) are visible to all tenants.
+
+### Registrars
+
+Every scheme belongs to a **registrar** — the authority that manages identifiers of that type (e.g. GS1 for GTINs). The `registrarId` is required when creating a scheme. See the [Registrars API](./registrars) for managing registrar records.
+
+### Qualifiers
+
+A scheme can optionally define **qualifiers** — sub-identifier dimensions that further refine an identifier. Common examples include batch number and serial number under a GTIN scheme. Each qualifier has:
+
+| Field | Description |
+|-------|-------------|
+| `key` | Machine-readable key (e.g. `"lot"`, `"ser"`) |
+| `description` | Human-readable label |
+| `validationPattern` | Regex for validating qualifier values |
+| `order` | Optional sort order for display |
+
+When updating a scheme's qualifiers, the entire qualifier set is replaced — existing qualifiers are deleted and the new list is created in their place.
+
+### IDR service instance linkage
+
+A scheme can optionally override which IDR service instance is used for link resolution via `idrServiceInstanceId`. If not set, resolution falls back to the registrar's IDR instance, then to the tenant's system default. See [Link resolution chain](#idr-resolution-chain) for the full precedence order.
+
+### What is an identifier?
+
+An identifier is a **specific value** under a scheme — for example, `"09506000134352"` under a GTIN scheme, or `"51824753556"` under an ABN scheme. When creating an identifier, its `value` is validated against the scheme's `validationPattern`; if the value does not match, the request is rejected with a `400` error.
+
+Identifiers are strictly tenant-scoped — unlike schemes, they are not shared across tenants.
+
+### Relationship to master data entities
+
+Identifiers can be linked to [organisations](./organisations), [facilities](./facilities), and [products](./products) as either a **primary identifier** or one of several **secondary identifiers**. These relationships are managed on the entity side (e.g. `primaryIdentifierId` and `secondaryIdentifierIds` on a facility record), not on the identifier itself.
+
+### What are links?
+
+Links are **published references** from an identifier to credential resources hosted on an upstream IDR service. When you publish a link, the Reference Implementation:
+
+1. Resolves the appropriate IDR service instance.
+2. Calls the upstream IDR to register the link.
+3. Stores a local **audit record** (a `LinkRegistration`) capturing what was published.
+
+Each link includes a `linkType` (the relationship type), a `targetUrl` (the credential resource URL), and a `mimeType`.
+
+### IDR resolution chain
+
+When publishing, retrieving, updating, or deleting links, the system must determine which IDR service instance to use. The resolution follows a three-tier precedence chain:
+
+1. **Scheme-level** — `IdentifierScheme.idrServiceInstanceId` (highest priority)
+2. **Registrar-level** — `Registrar.idrServiceInstanceId`
+3. **System default** — the tenant's primary IDR service instance, or the system-wide default
+
+The first non-null value in this chain is used.
+
+### Desynchronisation handling
+
+Because links exist on both the local database (as audit records) and the upstream IDR, the two can fall out of sync — for example, if a link is removed directly on the IDR outside of the Reference Implementation. The API handles this gracefully:
+
+- **GET a link** — if the link exists locally but is missing upstream, the response includes `desync: true` and a `warning` message, with the `link` field set to `null`.
+- **PATCH a link** — if the upstream link no longer exists, returns `409 Conflict` with `desync: true` and an error message advising deletion of the local record.
+- **DELETE a link** — if the upstream link is already absent, the local record is still cleaned up (no error is raised).
+
+## Identifier Scheme Endpoints
+
+### Create an identifier scheme
+
+```
+POST /api/v1/schemes
+```
+
+Creates a new identifier scheme with optional nested qualifiers. The scheme is associated with a registrar and scoped to the authenticated tenant.
+
+| Required Field | Description |
+|----------------|-------------|
+| `registrarId` | ID of the parent registrar |
+| `name` | Human-readable scheme name |
+| `primaryKey` | Key identifier used in URI construction (e.g. `"gtin"`) |
+| `validationPattern` | Regex for validating identifier values |
+| `linkTemplate` | ISO 18975 link template for URI construction |
+
+| Optional Field | Description |
+|----------------|-------------|
+| `idrServiceInstanceId` | Override IDR service instance for this scheme |
+| `qualifiers` | Array of qualifier definitions (each requires `key`, `description`, `validationPattern`) |
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: POST /api/v1/schemes { registrarId, name, ... }
+    RI->>RI: Validate required fields and qualifier structure
+    RI->>DB: Verify registrar exists and belongs to tenant
+    alt registrar not found
+        RI-->>Client: 404 Not Found
+    end
+    RI->>DB: Insert scheme with qualifiers
+    DB-->>RI: Created record (with qualifiers and registrar)
+    RI-->>Client: 201 Created
+```
+
+---
+
+### List identifier schemes
+
+```
+GET /api/v1/schemes
+```
+
+Returns identifier schemes for the authenticated tenant (including system defaults) with optional filtering. Results are paginated.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `registrarId` | string | — | Filter by registrar ID |
+| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `offset` | integer | `0` | Number of results to skip |
+
+---
+
+### Get an identifier scheme
+
+```
+GET /api/v1/schemes/{id}
+```
+
+Retrieves a specific identifier scheme by its database ID. The response includes the full qualifier list and the parent registrar. Returns schemes owned by the authenticated tenant or system defaults.
+
+---
+
+### Update an identifier scheme
+
+```
+PATCH /api/v1/schemes/{id}
+```
+
+Updates one or more fields of an existing identifier scheme. At least one updatable field must be provided. System-default schemes cannot be updated — only schemes owned by the authenticated tenant.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `name` | Scheme name (must be non-empty if provided) |
+| `primaryKey` | Primary key identifier |
+| `validationPattern` | Regex validation pattern |
+| `linkTemplate` | ISO 18975 link template |
+| `idrServiceInstanceId` | IDR service instance ID (set to `null` to clear) |
+| `qualifiers` | Replacement qualifier array (replaces all existing qualifiers) |
+
+---
+
+### Delete an identifier scheme
+
+```
+DELETE /api/v1/schemes/{id}
+```
+
+Permanently deletes an identifier scheme. Only schemes owned by the authenticated tenant can be deleted — system defaults are protected.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: DELETE /api/v1/schemes/{id}
+    RI->>DB: Fetch scheme (tenant-scoped, excludes system defaults)
+    alt not found or access denied
+        RI-->>Client: 404 Not Found
+    end
+    RI->>DB: Delete scheme
+    DB-->>RI: Deleted
+    RI-->>Client: 204 No Content
+```
+
+## Identifier Endpoints
+
+### Create an identifier
+
+```
+POST /api/v1/identifiers
+```
+
+Creates a new identifier after validating its value against the scheme's `validationPattern`. The scheme must exist and be accessible to the authenticated tenant (either tenant-owned or a system default).
+
+| Required Field | Description |
+|----------------|-------------|
+| `schemeId` | ID of the identifier scheme |
+| `value` | The identifier value (validated against scheme pattern) |
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: POST /api/v1/identifiers { schemeId, value }
+    RI->>RI: Validate required fields
+    RI->>DB: Look up scheme (tenant or system default)
+    alt scheme not found
+        RI-->>Client: 404 Not Found
+    end
+    RI->>RI: Test value against scheme.validationPattern
+    alt value does not match pattern
+        RI-->>Client: 400 Bad Request
+    end
+    RI->>DB: Insert identifier
+    DB-->>RI: Created record (with scheme)
+    RI-->>Client: 201 Created
+```
+
+---
+
+### List identifiers
+
+```
+GET /api/v1/identifiers
+```
+
+Returns identifiers for the authenticated tenant with optional filtering. Results are paginated.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `schemeId` | string | — | Filter by identifier scheme ID |
+| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `offset` | integer | `0` | Number of results to skip |
+
+---
+
+### Get an identifier
+
+```
+GET /api/v1/identifiers/{id}
+```
+
+Retrieves a specific identifier by its database ID. The response includes the full scheme with its registrar and qualifiers.
+
+---
+
+### Update an identifier
+
+```
+PATCH /api/v1/identifiers/{id}
+```
+
+Updates the value of an existing identifier. The new value is re-validated against the scheme's `validationPattern`.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `value` | New identifier value (re-validated against scheme pattern) |
+
+---
+
+### Delete an identifier
+
+```
+DELETE /api/v1/identifiers/{id}
+```
+
+Permanently deletes an identifier. Only identifiers owned by the authenticated tenant can be deleted.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: DELETE /api/v1/identifiers/{id}
+    RI->>DB: Fetch identifier (tenant-scoped)
+    alt not found
+        RI-->>Client: 404 Not Found
+    end
+    RI->>DB: Delete identifier
+    DB-->>RI: Deleted
+    RI-->>Client: 204 No Content
+```
+
+## Link Endpoints
+
+### Publish links
+
+```
+POST /api/v1/identifiers/{id}/links
+```
+
+Publishes one or more links for an identifier to the upstream IDR service. Each link is registered on the IDR and a local audit record is stored. Target URLs are validated for SSRF protection.
+
+| Required Field | Description |
+|----------------|-------------|
+| `links` | Non-empty array of link objects (each requires `linkType`, `targetUrl`, `mimeType`; optional `title`) |
+
+| Optional Field | Description |
+|----------------|-------------|
+| `qualifierPath` | Qualifier path appended to the IDR link |
+| `itemDescription` | Human-readable description for the IDR entry |
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+    participant IDR as IDR Service
+
+    Client->>RI: POST /api/v1/identifiers/{id}/links { links, ... }
+    RI->>RI: Validate links array and SSRF-check targetUrls
+    RI->>DB: Look up identifier (with scheme and registrar)
+    alt identifier not found
+        RI-->>Client: 404 Not Found
+    end
+    RI->>RI: Resolve IDR service (scheme → registrar → system default)
+    RI->>IDR: publishLinks(primaryKey, value, links, qualifierPath, options)
+    IDR-->>RI: Registration result (resolverUri, links with idrLinkIds)
+    RI->>DB: Bulk-insert audit records (LinkRegistration)
+    DB-->>RI: Audit records stored
+    RI-->>Client: 201 Created { resolverUri, identifierScheme, identifier, links }
+```
+
+---
+
+### List link registrations
+
+```
+GET /api/v1/identifiers/{id}/links
+```
+
+Returns link registration audit records for a specific identifier. The identifier must exist and belong to the authenticated tenant. Results are paginated.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `offset` | integer | `0` | Number of results to skip |
+
+---
+
+### Get a link
+
+```
+GET /api/v1/identifiers/{id}/links/{linkId}
+```
+
+Retrieves a link by its IDR link ID. The response combines the **live link data** fetched from the upstream IDR with the **local audit record**. If the link exists locally but is missing from the upstream IDR, the response includes a desynchronisation warning.
+
+| Response Field | Description |
+|----------------|-------------|
+| `link` | Live link data from the upstream IDR (or `null` if desynced) |
+| `localRecord` | The local `LinkRegistration` audit record |
+| `desync` | `true` if the link is missing upstream (only present when desynced) |
+| `warning` | Human-readable desync explanation (only present when desynced) |
+
+---
+
+### Update a link
+
+```
+PATCH /api/v1/identifiers/{id}/links/{linkId}
+```
+
+Updates a link on the upstream IDR and syncs the local audit record. The `href` field is SSRF-validated if provided. If the upstream link no longer exists, returns `409 Conflict` with a desynchronisation error.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `href` | New target URL (SSRF-validated) |
+| `rel` | New link relationship type |
+| `type` | New MIME type |
+
+---
+
+### Delete a link
+
+```
+DELETE /api/v1/identifiers/{id}/links/{linkId}
+```
+
+Deletes a link from both the upstream IDR and the local audit record. If the link has already been removed from the upstream IDR (out-of-band), the local record is still cleaned up — no error is raised.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+    participant IDR as IDR Service
+
+    Client->>RI: DELETE /api/v1/identifiers/{id}/links/{linkId}
+    RI->>DB: Look up identifier and local link record
+    alt not found
+        RI-->>Client: 404 Not Found
+    end
+    RI->>RI: Resolve IDR service (scheme → registrar → system default)
+    RI->>IDR: deleteLink(linkId)
+    alt link already absent from IDR
+        RI->>RI: Log warning (desync), continue
+    end
+    RI->>DB: Delete local LinkRegistration record
+    DB-->>RI: Deleted
+    RI-->>Client: 204 No Content
+```

--- a/documentation/docs/reference-implementation/api/registrars.md
+++ b/documentation/docs/reference-implementation/api/registrars.md
@@ -5,12 +5,171 @@ title: Registrars
 
 # Registrars API
 
-The Registrars API manages **registrars** — the organisations that maintain [identifier schemes](./identifiers). Each registrar can have multiple schemes registered under it.
+The Registrars API manages **registrars** — the organisations that maintain identifier schemes (e.g. GS1 for GTIN barcodes, the ATO for Australian Business Numbers). Registrars are one of the foundational configuration entities that underpin [identifier schemes](./identifiers) and, by extension, the identifiers assigned to products, facilities, and organisations.
 
 :::tip[Interactive API documentation]
-The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
 :::
 
-:::info[Documentation in progress]
-Detailed endpoint documentation for registrars is planned. Refer to the Swagger UI for current endpoint details.
-:::
+## Concepts
+
+### What is a registrar?
+
+A registrar represents a real-world organisation that defines and governs one or more identifier schemes. For example:
+
+- **GS1** is the registrar for schemes such as GTIN (Global Trade Item Number) and GLN (Global Location Number).
+- **Australian Taxation Office (ATO)** is the registrar for the ABN (Australian Business Number) scheme.
+
+In the Reference Implementation, a registrar record groups related identifier schemes together and provides the metadata needed when publishing those schemes to an Identity Resolver (IDR) service.
+
+### Relationship to identifier schemes
+
+A registrar has a one-to-many relationship with [identifier schemes](./identifiers). Each scheme belongs to exactly one registrar. When you create a scheme, you reference its parent registrar by ID. Deleting a registrar will cascade-delete all of its schemes (and their qualifier definitions).
+
+### Namespace
+
+The `namespace` field is the grouping key used when publishing identifier schemes to an IDR service. It typically matches the registrar's well-known abbreviation (e.g. `gs1`, `ato`). All schemes under a registrar share this namespace in the IDR.
+
+### IDR service instance linkage
+
+A registrar can optionally be linked to an **IDR service instance** via `idrServiceInstanceId`. This determines which configured IDR service is responsible for resolving identifiers issued under the registrar's schemes. The linkage is optional — set it to `null` to clear the association. If the linked service instance is deleted, the reference is automatically cleared (`onDelete: SetNull`).
+
+### Tenant scoping
+
+Registrars are scoped to a tenant (organisation). Each tenant manages its own registrars independently. However, **system default registrars** (those belonging to the system tenant) are visible to all tenants. This means the list endpoint returns both the tenant's own registrars and any system-wide defaults.
+
+System default registrars cannot be updated or deleted by regular tenants — only tenant-owned registrars may be modified.
+
+## Endpoints
+
+### Create a registrar
+
+```
+POST /api/v1/registrars
+```
+
+Creates a new registrar for the authenticated tenant. The request body must include `name`, `namespace`, and `url`. Optionally, an `idrServiceInstanceId` can be provided to link the registrar to an IDR service instance.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Human-readable name (e.g. "GS1") |
+| `namespace` | string | Yes | Grouping key for IDR publishing (e.g. "gs1") |
+| `url` | string | Yes | URL of the registrar's website |
+| `idrServiceInstanceId` | string | No | ID of an IDR service instance to link |
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: POST /api/v1/registrars { name, namespace, url }
+    RI->>RI: Validate required fields (name, namespace, url)
+    alt validation fails
+        RI-->>Client: 400 Bad Request
+    end
+    RI->>DB: Insert registrar record
+    DB-->>RI: Created record
+    RI-->>Client: 201 Created (registrar)
+```
+
+---
+
+### List registrars
+
+```
+GET /api/v1/registrars
+```
+
+Returns registrars for the authenticated tenant, **including system defaults**. Results are paginated and ordered by creation date (newest first).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `offset` | integer | `0` | Number of results to skip |
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: GET /api/v1/registrars?limit=20&offset=0
+    RI->>RI: Parse and validate pagination parameters
+    RI->>DB: Query registrars (tenant-owned + system defaults)
+    DB-->>RI: Registrar records + total count
+    RI-->>Client: 200 OK { data, pagination }
+```
+
+---
+
+### Get a registrar
+
+```
+GET /api/v1/registrars/{id}
+```
+
+Retrieves a specific registrar by its database ID. The registrar must belong to the authenticated tenant or be a system default. The response includes nested **schemes** and their **qualifier definitions**.
+
+---
+
+### Update a registrar
+
+```
+PATCH /api/v1/registrars/{id}
+```
+
+Updates one or more fields of an existing registrar. At least one updatable field must be provided. Only tenant-owned registrars can be updated — system defaults are read-only.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `name` | Registrar name (must be non-empty if provided) |
+| `namespace` | Namespace grouping key (must be non-empty if provided) |
+| `url` | Registrar URL (must be non-empty if provided) |
+| `idrServiceInstanceId` | IDR service instance ID (set to `null` to clear the linkage) |
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: PATCH /api/v1/registrars/{id} { name, ... }
+    RI->>RI: Validate at least one field provided
+    alt no updatable fields
+        RI-->>Client: 400 Bad Request
+    end
+    RI->>DB: Find registrar (tenant-owned only)
+    alt not found or system default
+        RI-->>Client: 404 Not Found
+    end
+    RI->>DB: Update registrar fields
+    DB-->>RI: Updated record
+    RI-->>Client: 200 OK (registrar)
+```
+
+---
+
+### Delete a registrar
+
+```
+DELETE /api/v1/registrars/{id}
+```
+
+Permanently deletes a registrar and all of its associated identifier schemes and qualifier definitions (cascade). Only tenant-owned registrars can be deleted — system defaults are protected.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+
+    Client->>RI: DELETE /api/v1/registrars/{id}
+    RI->>DB: Find registrar (tenant-owned only)
+    alt not found or system default
+        RI-->>Client: 404 Not Found
+    end
+    RI->>DB: Delete registrar (cascades to schemes)
+    DB-->>RI: Deleted
+    RI-->>Client: 204 No Content
+```

--- a/e2e/cypress/e2e/api/identifier_api/identifier-management.cy.ts
+++ b/e2e/cypress/e2e/api/identifier_api/identifier-management.cy.ts
@@ -71,6 +71,7 @@ describe('Identifier API', { testIsolation: false }, () => {
     it('GET /api/v1/identifiers — lists identifiers', () => {
       cy.request('/api/v1/identifiers').then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.data).to.be.an('array');
         expect(response.body.pagination).to.exist;
 
@@ -146,6 +147,7 @@ describe('Identifier API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -157,6 +159,7 @@ describe('Identifier API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -168,6 +171,32 @@ describe('Identifier API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid JSON body', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/identifiers',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 404 when POST references nonexistent schemeId', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/identifiers',
+        body: { schemeId: 'nonexistent-id', value: '51824753556' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -187,6 +216,7 @@ describe('Identifier API', { testIsolation: false }, () => {
           failOnStatusCode: false,
         }).then((response) => {
           expect(response.status).to.eq(400);
+          expect(response.body.error).to.be.a('string');
         });
 
         cy.request({ method: 'DELETE', url: `/api/v1/identifiers/${tempId}` });
@@ -200,6 +230,30 @@ describe('Identifier API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH — returns 404 for nonexistent identifier', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/identifiers/nonexistent-id',
+        body: { value: '12345678901' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE — returns 404 for nonexistent identifier', () => {
+      cy.request({
+        method: 'DELETE',
+        url: '/api/v1/identifiers/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -210,6 +264,7 @@ describe('Identifier API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -220,6 +275,7 @@ describe('Identifier API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });
@@ -230,6 +286,9 @@ describe('Identifier API', { testIsolation: false }, () => {
         expect(response.status).to.eq(200);
         expect(response.body.data.length).to.be.at.most(1);
         expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
       });
     });
   });

--- a/e2e/cypress/e2e/api/registrar_api/registrar-management.cy.ts
+++ b/e2e/cypress/e2e/api/registrar_api/registrar-management.cy.ts
@@ -44,6 +44,7 @@ describe('Registrar API', { testIsolation: false }, () => {
     it('GET /api/v1/registrars — lists registrars', () => {
       cy.request('/api/v1/registrars').then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.data).to.be.an('array');
         expect(response.body.pagination).to.exist;
         expect(response.body.pagination.total).to.be.a('number');
@@ -124,6 +125,9 @@ describe('Registrar API', { testIsolation: false }, () => {
         expect(response.body.data.length).to.be.at.most(1);
         expect(response.body.pagination).to.exist;
         expect(response.body.pagination.total).to.be.a('number');
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
       });
     });
   });
@@ -137,6 +141,7 @@ describe('Registrar API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -148,6 +153,7 @@ describe('Registrar API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -159,6 +165,20 @@ describe('Registrar API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid JSON body', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/registrars',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -182,6 +202,7 @@ describe('Registrar API', { testIsolation: false }, () => {
           failOnStatusCode: false,
         }).then((response) => {
           expect(response.status).to.eq(400);
+          expect(response.body.error).to.be.a('string');
         });
 
         // Clean up
@@ -196,6 +217,30 @@ describe('Registrar API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH — returns 404 for nonexistent registrar', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/registrars/nonexistent-id',
+        body: { name: 'Should not work' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE — returns 404 for nonexistent registrar', () => {
+      cy.request({
+        method: 'DELETE',
+        url: '/api/v1/registrars/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -206,6 +251,7 @@ describe('Registrar API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -216,6 +262,7 @@ describe('Registrar API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });

--- a/e2e/cypress/e2e/api/scheme_api/scheme-management.cy.ts
+++ b/e2e/cypress/e2e/api/scheme_api/scheme-management.cy.ts
@@ -98,6 +98,7 @@ describe('Scheme API', { testIsolation: false }, () => {
     it('GET /api/v1/schemes — lists schemes', () => {
       cy.request('/api/v1/schemes').then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.data).to.be.an('array');
         expect(response.body.pagination).to.exist;
 
@@ -220,6 +221,9 @@ describe('Scheme API', { testIsolation: false }, () => {
         expect(response.status).to.eq(200);
         expect(response.body.data.length).to.be.at.most(1);
         expect(response.body.pagination).to.exist;
+        expect(response.body.pagination.limit).to.eq(1);
+        expect(response.body.pagination.offset).to.eq(0);
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
       });
     });
   });
@@ -233,6 +237,7 @@ describe('Scheme API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -244,6 +249,7 @@ describe('Scheme API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -255,6 +261,7 @@ describe('Scheme API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -266,6 +273,7 @@ describe('Scheme API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -284,6 +292,38 @@ describe('Scheme API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid JSON body', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 404 when POST references nonexistent registrarId', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId: 'nonexistent-id',
+          name: 'Test',
+          primaryKey: `pk-nonexistent-${RUN_ID}`,
+          validationPattern: '.*',
+          linkTemplate: '/{primaryKey}/{value}',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -309,6 +349,7 @@ describe('Scheme API', { testIsolation: false }, () => {
           failOnStatusCode: false,
         }).then((response) => {
           expect(response.status).to.eq(400);
+          expect(response.body.error).to.be.a('string');
         });
 
         cy.request({ method: 'DELETE', url: `/api/v1/schemes/${tempId}` });
@@ -322,6 +363,30 @@ describe('Scheme API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('PATCH — returns 404 for nonexistent scheme', () => {
+      cy.request({
+        method: 'PATCH',
+        url: '/api/v1/schemes/nonexistent-id',
+        body: { name: 'Should not work' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('DELETE — returns 404 for nonexistent scheme', () => {
+      cy.request({
+        method: 'DELETE',
+        url: '/api/v1/schemes/nonexistent-id',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+        expect(response.body.error).to.be.a('string');
       });
     });
 
@@ -332,6 +397,18 @@ describe('Scheme API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for negative offset', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/schemes?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -82,19 +82,21 @@ async function main() {
 
   // ── Seed system Pyx IDR service instance ────────────────────────────────────
 
+  let idrAdapterType: string | null = null;
+  let idrConfig: unknown = null;
   let idrSeeded = false;
   if (encryptionService) {
     try {
       const idrAdapters = adapterRegistry[ServiceType.IDR];
       const permittedIdrTypes = Object.keys(idrAdapters) as Array<keyof typeof idrAdapters>;
-      const idrAdapterType = (process.env.SYSTEM_IDR_ADAPTER_TYPE as keyof typeof idrAdapters) || 'PYX_IDR';
+      idrAdapterType = (process.env.SYSTEM_IDR_ADAPTER_TYPE as keyof typeof idrAdapters) || 'PYX_IDR';
       const idrRegistryEntry = idrAdapters[idrAdapterType];
       if (!idrRegistryEntry) {
         throw new Error(
           `Unknown IDR adapter type: "${idrAdapterType}". Permitted types: ${permittedIdrTypes.join(', ')}`,
         );
       }
-      const idrConfig = idrRegistryEntry.configSchema.parse({
+      idrConfig = idrRegistryEntry.configSchema.parse({
         baseUrl: process.env.SYSTEM_IDR_BASE_URL,
         apiKey: process.env.SYSTEM_IDR_API_KEY,
         apiVersion: process.env.SYSTEM_IDR_API_VERSION || undefined,
@@ -572,6 +574,82 @@ async function main() {
     });
   } else {
     logger.info('Skipping custom seed (SKIP_CUSTOM_SEED is set)');
+  }
+
+  // ── Register identifier schemes with IDR service ────────────────────────────
+  // In the dev environment, the RI operates the Pyx IDR — register seeded schemes.
+  if (idrSeeded && idrAdapterType === 'PYX_IDR') {
+    try {
+      const { PyxIdentityResolverAdapter } = await import('@uncefact/untp-ri-services/server');
+      const pyxAdapter = new PyxIdentityResolverAdapter(
+        idrConfig as ConstructorParameters<typeof PyxIdentityResolverAdapter>[0],
+        logger.child({ service: 'IDR - Seed' }),
+      );
+
+      // Fetch seeded schemes grouped by registrar namespace
+      const schemes = await prisma.identifierScheme.findMany({
+        where: { tenantId: SYSTEM_TENANT_ID },
+        include: { registrar: true, qualifiers: { orderBy: { order: 'asc' } } },
+      });
+
+      // Group by registrar namespace
+      const grouped = new Map<string, typeof schemes>();
+      for (const scheme of schemes) {
+        const ns = scheme.registrar.namespace;
+        if (!grouped.has(ns)) grouped.set(ns, []);
+        grouped.get(ns)!.push(scheme);
+      }
+
+      for (const [namespace, nsSchemes] of grouped) {
+        const applicationIdentifiers = nsSchemes.flatMap((s) => {
+          const primary = {
+            title: s.name,
+            label: s.primaryKey,
+            shortcode: s.primaryKey,
+            ai: s.primaryKey,
+            type: 'I' as const,
+            regex: s.validationPattern,
+            qualifiers: s.qualifiers.map((q) => q.key),
+          };
+          const quals = s.qualifiers.map((q) => ({
+            title: q.description,
+            label: q.key,
+            shortcode: q.key,
+            ai: q.key,
+            type: 'Q' as const,
+            regex: q.validationPattern,
+          }));
+          return [primary, ...quals];
+        });
+
+        try {
+          await pyxAdapter.registerSchemes([{ namespace, applicationIdentifiers }]);
+          logger.info({ namespace, count: applicationIdentifiers.length }, 'Registered schemes with IDR');
+        } catch (error) {
+          const status = (error as { context?: { httpStatus?: number } })?.context?.httpStatus;
+          const message = error instanceof Error ? error.message : String(error);
+
+          if (status === 409) {
+            logger.info({ namespace }, 'Schemes already registered with IDR — skipping');
+          } else if (status === 400 || status === 422) {
+            logger.error(
+              { namespace, error: message },
+              'IDR scheme registration validation error — skipping namespace',
+            );
+          } else {
+            // Fatal: auth errors (401/403), server errors (5xx), network errors
+            throw error;
+          }
+        }
+      }
+
+      logger.info('IDR scheme registration complete');
+    } catch (error) {
+      logger.error({ error: error instanceof Error ? error.message : error }, 'IDR scheme registration failed');
+      throw error;
+    }
+  } else if (idrSeeded) {
+    logger.info({ adapterType: idrAdapterType }, 'Non-Pyx IDR adapter — skipping scheme registration');
   }
 
   logger.info(

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -89,8 +89,9 @@ async function main() {
     try {
       const idrAdapters = adapterRegistry[ServiceType.IDR];
       const permittedIdrTypes = Object.keys(idrAdapters) as Array<keyof typeof idrAdapters>;
-      idrAdapterType = (process.env.SYSTEM_IDR_ADAPTER_TYPE as keyof typeof idrAdapters) || 'PYX_IDR';
-      const idrRegistryEntry = idrAdapters[idrAdapterType];
+      const resolvedIdrAdapterType = (process.env.SYSTEM_IDR_ADAPTER_TYPE as keyof typeof idrAdapters) || 'PYX_IDR';
+      idrAdapterType = resolvedIdrAdapterType;
+      const idrRegistryEntry = idrAdapters[resolvedIdrAdapterType];
       if (!idrRegistryEntry) {
         throw new Error(
           `Unknown IDR adapter type: "${idrAdapterType}". Permitted types: ${permittedIdrTypes.join(', ')}`,

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -601,6 +601,7 @@ async function main() {
         grouped.get(ns)!.push(scheme);
       }
 
+      const failedNamespaces: string[] = [];
       for (const [namespace, nsSchemes] of grouped) {
         const applicationIdentifiers = nsSchemes.flatMap((s) => {
           const primary = {
@@ -631,8 +632,12 @@ async function main() {
           const message = error instanceof Error ? error.message : String(error);
 
           if (status === 409) {
-            logger.info({ namespace }, 'Schemes already registered with IDR — skipping');
+            logger.warn(
+              { namespace },
+              'Schemes already registered with IDR — skipping. If scheme definitions have changed, manually update or delete and re-register via the IDR.',
+            );
           } else if (status === 400 || status === 422) {
+            failedNamespaces.push(namespace);
             logger.error(
               { namespace, error: message },
               'IDR scheme registration validation error — skipping namespace',
@@ -644,7 +649,14 @@ async function main() {
         }
       }
 
-      logger.info('IDR scheme registration complete');
+      if (failedNamespaces.length > 0) {
+        logger.warn(
+          { failedNamespaces },
+          'IDR scheme registration completed with failures — some namespaces were not registered',
+        );
+      } else {
+        logger.info('IDR scheme registration complete');
+      }
     } catch (error) {
       logger.error({ error: error instanceof Error ? error.message : error }, 'IDR scheme registration failed');
       throw error;

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -615,8 +615,8 @@ describe('POST /api/v1/credentials', () => {
       const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
-      // resolveIdrService called with scheme and publishing service instance IDs
-      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1', undefined);
+      // resolveIdrService called with scheme IDR only
+      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1');
 
       // buildPublishLinks called with storage response, link title, and options
       expect(mockBuildPublishLinks).toHaveBeenCalledWith(STORAGE_RESPONSE, 'Digital Product Passport', {
@@ -634,7 +634,7 @@ describe('POST /api/v1/credentials', () => {
       expect(mockUpdateCredentialPublished).toHaveBeenCalledWith('cred-1', 'tenant-1', true);
     });
 
-    it('passes publishingOptions.serviceInstanceId to resolveIdrService', async () => {
+    it('ignores publishingOptions.serviceInstanceId (IDR determined by resolution chain)', async () => {
       setupPublishingHappyPath();
 
       const req = createFakeRequest(
@@ -642,7 +642,8 @@ describe('POST /api/v1/credentials', () => {
       );
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
-      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1', 'explicit-idr');
+      // serviceInstanceId should be ignored — resolveIdrService called with scheme IDR only
+      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1');
     });
 
     it('uses publishingOptions.linkTitle override when provided', async () => {
@@ -723,6 +724,36 @@ describe('POST /api/v1/credentials', () => {
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
       expect(mockResolveIdrService).not.toHaveBeenCalled();
+      expect(mockUpdateCredentialPublished).not.toHaveBeenCalled();
+    });
+
+    it('issues credential with IDR_PUBLISH_FAILED warning when publishLinks throws', async () => {
+      setupPublishingHappyPath();
+      mockPublishLinks.mockRejectedValueOnce(new Error('scheme not registered'));
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.credentialId).toBe('cred-1');
+      expect(json.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'IDR_PUBLISH_FAILED',
+            message: expect.stringContaining('scheme not registered'),
+          }),
+        ]),
+      );
+    });
+
+    it('does not mark credential as published when publishLinks throws', async () => {
+      setupPublishingHappyPath();
+      mockPublishLinks.mockRejectedValueOnce(new Error('IDR unavailable'));
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
       expect(mockUpdateCredentialPublished).not.toHaveBeenCalled();
     });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -191,21 +191,22 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     } else if (!primaryEntity.primaryIdentifier) {
       logger.warn({ tenantId, credentialId }, 'Publishing requested but no primary identifier resolved — skipping');
     } else {
+      // Resolve IDR service outside try-catch — config failures should be fatal
+      const idrService = await resolveIdrService(tenantId, primaryEntity.schemeIdrServiceInstanceId);
+
+      const linkTitle = publishingOptions.linkTitle || dataModel.name;
+      const links = buildPublishLinks(storageResponse, linkTitle, {
+        linkType: publishingOptions.linkType,
+        machineVerificationUrl: publishingOptions.machineVerificationUrl,
+        humanVerificationUrl: publishingOptions.humanVerificationUrl,
+      });
+
+      logger.info(
+        { tenantId, idrInstanceId: idrService.instanceId, primaryIdentifier: primaryEntity.primaryIdentifier },
+        'Publishing credential to IDR',
+      );
+
       try {
-        const idrService = await resolveIdrService(tenantId, primaryEntity.schemeIdrServiceInstanceId);
-
-        const linkTitle = publishingOptions.linkTitle || dataModel.name;
-        const links = buildPublishLinks(storageResponse, linkTitle, {
-          linkType: publishingOptions.linkType,
-          machineVerificationUrl: publishingOptions.machineVerificationUrl,
-          humanVerificationUrl: publishingOptions.humanVerificationUrl,
-        });
-
-        logger.info(
-          { tenantId, idrInstanceId: idrService.instanceId, primaryIdentifier: primaryEntity.primaryIdentifier },
-          'Publishing credential to IDR',
-        );
-
         await idrService.service.publishLinks(
           primaryEntity.schemePrimaryKey,
           primaryEntity.primaryIdentifier,
@@ -216,8 +217,6 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
             itemDescription: linkTitle,
           },
         );
-
-        await updateCredentialPublished(credentialId, tenantId, true);
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         logger.error(
@@ -228,6 +227,11 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
           code: 'IDR_PUBLISH_FAILED',
           message: `Failed to publish credential to identity resolver: ${detail}. Ensure the identifier scheme is registered with the IDR service. Contact your IDR operator if this persists.`,
         });
+      }
+
+      // Update published state outside try-catch — DB failure after successful publish is a separate concern
+      if (!cvcWarnings.some((w) => w.code === 'IDR_PUBLISH_FAILED')) {
+        await updateCredentialPublished(credentialId, tenantId, true);
       }
     }
   }

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -85,7 +85,6 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     };
     publishingOptions?: {
       publish?: boolean;
-      serviceInstanceId?: string;
       linkType?: string;
       linkTitle?: string;
       machineVerificationUrl?: string;
@@ -192,36 +191,44 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     } else if (!primaryEntity.primaryIdentifier) {
       logger.warn({ tenantId, credentialId }, 'Publishing requested but no primary identifier resolved — skipping');
     } else {
-      const idrService = await resolveIdrService(
-        tenantId,
-        primaryEntity.schemeIdrServiceInstanceId,
-        publishingOptions.serviceInstanceId,
-      );
+      try {
+        const idrService = await resolveIdrService(tenantId, primaryEntity.schemeIdrServiceInstanceId);
 
-      const linkTitle = publishingOptions.linkTitle || dataModel.name;
-      const links = buildPublishLinks(storageResponse, linkTitle, {
-        linkType: publishingOptions.linkType,
-        machineVerificationUrl: publishingOptions.machineVerificationUrl,
-        humanVerificationUrl: publishingOptions.humanVerificationUrl,
-      });
+        const linkTitle = publishingOptions.linkTitle || dataModel.name;
+        const links = buildPublishLinks(storageResponse, linkTitle, {
+          linkType: publishingOptions.linkType,
+          machineVerificationUrl: publishingOptions.machineVerificationUrl,
+          humanVerificationUrl: publishingOptions.humanVerificationUrl,
+        });
 
-      logger.info(
-        { tenantId, idrInstanceId: idrService.instanceId, primaryIdentifier: primaryEntity.primaryIdentifier },
-        'Publishing credential to IDR',
-      );
+        logger.info(
+          { tenantId, idrInstanceId: idrService.instanceId, primaryIdentifier: primaryEntity.primaryIdentifier },
+          'Publishing credential to IDR',
+        );
 
-      await idrService.service.publishLinks(
-        primaryEntity.schemePrimaryKey,
-        primaryEntity.primaryIdentifier,
-        links,
-        '/',
-        {
-          namespace: primaryEntity.schemeNamespace,
-          itemDescription: linkTitle,
-        },
-      );
+        await idrService.service.publishLinks(
+          primaryEntity.schemePrimaryKey,
+          primaryEntity.primaryIdentifier,
+          links,
+          '/',
+          {
+            namespace: primaryEntity.schemeNamespace,
+            itemDescription: linkTitle,
+          },
+        );
 
-      await updateCredentialPublished(credentialId, tenantId, true);
+        await updateCredentialPublished(credentialId, tenantId, true);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        logger.error(
+          { err: error, tenantId, credentialId, scheme: primaryEntity.schemePrimaryKey },
+          'Failed to publish credential to IDR',
+        );
+        cvcWarnings.push({
+          code: 'IDR_PUBLISH_FAILED',
+          message: `Failed to publish credential to identity resolver: ${detail}. Ensure the identifier scheme is registered with the IDR service. Contact your IDR operator if this persists.`,
+        });
+      }
     }
   }
 

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
@@ -254,6 +254,20 @@ describe('PATCH /api/v1/identifiers/[id]/links/[linkId]', () => {
 
     expect(res.status).toBe(404);
   });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+      url: 'http://localhost/api/v1/identifiers/ident-1/links/idr-link-1',
+    } as unknown as Request;
+    const res = await PATCH(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid JSON body');
+  });
 });
 
 describe('DELETE /api/v1/identifiers/[id]/links/[linkId]', () => {
@@ -287,6 +301,15 @@ describe('DELETE /api/v1/identifiers/[id]/links/[linkId]', () => {
 
   it('returns 404 when link registration not found', async () => {
     mockGetLinkRegistrationByIdrLinkId.mockResolvedValue(null);
+
+    const req = createFakeRequest();
+    const res = await DELETE(req, createContext());
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when identifier not found', async () => {
+    mockGetIdentifierById.mockResolvedValue(null);
 
     const req = createFakeRequest();
     const res = await DELETE(req, createContext());

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError } from '@/lib/api/validation';
+import { assertPublicUrl, ValidationError } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import {
   getIdentifierById,
@@ -74,7 +74,7 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links/[linkId]
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id: identifierId, linkId } = await params;
 
-  logger.info({ tenantId, identifierId, linkId }, 'Looking up identifier and local link record');
+  logger.info({ identifierId, linkId }, 'Looking up identifier and local link record');
   const identifier = await getIdentifierById(identifierId, tenantId);
   if (!identifier) {
     throw new NotFoundError('Identifier not found');
@@ -88,7 +88,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const scheme = identifier.scheme;
   const registrar = scheme.registrar;
 
-  logger.info({ tenantId, identifierId, linkId }, 'Resolving IDR service for link retrieval');
+  logger.info({ identifierId, linkId }, 'Resolving IDR service for link retrieval');
   const { service: idrService } = await resolveIdrService(
     tenantId,
     scheme.idrServiceInstanceId,
@@ -96,12 +96,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   );
 
   try {
-    logger.info({ tenantId, identifierId, linkId }, 'Fetching live link data from IDR');
+    logger.info({ identifierId, linkId }, 'Fetching live link data from IDR');
     const link = await idrService.getLinkById(linkId);
     return NextResponse.json({ link, localRecord });
   } catch (idrError: unknown) {
     if (idrError instanceof IdrLinkNotFoundError) {
-      logger.warn({ tenantId, identifierId, linkId }, 'Link desync — exists locally but missing from upstream IDR');
+      logger.warn({ identifierId, linkId }, 'Link desync — exists locally but missing from upstream IDR');
       return NextResponse.json(
         {
           link: null,
@@ -164,6 +164,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                   type: string
  *                 type:
  *                   type: string
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -197,7 +203,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id: identifierId, linkId } = await params;
 
-  logger.info({ tenantId, identifierId, linkId }, 'Parsing request body');
+  logger.info({ identifierId, linkId }, 'Parsing request body');
   let body: Record<string, unknown>;
   try {
     body = await req.json();
@@ -205,7 +211,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, identifierId, linkId }, 'Looking up identifier and local link record for update');
+  if (typeof body.href === 'string') await assertPublicUrl(body.href, 'href');
+
+  logger.info({ identifierId, linkId }, 'Looking up identifier and local link record for update');
   const identifier = await getIdentifierById(identifierId, tenantId);
   if (!identifier) {
     throw new NotFoundError('Identifier not found');
@@ -219,7 +227,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const scheme = identifier.scheme;
   const registrar = scheme.registrar;
 
-  logger.info({ tenantId, identifierId, linkId }, 'Resolving IDR service for link update');
+  logger.info({ identifierId, linkId }, 'Resolving IDR service for link update');
   const { service: idrService } = await resolveIdrService(
     tenantId,
     scheme.idrServiceInstanceId,
@@ -227,21 +235,21 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   );
 
   try {
-    logger.info({ tenantId, identifierId, linkId }, 'Updating link on upstream IDR');
+    logger.info({ identifierId, linkId }, 'Updating link on upstream IDR');
     const updatedLink = await idrService.updateLink(linkId, body);
 
-    logger.info({ tenantId, identifierId, linkId }, 'Syncing local record with upstream state');
+    logger.info({ identifierId, linkId }, 'Syncing local record with upstream state');
     await updateLinkRegistration(linkId, identifierId, tenantId, {
       linkType: updatedLink.rel,
       targetUrl: updatedLink.href,
       mimeType: updatedLink.type,
     });
 
-    logger.info({ tenantId, identifierId, linkId }, 'Link updated');
+    logger.info({ identifierId, linkId }, 'Link updated');
     return NextResponse.json(updatedLink);
   } catch (e: unknown) {
     if (e instanceof IdrLinkNotFoundError) {
-      logger.warn({ tenantId, identifierId, linkId }, 'Link desync — cannot update, missing from upstream IDR');
+      logger.warn({ identifierId, linkId }, 'Link desync — cannot update, missing from upstream IDR');
       return NextResponse.json(
         {
           error: `Link "${linkId}" no longer exists on the upstream IDR. It may have been removed out-of-band. Delete the local record to resolve this desynchronisation.`,
@@ -303,7 +311,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id: identifierId, linkId } = await params;
 
-  logger.info({ tenantId, identifierId, linkId }, 'Looking up identifier and local link record for deletion');
+  logger.info({ identifierId, linkId }, 'Looking up identifier and local link record for deletion');
   const identifier = await getIdentifierById(identifierId, tenantId);
   if (!identifier) {
     throw new NotFoundError('Identifier not found');
@@ -317,7 +325,7 @@ export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const scheme = identifier.scheme;
   const registrar = scheme.registrar;
 
-  logger.info({ tenantId, identifierId, linkId }, 'Resolving IDR service for link deletion');
+  logger.info({ identifierId, linkId }, 'Resolving IDR service for link deletion');
   const { service: idrService } = await resolveIdrService(
     tenantId,
     scheme.idrServiceInstanceId,
@@ -325,19 +333,19 @@ export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   );
 
   try {
-    logger.info({ tenantId, identifierId, linkId }, 'Deleting link from upstream IDR');
+    logger.info({ identifierId, linkId }, 'Deleting link from upstream IDR');
     await idrService.deleteLink(linkId);
   } catch (idrError: unknown) {
     if (idrError instanceof IdrLinkNotFoundError) {
-      logger.warn({ tenantId, identifierId, linkId }, 'Link desync — already absent from upstream IDR');
+      logger.warn({ identifierId, linkId }, 'Link desync — already absent from upstream IDR');
     } else {
       throw idrError;
     }
   }
 
-  logger.info({ tenantId, identifierId, linkId }, 'Cleaning up local link record');
+  logger.info({ identifierId, linkId }, 'Cleaning up local link record');
   await deleteLinkRegistration(linkId, identifierId, tenantId);
 
-  logger.info({ tenantId, identifierId, linkId }, 'Link deleted');
+  logger.info({ identifierId, linkId }, 'Link deleted');
   return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.test.ts
@@ -237,4 +237,26 @@ describe('GET /api/v1/identifiers/[id]/links', () => {
 
     expect(res.status).toBe(404);
   });
+
+  it('returns 400 for non-numeric limit', async () => {
+    mockGetIdentifierById.mockResolvedValue(MOCK_IDENTIFIER);
+
+    const req = { url: 'http://localhost/api/v1/identifiers/ident-1/links?limit=abc' } as unknown as Request;
+    const res = await GET(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('limit must be a positive integer');
+  });
+
+  it('returns 400 for negative offset', async () => {
+    mockGetIdentifierById.mockResolvedValue(MOCK_IDENTIFIER);
+
+    const req = { url: 'http://localhost/api/v1/identifiers/ident-1/links?offset=-1' } as unknown as Request;
+    const res = await GET(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('offset must be a non-negative integer');
+  });
 });

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { assertPublicUrl, ValidationError, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getIdentifierById, createManyLinkRegistrations, listLinkRegistrations } from '@/lib/prisma/repositories';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
@@ -63,7 +63,28 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links' });
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/LinkRegistration'
+ *               type: object
+ *               properties:
+ *                 resolverUri:
+ *                   type: string
+ *                   description: Canonical URI where this identifier can be resolved
+ *                 identifierScheme:
+ *                   type: string
+ *                   description: The identifier scheme (e.g. "gtin", "abn")
+ *                 identifier:
+ *                   type: string
+ *                   description: The identifier value
+ *                 links:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       idrLinkId:
+ *                         type: string
+ *                         description: IDR-assigned link identifier
+ *                       link:
+ *                         type: object
+ *                         description: The published link details
  *       400:
  *         description: Validation error
  *         content:
@@ -92,7 +113,7 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links' });
 export const POST = withTenantAuth(async (req, { tenantId, params }) => {
   const { id: identifierId } = await params;
 
-  logger.info({ tenantId, identifierId }, 'Parsing request body');
+  logger.info({ identifierId }, 'Parsing request body');
   let body: {
     links?: Array<Record<string, unknown>>;
     qualifierPath?: string;
@@ -104,12 +125,19 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, identifierId }, 'Validating input parameters');
+  logger.info({ identifierId }, 'Validating input parameters');
   if (!body.links || !Array.isArray(body.links) || body.links.length === 0) {
     throw new ValidationError('links is required and must be a non-empty array');
   }
 
-  logger.info({ tenantId, identifierId, linkCount: body.links.length }, 'Looking up identifier for link publishing');
+  // Validate targetUrl in each link for SSRF protection
+  for (const link of body.links) {
+    if (typeof link.targetUrl === 'string') {
+      await assertPublicUrl(link.targetUrl, 'links[].targetUrl');
+    }
+  }
+
+  logger.info({ identifierId, linkCount: body.links.length }, 'Looking up identifier for link publishing');
   const identifier = await getIdentifierById(identifierId, tenantId);
   if (!identifier) {
     throw new NotFoundError('Identifier not found');
@@ -119,14 +147,14 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
   const registrar = scheme.registrar;
   const namespace = registrar.namespace;
 
-  logger.info({ tenantId, identifierId, primaryKey: scheme.primaryKey, namespace }, 'Resolving IDR service');
+  logger.info({ identifierId, primaryKey: scheme.primaryKey, namespace }, 'Resolving IDR service');
   const { service: idrService } = await resolveIdrService(
     tenantId,
     scheme.idrServiceInstanceId,
     registrar.idrServiceInstanceId,
   );
 
-  logger.info({ tenantId, identifierId, linkCount: body.links.length }, 'Publishing links to IDR service');
+  logger.info({ identifierId, linkCount: body.links.length }, 'Publishing links to IDR service');
   const registration = await idrService.publishLinks(
     scheme.primaryKey,
     identifier.value,
@@ -135,7 +163,7 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
     { namespace, itemDescription: body.itemDescription },
   );
 
-  logger.info({ tenantId, identifierId, publishedCount: registration.links.length }, 'Storing audit records');
+  logger.info({ identifierId, publishedCount: registration.links.length }, 'Storing audit records');
   const auditRecords = registration.links.map((l) => ({
     tenantId,
     identifierId,
@@ -148,7 +176,7 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
   }));
   await createManyLinkRegistrations(auditRecords);
 
-  logger.info({ tenantId, identifierId, linkCount: registration.links.length }, 'Links published');
+  logger.info({ identifierId, linkCount: registration.links.length }, 'Links published');
   return NextResponse.json(registration, { status: 201 });
 });
 
@@ -193,6 +221,12 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
  *                     $ref: '#/components/schemas/LinkRegistration'
  *                 pagination:
  *                   $ref: '#/components/schemas/PaginationMeta'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
  *         content:
@@ -215,7 +249,7 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
 export const GET = withTenantAuth(async (req, { tenantId, params }) => {
   const { id: identifierId } = await params;
 
-  logger.info({ tenantId, identifierId }, 'Looking up identifier for link listing');
+  logger.info({ identifierId }, 'Looking up identifier for link listing');
   const identifier = await getIdentifierById(identifierId, tenantId);
   if (!identifier) {
     throw new NotFoundError('Identifier not found');
@@ -227,6 +261,6 @@ export const GET = withTenantAuth(async (req, { tenantId, params }) => {
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
   const { data, total } = await listLinkRegistrations(identifierId, tenantId, limit, offset);
-  logger.info({ tenantId, identifierId, count: data.length }, 'Link registrations listed');
+  logger.info({ identifierId, count: data.length }, 'Link registrations listed');
   return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
@@ -50,12 +50,12 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]' });
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, identifierId: id }, 'Looking up identifier');
+  logger.info({ identifierId: id }, 'Looking up identifier');
   const identifier = await getIdentifierById(id, tenantId);
   if (!identifier) {
     throw new NotFoundError('Identifier not found');
   }
-  logger.info({ tenantId, identifierId: id }, 'Identifier retrieved');
+  logger.info({ identifierId: id }, 'Identifier retrieved');
   return NextResponse.json(identifier);
 });
 
@@ -119,7 +119,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, identifierId: id }, 'Parsing request body');
+  logger.info({ identifierId: id }, 'Parsing request body');
 
   let body: { value?: string };
 
@@ -129,17 +129,17 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, identifierId: id }, 'Validating update fields');
+  logger.info({ identifierId: id }, 'Validating update fields');
   if (!isNonEmptyString(body.value)) {
     throw new ValidationError('value is required');
   }
 
-  logger.info({ tenantId, identifierId: id }, 'Updating identifier');
+  logger.info({ identifierId: id }, 'Updating identifier');
   const updated = await updateIdentifier(id, tenantId, {
     value: body.value,
   });
 
-  logger.info({ tenantId, identifierId: id }, 'Identifier updated');
+  logger.info({ identifierId: id }, 'Identifier updated');
   return NextResponse.json(updated);
 });
 
@@ -183,9 +183,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, identifierId: id }, 'Deleting identifier');
+  logger.info({ identifierId: id }, 'Deleting identifier');
   await deleteIdentifier(id, tenantId);
 
-  logger.info({ tenantId, identifierId: id }, 'Identifier deleted');
+  logger.info({ identifierId: id }, 'Identifier deleted');
   return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
@@ -64,7 +64,7 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing request body');
+  logger.info('Parsing request body');
   let body: {
     schemeId?: string;
     value?: string;
@@ -76,18 +76,18 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, schemeId: body.schemeId }, 'Validating input parameters');
+  logger.info({ schemeId: body.schemeId }, 'Validating input parameters');
   if (!isNonEmptyString(body.schemeId)) throw new ValidationError('schemeId is required');
   if (!isNonEmptyString(body.value)) throw new ValidationError('value is required');
 
-  logger.info({ tenantId, schemeId: body.schemeId }, 'Creating identifier');
+  logger.info({ schemeId: body.schemeId }, 'Creating identifier');
   const identifier = await createIdentifier({
     tenantId,
     schemeId: body.schemeId,
     value: body.value,
   });
 
-  logger.info({ tenantId, identifierId: identifier.id, schemeId: body.schemeId }, 'Identifier created');
+  logger.info({ identifierId: identifier.id, schemeId: body.schemeId }, 'Identifier created');
   return NextResponse.json(identifier, { status: 201 });
 });
 
@@ -151,16 +151,16 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing query parameters');
+  logger.info('Parsing query parameters');
   const url = new URL(req.url);
   const schemeId = url.searchParams.get('schemeId') ?? undefined;
   const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, schemeId, limit, offset }, 'Listing identifiers');
+  logger.info({ schemeId, limit, offset }, 'Listing identifiers');
   const { data, total } = await listIdentifiers(tenantId, { schemeId, limit, offset });
 
-  logger.info({ tenantId, count: data.length }, 'Identifiers listed');
+  logger.info({ count: data.length }, 'Identifiers listed');
   return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
@@ -50,12 +50,12 @@ const logger = apiLogger.child({ route: '/api/v1/registrars/[id]' });
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, registrarId: id }, 'Looking up registrar');
+  logger.info({ registrarId: id }, 'Looking up registrar');
   const registrar = await getRegistrarById(id, tenantId);
   if (!registrar) {
     throw new NotFoundError('Registrar not found');
   }
-  logger.info({ tenantId, registrarId: id }, 'Registrar retrieved');
+  logger.info({ registrarId: id }, 'Registrar retrieved');
   return NextResponse.json(registrar);
 });
 
@@ -129,7 +129,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, registrarId: id }, 'Parsing request body');
+  logger.info({ registrarId: id }, 'Parsing request body');
 
   let body: {
     name?: string;
@@ -154,7 +154,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   }
 
   logger.info(
-    { tenantId, registrarId: id, fields: { hasName, hasNamespace, hasUrl, hasIdrServiceInstanceId } },
+    { registrarId: id, fields: { hasName, hasNamespace, hasUrl, hasIdrServiceInstanceId } },
     'Updating registrar',
   );
   const updated = await updateRegistrar(id, tenantId, {
@@ -164,7 +164,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     ...(hasIdrServiceInstanceId && { idrServiceInstanceId: body.idrServiceInstanceId }),
   });
 
-  logger.info({ tenantId, registrarId: id }, 'Registrar updated');
+  logger.info({ registrarId: id }, 'Registrar updated');
   return NextResponse.json(updated);
 });
 
@@ -208,9 +208,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, registrarId: id }, 'Deleting registrar');
+  logger.info({ registrarId: id }, 'Deleting registrar');
   await deleteRegistrar(id, tenantId);
 
-  logger.info({ tenantId, registrarId: id }, 'Registrar deleted');
+  logger.info({ registrarId: id }, 'Registrar deleted');
   return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/registrars/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/route.ts
@@ -65,7 +65,7 @@ const logger = apiLogger.child({ route: '/api/v1/registrars' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing request body');
+  logger.info('Parsing request body');
   let body: {
     name?: string;
     namespace?: string;
@@ -79,12 +79,12 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, name: body.name, namespace: body.namespace }, 'Validating input parameters');
+  logger.info({ name: body.name, namespace: body.namespace }, 'Validating input parameters');
   if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
   if (!isNonEmptyString(body.namespace)) throw new ValidationError('namespace is required');
   if (!isNonEmptyString(body.url)) throw new ValidationError('url is required');
 
-  logger.info({ tenantId, namespace: body.namespace }, 'Creating registrar');
+  logger.info({ namespace: body.namespace }, 'Creating registrar');
   const registrar = await createRegistrar({
     tenantId,
     name: body.name,
@@ -93,7 +93,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     idrServiceInstanceId: body.idrServiceInstanceId,
   });
 
-  logger.info({ tenantId, registrarId: registrar.id }, 'Registrar created');
+  logger.info({ registrarId: registrar.id }, 'Registrar created');
   return NextResponse.json(registrar, { status: 201 });
 });
 
@@ -152,15 +152,15 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing query parameters');
+  logger.info('Parsing query parameters');
   const url = new URL(req.url);
   const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, limit, offset }, 'Listing registrars');
+  logger.info({ limit, offset }, 'Listing registrars');
   const { data, total } = await listRegistrars(tenantId, { limit, offset });
 
-  logger.info({ tenantId, count: data.length, total }, 'Registrars listed');
+  logger.info({ count: data.length, total }, 'Registrars listed');
   return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -50,12 +50,12 @@ const logger = apiLogger.child({ route: '/api/v1/schemes/[id]' });
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, schemeId: id }, 'Looking up scheme');
+  logger.info({ schemeId: id }, 'Looking up scheme');
   const scheme = await getIdentifierSchemeById(id, tenantId);
   if (!scheme) {
     throw new NotFoundError('Identifier scheme not found');
   }
-  logger.info({ tenantId, schemeId: id }, 'Scheme retrieved');
+  logger.info({ schemeId: id }, 'Scheme retrieved');
   return NextResponse.json(scheme);
 });
 
@@ -148,7 +148,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, schemeId: id }, 'Parsing request body');
+  logger.info({ schemeId: id }, 'Parsing request body');
 
   let body: {
     name?: string;
@@ -177,7 +177,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const hasIdrServiceInstanceId = body.idrServiceInstanceId !== undefined;
   const hasQualifiers = body.qualifiers !== undefined;
 
-  logger.info({ tenantId, schemeId: id }, 'Validating update fields');
+  logger.info({ schemeId: id }, 'Validating update fields');
   if (
     !hasName &&
     !hasPrimaryKey &&
@@ -203,7 +203,6 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 
   logger.info(
     {
-      tenantId,
       schemeId: id,
       fields: {
         hasName,
@@ -225,7 +224,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     ...(hasQualifiers && { qualifiers: body.qualifiers }),
   });
 
-  logger.info({ tenantId, schemeId: id }, 'Scheme updated');
+  logger.info({ schemeId: id }, 'Scheme updated');
   return NextResponse.json(updated);
 });
 
@@ -269,9 +268,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ tenantId, schemeId: id }, 'Deleting scheme');
+  logger.info({ schemeId: id }, 'Deleting scheme');
   await deleteIdentifierScheme(id, tenantId);
 
-  logger.info({ tenantId, schemeId: id }, 'Scheme deleted');
+  logger.info({ schemeId: id }, 'Scheme deleted');
   return new Response(null, { status: 204 });
 });

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
@@ -26,10 +26,12 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
 
 const mockCreateIdentifierScheme = jest.fn();
 const mockListIdentifierSchemes = jest.fn();
+const mockGetRegistrarById = jest.fn();
 
 jest.mock('@/lib/prisma/repositories', () => ({
   createIdentifierScheme: (input: unknown) => mockCreateIdentifierScheme(input),
   listIdentifierSchemes: (tenantId: string, opts: unknown) => mockListIdentifierSchemes(tenantId, opts),
+  getRegistrarById: (id: string, tenantId: string) => mockGetRegistrarById(id, tenantId),
 }));
 
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
@@ -67,6 +69,7 @@ const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
 describe('POST /api/v1/schemes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetRegistrarById.mockResolvedValue({ id: 'reg-1', name: 'GS1' });
   });
 
   it('creates a scheme and returns 201', async () => {
@@ -282,6 +285,26 @@ describe('POST /api/v1/schemes', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('linkTemplate is required');
+  });
+
+  it('returns 404 when registrarId does not exist', async () => {
+    mockGetRegistrarById.mockResolvedValue(null);
+
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'nonexistent-reg',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('Registrar not found');
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
   });
 
   it('returns 500 when repository throws', async () => {

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.ts
@@ -95,7 +95,7 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing request body');
+  logger.info('Parsing request body');
   let body: {
     registrarId?: string;
     name?: string;
@@ -117,7 +117,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     throw new ValidationError('Invalid JSON body');
   }
 
-  logger.info({ tenantId, registrarId: body.registrarId, name: body.name }, 'Validating input parameters');
+  logger.info({ registrarId: body.registrarId, name: body.name }, 'Validating input parameters');
   if (!isNonEmptyString(body.registrarId)) throw new ValidationError('registrarId is required');
   if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
   if (!isNonEmptyString(body.primaryKey)) throw new ValidationError('primaryKey is required');
@@ -138,7 +138,6 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   logger.info(
     {
-      tenantId,
       registrarId: body.registrarId,
       primaryKey: body.primaryKey,
       qualifierCount: body.qualifiers?.length ?? 0,
@@ -156,7 +155,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     qualifiers: body.qualifiers,
   });
 
-  logger.info({ tenantId, schemeId: scheme.id }, 'Scheme created');
+  logger.info({ schemeId: scheme.id }, 'Scheme created');
   return NextResponse.json(scheme, { status: 201 });
 });
 
@@ -220,16 +219,16 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info({ tenantId }, 'Parsing query parameters');
+  logger.info('Parsing query parameters');
   const url = new URL(req.url);
   const registrarId = url.searchParams.get('registrarId') ?? undefined;
   const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
   const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
   const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
 
-  logger.info({ tenantId, registrarId, limit, offset }, 'Listing schemes');
+  logger.info({ registrarId, limit, offset }, 'Listing schemes');
   const { data, total } = await listIdentifierSchemes(tenantId, { registrarId, limit, offset });
 
-  logger.info({ tenantId, count: data.length }, 'Schemes listed');
+  logger.info({ count: data.length }, 'Schemes listed');
   return NextResponse.json(buildPaginatedResponse(data, total, limit, offset));
 });

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { createIdentifierScheme, listIdentifierSchemes } from '@/lib/prisma/repositories';
+import { createIdentifierScheme, listIdentifierSchemes, getRegistrarById } from '@/lib/prisma/repositories';
+import { NotFoundError } from '@/lib/api/errors';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
@@ -134,6 +135,12 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       if (!isNonEmptyString(q.description)) throw new ValidationError('qualifier description is required');
       if (!isNonEmptyString(q.validationPattern)) throw new ValidationError('qualifier validationPattern is required');
     }
+  }
+
+  // Verify the registrar exists and belongs to this tenant
+  const registrar = await getRegistrarById(body.registrarId, tenantId);
+  if (!registrar) {
+    throw new NotFoundError('Registrar not found');
   }
 
   logger.info(

--- a/packages/reference-implementation/src/lib/services/cvc-validation.service.ts
+++ b/packages/reference-implementation/src/lib/services/cvc-validation.service.ts
@@ -12,7 +12,8 @@ export type CvcValidationWarningCode =
   | 'CVC_MISSING_CRITERION'
   | 'CVC_NO_CRITERIA'
   | 'CVC_NO_CONFORMITY'
-  | 'CVC_VALIDATION_ERROR';
+  | 'CVC_VALIDATION_ERROR'
+  | 'IDR_PUBLISH_FAILED';
 
 export type CvcValidationWarning = {
   code: CvcValidationWarningCode;

--- a/packages/reference-implementation/src/lib/services/resolve-idr-service.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-idr-service.ts
@@ -5,6 +5,17 @@ import type { ResolvedService } from './resolve-service';
 
 export type ResolvedIdrService = ResolvedService<IIdentityResolverService>;
 
+/**
+ * Resolves the IDR service instance for a given tenant and optional explicit overrides.
+ *
+ * Resolution precedence (highest to lowest):
+ * 1. Scheme-level: `IdentifierScheme.idrServiceInstanceId`
+ * 2. Registrar-level: `Registrar.idrServiceInstanceId`
+ * 3. System default: tenant's primary IDR service instance (or system-wide default)
+ *
+ * The credentials route uses a two-tier chain (scheme → system default),
+ * while the identifier links route uses the full three-tier chain.
+ */
 export async function resolveIdrService(
   tenantId: string,
   schemeIdrServiceInstanceId?: string | null,

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -41,7 +41,6 @@ const storageOptionsSchema = z.object({
 
 const publishingOptionsSchema = z.object({
   publish: z.boolean().optional().describe('Whether to publish the credential to the Identity Resolver'),
-  serviceInstanceId: z.string().optional().describe('IDR service instance ID'),
   linkType: z.string().optional().describe('UNTP link relation type (defaults to gs1:sustainabilityInfo)'),
   linkTitle: z.string().optional().describe('Title for the published link'),
   machineVerificationUrl: z.string().optional().describe('Machine verification URL'),

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
@@ -12,6 +12,7 @@ import {
   IdrLinkDeleteError,
   IdrResolverFetchError,
   IdrLinkTypesFetchError,
+  IdrSchemeRegistrationError,
 } from '../../errors';
 import type { Link } from '../../types';
 import type { PyxIdrConfig } from './pyx-idr.schema';
@@ -797,33 +798,32 @@ describe('PyxIdentityResolverAdapter', () => {
       );
     });
 
-    it('should log a warning when a scheme registration fails', async () => {
-      mockFetch.mockResolvedValueOnce({
+    it('should throw IdrSchemeRegistrationError when registration fails', async () => {
+      mockFetch.mockResolvedValue({
         ok: false,
-        status: 409,
-        statusText: 'Conflict',
-        text: jest.fn().mockResolvedValue('Already exists'),
+        status: 422,
+        text: jest.fn().mockResolvedValue('Validation failed'),
+        statusText: 'Unprocessable Entity',
       });
 
       const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
-      await adapter.registerSchemes([
-        {
-          namespace: 'untp',
-          applicationIdentifiers: [
-            {
-              title: 'ABN',
-              label: 'ABN',
-              shortcode: 'abn',
-              ai: '9991',
-              type: 'I' as const,
-              regex: '^\\d{11}$',
-            },
-          ],
-        },
-      ]);
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to register scheme untp'));
+      await expect(
+        adapter.registerSchemes([
+          {
+            namespace: 'untp',
+            applicationIdentifiers: [
+              {
+                title: 'ABN',
+                label: 'abn',
+                shortcode: 'abn',
+                ai: 'abn',
+                type: 'I' as const,
+                regex: '^\\d{11}$',
+              },
+            ],
+          },
+        ]),
+      ).rejects.toThrow(IdrSchemeRegistrationError);
     });
   });
 

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
@@ -20,6 +20,7 @@ import {
   IdrLinkDeleteError,
   IdrResolverFetchError,
   IdrLinkTypesFetchError,
+  IdrSchemeRegistrationError,
 } from '../../errors.js';
 export { IDR_SERVICE_TYPE } from '../../types.js';
 export { IdrLinkNotFoundError } from '../../errors.js';
@@ -282,7 +283,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => response.statusText);
-        this.logger.warn(`Failed to register scheme ${scheme.namespace}: HTTP ${response.status}: ${errorText}`);
+        throw new IdrSchemeRegistrationError(scheme.namespace, response.status, errorText);
       }
     }
   }

--- a/packages/services/src/identity-resolver/errors.ts
+++ b/packages/services/src/identity-resolver/errors.ts
@@ -98,3 +98,15 @@ export class IdrLinkTypesFetchError extends IdrError {
     );
   }
 }
+
+/** Failed to register an identifier scheme with the upstream IDR. */
+export class IdrSchemeRegistrationError extends IdrError {
+  constructor(namespace: string, httpStatus: number, detail: string) {
+    super(
+      `Failed to register scheme "${namespace}": HTTP ${httpStatus}: ${detail}`,
+      'IDR_SCHEME_REGISTRATION_FAILED',
+      502,
+      { namespace, httpStatus },
+    );
+  }
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -91,6 +91,7 @@ export {
   IdrLinkDeleteError,
   IdrResolverFetchError,
   IdrLinkTypesFetchError,
+  IdrSchemeRegistrationError,
 } from './identity-resolver/errors.js';
 export { PYX_IDR_ADAPTER_TYPE } from './identity-resolver/adapters/pyx/pyx-idr.adapter.js';
 export type { PyxIdrConfig } from './identity-resolver/adapters/pyx/pyx-idr.schema.js';


### PR DESCRIPTION
This PR clarifies the RI's relationship with IDR services (the RI is a consumer, not an administrator), hardens the identifier-related API routes against the project's conventions, and adds comprehensive documentation.

## IDR scheme registration

The `serviceInstanceId` override has been removed from `publishingOptions` in the credentials API. The IDR service is now determined solely by the resolution chain (scheme → registrar → system default). Publishing failures are no longer fatal; the credential is issued with an `IDR_PUBLISH_FAILED` warning, matching the existing CVC warnings pattern. The catch block is narrowed to only wrap `publishLinks`, so service resolution and database errors still propagate as fatal errors.

The Pyx adapter's `registerSchemes` method now throws `IdrSchemeRegistrationError` instead of silently logging, giving callers control over error handling policy. The seed script registers schemes with the local Pyx IDR after the custom seed runs, with tiered error handling (409 = warn and skip, auth/network = fatal, validation = log and continue).

## Identifier route audit

All identifier-related routes (registrars, schemes, identifiers, links) were audited against the project's API route, logger, and E2E test skills:

- Removed `tenantId` from log metadata across all routes (already injected by `withTenantAuth`)
- Added SSRF validation (`assertPublicUrl`) to link POST `targetUrl` and link PATCH `href` fields
- Fixed Swagger: added missing 400 responses for links GET pagination and links PATCH validation; corrected POST `/identifiers/{id}/links` 201 response schema to match actual IDR publish response shape
- Added missing unit tests for links pagination validation, link item edge cases, and SSRF rejection
- Strengthened E2E tests with `no ok property` assertions, `error` string assertions, pagination depth checks, and nonexistent ID tests

## Documentation

Replaced placeholder stubs with comprehensive API documentation for:

- **Registrars** — concepts (namespace, IDR linkage, tenant scoping, system defaults), full CRUD endpoints with mermaid diagrams
- **Identifiers** — three-section doc covering identifier schemes (with qualifiers), identifiers (with value validation), and link management (IDR resolution chain, desync handling), 15 endpoints total with mermaid diagrams

## Test plan

- [x] 1029 services tests pass
- [x] 124 identifier + credential route unit tests pass
- [x] Full monorepo build passes
- [x] Lint passes (0 errors)
- [ ] E2E tests (CI)