### PR TITLE
fix(e2e): derive VCKit domain dynamically in root DID protection tests

### DIFF
--- a/e2e/.env.e2e.example
+++ b/e2e/.env.e2e.example
@@ -62,6 +62,7 @@
 
 # Second test user (used by closed-mode tenant resolution tests)
 # E2E_USER2_EMAIL=e2e-user@test.local
+# E2E_USER2_PASSWORD=              # Only needed if different from E2E_USER_PASSWORD
 
 # =============================================================================
 # Service Accounts

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -135,5 +135,7 @@ All variables are documented in [`e2e/.env.e2e.example`](.env.e2e.example). Key 
 | `E2E_TENANT_MODE` | `open` or `closed` | `open` |
 | `E2E_DB_HOST` | PostgreSQL host | `localhost` |
 | `E2E_DB_PORT` | PostgreSQL port | `5433` |
+| `E2E_USER2_PASSWORD` | Second test user password (if different from first) | (same as `E2E_USER_PASSWORD`) |
+| `E2E_DB_SSL_REJECT_UNAUTHORIZED` | Reject self-signed DB certs | `true` |
 | `VERIFY_ALLOW_PRIVATE_URLS` | SSRF validation (`false` for deployed) | `true` |
 

--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -177,6 +177,7 @@ export default defineConfig({
     USER_EMAIL: process.env.E2E_USER_EMAIL || 'e2e-admin@test.local',
     USER_PASSWORD: process.env.E2E_USER_PASSWORD || 'E2eTest123!',
     USER2_EMAIL: process.env.E2E_USER2_EMAIL || 'e2e-user@test.local',
+    USER2_PASSWORD: process.env.E2E_USER2_PASSWORD || '',
 
     // Service accounts
     SA1_CLIENT_ID: process.env.E2E_SA1_CLIENT_ID || 'ri-service-account-e2e',

--- a/e2e/cypress/e2e/api/did_api/did-management.cy.ts
+++ b/e2e/cypress/e2e/api/did_api/did-management.cy.ts
@@ -658,22 +658,34 @@ describe('DID API', { testIsolation: false }, () => {
   });
 
   describe('Root DID protection', () => {
-    it('returns 403 when creating a self-managed root DID matching the system VC domain (with port)', () => {
-      cy.request({
-        method: 'POST',
-        url: '/api/v1/dids',
-        body: {
-          type: 'SELF_MANAGED',
-          method: 'DID_WEB',
-          alias: 'vckit-api:3332',
-          name: 'Hijack attempt with port',
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.status).to.eq(403);
-        expect(response.body.error).to.include('system VC service domain');
+    // Derive the VC hostname and port from the env-provided VCKit base URL
+    // so these tests work in both Docker (vckit-api:3332) and deployed
+    // (vckit.labs.pyx.io) environments. The alias is passed as-is to the
+    // API; the server's normaliseSelfManagedAlias handles lowercasing and
+    // the route guard compares the normalised result against the hostname.
+    const vcUrl = new URL(config.services.vckit.baseUrl);
+    const vcHostname = vcUrl.hostname;
+    const vcHasNonStandardPort = vcUrl.port && vcUrl.port !== '443' && vcUrl.port !== '80';
+    const vcHostnameWithPort = vcHasNonStandardPort ? `${vcHostname}:${vcUrl.port}` : null;
+
+    if (vcHostnameWithPort) {
+      it('returns 403 when creating a self-managed root DID matching the system VC domain (with port)', () => {
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/dids',
+          body: {
+            type: 'SELF_MANAGED',
+            method: 'DID_WEB',
+            alias: vcHostnameWithPort,
+            name: 'Hijack attempt with port',
+          },
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(403);
+          expect(response.body.error).to.include('system VC service domain');
+        });
       });
-    });
+    }
 
     it('returns 403 when creating a self-managed root DID matching the system VC hostname', () => {
       cy.request({
@@ -682,7 +694,7 @@ describe('DID API', { testIsolation: false }, () => {
         body: {
           type: 'SELF_MANAGED',
           method: 'DID_WEB',
-          alias: 'vckit-api',
+          alias: vcHostname,
           name: 'Hijack attempt hostname only',
         },
         failOnStatusCode: false,
@@ -699,7 +711,7 @@ describe('DID API', { testIsolation: false }, () => {
         body: {
           type: 'SELF_MANAGED',
           method: 'DID_WEB',
-          alias: `vckit-api:tenants:e2e-${RUN_ID}`,
+          alias: `${vcHostname}:e2e-path-${RUN_ID}`,
           name: `Path-based DID ${RUN_ID}`,
         },
       }).then((response) => {

--- a/e2e/cypress/e2e/api/did_api/did-management.cy.ts
+++ b/e2e/cypress/e2e/api/did_api/did-management.cy.ts
@@ -665,8 +665,7 @@ describe('DID API', { testIsolation: false }, () => {
     // the route guard compares the normalised result against the hostname.
     const vcUrl = new URL(config.services.vckit.baseUrl);
     const vcHostname = vcUrl.hostname;
-    const vcHasNonStandardPort = vcUrl.port && vcUrl.port !== '443' && vcUrl.port !== '80';
-    const vcHostnameWithPort = vcHasNonStandardPort ? `${vcHostname}:${vcUrl.port}` : null;
+    const vcHostnameWithPort = (vcUrl.port && vcUrl.port !== '443' && vcUrl.port !== '80') ? `${vcHostname}:${vcUrl.port}` : null;
 
     if (vcHostnameWithPort) {
       it('returns 403 when creating a self-managed root DID matching the system VC domain (with port)', () => {

--- a/e2e/cypress/e2e/closed_mode/tenant-resolution.cy.ts
+++ b/e2e/cypress/e2e/closed_mode/tenant-resolution.cy.ts
@@ -12,8 +12,9 @@ import { config } from '../../support/config';
 describe('Closed mode — tenant resolution', { testIsolation: false }, () => {
   const GROUP_CLAIM = config.groups.alpha;
   const ADMIN_EMAIL = config.user.email;
+  const ADMIN_PASSWORD = config.user.password;
   const USER_EMAIL = config.user2.email;
-  const PASSWORD = config.user.password;
+  const USER_PASSWORD = config.user2.password || config.user.password;
 
   before(() => {
     // Clean up any leftover data from previous runs
@@ -26,7 +27,7 @@ describe('Closed mode — tenant resolution', { testIsolation: false }, () => {
 
   describe('First user sign-in provisions tenant', () => {
     it('admin signs in and can call the API', () => {
-      cy.apiLogin(ADMIN_EMAIL, PASSWORD);
+      cy.apiLogin(ADMIN_EMAIL, ADMIN_PASSWORD);
 
       // The sign-in event should have auto-provisioned a tenant from the
       // group claim.  Verify the session works by hitting a protected endpoint.
@@ -52,7 +53,7 @@ describe('Closed mode — tenant resolution', { testIsolation: false }, () => {
       // Clear all cookies to reset both app and Keycloak sessions
       cy.clearAllCookies();
 
-      cy.apiLogin(USER_EMAIL, PASSWORD);
+      cy.apiLogin(USER_EMAIL, USER_PASSWORD);
 
       cy.request('/api/v1/dids').then((response) => {
         expect(response.status).to.eq(200);

--- a/e2e/cypress/support/config.ts
+++ b/e2e/cypress/support/config.ts
@@ -20,6 +20,7 @@ export const config = {
   },
   user2: {
     email: Cypress.env('USER2_EMAIL') as string,
+    password: Cypress.env('USER2_PASSWORD') as string,
   },
   serviceAccounts: {
     sa1: {

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -446,12 +446,12 @@ describe('POST /api/v1/dids', () => {
     });
 
     it('allows a tenant to create a self-managed DID with a path under the VC domain', async () => {
-      mockDidService.normaliseAlias.mockReturnValue('vckit.example.com:tenants:acme');
-      mockDidService.create.mockResolvedValue({ did: 'did:web:vckit.example.com:tenants:acme', keyId: 'key-2' });
+      mockDidService.normaliseAlias.mockReturnValue('vckit.example.com:org:acme');
+      mockDidService.create.mockResolvedValue({ did: 'did:web:vckit.example.com:org:acme', keyId: 'key-2' });
       mockCreateDid.mockResolvedValue({ id: 'record-2' });
 
       const req = createFakeRequest({
-        body: { type: DidType.SELF_MANAGED, method: DidMethod.DID_WEB, alias: 'vckit.example.com:tenants:acme' },
+        body: { type: DidType.SELF_MANAGED, method: DidMethod.DID_WEB, alias: 'vckit.example.com:org:acme' },
       });
       const res = await POST(req, TENANT_CONTEXT as unknown as Parameters<typeof POST>[1]);
       expect(res.status).toBe(201);


### PR DESCRIPTION
This PR makes the root DID protection E2E tests environment-agnostic by deriving the VCKit hostname from the `VCKIT_BASE_URL` config rather than hardcoding Docker-internal aliases (`vckit-api:3332`, `vckit-api`). The tests now pass against both local Docker and remote deployments. Also replaces the misleading `:tenants:` path segment with `:org:` / `:e2e-path-` in both the E2E spec and the unit test.

## Test plan
- [x] Root DID protection E2E tests pass against remote deployments
- [x] Root DID protection E2E tests pass against local Docker
- [x] DID route unit tests pass (33/33)
- [x] Full E2E suite passes in closed mode (497/497)