### PR TITLE
fix(api): audit and fix credentials API routes

### DIFF
--- a/e2e/cypress/e2e/api/credential_api/credential-management.cy.ts
+++ b/e2e/cypress/e2e/api/credential_api/credential-management.cy.ts
@@ -123,9 +123,7 @@ describe('Credential API', { testIsolation: false }, () => {
       cy.request(`/api/v1/credentials/${encryptedCredentialId}`).then(
         (response) => {
           expect(response.status).to.eq(200);
-          expect(response.body.credential).to.exist;
-
-          const cred = response.body.credential;
+          const cred = response.body;
           expect(cred.id).to.eq(encryptedCredentialId);
           expect(cred.storageUri).to.be.a('string');
           expect(cred.hash).to.be.a('string');
@@ -162,7 +160,7 @@ describe('Credential API', { testIsolation: false }, () => {
       cy.request(`/api/v1/credentials/${unencryptedCredentialId}`).then(
         (response) => {
           expect(response.status).to.eq(200);
-          expect(response.body.credential.decryptionKey).to.be.null;
+          expect(response.body.decryptionKey).to.be.null;
         },
       );
     });
@@ -188,7 +186,7 @@ describe('Credential API', { testIsolation: false }, () => {
       cy.request(`/api/v1/credentials/${publishedCredentialId}`).then(
         (response) => {
           expect(response.status).to.eq(200);
-          expect(response.body.credential).to.exist;
+          expect(response.body.id).to.eq(publishedCredentialId);
         },
       );
     });
@@ -349,6 +347,49 @@ describe('Credential API', { testIsolation: false }, () => {
         expect(response.status).to.eq(400);
       });
     });
+
+    it('returns 400 for invalid JSON body', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 when credentialType is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+          version: '0.6.1',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 when version is missing', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+          credentialType: 'DigitalProductPassport',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -361,11 +402,12 @@ describe('Credential API', { testIsolation: false }, () => {
 
         // Paginated response shape
         expect(response.body.data).to.be.an('array');
+        expect(response.body).to.not.have.property('ok');
         expect(response.body.pagination).to.exist;
         expect(response.body.pagination.total).to.be.a('number');
         expect(response.body.pagination.limit).to.eq(20);
         expect(response.body.pagination.offset).to.eq(0);
-        expect(response.body.pagination).to.have.property('hasMore');
+        expect(response.body.pagination.hasMore).to.be.a('boolean');
 
         // Should contain at least the credentials issued earlier in the suite
         expect(response.body.data.length).to.be.at.least(2);
@@ -469,6 +511,17 @@ describe('Credential API', { testIsolation: false }, () => {
       cy.request({
         method: 'GET',
         url: '/api/v1/credentials?offset=-1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('GET /api/v1/credentials?limit=abc — returns 400 for non-numeric limit', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/credentials?limit=abc',
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);

--- a/e2e/cypress/e2e/api/credential_api/credential-verify-page.cy.ts
+++ b/e2e/cypress/e2e/api/credential_api/credential-verify-page.cy.ts
@@ -121,7 +121,7 @@ describe('Verify Page', { testIsolation: false }, () => {
         const credId = response.body.credentialId;
 
         cy.request(`/api/v1/credentials/${credId}`).then((res) => {
-          const cred = res.body.credential;
+          const cred = res.body;
           unencryptedUri = cred.storageUri;
           unencryptedHash = cred.hash;
         });
@@ -142,7 +142,7 @@ describe('Verify Page', { testIsolation: false }, () => {
         const credId = response.body.credentialId;
 
         cy.request(`/api/v1/credentials/${credId}`).then((res) => {
-          const cred = res.body.credential;
+          const cred = res.body;
           encryptedUri = cred.storageUri;
           encryptedHash = cred.hash;
           encryptedKey = cred.decryptionKey;

--- a/e2e/cypress/e2e/api/credential_api/credential-verify.cy.ts
+++ b/e2e/cypress/e2e/api/credential_api/credential-verify.cy.ts
@@ -112,7 +112,7 @@ describe('Credential Verify API', { testIsolation: false }, () => {
         const credId = response.body.credentialId;
 
         cy.request(`/api/v1/credentials/${credId}`).then((res) => {
-          const cred = res.body.credential;
+          const cred = res.body;
           unencryptedUri = cred.storageUri;
           unencryptedHash = cred.hash;
         });
@@ -133,7 +133,7 @@ describe('Credential Verify API', { testIsolation: false }, () => {
         const credId = response.body.credentialId;
 
         cy.request(`/api/v1/credentials/${credId}`).then((res) => {
-          const cred = res.body.credential;
+          const cred = res.body;
           encryptedUri = cred.storageUri;
           encryptedHash = cred.hash;
           encryptedKey = cred.decryptionKey;
@@ -239,6 +239,31 @@ describe('Credential Verify API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
+      });
+    });
+
+    it('returns 400 for invalid decryptionKey format', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: { uri: unencryptedUri, decryptionKey: 'too-short' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    it('returns 400 for invalid JSON body', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials/verify',
+        body: 'not valid json',
+        headers: { 'Content-Type': 'application/json' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.be.a('string');
       });
     });
   });

--- a/packages/reference-implementation/src/app/api/v1/credentials/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/[id]/route.test.ts
@@ -1,0 +1,137 @@
+// Mock next/server before importing route handlers (jsdom lacks Request/Response)
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// Mock withTenantAuth — mirrors handleRouteError behaviour inline to avoid
+// import issues with mocked modules
+jest.mock('@/lib/api/with-tenant-auth', () => {
+  const { NotFoundError, errorMessage } = jest.requireActual('@/lib/api/errors');
+  const { ValidationError } = jest.requireActual('@/lib/api/validation');
+
+  function jsonResponse(body: unknown, init?: { status?: number }) {
+    return { status: init?.status ?? 200, json: async () => body };
+  }
+
+  return {
+    withTenantAuth:
+      (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
+        try {
+          return await handler(req, ctx);
+        } catch (e: unknown) {
+          if (e instanceof ValidationError) return jsonResponse({ error: (e as Error).message }, { status: 400 });
+          if (e instanceof NotFoundError) return jsonResponse({ error: (e as Error).message }, { status: 404 });
+          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        }
+      },
+  };
+});
+
+// Suppress logger output in tests
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: {
+    child: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+// Mock repository
+const mockGetCredentialById = jest.fn();
+jest.mock('@/lib/prisma/repositories', () => ({
+  getCredentialById: (...args: unknown[]) => mockGetCredentialById(...args),
+}));
+
+// Import handler after mocks are in place
+import { GET } from './route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createFakeRequest(): Request {
+  return {
+    method: 'GET',
+    url: 'http://localhost/api/v1/credentials/cred-1',
+    headers: new Headers(),
+  } as unknown as Request;
+}
+
+const AUTH_CONTEXT = { tenantId: 'tenant-1', params: Promise.resolve({ id: 'cred-1' }) };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/credentials/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // --- Happy path -----------------------------------------------------------
+
+  it('returns 200 with the credential object directly', async () => {
+    const credential = {
+      id: 'cred-1',
+      type: 'DigitalProductPassport',
+      vcData: { some: 'data' },
+      organisationId: 'tenant-1',
+    };
+    mockGetCredentialById.mockResolvedValue(credential);
+
+    const res = (await GET(createFakeRequest(), AUTH_CONTEXT)) as { status: number; json: () => Promise<unknown> };
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(credential);
+  });
+
+  it('calls getCredentialById with correct id and tenantId', async () => {
+    mockGetCredentialById.mockResolvedValue({ id: 'cred-1' });
+
+    await GET(createFakeRequest(), AUTH_CONTEXT);
+
+    expect(mockGetCredentialById).toHaveBeenCalledTimes(1);
+    expect(mockGetCredentialById).toHaveBeenCalledWith('cred-1', 'tenant-1');
+  });
+
+  // --- Error paths ----------------------------------------------------------
+
+  it('returns 404 when getCredentialById returns null', async () => {
+    mockGetCredentialById.mockResolvedValue(null);
+
+    const res = (await GET(createFakeRequest(), AUTH_CONTEXT)) as { status: number; json: () => Promise<unknown> };
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Credential not found' });
+  });
+
+  it('returns 500 when repository throws', async () => {
+    mockGetCredentialById.mockRejectedValue(new Error('DB connection lost'));
+
+    const res = (await GET(createFakeRequest(), AUTH_CONTEXT)) as { status: number; json: () => Promise<unknown> };
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'DB connection lost' });
+  });
+
+  // --- Tenant isolation -----------------------------------------------------
+
+  it('passes tenantId from context to repository for tenant isolation', async () => {
+    const ctx = { tenantId: 'other-tenant', params: Promise.resolve({ id: 'cred-99' }) };
+    mockGetCredentialById.mockResolvedValue({ id: 'cred-99' });
+
+    await GET(createFakeRequest(), ctx);
+
+    expect(mockGetCredentialById).toHaveBeenCalledWith('cred-99', 'other-tenant');
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/credentials/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/[id]/route.ts
@@ -27,31 +27,7 @@ const logger = apiLogger.child({ route: '/api/v1/credentials/[id]' });
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 credential:
- *                   type: object
- *                   properties:
- *                     id:
- *                       type: string
- *                     storageUri:
- *                       type: string
- *                     hash:
- *                       type: string
- *                     credentialType:
- *                       type: string
- *                     decryptionKey:
- *                       type: string
- *                       nullable: true
- *                       description: Decryption key for encrypted credentials (null if unencrypted)
- *                     isPublished:
- *                       type: boolean
- *                     createdAt:
- *                       type: string
- *                       format: date-time
- *                     updatedAt:
- *                       type: string
- *                       format: date-time
+ *               $ref: '#/components/schemas/Credential'
  *       401:
  *         description: Unauthorised — missing or invalid authentication
  *         content:
@@ -73,12 +49,14 @@ const logger = apiLogger.child({ route: '/api/v1/credentials/[id]' });
  */
 export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ tenantId, credentialId: id }, 'Looking up credential');
+  logger.info({ credentialId: id }, 'Looking up credential');
 
   const credential = await getCredentialById(id, tenantId);
   if (!credential) {
     throw new NotFoundError('Credential not found');
   }
 
-  return NextResponse.json({ credential });
+  logger.info({ credentialId: credential.id }, 'Credential retrieved');
+
+  return NextResponse.json(credential);
 });

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -107,6 +107,15 @@ jest.mock('@/lib/prisma/repositories', () => ({
   listCredentials: (...args: unknown[]) => mockListCredentials(...args),
 }));
 
+const mockAssertPublicUrl = jest.fn();
+jest.mock('@/lib/api/validation', () => {
+  const actual = jest.requireActual('@/lib/api/validation');
+  return {
+    ...actual,
+    assertPublicUrl: (...args: unknown[]) => mockAssertPublicUrl(...args),
+  };
+});
+
 const mockValidateCvcCompliance = jest.fn();
 jest.mock('@/lib/services/cvc-validation.service', () => ({
   validateCvcCompliance: (...args: unknown[]) => mockValidateCvcCompliance(...args),
@@ -220,6 +229,7 @@ function setupHappyPath() {
 describe('POST /api/v1/credentials', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
     setupHappyPath();
   });
 
@@ -276,6 +286,85 @@ describe('POST /api/v1/credentials', () => {
 
       expect(res.status).toBe(400);
       expect(json.error).toContain('version is required');
+    });
+  });
+
+  // ── SSRF validation ──────────────────────────────────────────────────
+
+  describe('SSRF validation', () => {
+    it('calls assertPublicUrl for machineVerificationUrl when SSRF protection enabled', async () => {
+      delete process.env.VERIFY_ALLOW_PRIVATE_URLS;
+      mockAssertPublicUrl.mockResolvedValue(undefined);
+
+      const req = createFakeRequest(
+        validBody({
+          publishingOptions: {
+            machineVerificationUrl: 'https://verify.example.com/api',
+          },
+        }),
+      );
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockAssertPublicUrl).toHaveBeenCalledWith(
+        'https://verify.example.com/api',
+        'publishingOptions.machineVerificationUrl',
+      );
+    });
+
+    it('calls assertPublicUrl for humanVerificationUrl when SSRF protection enabled', async () => {
+      delete process.env.VERIFY_ALLOW_PRIVATE_URLS;
+      mockAssertPublicUrl.mockResolvedValue(undefined);
+
+      const req = createFakeRequest(
+        validBody({
+          publishingOptions: {
+            humanVerificationUrl: 'https://verify.example.com/ui',
+          },
+        }),
+      );
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockAssertPublicUrl).toHaveBeenCalledWith(
+        'https://verify.example.com/ui',
+        'publishingOptions.humanVerificationUrl',
+      );
+    });
+
+    it('returns 400 when machineVerificationUrl is a private address', async () => {
+      delete process.env.VERIFY_ALLOW_PRIVATE_URLS;
+      const { ValidationError: VE } = jest.requireActual('@/lib/api/validation');
+      mockAssertPublicUrl.mockRejectedValue(
+        new VE('publishingOptions.machineVerificationUrl must not point to a private or reserved network address'),
+      );
+
+      const req = createFakeRequest(
+        validBody({
+          publishingOptions: {
+            machineVerificationUrl: 'http://127.0.0.1:3000/verify',
+          },
+        }),
+      );
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('private or reserved');
+    });
+
+    it('skips SSRF validation when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
+      process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+
+      const req = createFakeRequest(
+        validBody({
+          publishingOptions: {
+            machineVerificationUrl: 'http://127.0.0.1:3000/verify',
+            humanVerificationUrl: 'http://127.0.0.1:3000/ui',
+          },
+        }),
+      );
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockAssertPublicUrl).not.toHaveBeenCalled();
     });
   });
 
@@ -694,6 +783,38 @@ describe('POST /api/v1/credentials', () => {
         machineVerificationUrl: 'https://verify.example.com/api',
         humanVerificationUrl: 'https://verify.example.com/ui',
       });
+    });
+
+    it('passes qualifierPath to publishLinks when provided', async () => {
+      setupPublishingHappyPath();
+
+      const req = createFakeRequest(
+        validBody({ publishingOptions: { publish: true, qualifierPath: '/10/LOT123/21/SER456' } }),
+      );
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockPublishLinks).toHaveBeenCalledWith(
+        'gtin',
+        '09506000134352',
+        expect.any(Array),
+        '/10/LOT123/21/SER456',
+        expect.objectContaining({ namespace: 'gs1' }),
+      );
+    });
+
+    it('defaults qualifierPath to / when not provided', async () => {
+      setupPublishingHappyPath();
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockPublishLinks).toHaveBeenCalledWith(
+        'gtin',
+        '09506000134352',
+        expect.any(Array),
+        '/',
+        expect.objectContaining({ namespace: 'gs1' }),
+      );
     });
 
     it('skips publishing when publish not requested', async () => {

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -5,6 +5,7 @@ import {
   parsePositiveInt,
   parseNonNegativeInt,
   parseBooleanString,
+  assertPublicUrl,
 } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
@@ -58,6 +59,12 @@ const logger = apiLogger.child({ route: '/api/v1/credentials' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Data model or service instance not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised
  *         content:
@@ -87,11 +94,13 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       publish?: boolean;
       linkType?: string;
       linkTitle?: string;
+      qualifierPath?: string;
       machineVerificationUrl?: string;
       humanVerificationUrl?: string;
     };
   };
 
+  logger.info('Parsing request body');
   try {
     body = await req.json();
   } catch {
@@ -100,6 +109,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   // ── Step 1: Validate request ────────────────────────────────────────────
 
+  logger.info('Validating input parameters');
   if (!body.credentialPayload || typeof body.credentialPayload !== 'object') {
     throw new ValidationError('credentialPayload is required and must be an object');
   }
@@ -117,12 +127,24 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   const storageOptions = body.storageOptions ?? {};
   const publishingOptions = body.publishingOptions ?? {};
 
+  // ── SSRF validation for URL fields ────────────────────────────────────
+  if (process.env.VERIFY_ALLOW_PRIVATE_URLS !== 'true') {
+    if (publishingOptions.machineVerificationUrl) {
+      await assertPublicUrl(publishingOptions.machineVerificationUrl, 'publishingOptions.machineVerificationUrl');
+    }
+    if (publishingOptions.humanVerificationUrl) {
+      await assertPublicUrl(publishingOptions.humanVerificationUrl, 'publishingOptions.humanVerificationUrl');
+    }
+  }
+
   // ── Step 2: Resolve data model ──────────────────────────────────────────
 
+  logger.info({ credentialType, version }, 'Resolving data model');
   const { dataModel, bridge, schemaUrls } = await resolveDataModel(tenantId, credentialType, version);
 
   // ── Step 3: Validate payload ────────────────────────────────────────────
 
+  logger.info('Validating credential payload against schema');
   await validateCredentialPayload(credentialPayload, schemaUrls);
 
   // ── Step 3.5: CVC validation (advisory) ─────────────────────────────
@@ -135,7 +157,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     const subject = credentialPayload.credentialSubject as Record<string, unknown>;
     refs = bridge.extractRefs(subject);
   } catch (error) {
-    logger.error({ err: error, tenantId, credentialType }, 'Reference extraction failed');
+    logger.error({ err: error, credentialType }, 'Reference extraction failed');
     cvcWarnings = [
       {
         code: 'CVC_VALIDATION_ERROR' as const,
@@ -156,7 +178,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       const result = await validateCvcCompliance(tenantId, refs.conformity);
       cvcWarnings = result.warnings;
     } catch (error) {
-      logger.error({ err: error, tenantId, credentialType }, 'CVC compliance validation failed');
+      logger.error({ err: error, credentialType }, 'CVC compliance validation failed');
       cvcWarnings = [
         {
           code: 'CVC_VALIDATION_ERROR' as const,
@@ -168,11 +190,13 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   // ── Step 4: Resolve services ────────────────────────────────────────────
 
+  logger.info('Resolving VC and storage services');
   const vcService = await resolveVcService(tenantId, signingOptions.serviceInstanceId);
   const storageService = await resolveStorageService(tenantId, storageOptions.serviceInstanceId);
 
   // ── Step 5: Issue credential ────────────────────────────────────────────
 
+  logger.info({ credentialType }, 'Issuing credential');
   const { credentialId, storageResponse, primaryEntity } = await issueCredential({
     tenantId,
     credentialPayload,
@@ -187,9 +211,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 
   if (publishingOptions.publish === true) {
     if (!primaryEntity.schemePrimaryKey || !primaryEntity.schemeNamespace) {
-      logger.warn({ tenantId, credentialId }, 'Publishing requested but entity has no scheme configuration — skipping');
+      logger.warn({ credentialId }, 'Publishing requested but entity has no scheme configuration — skipping');
     } else if (!primaryEntity.primaryIdentifier) {
-      logger.warn({ tenantId, credentialId }, 'Publishing requested but no primary identifier resolved — skipping');
+      logger.warn({ credentialId }, 'Publishing requested but no primary identifier resolved — skipping');
     } else {
       // Resolve IDR service outside try-catch — config failures should be fatal
       const idrService = await resolveIdrService(tenantId, primaryEntity.schemeIdrServiceInstanceId);
@@ -202,7 +226,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       });
 
       logger.info(
-        { tenantId, idrInstanceId: idrService.instanceId, primaryIdentifier: primaryEntity.primaryIdentifier },
+        { idrInstanceId: idrService.instanceId, primaryIdentifier: primaryEntity.primaryIdentifier },
         'Publishing credential to IDR',
       );
 
@@ -211,7 +235,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
           primaryEntity.schemePrimaryKey,
           primaryEntity.primaryIdentifier,
           links,
-          '/',
+          publishingOptions.qualifierPath || '/',
           {
             namespace: primaryEntity.schemeNamespace,
             itemDescription: linkTitle,
@@ -220,7 +244,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         logger.error(
-          { err: error, tenantId, credentialId, scheme: primaryEntity.schemePrimaryKey },
+          { err: error, credentialId, scheme: primaryEntity.schemePrimaryKey },
           'Failed to publish credential to IDR',
         );
         cvcWarnings.push({
@@ -236,6 +260,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     }
   }
 
+  logger.info({ credentialId }, 'Credential issued successfully');
   const response: Record<string, unknown> = { credentialId };
   if (cvcWarnings.length > 0) response.warnings = cvcWarnings;
   return NextResponse.json(response, { status: 201 });
@@ -272,7 +297,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         schema:
  *           type: integer
  *           minimum: 1
- *           default: 100
+ *           default: 20
  *         description: Maximum number of results
  *       - in: query
  *         name: offset

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -59,14 +59,14 @@ const logger = apiLogger.child({ route: '/api/v1/credentials' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
- *       404:
- *         description: Data model or service instance not found
+ *       401:
+ *         description: Unauthorised
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
- *       401:
- *         description: Unauthorised
+ *       404:
+ *         description: Data model or service instance not found
  *         content:
  *           application/json:
  *             schema:
@@ -103,7 +103,8 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   logger.info('Parsing request body');
   try {
     body = await req.json();
-  } catch {
+  } catch (e) {
+    logger.warn({ err: e }, 'Failed to parse request body as JSON');
     throw new ValidationError('Invalid JSON body');
   }
 
@@ -161,7 +162,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     cvcWarnings = [
       {
         code: 'CVC_VALIDATION_ERROR' as const,
-        message: 'Failed to extract references from credential payload',
+        message: publishingOptions.publish
+          ? 'Failed to extract references from credential payload — publishing will be skipped'
+          : 'Failed to extract references from credential payload',
       },
     ];
   }
@@ -212,8 +215,16 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   if (publishingOptions.publish === true) {
     if (!primaryEntity.schemePrimaryKey || !primaryEntity.schemeNamespace) {
       logger.warn({ credentialId }, 'Publishing requested but entity has no scheme configuration — skipping');
+      cvcWarnings.push({
+        code: 'PUBLISH_SKIPPED' as const,
+        message: 'Publishing was requested but the entity has no identity scheme configuration',
+      });
     } else if (!primaryEntity.primaryIdentifier) {
       logger.warn({ credentialId }, 'Publishing requested but no primary identifier resolved — skipping');
+      cvcWarnings.push({
+        code: 'PUBLISH_SKIPPED' as const,
+        message: 'Publishing was requested but no primary identifier could be resolved from the credential payload',
+      });
     } else {
       // Resolve IDR service outside try-catch — config failures should be fatal
       const idrService = await resolveIdrService(tenantId, primaryEntity.schemeIdrServiceInstanceId);
@@ -253,9 +264,19 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
         });
       }
 
-      // Update published state outside try-catch — DB failure after successful publish is a separate concern
       if (!cvcWarnings.some((w) => w.code === 'IDR_PUBLISH_FAILED')) {
-        await updateCredentialPublished(credentialId, tenantId, true);
+        try {
+          await updateCredentialPublished(credentialId, tenantId, true);
+        } catch (error) {
+          logger.error(
+            { err: error, credentialId },
+            'Failed to update published status — credential was published to IDR but DB record is stale',
+          );
+          cvcWarnings.push({
+            code: 'DB_STATUS_UPDATE_FAILED' as const,
+            message: 'Credential was published to IDR but the published status could not be saved',
+          });
+        }
       }
     }
   }

--- a/packages/reference-implementation/src/lib/api/validation.test.ts
+++ b/packages/reference-implementation/src/lib/api/validation.test.ts
@@ -165,11 +165,13 @@ describe('assertPublicUrl', () => {
     );
   });
 
-  it('re-throws unexpected errors from validatePublicUrl', async () => {
+  it('wraps unexpected errors from validatePublicUrl in ValidationError', async () => {
     mockValidatePublicUrl.mockRejectedValue(new TypeError('Unexpected internal error'));
 
-    await expect(assertPublicUrl('https://example.com/test', 'schemaUrl')).rejects.toThrow(TypeError);
-    await expect(assertPublicUrl('https://example.com/test', 'schemaUrl')).rejects.toThrow('Unexpected internal error');
+    await expect(assertPublicUrl('https://example.com/test', 'schemaUrl')).rejects.toThrow(ValidationError);
+    await expect(assertPublicUrl('https://example.com/test', 'schemaUrl')).rejects.toThrow(
+      /schemaUrl could not be validated: Unexpected internal error/,
+    );
   });
 
   it('resolves without throwing for a valid public URL', async () => {

--- a/packages/reference-implementation/src/lib/api/validation.ts
+++ b/packages/reference-implementation/src/lib/api/validation.ts
@@ -95,6 +95,8 @@ export async function assertPublicUrl(url: string, paramName: string): Promise<v
     if (e instanceof Error && e.message.includes('private or reserved')) {
       throw new ValidationError(`${paramName} must not point to a private or reserved network address`);
     }
-    throw e;
+    throw new ValidationError(
+      `${paramName} could not be validated: ${e instanceof Error ? e.message : 'unexpected error'}`,
+    );
   }
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/cvc.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/cvc.repository.ts
@@ -38,7 +38,7 @@ export async function importCatalogue(input: ImportCatalogueInput): Promise<Impo
   const { tenantId, canonicalId, name, sourceUrl, specVersion, metadata, schemes } = input;
 
   return prisma.$transaction(
-    async (tx) => {
+    async (tx: Prisma.TransactionClient) => {
       // Delete existing catalogue for the same canonicalId + tenantId
       await tx.cvcCatalogue.deleteMany({
         where: { canonicalId, tenantId },
@@ -105,7 +105,7 @@ export async function importCatalogue(input: ImportCatalogueInput): Promise<Impo
           specVersion,
           metadata: metadata as Prisma.InputJsonValue | undefined,
           schemes: {
-            create: schemes.map((scheme) => ({
+            create: schemes.map((scheme: ImportCatalogueInput['schemes'][0]) => ({
               canonicalId: scheme.canonicalId,
               tenantId,
               name: scheme.name,
@@ -113,7 +113,7 @@ export async function importCatalogue(input: ImportCatalogueInput): Promise<Impo
               description: scheme.description,
               metadata: scheme.metadata as Prisma.InputJsonValue | undefined,
               profiles: {
-                create: scheme.profiles.map((profile) => {
+                create: scheme.profiles.map((profile: ImportCatalogueInput['schemes'][0]['profiles'][0]) => {
                   profileCount++;
                   return {
                     canonicalId: profile.canonicalId,
@@ -140,19 +140,23 @@ export async function importCatalogue(input: ImportCatalogueInput): Promise<Impo
       // Create ProfileCriterion join rows
       for (const scheme of catalogue.schemes) {
         for (const profile of scheme.profiles) {
-          const inputScheme = schemes.find((s) => s.canonicalId === scheme.canonicalId);
+          const inputScheme = schemes.find(
+            (s: ImportCatalogueInput['schemes'][0]) => s.canonicalId === scheme.canonicalId,
+          );
           if (!inputScheme) {
             throw new Error(`Import consistency error: no input scheme for canonicalId "${scheme.canonicalId}"`);
           }
 
-          const inputProfile = inputScheme.profiles.find((p) => p.canonicalId === profile.canonicalId);
+          const inputProfile = inputScheme.profiles.find(
+            (p: ImportCatalogueInput['schemes'][0]['profiles'][0]) => p.canonicalId === profile.canonicalId,
+          );
           if (!inputProfile) {
             throw new Error(`Import consistency error: no input profile for canonicalId "${profile.canonicalId}"`);
           }
 
           if (inputProfile.criteria.length > 0) {
             await tx.profileCriterion.createMany({
-              data: inputProfile.criteria.map((c) => {
+              data: inputProfile.criteria.map((c: ImportCatalogueInput['schemes'][0]['profiles'][0]['criteria'][0]) => {
                 const criterionId = criterionIdMap.get(c.canonicalId);
                 if (criterionId === undefined) {
                   throw new Error(`Import consistency error: no criterion ID for canonicalId "${c.canonicalId}"`);
@@ -186,7 +190,7 @@ export async function importCatalogue(input: ImportCatalogueInput): Promise<Impo
 // ---------------------------------------------------------------------------
 
 export async function deleteCatalogue(id: string, tenantId: string): Promise<void> {
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.cvcCatalogue.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -85,7 +85,7 @@ export type ListDataModelOptions = {
 export async function createDataModel(tenantId: string, input: CreateDataModelInput): Promise<DataModelWithRelations> {
   const isExtension = input.isExtension ?? true;
 
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     if (isExtension) {
       if (!input.parentConfigId) {
         throw new ValidationError('parentConfigId is required for extension configs');
@@ -186,7 +186,7 @@ export async function updateDataModel(
   tenantId: string,
   input: UpdateDataModelInput,
 ): Promise<DataModelWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.dataModel.findFirst({
       where: { id, tenantId, isExtension: true },
     });
@@ -214,7 +214,7 @@ export async function updateDataModel(
  * System-provisioned and core configs cannot be removed by tenants.
  */
 export async function deleteDataModel(id: string, tenantId: string): Promise<void> {
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.dataModel.findFirst({
       where: { id, tenantId, isExtension: true },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -60,7 +60,7 @@ export async function createDid(input: CreateDidInput): Promise<Did> {
   };
 
   if (input.isDefault) {
-    return prisma.$transaction(async (tx) => {
+    return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.did.updateMany({
         where: {
           tenantId: input.tenantId,
@@ -159,10 +159,10 @@ export async function listDids(
     prisma.did.count({ where }),
   ]);
 
-  const tenantHasDefault = data.some((d) => d.isDefault && d.type !== 'DEFAULT');
+  const tenantHasDefault = data.some((d: Did) => d.isDefault && d.type !== 'DEFAULT');
   if (tenantHasDefault) {
     return {
-      data: data.map((d) => (d.type === 'DEFAULT' && d.isDefault ? { ...d, isDefault: false } : d)),
+      data: data.map((d: Did) => (d.type === 'DEFAULT' && d.isDefault ? { ...d, isDefault: false } : d)),
       total,
     };
   }
@@ -177,7 +177,7 @@ export async function listDids(
  * (excluding system DEFAULT type DIDs) within the same transaction.
  */
 export async function updateDid(id: string, tenantId: string, input: UpdateDidInput): Promise<Did> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.did.findFirst({
       where: { id, tenantId },
     });
@@ -218,7 +218,7 @@ export async function updateDid(id: string, tenantId: string, input: UpdateDidIn
  * Validates that the DID belongs to the specified organisation.
  */
 export async function updateDidStatus(id: string, tenantId: string, status: DidStatus): Promise<Did> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.did.findFirst({
       where: { id, tenantId },
     });
@@ -239,7 +239,7 @@ export async function updateDidStatus(id: string, tenantId: string, status: DidS
  * Validates that the DID exists and belongs to the specified organisation.
  */
 export async function deleteDid(id: string, tenantId: string): Promise<void> {
-  await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.did.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
@@ -101,7 +101,7 @@ export async function createFacilities(
   tenantId: string,
   inputs: CreateFacilityInput[],
 ): Promise<FacilityWithRelations[]> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const results: FacilityWithRelations[] = [];
 
     for (const input of inputs) {
@@ -145,7 +145,7 @@ export async function createFacilities(
           ...(secondaryIdentifierIds?.length && {
             secondaryIdentifiers: {
               createMany: {
-                data: secondaryIdentifierIds.map((identifierId) => ({ identifierId })),
+                data: secondaryIdentifierIds.map((identifierId: string) => ({ identifierId })),
               },
             },
           }),
@@ -214,9 +214,9 @@ export async function listFacilities(
     prisma.facility.count({ where }),
   ]);
 
-  const data: FacilityListItem[] = rows.map(({ secondaryIdentifiers, ...rest }) => ({
+  const data: FacilityListItem[] = rows.map(({ secondaryIdentifiers, ...rest }: FacilityListRow) => ({
     ...rest,
-    secondaryIdentifierIds: secondaryIdentifiers.map((si) => si.identifierId),
+    secondaryIdentifierIds: secondaryIdentifiers.map((si: { identifierId: string }) => si.identifierId),
   }));
 
   return { data, total };
@@ -231,7 +231,7 @@ export async function updateFacility(
   tenantId: string,
   input: UpdateFacilityInput,
 ): Promise<FacilityWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.facility.findFirst({
       where: { id, tenantId },
     });
@@ -273,7 +273,7 @@ export async function updateFacility(
       });
       if (secondaryIdentifierIds.length > 0) {
         await tx.facilitySecondaryIdentifier.createMany({
-          data: secondaryIdentifierIds.map((identifierId) => ({
+          data: secondaryIdentifierIds.map((identifierId: string) => ({
             facilityId: id,
             identifierId,
           })),
@@ -330,7 +330,7 @@ export async function getFacilityByIdentifierValue(
  * Deletes a facility. Validates tenant ownership before deletion.
  */
 export async function deleteFacility(id: string, tenantId: string): Promise<Facility> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.facility.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
@@ -43,6 +43,8 @@ export type UpdateIdentifierSchemeInput = {
 /**
  * Options for listing identifier schemes
  */
+type QualifierInput = { key: string; description: string; validationPattern: string; order?: number };
+
 export type ListIdentifierSchemesOptions = {
   registrarId?: string;
   limit?: number;
@@ -64,7 +66,7 @@ export async function createIdentifierScheme(input: CreateIdentifierSchemeInput)
       idrServiceInstanceId: input.idrServiceInstanceId,
       ...(input.qualifiers && {
         qualifiers: {
-          create: input.qualifiers.map((q) => ({
+          create: input.qualifiers.map((q: QualifierInput) => ({
             key: q.key,
             description: q.description,
             validationPattern: q.validationPattern,
@@ -142,7 +144,7 @@ export async function updateIdentifierScheme(
   tenantId: string,
   input: UpdateIdentifierSchemeInput,
 ): Promise<IdentifierScheme> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.identifierScheme.findFirst({
       where: { id, tenantId },
     });
@@ -170,7 +172,7 @@ export async function updateIdentifierScheme(
         }),
         ...(input.qualifiers !== undefined && {
           qualifiers: {
-            create: input.qualifiers.map((q) => ({
+            create: input.qualifiers.map((q: QualifierInput) => ({
               key: q.key,
               description: q.description,
               validationPattern: q.validationPattern,
@@ -192,7 +194,7 @@ export async function updateIdentifierScheme(
  * Validates that the scheme belongs to the specified organisation.
  */
 export async function deleteIdentifierScheme(id: string, tenantId: string): Promise<IdentifierScheme> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.identifierScheme.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
@@ -83,7 +83,7 @@ async function validateIdentifierValue(
  * Identifiers are scoped to a single tenant (not shared with system defaults).
  */
 export async function createIdentifier(input: CreateIdentifierInput): Promise<Identifier> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     await validateIdentifierValue(tx, input.schemeId, input.value, input.tenantId);
 
     return tx.identifier.create({
@@ -162,7 +162,7 @@ export async function updateIdentifier(
   tenantId: string,
   input: UpdateIdentifierInput,
 ): Promise<Identifier> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.identifier.findFirst({
       where: { id, tenantId },
     });
@@ -192,7 +192,7 @@ export async function updateIdentifier(
  * Validates that the identifier belongs to the specified organisation.
  */
 export async function deleteIdentifier(id: string, tenantId: string): Promise<Identifier> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.identifier.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/link-registration.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/link-registration.repository.ts
@@ -1,4 +1,4 @@
-import { LinkRegistration } from '../generated';
+import { LinkRegistration, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { NotFoundError } from '@/lib/api/errors';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
@@ -74,7 +74,7 @@ export async function updateLinkRegistration(
   tenantId: string,
   data: { linkType?: string; targetUrl?: string; mimeType?: string },
 ): Promise<LinkRegistration> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.linkRegistration.findFirst({
       where: { idrLinkId, identifierId, tenantId },
     });
@@ -97,7 +97,7 @@ export async function deleteLinkRegistration(
   identifierId: string,
   tenantId: string,
 ): Promise<LinkRegistration> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.linkRegistration.findFirst({
       where: { idrLinkId, identifierId, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
@@ -99,7 +99,7 @@ export async function createOrganisations(
   tenantId: string,
   inputs: CreateOrganisationInput[],
 ): Promise<OrganisationEntityWithRelations[]> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const results: OrganisationEntityWithRelations[] = [];
 
     for (const input of inputs) {
@@ -133,7 +133,7 @@ export async function createOrganisations(
       // Create join rows for secondary identifiers
       if (input.secondaryIdentifierIds?.length) {
         await tx.organisationSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId) => ({
+          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
             organisationId: organisation.id,
             identifierId,
           })),
@@ -208,9 +208,9 @@ export async function listOrganisations(
     prisma.organisationEntity.count({ where }),
   ]);
 
-  const data = rows.map(({ secondaryIdentifiers, ...rest }) => ({
+  const data = rows.map(({ secondaryIdentifiers, ...rest }: OrganisationListRow) => ({
     ...rest,
-    secondaryIdentifierIds: secondaryIdentifiers.map((si) => si.identifierId),
+    secondaryIdentifierIds: secondaryIdentifiers.map((si: { identifierId: string }) => si.identifierId),
   }));
 
   return { data, total };
@@ -225,7 +225,7 @@ export async function updateOrganisation(
   tenantId: string,
   input: UpdateOrganisationInput,
 ): Promise<OrganisationEntityWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     // Ownership check
     const existing = await tx.organisationEntity.findFirst({
       where: { id, tenantId },
@@ -256,7 +256,7 @@ export async function updateOrganisation(
       });
       if (input.secondaryIdentifierIds.length > 0) {
         await tx.organisationSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId) => ({
+          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
             organisationId: id,
             identifierId,
           })),
@@ -308,7 +308,7 @@ export async function getOrganisationByIdentifierValue(
  * Join table rows (secondary identifiers) cascade automatically.
  */
 export async function deleteOrganisation(id: string, tenantId: string): Promise<OrganisationEntityWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.organisationEntity.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -147,7 +147,7 @@ function validateNoPrimarySecondaryOverlap(
  * Validates hierarchy constraints, foreign key references, and identifier ownership.
  */
 export async function createProducts(tenantId: string, inputs: CreateProductInput[]): Promise<ProductWithRelations[]> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const results: ProductWithRelations[] = [];
 
     for (const input of inputs) {
@@ -217,7 +217,7 @@ export async function createProducts(tenantId: string, inputs: CreateProductInpu
       // Create join rows for secondary identifiers
       if (input.secondaryIdentifierIds?.length) {
         await tx.productSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId) => ({
+          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
             productId: product.id,
             identifierId,
           })),
@@ -306,9 +306,9 @@ export async function listProducts(
     prisma.product.count({ where }),
   ]);
 
-  const data: ProductListItem[] = rows.map(({ secondaryIdentifiers, ...rest }) => ({
+  const data: ProductListItem[] = rows.map(({ secondaryIdentifiers, ...rest }: ProductListRow) => ({
     ...rest,
-    secondaryIdentifierIds: secondaryIdentifiers.map((si) => si.identifierId),
+    secondaryIdentifierIds: secondaryIdentifiers.map((si: { identifierId: string }) => si.identifierId),
   }));
 
   return { data, total };
@@ -324,7 +324,7 @@ export async function updateProduct(
   tenantId: string,
   input: UpdateProductInput,
 ): Promise<ProductWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     // Ownership check
     const existing = await tx.product.findFirst({
       where: { id, tenantId },
@@ -386,7 +386,7 @@ export async function updateProduct(
       });
       if (input.secondaryIdentifierIds.length > 0) {
         await tx.productSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId) => ({
+          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
             productId: id,
             identifierId,
           })),
@@ -459,17 +459,17 @@ export async function getProductByIdentifierValue(
  * Detaches ITEM children (sets parentId to null) before deleting.
  */
 export async function deleteProduct(id: string, tenantId: string): Promise<Product> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.product.findFirst({ where: { id, tenantId } });
     if (!existing) throw new NotFoundError('Product not found or access denied');
 
     const children = await tx.product.findMany({ where: { parentId: id, tenantId } });
-    const batches = children.filter((c) => c.level === 'BATCH');
+    const batches = children.filter((c: Product) => c.level === 'BATCH');
     if (batches.length > 0) {
       throw new ValidationError(`Cannot delete: ${batches.length} BATCH product(s) depend on this MODEL`);
     }
 
-    const items = children.filter((c) => c.level === 'ITEM');
+    const items = children.filter((c: Product) => c.level === 'ITEM');
     if (items.length > 0) {
       await tx.product.updateMany({ where: { parentId: id, level: 'ITEM' }, data: { parentId: null } });
     }

--- a/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
@@ -100,7 +100,7 @@ export async function listRegistrars(
  * Validates that the registrar belongs to the specified organisation.
  */
 export async function updateRegistrar(id: string, tenantId: string, input: UpdateRegistrarInput): Promise<Registrar> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.registrar.findFirst({
       where: { id, tenantId },
     });
@@ -126,7 +126,7 @@ export async function updateRegistrar(id: string, tenantId: string, input: Updat
  * Validates that the registrar belongs to the specified organisation.
  */
 export async function deleteRegistrar(id: string, tenantId: string): Promise<Registrar> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.registrar.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
@@ -95,7 +95,7 @@ export async function createRenderTemplate(
   tenantId: string,
   input: CreateRenderTemplateInput,
 ): Promise<RenderTemplateWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     if (input.isDefault) {
       await tx.renderTemplate.updateMany({
         where: {
@@ -180,10 +180,10 @@ export async function listRenderTemplates(
     }),
   ]);
 
-  const tenantDefaultDataModels = new Set(tenantDefaults.map((t) => t.dataModelId));
+  const tenantDefaultDataModels = new Set(tenantDefaults.map((t: { dataModelId: string }) => t.dataModelId));
 
   return {
-    data: data.map((t) =>
+    data: data.map((t: RenderTemplateWithRelations) =>
       t.tenantId === SYSTEM_TENANT_ID && t.isDefault && tenantDefaultDataModels.has(t.dataModelId)
         ? { ...t, isDefault: false }
         : t,
@@ -202,7 +202,7 @@ export async function updateRenderTemplate(
   tenantId: string,
   input: UpdateRenderTemplateInput,
 ): Promise<RenderTemplateWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.renderTemplate.findFirst({
       where: { id, tenantId },
     });
@@ -249,7 +249,7 @@ export async function updateRenderTemplate(
  * Deletes a render template. Only tenant-owned templates can be deleted.
  */
 export async function deleteRenderTemplate(id: string, tenantId: string): Promise<RenderTemplateWithRelations> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.renderTemplate.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -33,7 +33,7 @@ export type ListServiceInstancesOptions = {
  * any existing primary for this org + serviceType combination.
  */
 export async function createServiceInstance(input: CreateServiceInstanceInput): Promise<ServiceInstance> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     if (input.isPrimary) {
       await tx.serviceInstance.updateMany({
         where: {
@@ -133,10 +133,10 @@ export async function listServiceInstances(
     }),
   ]);
 
-  const tenantPrimaryTypes = new Set(tenantPrimaries.map((p) => p.serviceType));
+  const tenantPrimaryTypes = new Set(tenantPrimaries.map((p: { serviceType: ServiceType }) => p.serviceType));
 
   return {
-    data: data.map((i) =>
+    data: data.map((i: ServiceInstance) =>
       i.tenantId === SYSTEM_TENANT_ID && i.isPrimary && tenantPrimaryTypes.has(i.serviceType)
         ? { ...i, isPrimary: false }
         : i,
@@ -154,7 +154,7 @@ export async function updateServiceInstance(
   tenantId: string,
   input: UpdateServiceInstanceInput,
 ): Promise<ServiceInstance> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.serviceInstance.findFirst({
       where: { id, tenantId },
     });
@@ -191,7 +191,7 @@ export async function updateServiceInstance(
  * Deletes a service instance. Cannot delete system defaults.
  */
 export async function deleteServiceInstance(id: string, tenantId: string): Promise<ServiceInstance> {
-  return prisma.$transaction(async (tx) => {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const existing = await tx.serviceInstance.findFirst({
       where: { id, tenantId },
     });

--- a/packages/reference-implementation/src/lib/services/cvc-validation.service.ts
+++ b/packages/reference-implementation/src/lib/services/cvc-validation.service.ts
@@ -13,7 +13,9 @@ export type CvcValidationWarningCode =
   | 'CVC_NO_CRITERIA'
   | 'CVC_NO_CONFORMITY'
   | 'CVC_VALIDATION_ERROR'
-  | 'IDR_PUBLISH_FAILED';
+  | 'IDR_PUBLISH_FAILED'
+  | 'PUBLISH_SKIPPED'
+  | 'DB_STATUS_UPDATE_FAILED';
 
 export type CvcValidationWarning = {
   code: CvcValidationWarningCode;

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -43,6 +43,10 @@ const publishingOptionsSchema = z.object({
   publish: z.boolean().optional().describe('Whether to publish the credential to the Identity Resolver'),
   linkType: z.string().optional().describe('UNTP link relation type (defaults to gs1:sustainabilityInfo)'),
   linkTitle: z.string().optional().describe('Title for the published link'),
+  qualifierPath: z
+    .string()
+    .optional()
+    .describe('Qualifier path for sub-identifiers (e.g. /10/LOT123/21/SER456). Defaults to /'),
   machineVerificationUrl: z.string().optional().describe('Machine verification URL'),
   humanVerificationUrl: z.string().optional().describe('Human verification URL'),
 });
@@ -70,6 +74,19 @@ export const cvcValidationWarningSchema = z.object({
 export const credentialIssueResponseSchema = z.object({
   credentialId: z.string().describe('Database ID of the stored credential record'),
   warnings: z.array(cvcValidationWarningSchema).optional().describe('CVC compliance warnings (advisory only)'),
+});
+
+/** Credential resource as returned by GET /credentials and GET /credentials/:id. */
+export const credentialSchema = z.object({
+  id: z.string().describe('Database ID'),
+  tenantId: z.string().describe('Tenant ID'),
+  storageUri: z.string().describe('URI where the credential is stored'),
+  hash: z.string().describe('SHA-256 hash of the credential'),
+  credentialType: z.string().describe('Type of credential (e.g. DigitalProductPassport)'),
+  decryptionKey: z.string().nullable().describe('AES-256-GCM decryption key (null if unencrypted)'),
+  isPublished: z.boolean().describe('Whether the credential has been published to IDR'),
+  createdAt: z.string().describe('ISO 8601 timestamp'),
+  updatedAt: z.string().describe('ISO 8601 timestamp'),
 });
 
 // ============================================================================
@@ -279,6 +296,7 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     DidDocument: didDocumentResponseSchema,
     CredentialIssueRequest: credentialIssueRequestSchema,
     CredentialIssueResponse: credentialIssueResponseSchema,
+    Credential: credentialSchema,
     CvcValidationWarning: cvcValidationWarningSchema,
     Registrar: registrarSchema,
     SchemeQualifier: schemeQualifierSchema,

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -81,12 +81,15 @@ export const credentialSchema = z.object({
   id: z.string().describe('Database ID'),
   tenantId: z.string().describe('Tenant ID'),
   storageUri: z.string().describe('URI where the credential is stored'),
-  hash: z.string().describe('SHA-256 hash of the credential'),
+  hash: z.string().describe('Content hash of the stored credential'),
   credentialType: z.string().describe('Type of credential (e.g. DigitalProductPassport)'),
-  decryptionKey: z.string().nullable().describe('AES-256-GCM decryption key (null if unencrypted)'),
+  decryptionKey: z.string().nullable().describe('AES-GCM decryption key (null if unencrypted)'),
   isPublished: z.boolean().describe('Whether the credential has been published to IDR'),
-  createdAt: z.string().describe('ISO 8601 timestamp'),
-  updatedAt: z.string().describe('ISO 8601 timestamp'),
+  organisationId: z.string().nullable().describe('ID of the linked organisation entity (null if none)'),
+  facilityId: z.string().nullable().describe('ID of the linked facility entity (null if none)'),
+  productId: z.string().nullable().describe('ID of the linked product entity (null if none)'),
+  createdAt: z.string().datetime().describe('ISO 8601 timestamp'),
+  updatedAt: z.string().datetime().describe('ISO 8601 timestamp'),
 });
 
 // ============================================================================


### PR DESCRIPTION
This PR addresses all findings from a systematic audit of the credentials API routes (`POST /credentials`, `GET /credentials`, `GET /credentials/:id`, `POST /credentials/verify`), bringing them into compliance with the project's REST conventions, Swagger documentation standards, error handling robustness, and E2E test coverage requirements.

## Changes

**Response convention:**
- Removed `{ credential }` envelope from `GET /credentials/:id`, now returns the resource directly

**Security:**
- Added SSRF validation (`assertPublicUrl`) for `publishingOptions.machineVerificationUrl` and `publishingOptions.humanVerificationUrl`, gated by `VERIFY_ALLOW_PRIVATE_URLS`
- Unknown errors from `assertPublicUrl` now wrapped as ValidationError (400) instead of re-throwing as unclassified 500

**New functionality:**
- Added `qualifierPath` to `publishingOptions` for IDR publishing (defaults to `/` when absent). Relates to #478

**Error handling:**
- `PUBLISH_SKIPPED` warning added to response when publishing is requested but entity lacks scheme configuration or primary identifier
- `updateCredentialPublished` wrapped in try-catch to prevent 500 after successful IDR publish (returns `DB_STATUS_UPDATE_FAILED` warning instead)
- Reference extraction failure message now notes publishing will be skipped when `publish: true`
- JSON body parse failure now logs the original error before throwing ValidationError

**Swagger fixes:**
- Fixed `GET /credentials` limit default (100 to 20, matching `DEFAULT_PAGE_LIMIT`)
- Added missing 404 response to `POST /credentials` Swagger
- Added `Credential` Zod schema with all fields (including FK fields) and registered in `generateOpenAPISchemas()`
- Updated `GET /credentials/:id` to use `$ref: Credential` instead of inline schema
- Added `qualifierPath` to `publishingOptionsSchema`
- Fixed response code ordering (401 before 404)

**Logging:**
- Added step-level logging throughout `POST /credentials` handler
- Removed redundant `tenantId` from log metadata (auto-injected by `withTenantAuth` request context)
- Added completion log to `GET /credentials/:id`

**Unit tests:**
- Created missing `[id]/route.test.ts` (5 tests for GET by ID)
- Added 4 SSRF validation tests and 2 qualifier path tests to `route.test.ts`
- Updated `assertPublicUrl` test for new wrapping behaviour

**E2E tests:**
- Updated all `response.body.credential` references to `response.body` for the new direct-return shape
- Added missing unhappy path tests: missing `credentialType`, missing `version`, invalid JSON body, non-numeric `limit`, invalid `decryptionKey` format
- Added `no ok property` assertion on list endpoint
- Changed `hasMore` assertion to verify boolean type

## Test plan
- [x] 168 credential and validation unit tests pass
- [x] E2E specs updated for new response shape (requires Docker stack to run)