### PR TITLE
feat(did): add shared DID context with paginated fetch hook

### DIFF
--- a/docs/adr/2026-03-21-paginated-fetch-hook-with-reducer.md
+++ b/docs/adr/2026-03-21-paginated-fetch-hook-with-reducer.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Context
 
@@ -52,4 +52,3 @@ A related card exists to install React Query. Once available, the hook internals
 
 - `packages/reference-implementation/src/hooks/use-paginated-fetch.ts` — implementation
 - `packages/reference-implementation/src/lib/api/pagination.ts` — `PaginatedResponse<T>` and `PaginationMeta` types
-- Related card: "Install TanStack React Query and add QueryClientProvider to the reference implementation"

--- a/docs/adr/2026-03-21-paginated-fetch-hook-with-reducer.md
+++ b/docs/adr/2026-03-21-paginated-fetch-hook-with-reducer.md
@@ -1,0 +1,55 @@
+# ADR: Reusable paginated fetch hook with useReducer
+
+## Status
+
+proposed
+
+## Context
+
+The reference implementation needs to display paginated lists of resources (DIDs, credentials, etc.) across multiple pages. Each paginated view requires the same state management: loading indicators, error handling, page navigation, and page size changes. Without a shared abstraction, this logic would be duplicated in every context or component that consumes a paginated API endpoint.
+
+The API layer already returns a consistent `PaginatedResponse<T>` shape with `data` and `pagination` (containing `total`, `limit`, `offset`, `hasMore`). A client-side hook can leverage this consistent shape to provide a generic solution.
+
+## Decision
+
+We introduced a `usePaginatedFetch<T>` hook in `src/hooks/use-paginated-fetch.ts` that:
+
+1. **Uses `useReducer`** to manage interrelated state (`data`, `pagination`, `isLoading`, `error`, `limit`, `offset`, `fetchVersion`) as a single state machine. This was chosen over multiple `useState` calls because the state values are interdependent — changing the page size must also reset the offset, and fetching must atomically update loading, data, and error.
+
+2. **Accepts a generic `fetchFn`** parameter `(params: { limit, offset }) => Promise<PaginatedResponse<T>>`, making it reusable for any paginated API endpoint without coupling to a specific service.
+
+3. **Stores `fetchFn` in a ref** to avoid requiring callers to memoise the function and to prevent stale closures.
+
+4. **Uses a `fetchVersion` counter** for the refresh mechanism — incrementing it re-triggers the `useEffect` without changing pagination params.
+
+5. **Supports `fetchOnMount: false`** via a negative initial `fetchVersion` (-1), which the effect skips. Calling `refresh()` increments it to 0, enabling fetching.
+
+This hook is consumed by context providers (e.g. `DidProvider`) which add domain-specific derived state (filtered lists, default item) on top of the generic pagination.
+
+## Consequences
+
+**What becomes easier:**
+- Adding new paginated resource views requires only calling the hook with the appropriate service function
+- Pagination state transitions are explicit and predictable via the reducer
+- The hook is testable in isolation with `renderHook`
+
+**What becomes harder:**
+- The hook assumes all paginated endpoints follow the `PaginatedResponse<T>` shape — endpoints with different response formats would need a separate approach
+- Server-side filtering (e.g. filtering by DID type) is not built into the hook — consumers must handle this at the `fetchFn` level
+
+## Alternatives Considered
+
+### Multiple `useState` calls
+Rejected because the state values are interdependent. Setting page size must also reset offset, and a fetch completion must atomically update data, pagination, and loading. With separate `useState` calls, these updates would cause multiple re-renders and risk inconsistent intermediate states.
+
+### Hardcoded high limit (e.g. `limit: 1000`)
+Rejected because it doesn't scale and prevents consumers from implementing proper pagination UI. A proper pagination hook supports the related cards that need paginated list views.
+
+### TanStack React Query
+A related card exists to install React Query. Once available, the hook internals can be refactored to use `useQuery` while keeping the same external API. The current `useReducer` approach is a pragmatic interim solution that doesn't block the React Query migration.
+
+## References
+
+- `packages/reference-implementation/src/hooks/use-paginated-fetch.ts` — implementation
+- `packages/reference-implementation/src/lib/api/pagination.ts` — `PaginatedResponse<T>` and `PaginationMeta` types
+- Related card: "Install TanStack React Query and add QueryClientProvider to the reference implementation"

--- a/packages/reference-implementation/src/app/(protected)/layout.tsx
+++ b/packages/reference-implementation/src/app/(protected)/layout.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { type NavMenuItemConfig, type MoreOptionGroup, Loader } from '@reference-implementation/components';
 import { AuthProvider, useAuth } from '@/contexts/auth';
+import { DidProvider } from '@/contexts/did/DidContext';
 import { Sidebar, MobileSidebar } from '@/components/sidebar';
 import { LogOut } from 'lucide-react';
 
@@ -147,7 +148,9 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
 export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
   return (
     <AuthProvider>
-      <ProtectedContent>{children}</ProtectedContent>
+      <DidProvider>
+        <ProtectedContent>{children}</ProtectedContent>
+      </DidProvider>
     </AuthProvider>
   );
 }

--- a/packages/reference-implementation/src/app/(protected)/layout.tsx
+++ b/packages/reference-implementation/src/app/(protected)/layout.tsx
@@ -138,7 +138,11 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
 
       <main className='flex-1 overflow-auto pt-16 md:pt-0'>
         <div className='px-6 py-6'>
-          {isLoading ? <Loader size={60} text='Loading...' className='min-h-[calc(100vh-3rem)]' /> : children}
+          {isLoading ? (
+            <Loader size={60} text='Loading...' className='min-h-[calc(100vh-3rem)]' />
+          ) : (
+            <DidProvider>{children}</DidProvider>
+          )}
         </div>
       </main>
     </div>
@@ -148,9 +152,7 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
 export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
   return (
     <AuthProvider>
-      <DidProvider>
-        <ProtectedContent>{children}</ProtectedContent>
-      </DidProvider>
+      <ProtectedContent>{children}</ProtectedContent>
     </AuthProvider>
   );
 }

--- a/packages/reference-implementation/src/contexts/did/DidContext.test.tsx
+++ b/packages/reference-implementation/src/contexts/did/DidContext.test.tsx
@@ -1,0 +1,299 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import type { Did } from '@/lib/prisma/generated';
+import type { PaginatedResponse } from '@/lib/api/pagination';
+import { DidProvider, useDids } from './DidContext';
+
+// Mock the DID service
+jest.mock('@/lib/api/services/did.service');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { listDids } = require('@/lib/api/services/did.service') as {
+  listDids: jest.Mock;
+};
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const baseDid: Did = {
+  id: 'did-001',
+  tenantId: 'tenant-001',
+  did: 'did:web:example.com:managed',
+  type: 'MANAGED' as Did['type'],
+  method: 'DID_WEB' as Did['method'],
+  name: 'Managed DID',
+  description: 'A managed DID',
+  keyId: 'key-001',
+  status: 'VERIFIED' as Did['status'],
+  isDefault: true,
+  createdAt: new Date('2026-01-15T10:00:00Z'),
+  updatedAt: new Date('2026-02-20T14:30:00Z'),
+  serviceInstanceId: 'svc-inst-001',
+};
+
+const selfManagedDid: Did = {
+  id: 'did-002',
+  tenantId: 'tenant-001',
+  did: 'did:web:my-domain.com',
+  type: 'SELF_MANAGED' as Did['type'],
+  method: 'DID_WEB' as Did['method'],
+  name: 'Self-Managed DID',
+  description: null,
+  keyId: 'key-002',
+  status: 'UNVERIFIED' as Did['status'],
+  isDefault: false,
+  createdAt: new Date('2026-02-01T08:00:00Z'),
+  updatedAt: new Date('2026-02-01T08:00:00Z'),
+  serviceInstanceId: null,
+};
+
+const defaultTypeDid: Did = {
+  id: 'did-003',
+  tenantId: 'tenant-001',
+  did: 'did:web:example.com:default',
+  type: 'DEFAULT' as Did['type'],
+  method: 'DID_WEB' as Did['method'],
+  name: 'Default Type DID',
+  description: null,
+  keyId: 'key-003',
+  status: 'VERIFIED' as Did['status'],
+  isDefault: false,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  serviceInstanceId: null,
+};
+
+function createPaginatedResponse(dids: Did[]): PaginatedResponse<Did> {
+  return {
+    data: dids,
+    pagination: {
+      total: dids.length,
+      limit: 20,
+      offset: 0,
+      hasMore: false,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test component
+// ---------------------------------------------------------------------------
+
+function TestComponent() {
+  const { dids, managedDids, selfManagedDids, defaultDid, isLoading, error, refresh, goToPage, setPageSize } =
+    useDids();
+
+  return (
+    <div>
+      <div data-testid='loading'>{isLoading ? 'loading' : 'not-loading'}</div>
+      <div data-testid='error'>{error ? error.message : 'no-error'}</div>
+      <div data-testid='dids-count'>{dids.length}</div>
+      <div data-testid='managed-count'>{managedDids.length}</div>
+      <div data-testid='self-managed-count'>{selfManagedDids.length}</div>
+      <div data-testid='default-did'>{defaultDid?.id ?? 'none'}</div>
+      <div data-testid='did-ids'>{dids.map((d) => d.id).join(',')}</div>
+      <button data-testid='refresh-btn' onClick={refresh}>
+        Refresh
+      </button>
+      <button data-testid='go-to-page-btn' onClick={() => goToPage(20)}>
+        Page 2
+      </button>
+      <button data-testid='set-page-size-btn' onClick={() => setPageSize(50)}>
+        Size 50
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DidContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('DidProvider', () => {
+    it('fetches DIDs on mount and provides them via context', async () => {
+      listDids.mockResolvedValue(createPaginatedResponse([baseDid, selfManagedDid]));
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      expect(screen.getByTestId('dids-count')).toHaveTextContent('2');
+      expect(screen.getByTestId('did-ids')).toHaveTextContent('did-001,did-002');
+      expect(listDids).toHaveBeenCalledWith({ limit: 20, offset: 0 });
+    });
+
+    it('categorises DIDs into managed, self-managed, and default', async () => {
+      listDids.mockResolvedValue(createPaginatedResponse([baseDid, selfManagedDid, defaultTypeDid]));
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      expect(screen.getByTestId('managed-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('self-managed-count')).toHaveTextContent('1');
+      // defaultDid is baseDid (isDefault: true), not the DEFAULT type DID
+      expect(screen.getByTestId('default-did')).toHaveTextContent('did-001');
+    });
+
+    it('returns null for defaultDid when no DID has isDefault: true', async () => {
+      const nonDefaultDid = { ...baseDid, isDefault: false };
+      listDids.mockResolvedValue(createPaginatedResponse([nonDefaultDid]));
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      expect(screen.getByTestId('default-did')).toHaveTextContent('none');
+    });
+
+    it('returns isLoading true with empty arrays while fetching', async () => {
+      let resolveFetch!: (value: PaginatedResponse<Did>) => void;
+      listDids.mockReturnValue(
+        new Promise<PaginatedResponse<Did>>((resolve) => {
+          resolveFetch = resolve;
+        }),
+      );
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('loading');
+      });
+
+      expect(screen.getByTestId('dids-count')).toHaveTextContent('0');
+      expect(screen.getByTestId('managed-count')).toHaveTextContent('0');
+      expect(screen.getByTestId('self-managed-count')).toHaveTextContent('0');
+
+      // Resolve to clean up
+      resolveFetch(createPaginatedResponse([]));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+    });
+
+    it('sets error and returns empty arrays when fetch fails', async () => {
+      listDids.mockRejectedValue(new Error('API unavailable'));
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      expect(screen.getByTestId('error')).toHaveTextContent('API unavailable');
+      expect(screen.getByTestId('dids-count')).toHaveTextContent('0');
+    });
+
+    it('re-fetches when refresh is called', async () => {
+      listDids.mockResolvedValue(createPaginatedResponse([baseDid]));
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      expect(listDids).toHaveBeenCalledTimes(1);
+
+      screen.getByTestId('refresh-btn').click();
+
+      await waitFor(() => {
+        expect(listDids).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('fetches with new offset when goToPage is called', async () => {
+      listDids.mockResolvedValue(createPaginatedResponse([baseDid]));
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      screen.getByTestId('go-to-page-btn').click();
+
+      await waitFor(() => {
+        expect(listDids).toHaveBeenCalledWith({ limit: 20, offset: 20 });
+      });
+    });
+
+    it('fetches with new limit and resets offset when setPageSize is called', async () => {
+      listDids.mockResolvedValue(createPaginatedResponse([baseDid]));
+
+      render(
+        <DidProvider>
+          <TestComponent />
+        </DidProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      screen.getByTestId('set-page-size-btn').click();
+
+      await waitFor(() => {
+        expect(listDids).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+      });
+    });
+  });
+
+  describe('useDids', () => {
+    it('throws error when used outside DidProvider', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      function OutsideComponent() {
+        useDids();
+        return null;
+      }
+
+      expect(() => {
+        render(<OutsideComponent />);
+      }).toThrow('useDids must be used within a DidProvider');
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/packages/reference-implementation/src/contexts/did/DidContext.tsx
+++ b/packages/reference-implementation/src/contexts/did/DidContext.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { createContext, useContext, ReactNode } from 'react';
+import type { Did } from '@/lib/prisma/generated';
+import type { PaginationMeta } from '@/lib/api/pagination';
+import { listDids } from '@/lib/api/services/did.service';
+import { usePaginatedFetch } from '@/hooks/use-paginated-fetch';
+
+interface DidContextType {
+  dids: Did[];
+  managedDids: Did[];
+  selfManagedDids: Did[];
+  defaultDid: Did | null;
+  pagination: PaginationMeta | null;
+  isLoading: boolean;
+  error: Error | null;
+  refresh: () => void;
+  goToPage: (offset: number) => void;
+  setPageSize: (limit: number) => void;
+}
+
+const DidContext = createContext<DidContextType | undefined>(undefined);
+
+interface DidProviderProps {
+  children: ReactNode;
+}
+
+export function DidProvider({ children }: DidProviderProps) {
+  const {
+    data: dids,
+    pagination,
+    isLoading,
+    error,
+    refresh,
+    goToPage,
+    setPageSize,
+  } = usePaginatedFetch(({ limit, offset }) => listDids({ limit, offset }), { fetchOnMount: true });
+
+  const managedDids = dids.filter((d) => d.type === 'MANAGED');
+  const selfManagedDids = dids.filter((d) => d.type === 'SELF_MANAGED');
+  const defaultDid = dids.find((d) => d.isDefault) ?? null;
+
+  const value: DidContextType = {
+    dids,
+    managedDids,
+    selfManagedDids,
+    defaultDid,
+    pagination,
+    isLoading,
+    error,
+    refresh,
+    goToPage,
+    setPageSize,
+  };
+
+  return <DidContext.Provider value={value}>{children}</DidContext.Provider>;
+}
+
+export function useDids() {
+  const context = useContext(DidContext);
+  if (context === undefined) {
+    throw new Error('useDids must be used within a DidProvider');
+  }
+  return context;
+}

--- a/packages/reference-implementation/src/contexts/did/DidContext.tsx
+++ b/packages/reference-implementation/src/contexts/did/DidContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, useContext, useMemo, ReactNode } from 'react';
 import type { Did } from '@/lib/prisma/generated';
 import type { PaginationMeta } from '@/lib/api/pagination';
 import { listDids } from '@/lib/api/services/did.service';
@@ -36,22 +36,25 @@ export function DidProvider({ children }: DidProviderProps) {
     setPageSize,
   } = usePaginatedFetch(({ limit, offset }) => listDids({ limit, offset }), { fetchOnMount: true });
 
-  const managedDids = dids.filter((d) => d.type === 'MANAGED');
-  const selfManagedDids = dids.filter((d) => d.type === 'SELF_MANAGED');
-  const defaultDid = dids.find((d) => d.isDefault) ?? null;
+  const managedDids = useMemo(() => dids.filter((d) => d.type === 'MANAGED'), [dids]);
+  const selfManagedDids = useMemo(() => dids.filter((d) => d.type === 'SELF_MANAGED'), [dids]);
+  const defaultDid = useMemo(() => dids.find((d) => d.isDefault) ?? null, [dids]);
 
-  const value: DidContextType = {
-    dids,
-    managedDids,
-    selfManagedDids,
-    defaultDid,
-    pagination,
-    isLoading,
-    error,
-    refresh,
-    goToPage,
-    setPageSize,
-  };
+  const value: DidContextType = useMemo(
+    () => ({
+      dids,
+      managedDids,
+      selfManagedDids,
+      defaultDid,
+      pagination,
+      isLoading,
+      error,
+      refresh,
+      goToPage,
+      setPageSize,
+    }),
+    [dids, managedDids, selfManagedDids, defaultDid, pagination, isLoading, error, refresh, goToPage, setPageSize],
+  );
 
   return <DidContext.Provider value={value}>{children}</DidContext.Provider>;
 }

--- a/packages/reference-implementation/src/hooks/use-paginated-fetch.test.ts
+++ b/packages/reference-implementation/src/hooks/use-paginated-fetch.test.ts
@@ -1,0 +1,232 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import type { PaginatedResponse, PaginationMeta } from '@/lib/api/pagination';
+
+import { usePaginatedFetch } from './use-paginated-fetch';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockResponse<T>(data: T[], overrides?: Partial<PaginationMeta>): PaginatedResponse<T> {
+  return {
+    data,
+    pagination: {
+      total: data.length,
+      limit: 20,
+      offset: 0,
+      hasMore: false,
+      ...overrides,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('usePaginatedFetch', () => {
+  // -----------------------------------------------------------------------
+  // 1. Fetches on mount with defaults
+  // -----------------------------------------------------------------------
+  it('fetches on mount with default limit and offset', async () => {
+    const items = [{ id: 1 }, { id: 2 }];
+    const fetchFn = jest.fn().mockResolvedValue(createMockResponse(items));
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn));
+
+    // fetchFn should be called with defaults
+    expect(fetchFn).toHaveBeenCalledWith({ limit: 20, offset: 0 });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(items);
+    expect(result.current.pagination).toEqual(
+      expect.objectContaining({ total: 2, limit: 20, offset: 0, hasMore: false }),
+    );
+    expect(result.current.error).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Custom limit
+  // -----------------------------------------------------------------------
+  it('uses a custom limit when provided', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(createMockResponse([]));
+
+    renderHook(() => usePaginatedFetch(fetchFn, { limit: 50 }));
+
+    expect(fetchFn).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. fetchOnMount: false
+  // -----------------------------------------------------------------------
+  it('does not fetch on mount when fetchOnMount is false', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(createMockResponse([]));
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn, { fetchOnMount: false }));
+
+    // Should not have been called
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+
+    // Now call refresh — it should trigger a fetch
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Loading state
+  // -----------------------------------------------------------------------
+  it('sets isLoading to true during fetch and false after', async () => {
+    let resolveFetch!: (value: PaginatedResponse<{ id: number }>) => void;
+    const fetchFn = jest.fn().mockReturnValue(
+      new Promise<PaginatedResponse<{ id: number }>>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn));
+
+    // isLoading should become true once the effect fires
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    // Resolve the promise
+    await act(async () => {
+      resolveFetch(createMockResponse([{ id: 1 }]));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([{ id: 1 }]);
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Error handling
+  // -----------------------------------------------------------------------
+  it('sets error when fetchFn rejects with an Error', async () => {
+    const fetchFn = jest.fn().mockRejectedValue(new Error('Network failure'));
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('Network failure');
+    expect(result.current.data).toEqual([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. refresh()
+  // -----------------------------------------------------------------------
+  it('re-fetches with the same limit and offset when refresh is called', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(createMockResponse([{ id: 1 }]));
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    // Both calls should use the same params
+    expect(fetchFn).toHaveBeenNthCalledWith(1, { limit: 20, offset: 0 });
+    expect(fetchFn).toHaveBeenNthCalledWith(2, { limit: 20, offset: 0 });
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. goToPage()
+  // -----------------------------------------------------------------------
+  it('fetches with the given offset when goToPage is called', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(createMockResponse([{ id: 1 }], { total: 40, hasMore: true }));
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      result.current.goToPage(20);
+    });
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith({ limit: 20, offset: 20 });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 8. setPageSize()
+  // -----------------------------------------------------------------------
+  it('fetches with new limit and resets offset when setPageSize is called', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(createMockResponse([]));
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // First move to a non-zero offset
+    await act(async () => {
+      result.current.goToPage(40);
+    });
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith({ limit: 20, offset: 40 });
+    });
+
+    // Now change page size — offset should reset to 0
+    await act(async () => {
+      result.current.setPageSize(50);
+    });
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 9. Non-Error thrown
+  // -----------------------------------------------------------------------
+  it('wraps a non-Error thrown value in an Error', async () => {
+    const fetchFn = jest.fn().mockRejectedValue('something went wrong');
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchFn));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('something went wrong');
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/packages/reference-implementation/src/hooks/use-paginated-fetch.ts
+++ b/packages/reference-implementation/src/hooks/use-paginated-fetch.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+
+import type { PaginatedResponse, PaginationMeta } from '@/lib/api/pagination';
+import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type FetchFn<T> = (params: { limit: number; offset: number }) => Promise<PaginatedResponse<T>>;
+
+interface UsePaginatedFetchOptions {
+  /** Number of items per page. Defaults to `DEFAULT_PAGE_LIMIT`. */
+  limit?: number;
+  /** Whether to fetch immediately on mount. Defaults to `true`. */
+  fetchOnMount?: boolean;
+}
+
+interface PaginatedFetchState<T> {
+  data: T[];
+  pagination: PaginationMeta | null;
+  isLoading: boolean;
+  error: Error | null;
+  limit: number;
+  offset: number;
+  fetchVersion: number;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+type PaginatedFetchAction<T> =
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; data: T[]; pagination: PaginationMeta }
+  | { type: 'FETCH_ERROR'; error: Error }
+  | { type: 'SET_PAGE'; offset: number }
+  | { type: 'SET_PAGE_SIZE'; limit: number }
+  | { type: 'REFRESH' };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function reducer<T>(state: PaginatedFetchState<T>, action: PaginatedFetchAction<T>): PaginatedFetchState<T> {
+  switch (action.type) {
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null };
+
+    case 'FETCH_SUCCESS':
+      return {
+        ...state,
+        data: action.data,
+        pagination: action.pagination,
+        isLoading: false,
+      };
+
+    case 'FETCH_ERROR':
+      return { ...state, error: action.error, isLoading: false };
+
+    case 'SET_PAGE':
+      return { ...state, offset: action.offset };
+
+    case 'SET_PAGE_SIZE':
+      return { ...state, limit: action.limit, offset: 0 };
+
+    case 'REFRESH':
+      return { ...state, fetchVersion: state.fetchVersion + 1 };
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function usePaginatedFetch<T>(fetchFn: FetchFn<T>, options: UsePaginatedFetchOptions = {}) {
+  const { limit = DEFAULT_PAGE_LIMIT, fetchOnMount = true } = options;
+
+  const [state, dispatch] = useReducer(reducer<T>, {
+    data: [],
+    pagination: null,
+    isLoading: false,
+    error: null,
+    limit,
+    offset: 0,
+    fetchVersion: fetchOnMount ? 0 : -1,
+  });
+
+  // Keep fetchFn in a ref so callers don't need to memoise it.
+  const fetchFnRef = useRef(fetchFn);
+  fetchFnRef.current = fetchFn;
+
+  useEffect(() => {
+    if (state.fetchVersion < 0) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const performFetch = async () => {
+      dispatch({ type: 'FETCH_START' });
+
+      try {
+        const result = await fetchFnRef.current({
+          limit: state.limit,
+          offset: state.offset,
+        });
+
+        if (!cancelled) {
+          dispatch({
+            type: 'FETCH_SUCCESS',
+            data: result.data,
+            pagination: result.pagination,
+          });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          dispatch({
+            type: 'FETCH_ERROR',
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        }
+      }
+    };
+
+    performFetch();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [state.limit, state.offset, state.fetchVersion]);
+
+  const refresh = useCallback(() => dispatch({ type: 'REFRESH' }), []);
+
+  const goToPage = useCallback((offset: number) => dispatch({ type: 'SET_PAGE', offset }), []);
+
+  const setPageSize = useCallback((newLimit: number) => dispatch({ type: 'SET_PAGE_SIZE', limit: newLimit }), []);
+
+  return {
+    data: state.data,
+    pagination: state.pagination,
+    isLoading: state.isLoading,
+    error: state.error,
+    refresh,
+    goToPage,
+    setPageSize,
+  };
+}

--- a/packages/reference-implementation/src/hooks/use-paginated-fetch.ts
+++ b/packages/reference-implementation/src/hooks/use-paginated-fetch.ts
@@ -84,7 +84,7 @@ export function usePaginatedFetch<T>(fetchFn: FetchFn<T>, options: UsePaginatedF
   const [state, dispatch] = useReducer(reducer<T>, {
     data: [],
     pagination: null,
-    isLoading: false,
+    isLoading: fetchOnMount,
     error: null,
     limit,
     offset: 0,


### PR DESCRIPTION
This PR adds a shared DID context provider so that any protected page can access the tenant's decentralised identifiers without duplicating fetch logic. It introduces a reusable `usePaginatedFetch` hook (backed by `useReducer`) that manages paginated API responses, then builds a `DidProvider` on top of it that exposes categorised DID lists (`managedDids`, `selfManagedDids`, `defaultDid`), loading/error state, and pagination controls via a `useDids()` hook.

The `DidProvider` is placed inside `ProtectedContent` in the `(protected)` layout, so it only mounts after authentication is confirmed, avoiding unnecessary 401 requests. Context values are memoised to prevent unnecessary re-renders of consumers.

## Changes

- **`src/hooks/use-paginated-fetch.ts`**: Generic hook accepting a fetch function and options (`limit`, `fetchOnMount`). Uses `useReducer` for atomic state transitions across `data`, `pagination`, `isLoading`, `error`, `limit`, `offset`, and `fetchVersion`. Exposes `refresh()`, `goToPage()`, and `setPageSize()`.
- **`src/contexts/did/DidContext.tsx`**: Thin provider wrapping `usePaginatedFetch` with `listDids`, deriving filtered lists via `useMemo`.
- **`src/app/(protected)/layout.tsx`**: Wraps page children with `DidProvider` inside the authenticated content gate.
- **`docs/adr/`**: Records the architectural decision for the paginated fetch hook pattern.

## Test plan

- [x] `usePaginatedFetch` hook: 9 tests covering mount fetch, custom limit, `fetchOnMount: false`, loading state transitions, error handling, refresh, `goToPage`, `setPageSize`, and non-Error wrapping
- [x] `DidContext`: 9 tests covering mount fetch, DID categorisation (managed/self-managed/default), null default DID, loading state with empty arrays, error state, refresh, pagination controls, and `useDids()` outside provider guard
- [x] Full RI test suite: all 1094 existing tests pass (18 new tests added)