### PR TITLE
feat(ui): add sidebar navigation routing and DIDs page shell

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,6 +49,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/postcss": "^4.1.16",
     "ajv": "^8.16.0",

--- a/packages/components/src/components/ui/index.ts
+++ b/packages/components/src/components/ui/index.ts
@@ -6,3 +6,4 @@ export * from './sheet.js';
 export * from './tooltip.js';
 export * from './input.js';
 export * from './separator.js';
+export * from './tabs.js';

--- a/packages/components/src/components/ui/tabs.tsx
+++ b/packages/components/src/components/ui/tabs.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '../../lib/utils.js';
+
+function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return <TabsPrimitive.Root data-slot='tabs' className={cn('flex flex-col gap-2', className)} {...props} />;
+}
+
+function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot='tabs-list'
+      className={cn(
+        'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot='tabs-trigger'
+      className={cn(
+        "inline-flex items-center justify-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content data-slot='tabs-content' className={cn('flex-1 outline-none', className)} {...props} />;
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/page.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/page.test.tsx
@@ -8,7 +8,10 @@ function MockTabs({ children, defaultValue }: { children: React.ReactNode; defau
     <div data-testid='tabs' data-active-tab={activeTab}>
       {React.Children.map(children, (child) => {
         if (React.isValidElement(child)) {
-          return React.cloneElement(child as React.ReactElement<{ activeTab: string; setActiveTab: (v: string) => void }>, { activeTab, setActiveTab });
+          return React.cloneElement(
+            child as React.ReactElement<{ activeTab: string; setActiveTab: (v: string) => void }>,
+            { activeTab, setActiveTab },
+          );
         }
         return child;
       })}
@@ -16,12 +19,24 @@ function MockTabs({ children, defaultValue }: { children: React.ReactNode; defau
   );
 }
 
-function MockTabsList({ children, activeTab, setActiveTab, ...rest }: { children: React.ReactNode; activeTab?: string; setActiveTab?: (v: string) => void } & React.HTMLAttributes<HTMLDivElement>) {
+function MockTabsList({
+  children,
+  activeTab,
+  setActiveTab,
+  ...rest
+}: {
+  children: React.ReactNode;
+  activeTab?: string;
+  setActiveTab?: (v: string) => void;
+} & React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div role='tablist' {...rest}>
       {React.Children.map(children, (child) => {
         if (React.isValidElement(child)) {
-          return React.cloneElement(child as React.ReactElement<{ activeTab: string; setActiveTab: (v: string) => void }>, { activeTab, setActiveTab });
+          return React.cloneElement(
+            child as React.ReactElement<{ activeTab: string; setActiveTab: (v: string) => void }>,
+            { activeTab, setActiveTab },
+          );
         }
         return child;
       })}
@@ -29,7 +44,16 @@ function MockTabsList({ children, activeTab, setActiveTab, ...rest }: { children
   );
 }
 
-function MockTabsTrigger({ children, value, activeTab, setActiveTab, ...rest }: { children: React.ReactNode; value: string; activeTab?: string; setActiveTab?: (v: string) => void } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value'>) {
+function MockTabsTrigger({
+  children,
+  value,
+  activeTab,
+  setActiveTab,
+  ...rest
+}: { children: React.ReactNode; value: string; activeTab?: string; setActiveTab?: (v: string) => void } & Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'value'
+>) {
   return (
     <button
       role='tab'
@@ -42,7 +66,12 @@ function MockTabsTrigger({ children, value, activeTab, setActiveTab, ...rest }: 
   );
 }
 
-function MockTabsContent({ children, value, activeTab, ...rest }: { children: React.ReactNode; value: string; activeTab?: string } & React.HTMLAttributes<HTMLDivElement>) {
+function MockTabsContent({
+  children,
+  value,
+  activeTab,
+  ...rest
+}: { children: React.ReactNode; value: string; activeTab?: string } & React.HTMLAttributes<HTMLDivElement>) {
   if (activeTab !== value) return null;
   return <div {...rest}>{children}</div>;
 }

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/page.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/page.test.tsx
@@ -94,12 +94,13 @@ describe('DidsPage', () => {
     expect(screen.getByTestId('managed-tab-content')).toBeInTheDocument();
   });
 
-  it('renders self-hosted tab content panel when selected', async () => {
+  it('renders self-hosted tab content panel and hides managed panel when selected', async () => {
     const user = userEvent.setup();
     render(<DidsPage />);
 
     await user.click(screen.getByRole('tab', { name: 'Self hosted' }));
 
     expect(screen.getByTestId('self-hosted-tab-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('managed-tab-content')).not.toBeInTheDocument();
   });
 });

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/page.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/page.test.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+function MockTabs({ children, defaultValue }: { children: React.ReactNode; defaultValue?: string }) {
+  const [activeTab, setActiveTab] = useState(defaultValue ?? '');
+  return (
+    <div data-testid='tabs' data-active-tab={activeTab}>
+      {React.Children.map(children, (child) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child as React.ReactElement<{ activeTab: string; setActiveTab: (v: string) => void }>, { activeTab, setActiveTab });
+        }
+        return child;
+      })}
+    </div>
+  );
+}
+
+function MockTabsList({ children, activeTab, setActiveTab, ...rest }: { children: React.ReactNode; activeTab?: string; setActiveTab?: (v: string) => void } & React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div role='tablist' {...rest}>
+      {React.Children.map(children, (child) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child as React.ReactElement<{ activeTab: string; setActiveTab: (v: string) => void }>, { activeTab, setActiveTab });
+        }
+        return child;
+      })}
+    </div>
+  );
+}
+
+function MockTabsTrigger({ children, value, activeTab, setActiveTab, ...rest }: { children: React.ReactNode; value: string; activeTab?: string; setActiveTab?: (v: string) => void } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value'>) {
+  return (
+    <button
+      role='tab'
+      data-state={activeTab === value ? 'active' : 'inactive'}
+      onClick={() => setActiveTab?.(value)}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MockTabsContent({ children, value, activeTab, ...rest }: { children: React.ReactNode; value: string; activeTab?: string } & React.HTMLAttributes<HTMLDivElement>) {
+  if (activeTab !== value) return null;
+  return <div {...rest}>{children}</div>;
+}
+
+jest.mock('@reference-implementation/components', () => ({
+  Tabs: MockTabs,
+  TabsList: MockTabsList,
+  TabsTrigger: MockTabsTrigger,
+  TabsContent: MockTabsContent,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { default: DidsPage } = require('./page');
+
+describe('DidsPage', () => {
+  it('renders the page title', () => {
+    render(<DidsPage />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('DIDs (Decentralised Identifiers)');
+  });
+
+  it('renders both tab triggers', () => {
+    render(<DidsPage />);
+
+    expect(screen.getByRole('tab', { name: 'Managed' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Self hosted' })).toBeInTheDocument();
+  });
+
+  it('has the Managed tab active by default', () => {
+    render(<DidsPage />);
+
+    expect(screen.getByRole('tab', { name: 'Managed' })).toHaveAttribute('data-state', 'active');
+    expect(screen.getByRole('tab', { name: 'Self hosted' })).toHaveAttribute('data-state', 'inactive');
+  });
+
+  it('switches active tab when clicking Self hosted', async () => {
+    const user = userEvent.setup();
+    render(<DidsPage />);
+
+    await user.click(screen.getByRole('tab', { name: 'Self hosted' }));
+
+    expect(screen.getByRole('tab', { name: 'Self hosted' })).toHaveAttribute('data-state', 'active');
+    expect(screen.getByRole('tab', { name: 'Managed' })).toHaveAttribute('data-state', 'inactive');
+  });
+
+  it('renders managed tab content panel by default', () => {
+    render(<DidsPage />);
+
+    expect(screen.getByTestId('managed-tab-content')).toBeInTheDocument();
+  });
+
+  it('renders self-hosted tab content panel when selected', async () => {
+    const user = userEvent.setup();
+    render(<DidsPage />);
+
+    await user.click(screen.getByRole('tab', { name: 'Self hosted' }));
+
+    expect(screen.getByTestId('self-hosted-tab-content')).toBeInTheDocument();
+  });
+});

--- a/packages/reference-implementation/src/app/(protected)/configuration/dids/page.tsx
+++ b/packages/reference-implementation/src/app/(protected)/configuration/dids/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@reference-implementation/components';
+
+export default function DidsPage() {
+  return (
+    <div data-testid='dids-page'>
+      <h1 className='text-2xl font-semibold mb-6'>DIDs (Decentralised Identifiers)</h1>
+
+      <Tabs defaultValue='managed'>
+        <TabsList className='bg-muted/50 p-1'>
+          <TabsTrigger value='managed'>Managed</TabsTrigger>
+          <TabsTrigger value='self-hosted'>Self hosted</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value='managed' data-testid='managed-tab-content'>
+          <div />
+        </TabsContent>
+
+        <TabsContent value='self-hosted' data-testid='self-hosted-tab-content'>
+          <div />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/packages/reference-implementation/src/app/(protected)/layout.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/layout.test.tsx
@@ -25,9 +25,15 @@ jest.mock('@/contexts/auth', () => ({
 jest.mock('@/components/sidebar', () => ({
   Sidebar: ({ onNavClick, selectedNavId }: { onNavClick: (id: string) => void; selectedNavId?: string }) => (
     <div data-testid='sidebar' data-selected-nav-id={selectedNavId}>
-      <button data-testid='nav-dids' onClick={() => onNavClick('dids')}>DIDs</button>
-      <button data-testid='nav-credentials' onClick={() => onNavClick('credentials')}>Credentials</button>
-      <button data-testid='nav-resources' onClick={() => onNavClick('resources')}>Resources</button>
+      <button data-testid='nav-dids' onClick={() => onNavClick('dids')}>
+        DIDs
+      </button>
+      <button data-testid='nav-credentials' onClick={() => onNavClick('credentials')}>
+        Credentials
+      </button>
+      <button data-testid='nav-resources' onClick={() => onNavClick('resources')}>
+        Resources
+      </button>
     </div>
   ),
   MobileSidebar: () => <div data-testid='mobile-sidebar' />,
@@ -48,7 +54,11 @@ describe('ProtectedLayout navigation', () => {
 
   it('calls router.push when clicking a mapped nav item', async () => {
     const user = userEvent.setup();
-    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+    render(
+      <ProtectedLayout>
+        <div>Content</div>
+      </ProtectedLayout>,
+    );
 
     await user.click(screen.getByTestId('nav-dids'));
 
@@ -57,7 +67,11 @@ describe('ProtectedLayout navigation', () => {
 
   it('does not call router.push when clicking an unmapped nav item', async () => {
     const user = userEvent.setup();
-    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+    render(
+      <ProtectedLayout>
+        <div>Content</div>
+      </ProtectedLayout>,
+    );
 
     await user.click(screen.getByTestId('nav-credentials'));
 
@@ -66,7 +80,11 @@ describe('ProtectedLayout navigation', () => {
 
   it('does not call router.push for external nav items', async () => {
     const user = userEvent.setup();
-    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+    render(
+      <ProtectedLayout>
+        <div>Content</div>
+      </ProtectedLayout>,
+    );
 
     await user.click(screen.getByTestId('nav-resources'));
 
@@ -75,21 +93,33 @@ describe('ProtectedLayout navigation', () => {
 
   it('derives selectedNavId from the current pathname', () => {
     mockPathname.mockReturnValue('/configuration/dids');
-    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+    render(
+      <ProtectedLayout>
+        <div>Content</div>
+      </ProtectedLayout>,
+    );
 
     expect(screen.getByTestId('sidebar')).toHaveAttribute('data-selected-nav-id', 'dids');
   });
 
   it('sets selectedNavId to undefined for unrecognised paths', () => {
     mockPathname.mockReturnValue('/dashboard');
-    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+    render(
+      <ProtectedLayout>
+        <div>Content</div>
+      </ProtectedLayout>,
+    );
 
     expect(screen.getByTestId('sidebar')).not.toHaveAttribute('data-selected-nav-id', 'dids');
   });
 
   it('matches sub-paths to the correct nav item', () => {
     mockPathname.mockReturnValue('/configuration/dids/create');
-    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+    render(
+      <ProtectedLayout>
+        <div>Content</div>
+      </ProtectedLayout>,
+    );
 
     expect(screen.getByTestId('sidebar')).toHaveAttribute('data-selected-nav-id', 'dids');
   });

--- a/packages/reference-implementation/src/app/(protected)/layout.test.tsx
+++ b/packages/reference-implementation/src/app/(protected)/layout.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProtectedLayout from './layout';
+
+const mockPush = jest.fn();
+const mockPathname = jest.fn(() => '/configuration/dids');
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  usePathname: () => mockPathname(),
+}));
+
+jest.mock('@/contexts/auth', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => ({
+    user: { name: 'Test User', email: 'test@example.com', roles: [] },
+    isLoading: false,
+    isAuthenticated: true,
+    logout: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/sidebar', () => ({
+  Sidebar: ({ onNavClick, selectedNavId }: { onNavClick: (id: string) => void; selectedNavId?: string }) => (
+    <div data-testid='sidebar' data-selected-nav-id={selectedNavId}>
+      <button data-testid='nav-dids' onClick={() => onNavClick('dids')}>DIDs</button>
+      <button data-testid='nav-credentials' onClick={() => onNavClick('credentials')}>Credentials</button>
+      <button data-testid='nav-resources' onClick={() => onNavClick('resources')}>Resources</button>
+    </div>
+  ),
+  MobileSidebar: () => <div data-testid='mobile-sidebar' />,
+}));
+
+jest.mock('@reference-implementation/components', () => ({
+  Loader: () => <div data-testid='loader' />,
+}));
+
+jest.mock('lucide-react', () => ({
+  LogOut: () => <span>LogOut</span>,
+}));
+
+describe('ProtectedLayout navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls router.push when clicking a mapped nav item', async () => {
+    const user = userEvent.setup();
+    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+
+    await user.click(screen.getByTestId('nav-dids'));
+
+    expect(mockPush).toHaveBeenCalledWith('/configuration/dids');
+  });
+
+  it('does not call router.push when clicking an unmapped nav item', async () => {
+    const user = userEvent.setup();
+    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+
+    await user.click(screen.getByTestId('nav-credentials'));
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('does not call router.push for external nav items', async () => {
+    const user = userEvent.setup();
+    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+
+    await user.click(screen.getByTestId('nav-resources'));
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('derives selectedNavId from the current pathname', () => {
+    mockPathname.mockReturnValue('/configuration/dids');
+    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+
+    expect(screen.getByTestId('sidebar')).toHaveAttribute('data-selected-nav-id', 'dids');
+  });
+
+  it('sets selectedNavId to undefined for unrecognised paths', () => {
+    mockPathname.mockReturnValue('/dashboard');
+    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+
+    expect(screen.getByTestId('sidebar')).not.toHaveAttribute('data-selected-nav-id', 'dids');
+  });
+
+  it('matches sub-paths to the correct nav item', () => {
+    mockPathname.mockReturnValue('/configuration/dids/create');
+    render(<ProtectedLayout><div>Content</div></ProtectedLayout>);
+
+    expect(screen.getByTestId('sidebar')).toHaveAttribute('data-selected-nav-id', 'dids');
+  });
+});

--- a/packages/reference-implementation/src/app/(protected)/layout.tsx
+++ b/packages/reference-implementation/src/app/(protected)/layout.tsx
@@ -76,7 +76,7 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
 
-  const selectedNavId = resolveNavIdFromPathname(pathname);
+  const selectedNavId = pathname ? resolveNavIdFromPathname(pathname) : undefined;
 
   // Redirect to login page if user is not authenticated
   useEffect(() => {

--- a/packages/reference-implementation/src/app/(protected)/layout.tsx
+++ b/packages/reference-implementation/src/app/(protected)/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import React, { useMemo, useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
 import { type NavMenuItemConfig, type MoreOptionGroup, Loader } from '@reference-implementation/components';
 import { AuthProvider, useAuth } from '@/contexts/auth';
 import { Sidebar, MobileSidebar } from '@/components/sidebar';
@@ -50,11 +50,33 @@ const navItems: NavMenuItemConfig[] = [
   },
 ];
 
+/**
+ * Maps nav item IDs to their corresponding route paths.
+ * Extend this map as new pages are added.
+ */
+const NAV_ROUTE_MAP: Record<string, string> = {
+  dids: '/configuration/dids',
+};
+
+/**
+ * Derives the reverse mapping from route paths to nav item IDs,
+ * sorted by path length descending so longer (more specific) paths match first.
+ */
+const ROUTE_TO_NAV_ENTRIES = Object.entries(NAV_ROUTE_MAP)
+  .map(([navId, path]) => ({ navId, path }))
+  .sort((a, b) => b.path.length - a.path.length);
+
+function resolveNavIdFromPathname(pathname: string): string | undefined {
+  const match = ROUTE_TO_NAV_ENTRIES.find(({ path }) => pathname.startsWith(path));
+  return match?.navId;
+}
+
 function ProtectedContent({ children }: { children: React.ReactNode }) {
   const { user, isLoading: authLoading, isAuthenticated, logout } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
 
-  const [selectedNavId, setSelectedNavId] = useState<string>('credentials');
+  const selectedNavId = useMemo(() => resolveNavIdFromPathname(pathname), [pathname]);
 
   // Redirect to login page if user is not authenticated
   useEffect(() => {
@@ -85,9 +107,10 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
 
   // Handle navigation click in the sidebar
   const handleNavClick = (navId: string) => {
-    // TODO: Implement navigation logic as pages become available.
-    setSelectedNavId(navId);
-    console.log('Navigation clicked:', navId);
+    const route = NAV_ROUTE_MAP[navId];
+    if (route) {
+      router.push(route);
+    }
   };
 
   // Handle logo click in the sidebar

--- a/packages/reference-implementation/src/app/(protected)/layout.tsx
+++ b/packages/reference-implementation/src/app/(protected)/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { type NavMenuItemConfig, type MoreOptionGroup, Loader } from '@reference-implementation/components';
 import { AuthProvider, useAuth } from '@/contexts/auth';
@@ -76,7 +76,7 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
 
-  const selectedNavId = useMemo(() => resolveNavIdFromPathname(pathname), [pathname]);
+  const selectedNavId = resolveNavIdFromPathname(pathname);
 
   // Redirect to login page if user is not authenticated
   useEffect(() => {
@@ -110,6 +110,8 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
     const route = NAV_ROUTE_MAP[navId];
     if (route) {
       router.push(route);
+    } else if (process.env.NODE_ENV === 'development') {
+      console.warn(`No route mapped for nav item "${navId}"`);
     }
   };
 
@@ -128,34 +130,27 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
   // Default logo for the sidebar. Will dynamically change based on organization settings.
   const logo = <span className='text-xl font-semibold'>UNTP Reference Implementation</span>;
 
+  const sidebarProps = {
+    user: userForSidebar,
+    menuGroups,
+    logo,
+    onLogoClick: handleLogoClick,
+    navItems,
+    selectedNavId,
+    onNavClick: handleNavClick,
+    isLoading,
+  };
+
   return (
     <div className='flex h-screen overflow-hidden'>
       {/* Mobile Sidebar/Navbar - hidden on desktop */}
       <div className='md:hidden'>
-        <MobileSidebar
-          user={userForSidebar}
-          menuGroups={menuGroups}
-          logo={logo}
-          onLogoClick={handleLogoClick}
-          navItems={navItems}
-          selectedNavId={selectedNavId}
-          onNavClick={handleNavClick}
-          isLoading={isLoading}
-        />
+        <MobileSidebar {...sidebarProps} />
       </div>
 
       {/* Desktop Sidebar - hidden on mobile */}
       <div className='hidden md:block'>
-        <Sidebar
-          user={userForSidebar}
-          menuGroups={menuGroups}
-          logo={logo}
-          onLogoClick={handleLogoClick}
-          navItems={navItems}
-          selectedNavId={selectedNavId}
-          onNavClick={handleNavClick}
-          isLoading={isLoading}
-        />
+        <Sidebar {...sidebarProps} />
       </div>
 
       <main className='flex-1 overflow-auto pt-16 md:pt-0'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6965,6 +6965,20 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
+"@radix-ui/react-tabs@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz#3537ce379d7e7ff4eeb6b67a0973e139c2ac1f15"
+  integrity sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-roving-focus" "1.1.11"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-tooltip@^1.1.8", "@radix-ui/react-tooltip@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz#3f50267e25bccfc9e20bb3036bfd9ab4c2c30c2c"


### PR DESCRIPTION
This PR wires up the sidebar navigation so clicking nav items routes to the correct pages, and creates the DIDs page shell at `/configuration/dids` with two tabs (Managed / Self hosted).

Previously, `handleNavClick` in the protected layout only logged to console. It now uses a `NAV_ROUTE_MAP` to map nav item IDs to route paths and calls `router.push()`. The sidebar also derives `selectedNavId` from `usePathname()` instead of local state, so direct navigation (bookmarks, URL entry) correctly highlights the active nav item, including sub-path matches.

The DIDs page renders an h1 title and shadcn/ui Tabs with empty placeholder content, ready for the managed and self-hosted DID list cards to fill in.

## Changes

- **`packages/components`**: Added `@radix-ui/react-tabs` dependency and shadcn/ui `Tabs` component (`tabs.tsx`), exported via barrel
- **`layout.tsx`**: Replaced `useState` + `console.log` with `NAV_ROUTE_MAP` + `usePathname()` for URL-based nav selection and routing; extracted shared sidebar props to reduce duplication
- **`configuration/dids/page.tsx`**: New page with title and two-tab shell (Managed / Self hosted)

## Test plan

- [x] 6 layout navigation tests: mapped nav items route correctly, unmapped items do not call router.push, selectedNavId derived from pathname (including sub-paths)
- [x] 6 DIDs page tests: title renders, both tabs render, Managed active by default, tab switching works, tab content panels render with mutual exclusivity
- [x] All 12 tests pass
- [x] Components package builds successfully with new Tabs export
- [x] No regressions in existing tests (sidebar test failures are pre-existing, caused by unrelated JsonForm.tsx TS error)