### PR TITLE
docs(api): add credentials API documentation

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -125,7 +125,7 @@ The three required fields are validated:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `credentialPayload` | object | Yes | The full credential payload conforming to the UNTP schema |
+| `credentialPayload` | object | Yes | The full credential payload conforming to the UNTP schema for the specified type and version |
 | `credentialType` | string | Yes | Must match a registered [data model](./data-models) (e.g., `DigitalProductPassport`) |
 | `version` | string | Yes | Must match a registered data model version (e.g., `0.6.1`) |
 
@@ -298,7 +298,7 @@ sequenceDiagram
 | `hash` | string | No | Expected SHA-256 hash (64-character hex string). If provided, the fetched credential's hash is verified against it. |
 | `decryptionKey` | string | No | AES-GCM decryption key (64-character hex string). Required for encrypted credentials. |
 
-The endpoint always returns HTTP 200 when the verification pipeline completes, even if the credential fails verification. Check the `verified` field for the outcome. Processing errors (decryption failure, hash mismatch, unsupported type) return non-200 status codes with a `code` field.
+The endpoint always returns HTTP 200 for a completed verification attempt, even if the credential fails verification. Check the `verified` field for the outcome. Processing errors (decryption failure, hash mismatch, unsupported type) that prevent a verification attempt return non-200 status codes with a `code` field.
 
 ### Environment Variables
 

--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -1,0 +1,308 @@
+---
+sidebar_position: 11
+title: Credentials
+---
+
+# Credentials API
+
+Credentials are the core output of the Reference Implementation. Everything else in the system — [DIDs](./dids), [services](./services), [data models](./data-models), [identifiers](./identifiers), and [master data](./organisations) — exists to support one goal: **issuing trusted, verifiable digital documents about products, facilities, organisations, and supply chain events**.
+
+A credential is a digitally signed statement. A company issues a credential that says "this product was made sustainably" or "this facility passed a conformity assessment". Because the credential is cryptographically signed, anyone who receives it can verify that the statement hasn't been tampered with and that it really came from the company that claims to have issued it, without needing to contact the issuer directly.
+
+The Credentials API has two sides:
+
+- **Issuance** (authenticated) — a tenant creates a credential, the system validates it, signs it, stores it, and optionally publishes it so it can be discovered by resolving an identifier.
+- **Verification** (public, no login required) — anyone with a link to a stored credential can check whether it's genuine, untampered, and still valid.
+
+:::tip[Interactive API documentation]
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic. Refer to Swagger for exact payload shapes. All endpoints except [Verify](#verify-a-credential) require authentication. See [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+:::
+
+## Concepts
+
+### What's Inside a Credential?
+
+Every credential issued by the Reference Implementation follows the [W3C Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/) and the [UNTP Verifiable Credential profile](https://untp.unece.org/docs/specification/VerifiableCredentials). In plain terms, a credential contains:
+
+- **Who issued it** — the issuer's [DID](./dids) (a cryptographic identity)
+- **What it says** — the credential subject (e.g., product sustainability data, conformity assessment results)
+- **When it was issued** — a timestamp
+- **A digital signature** — proof that the issuer really signed it and that nobody changed it afterwards
+- **A credential status** — a mechanism for the issuer to revoke or suspend the credential later if needed (managed via [BitstringStatusList](https://www.w3.org/TR/vc-bitstring-status-list/) by the [VC service](../services/verifiable-credential-service))
+
+### How Credentials Are Packaged
+
+UNTP credentials use the [**enveloped** form](https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials): the credential payload is signed as a [JWT (JSON Web Token)](https://datatracker.ietf.org/doc/html/rfc7519), and the JWT is wrapped inside a [JSON-LD](https://www.w3.org/TR/json-ld11/) envelope. This means you get the best of both worlds — compact, efficient JWT signatures with the semantic richness of linked data.
+
+When the Reference Implementation issues a credential, the result is an `EnvelopedVerifiableCredential` that looks like this:
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2"],
+  "type": "EnvelopedVerifiableCredential",
+  "id": "data:application/vc+jwt,eyJhbGciOiJFZDI1NTE5..."
+}
+```
+
+The `id` field contains the actual JWT. The verification endpoint knows how to unwrap this and decode the original credential payload.
+
+### Credential Types
+
+The type of credential determines what kind of data it contains and which schema is used to validate it. Credential types are defined by [data models](./data-models) — see the [Data Models API](./data-models) for the full list of core UNTP types and how extension data models work.
+
+### Encryption and Privacy
+
+When a credential is issued, two things are created: the **signed credential** (stored externally by the [storage service](./services)) and a **credential record** (stored in the Reference Implementation's database, tracking metadata like the storage URI, hash, and published status).
+
+By default, the [storage service](./services) **encrypts** the signed credential before storing it. When encrypted, the file at the storage URI is unreadable without the decryption key. The decryption key is returned by the storage service and saved in the credential record so it can be provided later during [verification](#verify-a-credential).
+
+This matters for privacy: a credential about a product's supply chain might contain commercially sensitive information. Encryption ensures that only someone with the key can read it, even if they have the storage URL.
+
+| Setting | What Happens |
+|---------|-------------|
+| `encrypt: true` (default) | Credential encrypted before storage. A `decryptionKey` is returned. |
+| `encrypt: false` | Credential stored in plaintext. Anyone with the URL can read it. |
+
+### Integrity Hashing
+
+Every stored credential has a **content hash** — a fingerprint computed from the credential's contents. If even one character changes, the hash changes. This allows anyone to detect that the credential at a storage URI hasn't been swapped or modified after being stored. During [verification](#verify-a-credential), the computed hash is compared against the expected hash.
+
+### Discoverability via the Identity Resolver
+
+A credential on its own is just a file at a URL. To make it useful, it needs to be **discoverable** — someone who knows a product's identifier should be able to find the credential. This is the role of the [UNTP Identity Resolver](https://untp.unece.org/docs/specification/IdentityResolver) and [Decentralised Access Control](https://untp.unece.org/docs/specification/DecentralisedAccessControl) specifications.
+
+This is where the [Identity Resolver](./identifiers#links) comes in. When a credential is published, the Reference Implementation registers a link with the Identity Resolver that connects the entity's identifier (e.g., a GS1 GTIN) to the credential's storage URL. Now anyone who resolves that identifier can find the credential.
+
+Publishing is optional and requires the credential's primary entity (product, facility, or organisation) to have a configured [identifier scheme](./identifiers#identifier-schemes) with an IDR service.
+
+### CVC Compliance (Conformity Credentials Only)
+
+For [Digital Conformity Credentials](./data-models), the issuance pipeline performs an extra advisory check: it compares the conformity criteria, standards, and regulations referenced in the credential against the tenant's imported [CVC (Conformity Vocabulary Catalogue)](https://untp.unece.org/docs/specification/ConformityVocabularyCatalog) data. This helps catch mistakes like referencing a non-existent standard or missing a required criterion.
+
+CVC validation is **advisory only** — it never blocks issuance. If issues are found, the credential is still issued but the response includes warnings.
+
+### The Issuance Pipeline
+
+Issuing a credential involves six stages. Each stage can fail independently, and failures at different stages produce different HTTP status codes and warning codes. See the [Issue a Credential](#issue-a-credential) endpoint for the full request and response reference.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant DB as Database
+    participant VC as VC Service
+    participant Storage as Storage Service
+    participant IDR as Identity Resolver
+
+    Client->>RI: POST /api/v1/credentials
+    RI->>RI: 1. Validate request fields
+    RI->>DB: 2. Resolve data model + bridge
+    DB-->>RI: Data model config + schema URLs
+    RI->>RI: 3. Validate payload (JSON Schema + JSON-LD)
+    RI->>RI: 3.5. CVC validation (advisory, DCC only)
+    RI->>DB: 4. Resolve VC + storage service instances
+    DB-->>RI: Decrypted service configs
+    RI->>VC: 5a. Issue credential status
+    VC-->>RI: Credential status (BitstringStatusList entry)
+    RI->>VC: 5b. Sign credential (with status)
+    VC-->>RI: Enveloped verifiable credential
+    RI->>Storage: 5c. Store credential (optional encryption)
+    Storage-->>RI: Storage URI + hash + decryption key
+    RI->>DB: 5d. Resolve primary entity from refs
+    RI->>DB: 5e. Save credential record
+    DB-->>RI: Credential ID
+    opt publish = true
+        RI->>IDR: 6. Publish links for primary identifier
+        IDR-->>RI: Link registration
+        RI->>DB: Update isPublished = true
+    end
+    RI-->>Client: 201 { credentialId, warnings? }
+```
+
+#### Stage 1: Request Validation
+
+The three required fields are validated:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `credentialPayload` | object | Yes | The full credential payload conforming to the UNTP schema |
+| `credentialType` | string | Yes | Must match a registered [data model](./data-models) (e.g., `DigitalProductPassport`) |
+| `version` | string | Yes | Must match a registered data model version (e.g., `0.6.1`) |
+
+#### Stage 2: Data Model Resolution
+
+The `credentialType` and `version` are used to look up a registered [data model](./data-models). The data model provides the JSON Schema URL(s) for validation, the JSON-LD context URL, and the [bridge](./data-models#data-model-bridges) that extracts entity references from the payload.
+
+For [extension data models](./data-models#extension-data-models), both the parent schema and the extension schema are validated.
+
+#### Stage 3: Payload Validation
+
+The credential payload is validated in two passes:
+
+1. **JSON Schema validation** against the data model's schema URL(s). This catches structural issues such as missing required fields, incorrect types, or invalid enum values.
+2. **JSON-LD expansion** to verify the payload is valid linked data with a resolvable `@context`.
+
+If either check fails, the request is rejected with HTTP 400.
+
+#### Stage 3.5: CVC Compliance Validation (Advisory)
+
+For [Digital Conformity Credentials](./data-models) (DCC), the issuance pipeline performs an advisory check against the tenant's imported CVC (Conformity Vocabulary Catalogue) data. This check verifies that the conformity criteria, standards, and regulations referenced in the credential payload correspond to entries in the tenant's CVC catalogues.
+
+CVC validation is advisory only. It never blocks issuance. If the check fails or no CVC data is available, the credential is issued with warnings in the response. Warning codes include:
+
+| Code | Meaning |
+|------|---------|
+| `CVC_NO_CONFORMITY` | DCC credential payload has no conformity data to validate |
+| `CVC_NO_SCOPE` | No conformity scope (standard, regulation, or criterion) found in the payload |
+| `CVC_SCOPE_NOT_FOUND` | Referenced scope URL not found in imported CVC catalogues |
+| `CVC_UNKNOWN_CRITERION` | Referenced criterion URL not found in imported CVC catalogues |
+| `CVC_MISSING_CRITERION` | A required criterion from the scheme profile is not present in the credential |
+| `CVC_NO_CRITERIA` | No criteria found in the payload |
+| `CVC_VALIDATION_ERROR` | CVC validation could not be performed (infrastructure or extraction failure) |
+
+#### Stage 4: Service Resolution
+
+Three external services are involved in issuance. Each is resolved via the [service resolution chain](../services/service-architecture#system-services-vs-tenant-services):
+
+| Service | Purpose | Override Field |
+|---------|---------|---------------|
+| **VC Service** | Signs the credential payload | `signingOptions.serviceInstanceId` |
+| **Storage Service** | Stores the signed credential | `storageOptions.serviceInstanceId` |
+| **IDR Service** | Publishes links (only when `publish: true`) | Resolved from the entity's scheme configuration |
+
+If no explicit `serviceInstanceId` is provided, the tenant's primary instance for that service type is used. If no primary exists, the system default is used.
+
+#### Stage 5: Sign, Store, and Record
+
+The credential payload is signed by the VC service, producing an [Enveloped Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials). The signed credential is then stored by the storage service.
+
+**Encryption**: By default, the stored credential is encrypted with AES-GCM. The decryption key is returned in the credential record and must be provided when [verifying](#verify-a-credential) encrypted credentials. Set `storageOptions.encrypt` to `false` to store the credential unencrypted.
+
+**Entity linking**: The data model bridge extracts entity references (organisations, facilities, products) from the credential payload. The primary entity (priority: product > facility > organisation) is linked to the credential record in the database. This link enables the optional publishing step.
+
+#### Stage 6: IDR Publishing (Optional)
+
+When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#links) for the primary entity's identifier. This makes the credential discoverable via the entity's identifier scheme (e.g., resolving a GS1 GTIN leads to the credential).
+
+Publishing requires the primary entity to have:
+- A primary identifier with a configured [identifier scheme](./identifiers#identifier-schemes)
+- The scheme must have a registrar with a namespace
+- An IDR service instance (configured on the scheme, or the tenant/system default)
+
+If any of these are missing, publishing is silently skipped and a `PUBLISH_SKIPPED` warning is included in the response.
+
+| Publishing Option | Type | Description |
+|-------------------|------|-------------|
+| `publish` | boolean | Whether to publish to the identity resolver |
+| `linkType` | string | Link relation type (defaults to `gs1:sustainabilityInfo`) |
+| `linkTitle` | string | Human-readable title for the link (defaults to the data model name) |
+| `qualifierPath` | string | Qualifier path for sub-identifiers, e.g., `/10/LOT123/21/SER456` (defaults to `/`) |
+| `machineVerificationUrl` | string | URL for machine-readable verification of the credential |
+| `humanVerificationUrl` | string | URL for human-readable verification of the credential |
+
+## Issuance Endpoints
+
+### Issue a Credential
+
+```
+POST /api/v1/credentials
+```
+
+Validates, signs, stores, and optionally publishes a verifiable credential. Returns the credential's database ID and any advisory warnings.
+
+**Request body fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `credentialPayload` | object | Yes | Full credential payload conforming to the UNTP schema for the specified type and version |
+| `credentialType` | string | Yes | Registered data model type (e.g., `DigitalProductPassport`) |
+| `version` | string | Yes | Registered data model version (e.g., `0.6.1`) |
+| `signingOptions.serviceInstanceId` | string | No | Explicit VC service instance for signing |
+| `storageOptions.serviceInstanceId` | string | No | Explicit storage service instance |
+| `storageOptions.encrypt` | boolean | No | Whether to encrypt (default: `true`) |
+| `publishingOptions.publish` | boolean | No | Whether to publish to IDR |
+| `publishingOptions.linkType` | string | No | Link relation type |
+| `publishingOptions.linkTitle` | string | No | Link title |
+| `publishingOptions.qualifierPath` | string | No | Qualifier path (default: `/`) |
+| `publishingOptions.machineVerificationUrl` | string | No | Machine verification URL |
+| `publishingOptions.humanVerificationUrl` | string | No | Human verification URL |
+
+---
+
+### List Credentials
+
+```
+GET /api/v1/credentials
+```
+
+Returns a paginated list of credentials for the authenticated tenant.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `credentialType` | string | Filter by credential type (case-sensitive exact match) |
+| `isPublished` | `"true"` or `"false"` | Filter by published status |
+| `limit` | integer | Maximum results (default: 20, max: 100) |
+| `offset` | integer | Number of results to skip (default: 0) |
+
+---
+
+### Get a Credential
+
+```
+GET /api/v1/credentials/{id}
+```
+
+Retrieves a specific credential record by its database ID. The response includes the storage URI, hash, decryption key (if encrypted), credential type, published status, and linked entity IDs.
+
+## Verification Endpoint
+
+### Verify a Credential
+
+```
+POST /api/v1/credentials/verify
+```
+
+**This endpoint does not require authentication.** It is designed for third-party verification of credentials using parameters typically encoded in a QR code or [verification link](../verify-page#verify-link).
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    participant Storage as Storage URI
+    participant VC as System VC Service
+
+    Client->>RI: POST /api/v1/credentials/verify { uri, hash?, decryptionKey? }
+    RI->>RI: Validate input + SSRF check
+    RI->>Storage: Fetch credential (10s timeout)
+    Storage-->>RI: Credential (possibly encrypted)
+    opt encrypted
+        RI->>RI: Decrypt with decryptionKey
+    end
+    opt hash provided
+        RI->>RI: Compute hash and compare
+    end
+    RI->>RI: Validate credential type (EnvelopedVerifiableCredential)
+    RI->>VC: Verify credential signature
+    VC-->>RI: Verification result
+    RI->>RI: Decode JWT payload
+    RI-->>Client: 200 { verified, credential, decodedCredential?, warnings?, error? }
+```
+
+**Request body fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `uri` | string (URL) | Yes | Storage URI where the credential is stored. Must be HTTP(S). |
+| `hash` | string | No | Expected SHA-256 hash (64-character hex string). If provided, the fetched credential's hash is verified against it. |
+| `decryptionKey` | string | No | AES-GCM decryption key (64-character hex string). Required for encrypted credentials. |
+
+The endpoint always returns HTTP 200 when the verification pipeline completes, even if the credential fails verification. Check the `verified` field for the outcome. Processing errors (decryption failure, hash mismatch, unsupported type) return non-200 status codes with a `code` field.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VERIFY_ALLOW_PRIVATE_URLS` | `false` | Set to `true` to bypass SSRF checks (development only) |
+| `VERIFY_MAX_CREDENTIAL_SIZE` | `10485760` (10 MB) | Maximum credential response size in bytes |

--- a/documentation/docs/reference-implementation/api/identifiers.md
+++ b/documentation/docs/reference-implementation/api/identifiers.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: Identifiers
 ---
 

--- a/documentation/docs/reference-implementation/api/registrars.md
+++ b/documentation/docs/reference-implementation/api/registrars.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 9
 title: Registrars
 ---
 


### PR DESCRIPTION
This PR adds API documentation for the credentials endpoints, covering the full credential lifecycle: issuance, listing, retrieval, and verification.

The concepts section explains the big ideas before the endpoint details: what credentials are, how they're packaged (enveloped form with JWT signatures), encryption and privacy, integrity hashing, discoverability via the Identity Resolver, credential status, and CVC compliance validation for conformity credentials. Links to the relevant UNTP specifications throughout.

Also swaps the sidebar positions of Registrars (now 9) and Identifiers (now 10) for a more logical reading order, with Credentials last (11).

## Test plan
- [x] `docusaurus build` passes with no broken links
- [x] Page renders correctly on the local dev server
- [x] All internal cross-references resolve (data models, services, DIDs, identifiers, verify page)
- [x] All external links point to correct UNTP spec pages