### PR TITLE
fix(api): enforce issuer DID ownership on credential issuance

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -83,7 +83,7 @@ CVC validation is **advisory only** — it never blocks issuance. If issues are 
 
 ### The Issuance Pipeline
 
-Issuing a credential involves six stages. Each stage can fail independently, and failures at different stages produce different HTTP status codes and warning codes. See the [Issue a Credential](#issue-a-credential) endpoint for the full request and response reference.
+Issuing a credential involves eight stages. Each stage can fail independently, and failures at different stages produce different HTTP status codes and warning codes. See the [Issue a Credential](#issue-a-credential) endpoint for the full request and response reference.
 
 ```mermaid
 sequenceDiagram
@@ -100,19 +100,22 @@ sequenceDiagram
     DB-->>RI: Data model config + schema URLs
     RI->>RI: 3. Validate payload (JSON Schema + JSON-LD)
     RI->>RI: 3.5. CVC validation (advisory, DCC only)
-    RI->>DB: 4. Resolve VC + storage service instances
+    RI->>DB: 4. Validate issuer DID ownership
+    DB-->>RI: DID record (tenant-owned or system default)
+    RI->>RI: 5. Validate DID has service association
+    RI->>DB: 6. Resolve services (VC from DID, storage + IDR by tenant)
     DB-->>RI: Decrypted service configs
-    RI->>VC: 5a. Issue credential status
+    RI->>VC: 7a. Issue credential status
     VC-->>RI: Credential status (BitstringStatusList entry)
-    RI->>VC: 5b. Sign credential (with status)
+    RI->>VC: 7b. Sign credential (with status)
     VC-->>RI: Enveloped verifiable credential
-    RI->>Storage: 5c. Store credential (optional encryption)
+    RI->>Storage: 7c. Store credential (optional encryption)
     Storage-->>RI: Storage URI + hash + decryption key
-    RI->>DB: 5d. Resolve primary entity from refs
-    RI->>DB: 5e. Save credential record
+    RI->>DB: 7d. Resolve primary entity from refs
+    RI->>DB: 7e. Save credential record
     DB-->>RI: Credential ID
     opt publish = true
-        RI->>IDR: 6. Publish links for primary identifier
+        RI->>IDR: 8. Publish links for primary identifier
         IDR-->>RI: Link registration
         RI->>DB: Update isPublished = true
     end
@@ -160,19 +163,32 @@ CVC validation is advisory only. It never blocks issuance. If the check fails or
 | `CVC_NO_CRITERIA` | No criteria found in the payload |
 | `CVC_VALIDATION_ERROR` | CVC validation could not be performed (infrastructure or extraction failure) |
 
-#### Stage 4: Service Resolution
+#### Stage 4: Issuer DID Ownership Validation
 
-Three external services are involved in issuance. Each is resolved via the [service resolution chain](../services/service-architecture#system-services-vs-tenant-services):
+The `issuer.id` field in the credential payload must contain a [DID](./dids) that the authenticated tenant is authorised to use. The Reference Implementation looks up the DID and verifies that it either:
 
-| Service | Purpose | Override Field |
-|---------|---------|---------------|
-| **VC Service** | Signs the credential payload | `signingOptions.serviceInstanceId` |
-| **Storage Service** | Stores the signed credential | `storageOptions.serviceInstanceId` |
-| **IDR Service** | Publishes links (only when `publish: true`) | Resolved from the entity's scheme configuration |
+- belongs to the authenticated tenant, or
+- is a [system default DID](./dids#system-dids-vs-tenant-dids) — available to all tenants as part of the [incremental adoption ramp](../overview#incremental-adoption)
 
-If no explicit `serviceInstanceId` is provided, the tenant's primary instance for that service type is used. If no primary exists, the system default is used.
+**If the DID is not registered to the tenant and is not a system default DID, the request is rejected with HTTP 400.** A tenant cannot issue credentials using a DID that belongs to another tenant.
 
-#### Stage 5: Sign, Store, and Record
+#### Stage 5: DID Service Association Check
+
+The issuer DID must have an associated [VC service instance](./services) — this is the service that holds the DID's key material and will perform signing. If the DID has no association (e.g., the service instance was [force-deleted](./services#delete-a-service-instance)), the request is rejected with HTTP 400. The DID must be re-imported or re-created to restore the association.
+
+#### Stage 6: Service Resolution
+
+The **VC service** is resolved from the issuer DID's associated service instance. This ensures signing always happens on the VC service that holds the DID's key material, regardless of whether the DID is a tenant-owned DID or a [system default DID](./dids#system-dids-vs-tenant-dids). The caller does not need to specify which VC service to use; the DID determines it.
+
+The **storage service** and **IDR service** follow the standard [resolution chain](../services/service-architecture#system-services-vs-tenant-services):
+
+| Service | Purpose | How Resolved |
+|---------|---------|-------------|
+| **VC Service** | Signs the credential payload | From the issuer DID's associated service instance |
+| **Storage Service** | Stores the signed credential | `storageOptions.serviceInstanceId`, or tenant primary, or system default |
+| **IDR Service** | Publishes links (only when `publish: true`) | From the entity's scheme configuration |
+
+#### Stage 7: Sign, Store, and Record
 
 The credential payload is signed by the VC service, producing an [Enveloped Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials). The signed credential is then stored by the storage service.
 
@@ -180,7 +196,7 @@ The credential payload is signed by the VC service, producing an [Enveloped Veri
 
 **Entity linking**: The data model bridge extracts entity references (organisations, facilities, products) from the credential payload. The primary entity (priority: product > facility > organisation) is linked to the credential record in the database. This link enables the optional publishing step.
 
-#### Stage 6: IDR Publishing (Optional)
+#### Stage 8: IDR Publishing (Optional)
 
 When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#links) for the primary entity's identifier. This makes the credential discoverable via the entity's identifier scheme (e.g., resolving a GS1 GTIN leads to the credential).
 
@@ -217,7 +233,6 @@ Validates, signs, stores, and optionally publishes a verifiable credential. Retu
 | `credentialPayload` | object | Yes | Full credential payload conforming to the UNTP schema for the specified type and version |
 | `credentialType` | string | Yes | Registered data model type (e.g., `DigitalProductPassport`) |
 | `version` | string | Yes | Registered data model version (e.g., `0.6.1`) |
-| `signingOptions.serviceInstanceId` | string | No | Explicit VC service instance for signing |
 | `storageOptions.serviceInstanceId` | string | No | Explicit storage service instance |
 | `storageOptions.encrypt` | boolean | No | Whether to encrypt (default: `true`) |
 | `publishingOptions.publish` | boolean | No | Whether to publish to IDR |

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -91,6 +91,8 @@ The [verify endpoint](#verify-a-did) runs the following checks in order. All che
 
 DIDs exist at two levels — the **system default DID** (created during [startup](../operations/startup#step-2-database-seed), owned by the [system tenant](../system-architecture#system-tenant), read-only and visible to all tenants) and **tenant DIDs** (created or imported by a tenant through this API, scoped exclusively to that tenant). When listing DIDs, tenants see both their own DIDs and the system default.
 
+**Credential signing is restricted to these two pools.** When [issuing a credential](./credentials#stage-4-issuer-did-ownership-validation), the `issuer.id` in the credential payload must be a DID that belongs to the authenticated tenant or a system default DID — available to all tenants as part of the [incremental adoption ramp](../overview#incremental-adoption). A tenant cannot issue credentials using a DID that belongs to another tenant.
+
 ### Service Instance Association
 
 When creating a DID, you can specify which [verifiable credential service instance](./services) to use via `serviceInstanceId`. If omitted, the service instance is resolved using the same [resolution chain](../services/service-architecture#system-services-vs-tenant-services) as other operations — the tenant's [primary](./services#primary-instances) VC service instance if one is set, otherwise the system default.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -137,3 +137,9 @@ All variables are documented in [`e2e/.env.e2e.example`](.env.e2e.example). Key 
 | `E2E_DB_PORT` | PostgreSQL port | `5433` |
 | `VERIFY_ALLOW_PRIVATE_URLS` | SSRF validation (`false` for deployed) | `true` |
 
+### did:web and HTTPS
+
+Some credential issuance tests (issuing with a tenant-created DID, issuing with a DID on a non-primary VC service instance) require VCKit to resolve `did:web` DID documents during signing. The `did:web` specification requires HTTPS, so these tests are **automatically skipped** when the VCKit base URL is not HTTPS (i.e. in the local Docker Compose environment where VCKit runs on `http://vckit-api:3332`).
+
+These tests run when VCKit is deployed with a publicly resolvable HTTPS domain (e.g. `https://vckit.example.com`). The remaining DID ownership enforcement tests (system default DID issuance, cross-tenant rejection, fabricated DID rejection) run in all environments.
+

--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -616,6 +616,45 @@ export default defineConfig({
             await client.end();
           }
         },
+        async seedForeignTenantDid() {
+          const client = getDbClient();
+          try {
+            await client.connect();
+            const foreignTenantId = 'e2e-foreign-tenant';
+            const foreignDidId = 'e2e-foreign-did';
+            const foreignDid = `did:web:foreign-tenant.example.com:e2e-${Date.now()}`;
+
+            // Create a foreign tenant (update timestamp if it already exists from a previous run)
+            await client.query(
+              `INSERT INTO "Tenant" (id, name, "createdAt", "updatedAt")
+               VALUES ($1, 'E2E Foreign Tenant', NOW(), NOW())
+               ON CONFLICT (id) DO UPDATE SET "updatedAt" = NOW()`,
+              [foreignTenantId],
+            );
+
+            // Create a DID belonging to that foreign tenant
+            await client.query(
+              `INSERT INTO "Did" (id, "tenantId", did, type, method, "keyId", name, status, "isDefault", "createdAt", "updatedAt")
+               VALUES ($1, $2, $3, 'MANAGED', 'DID_WEB', 'foreign-key-1', 'Foreign DID', 'ACTIVE', false, NOW(), NOW())
+               ON CONFLICT (id) DO UPDATE SET did = $3, "updatedAt" = NOW()`,
+              [foreignDidId, foreignTenantId, foreignDid],
+            );
+
+            return { tenantId: foreignTenantId, didId: foreignDidId, did: foreignDid };
+          } finally {
+            await client.end();
+          }
+        },
+        async cleanupForeignTenantDid() {
+          const client = getDbClient();
+          try {
+            await client.connect();
+            await deleteTenantData(client, 'e2e-foreign-tenant');
+            return null;
+          } finally {
+            await client.end();
+          }
+        },
       });
     },
   },

--- a/e2e/cypress/e2e/api/credential_api/credential-management.cy.ts
+++ b/e2e/cypress/e2e/api/credential_api/credential-management.cy.ts
@@ -4,6 +4,7 @@ describe('Credential API', { testIsolation: false }, () => {
   const RUN_ID = Date.now();
   let testTenantId: string;
   let defaultDidValue: string;
+  let tenantDidValue: string;
   let encryptedCredentialId: string;
   let unencryptedCredentialId: string;
   let publishedCredentialId: string;
@@ -89,10 +90,13 @@ describe('Credential API', { testIsolation: false }, () => {
   });
 
   // -----------------------------------------------------------------------
-  // Issue and retrieve
+  // DID ownership enforcement
   // -----------------------------------------------------------------------
-  describe('Issue and retrieve credentials', () => {
-    it('looks up the system default DID to use as issuer', () => {
+  describe('DID ownership enforcement', () => {
+    let foreignDid: string;
+
+    before(() => {
+      // Look up the system default DID
       cy.request('/api/v1/dids').then((response) => {
         expect(response.status).to.eq(200);
         const defaultDid = response.body.data.find(
@@ -101,8 +105,158 @@ describe('Credential API', { testIsolation: false }, () => {
         expect(defaultDid).to.exist;
         defaultDidValue = defaultDid.did;
       });
+
+      // Create a tenant-owned MANAGED DID (only when VCKit has an HTTPS
+      // endpoint — did:web resolution requires HTTPS for signing)
+      if (config.services.vckit.baseUrl.startsWith('https://')) {
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/dids',
+          body: {
+            type: 'MANAGED',
+            method: 'DID_WEB',
+            alias: `e2e-cred-did-${RUN_ID}`,
+            name: `E2E Credential DID ${RUN_ID}`,
+          },
+        }).then((response) => {
+          expect(response.status).to.eq(201);
+          tenantDidValue = response.body.did;
+        });
+      }
+
+      // Seed a DID belonging to a different tenant
+      cy.task('seedForeignTenantDid').then((result: any) => {
+        foreignDid = result.did;
+      });
     });
 
+    after(() => {
+      cy.task('cleanupForeignTenantDid');
+    });
+
+    it('issues a credential using the system default DID', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(defaultDidValue),
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.credentialId).to.be.a('string');
+      });
+    });
+
+    // Signing with a tenant-created managed DID requires VCKit to resolve
+    // the did:web document over HTTPS. In Docker CI the VCKit domain is an
+    // internal hostname over HTTP, so did:web resolution fails. Skip when
+    // VCKit is not on an HTTPS endpoint.
+    it('issues a credential using a tenant-owned DID', function () {
+      if (!config.services.vckit.baseUrl.startsWith('https://')) this.skip();
+
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(tenantDidValue),
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.credentialId).to.be.a('string');
+      });
+    });
+
+    it('rejects issuance with a DID belonging to another tenant', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload(foreignDid),
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('not registered to your tenant');
+      });
+    });
+
+    it('rejects issuance with a fabricated DID that does not exist', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/credentials',
+        body: {
+          credentialPayload: buildCredentialPayload('did:web:nonexistent.example.com'),
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.1',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('not registered to your tenant');
+      });
+    });
+
+    // Same did:web HTTPS constraint as the tenant-owned DID test above.
+    it('issues a credential using a DID on a non-primary VC service instance', function () {
+      if (!config.services.vckit.baseUrl.startsWith('https://')) this.skip();
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/services',
+        body: {
+          serviceType: 'VC',
+          adapterType: 'VCKIT',
+          name: 'E2E VCKit VC Secondary',
+          config: {
+            baseUrl: config.services.vckit.baseUrl,
+            apiKey: config.services.vckit.apiKey,
+          },
+          isPrimary: false,
+        },
+      }).then((res) => {
+        expect(res.status).to.eq(201);
+        const secondVcServiceId = res.body.id;
+
+        return cy.request({
+          method: 'POST',
+          url: '/api/v1/dids',
+          body: {
+            type: 'MANAGED',
+            method: 'DID_WEB',
+            alias: `e2e-secondary-did-${RUN_ID}`,
+            name: `E2E Secondary DID ${RUN_ID}`,
+            serviceInstanceId: secondVcServiceId,
+          },
+        });
+      }).then((didRes) => {
+        expect(didRes.status).to.eq(201);
+        const secondaryDid = didRes.body.did;
+
+        cy.request({
+          method: 'POST',
+          url: '/api/v1/credentials',
+          body: {
+            credentialPayload: buildCredentialPayload(secondaryDid),
+            credentialType: 'DigitalProductPassport',
+            version: '0.6.1',
+          },
+        }).then((response) => {
+          expect(response.status).to.eq(201);
+          expect(response.body.credentialId).to.be.a('string');
+        });
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Issue and retrieve
+  // -----------------------------------------------------------------------
+  describe('Issue and retrieve credentials', () => {
     it('POST /api/v1/credentials — issues an encrypted credential', () => {
       cy.request({
         method: 'POST',

--- a/packages/reference-implementation/README.md
+++ b/packages/reference-implementation/README.md
@@ -45,6 +45,14 @@ The RI runs on [http://localhost:3003](http://localhost:3003) with hot reloading
 - [Authentication](https://uncefact.github.io/tests-untp/docs/next/reference-implementation/authentication) — browser sessions, service accounts, and obtaining tokens
 - [API Documentation](http://localhost:3003/api-docs) — interactive Swagger UI (requires running instance)
 
+### Credential Issuance and DID Ownership
+
+When issuing a credential, the `issuer.id` in the credential payload must be a DID that belongs to the authenticated tenant or a [system default DID](https://uncefact.github.io/tests-untp/docs/next/reference-implementation/api/dids#system-dids-vs-tenant-dids). The VC service used for signing is determined by the DID's associated service instance, not the tenant's primary. This ensures signing always happens on the VC service that holds the DID's key material.
+
+**did:web and HTTPS**: Managed DIDs use the `did:web` method, which requires the DID document to be resolvable over HTTPS. In local Docker development, VCKit runs on HTTP with an internal hostname, so managed DIDs created locally cannot be used for credential issuance. Use the system default DID for local development, or deploy VCKit with a publicly resolvable HTTPS domain.
+
+See the [Credentials API documentation](https://uncefact.github.io/tests-untp/docs/next/reference-implementation/api/credentials) for the full issuance pipeline.
+
 ### Resetting Services
 
 To tear down all containers **and remove all data volumes** (databases, Keycloak realm data, etc.):

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -102,9 +102,11 @@ jest.mock('@uncefact/untp-ri-services', () => ({
 // Repository mocks
 const mockUpdateCredentialPublished = jest.fn();
 const mockListCredentials = jest.fn();
+const mockGetDidByDid = jest.fn();
 jest.mock('@/lib/prisma/repositories', () => ({
   updateCredentialPublished: (...args: unknown[]) => mockUpdateCredentialPublished(...args),
   listCredentials: (...args: unknown[]) => mockListCredentials(...args),
+  getDidByDid: (...args: unknown[]) => mockGetDidByDid(...args),
 }));
 
 const mockAssertPublicUrl = jest.fn();
@@ -173,6 +175,7 @@ const AUTH_CONTEXT = { tenantId: 'tenant-1', params: Promise.resolve({}) };
 const VALID_PAYLOAD = {
   '@context': ['https://www.w3.org/ns/credentials/v2'],
   type: ['VerifiableCredential', 'DigitalProductPassport'],
+  issuer: { type: ['CredentialIssuer'], id: 'did:web:vckit.example.com:tenant-1', name: 'Tenant 1' },
   credentialSubject: { id: 'urn:example:product:123' },
 };
 
@@ -213,6 +216,12 @@ function setupHappyPath() {
   });
   mockValidateCredentialPayload.mockResolvedValue(undefined);
   mockValidateCvcCompliance.mockResolvedValue({ warnings: [] });
+  mockGetDidByDid.mockResolvedValue({
+    id: 'did-1',
+    did: 'did:web:vckit.example.com:tenant-1',
+    tenantId: 'tenant-1',
+    serviceInstanceId: 'vc-1',
+  });
   mockResolveVcService.mockResolvedValue({ service: {}, instanceId: 'vc-1' });
   mockResolveStorageService.mockResolvedValue({ service: {}, instanceId: 'storage-1' });
   mockIssueCredential.mockResolvedValue({
@@ -579,14 +588,160 @@ describe('POST /api/v1/credentials', () => {
     });
   });
 
+  // ── DID ownership validation ────────────────────────────────────────
+
+  describe('DID ownership validation', () => {
+    it('allows issuance when issuer DID belongs to the tenant', async () => {
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(res.status).toBe(201);
+      expect(mockGetDidByDid).toHaveBeenCalledWith('did:web:vckit.example.com:tenant-1', 'tenant-1');
+    });
+
+    it('allows issuance when issuer DID is a system default', async () => {
+      mockGetDidByDid.mockResolvedValue({
+        id: 'sys-did',
+        did: 'did:web:vckit.example.com',
+        type: 'DEFAULT',
+        tenantId: 'system-tenant',
+        serviceInstanceId: 'system-vc-instance',
+      });
+
+      const payload = {
+        ...VALID_PAYLOAD,
+        issuer: { type: ['CredentialIssuer'], id: 'did:web:vckit.example.com', name: 'System' },
+      };
+      const req = createFakeRequest(validBody({ credentialPayload: payload }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(res.status).toBe(201);
+    });
+
+    it('returns 400 when issuer DID does not belong to the tenant', async () => {
+      mockGetDidByDid.mockResolvedValue(null);
+
+      const payload = {
+        ...VALID_PAYLOAD,
+        issuer: { type: ['CredentialIssuer'], id: 'did:web:other-tenant.example.com', name: 'Other' },
+      };
+      const req = createFakeRequest(validBody({ credentialPayload: payload }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('not registered to your tenant');
+      expect(mockIssueCredential).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when issuer is missing from credential payload', async () => {
+      const { issuer: _, ...payloadWithoutIssuer } = VALID_PAYLOAD;
+      const req = createFakeRequest(validBody({ credentialPayload: payloadWithoutIssuer }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('credentialPayload.issuer.id is required');
+    });
+
+    it('returns 400 when issuer is an object without an id field', async () => {
+      const payload = {
+        ...VALID_PAYLOAD,
+        issuer: { type: ['CredentialIssuer'], name: 'No ID Issuer' },
+      };
+      const req = createFakeRequest(validBody({ credentialPayload: payload }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('credentialPayload.issuer.id is required');
+      expect(mockGetDidByDid).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when getDidByDid throws an unexpected error', async () => {
+      mockGetDidByDid.mockRejectedValue(new Error('DB connection lost'));
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(res.status).toBe(500);
+      expect(mockIssueCredential).not.toHaveBeenCalled();
+    });
+
+    it('extracts issuer.id when issuer is a string', async () => {
+      const payload = { ...VALID_PAYLOAD, issuer: 'did:web:vckit.example.com:tenant-1' };
+      const req = createFakeRequest(validBody({ credentialPayload: payload }));
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockGetDidByDid).toHaveBeenCalledWith('did:web:vckit.example.com:tenant-1', 'tenant-1');
+    });
+
+    it('does not call service resolution when DID validation fails', async () => {
+      mockGetDidByDid.mockResolvedValue(null);
+
+      const payload = {
+        ...VALID_PAYLOAD,
+        issuer: { type: ['CredentialIssuer'], id: 'did:web:attacker.example.com', name: 'Attacker' },
+      };
+      const req = createFakeRequest(validBody({ credentialPayload: payload }));
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockResolveVcService).not.toHaveBeenCalled();
+      expect(mockResolveStorageService).not.toHaveBeenCalled();
+    });
+
+    it('resolves the VC service using the DID serviceInstanceId', async () => {
+      const req = createFakeRequest(validBody());
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockResolveVcService).toHaveBeenCalledWith('tenant-1', 'vc-1');
+    });
+
+    it('resolves the system DID VC service instance for system default DIDs', async () => {
+      mockGetDidByDid.mockResolvedValue({
+        id: 'sys-did',
+        did: 'did:web:vckit.example.com',
+        type: 'DEFAULT',
+        tenantId: 'system-tenant',
+        serviceInstanceId: 'system-vc-instance',
+      });
+
+      const payload = {
+        ...VALID_PAYLOAD,
+        issuer: { type: ['CredentialIssuer'], id: 'did:web:vckit.example.com', name: 'System' },
+      };
+      const req = createFakeRequest(validBody({ credentialPayload: payload }));
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockResolveVcService).toHaveBeenCalledWith('tenant-1', 'system-vc-instance');
+    });
+
+    it('returns 400 when DID has no associated VC service instance', async () => {
+      mockGetDidByDid.mockResolvedValue({
+        id: 'did-1',
+        did: 'did:web:vckit.example.com:tenant-1',
+        tenantId: 'tenant-1',
+        serviceInstanceId: null,
+      });
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('has no associated VC service instance');
+      expect(mockIssueCredential).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Service resolution ──────────────────────────────────────────────
 
   describe('service resolution', () => {
-    it('passes signingOptions.serviceInstanceId to resolveVcService', async () => {
-      const req = createFakeRequest(validBody({ signingOptions: { serviceInstanceId: 'custom-vc' } }));
+    it('resolves VC service using the DID serviceInstanceId by default', async () => {
+      const req = createFakeRequest(validBody());
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
-      expect(mockResolveVcService).toHaveBeenCalledWith('tenant-1', 'custom-vc');
+      expect(mockResolveVcService).toHaveBeenCalledWith('tenant-1', 'vc-1');
     });
 
     it('passes storageOptions.serviceInstanceId to resolveStorageService', async () => {
@@ -594,13 +749,6 @@ describe('POST /api/v1/credentials', () => {
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
       expect(mockResolveStorageService).toHaveBeenCalledWith('tenant-1', 'custom-storage');
-    });
-
-    it('passes undefined when no signingOptions provided', async () => {
-      const req = createFakeRequest(validBody());
-      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
-
-      expect(mockResolveVcService).toHaveBeenCalledWith('tenant-1', undefined);
     });
 
     it('passes undefined when no storageOptions provided', async () => {

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -17,6 +17,7 @@ import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
 import { resolveStorageService } from '@/lib/services/resolve-storage-service';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
+import { getDidByDid } from '@/lib/prisma/repositories';
 import { buildPublishLinks } from '@uncefact/untp-ri-services';
 import type { CredentialPayload, ExtractedRefs } from '@uncefact/untp-ri-services';
 import { validateCvcCompliance } from '@/lib/services/cvc-validation.service';
@@ -35,9 +36,10 @@ const logger = apiLogger.child({ route: '/api/v1/credentials' });
  *     summary: Issue a verifiable credential
  *     description: |
  *       Validates a credential payload via JSON Schema and JSON-LD expansion,
- *       signs it, stores the enveloped credential (optionally encrypted),
- *       optionally publishes it to the Identity Resolver, links it to its
- *       primary entity, and returns the credential ID.
+ *       verifies that the issuer DID belongs to the authenticated tenant or is
+ *       a system default DID, signs it, stores the enveloped credential
+ *       (optionally encrypted), optionally publishes it to the Identity
+ *       Resolver, links it to its primary entity, and returns the credential ID.
  *     tags:
  *       - Credentials
  *     requestBody:
@@ -54,7 +56,7 @@ const logger = apiLogger.child({ route: '/api/v1/credentials' });
  *             schema:
  *               $ref: '#/components/schemas/CredentialIssueResponse'
  *       400:
- *         description: Validation error
+ *         description: Validation error (invalid payload, unknown data model, or issuer DID not registered to tenant)
  *         content:
  *           application/json:
  *             schema:
@@ -83,9 +85,6 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     credentialPayload?: CredentialPayload;
     credentialType?: string;
     version?: string;
-    signingOptions?: {
-      serviceInstanceId?: string;
-    };
     storageOptions?: {
       serviceInstanceId?: string;
       encrypt?: boolean;
@@ -124,7 +123,6 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   }
 
   const { credentialPayload, credentialType, version } = body;
-  const signingOptions = body.signingOptions ?? {};
   const storageOptions = body.storageOptions ?? {};
   const publishingOptions = body.publishingOptions ?? {};
 
@@ -191,13 +189,48 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     }
   }
 
-  // ── Step 4: Resolve services ────────────────────────────────────────────
+  // ── Step 4: Validate issuer DID ownership ────────────────────────────────
+  // The issuer DID in the credential payload must belong to the authenticated
+  // tenant or be the system default DID. This prevents a tenant from signing
+  // credentials with a DID they do not control.
 
-  logger.info('Resolving VC and storage services');
-  const vcService = await resolveVcService(tenantId, signingOptions.serviceInstanceId);
+  const issuer = credentialPayload.issuer;
+  const issuerDid = typeof issuer === 'string' ? issuer : issuer?.id;
+  if (!issuerDid) {
+    throw new ValidationError('credentialPayload.issuer.id is required');
+  }
+
+  logger.info({ issuerDid }, 'Validating issuer DID ownership');
+  const didRecord = await getDidByDid(issuerDid, tenantId);
+  if (!didRecord) {
+    logger.warn({ issuerDid, tenantId }, 'Issuer DID not found for tenant');
+    throw new ValidationError(
+      `Issuer DID "${issuerDid}" is not registered to your tenant. ` +
+        'You can only issue credentials with a DID that belongs to your tenant or the system default DID.',
+    );
+  }
+
+  // ── Step 5: Validate DID has a VC service association ──────────────────
+
+  if (!didRecord.serviceInstanceId) {
+    logger.warn({ issuerDid }, 'Issuer DID has no associated VC service instance');
+    throw new ValidationError(
+      `Issuer DID "${issuerDid}" has no associated VC service instance. ` +
+        'The DID may have lost its service association (e.g., the service instance was force-deleted). ' +
+        'Re-import or re-create the DID to restore the association.',
+    );
+  }
+
+  // ── Step 6: Resolve services ────────────────────────────────────────────
+  // The VC service is resolved from the DID's associated service instance,
+  // ensuring signing always happens on the VC service that holds the DID's
+  // key material. This works for both tenant-owned and system default DIDs.
+
+  logger.info({ vcServiceInstanceId: didRecord.serviceInstanceId }, 'Resolving VC and storage services');
+  const vcService = await resolveVcService(tenantId, didRecord.serviceInstanceId);
   const storageService = await resolveStorageService(tenantId, storageOptions.serviceInstanceId);
 
-  // ── Step 5: Issue credential ────────────────────────────────────────────
+  // ── Step 7: Issue credential ────────────────────────────────────────────
 
   logger.info({ credentialType }, 'Issuing credential');
   const { credentialId, storageResponse, primaryEntity } = await issueCredential({
@@ -210,7 +243,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     storageOptions,
   });
 
-  // ── Step 6: Publish to IDR ──────────────────────────────────────────────
+  // ── Step 8: Publish to IDR ──────────────────────────────────────────────
 
   if (publishingOptions.publish === true) {
     if (!primaryEntity.schemePrimaryKey || !primaryEntity.schemeNamespace) {

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -205,7 +205,7 @@ describe('did.repository', () => {
       expect(mockDid.findFirst).toHaveBeenCalledWith({
         where: {
           id: 'did-record-1',
-          OR: [{ tenantId: ORG_ID }, { isDefault: true, type: 'DEFAULT' }],
+          OR: [{ tenantId: ORG_ID }, { type: 'DEFAULT' }],
         },
       });
       expect(result).toEqual(DID_RECORD);
@@ -251,7 +251,7 @@ describe('did.repository', () => {
       expect(mockDid.findFirst).toHaveBeenCalledWith({
         where: {
           did: 'did:web:example.com:org:123',
-          OR: [{ tenantId: ORG_ID }, { isDefault: true, type: 'DEFAULT' }],
+          OR: [{ tenantId: ORG_ID }, { type: 'DEFAULT' }],
         },
       });
       expect(result).toEqual(DID_RECORD);
@@ -266,7 +266,7 @@ describe('did.repository', () => {
       expect(mockDid.findFirst).toHaveBeenCalledWith({
         where: {
           did: 'did:web:example.com:org:123',
-          OR: [{ tenantId: 'other-org' }, { isDefault: true, type: 'DEFAULT' }],
+          OR: [{ tenantId: 'other-org' }, { type: 'DEFAULT' }],
         },
       });
       expect(result).toEqual(defaultDid);
@@ -300,7 +300,7 @@ describe('did.repository', () => {
 
       expect(mockDid.findMany).toHaveBeenCalledWith({
         where: {
-          OR: [{ tenantId: ORG_ID }, { isDefault: true, type: 'DEFAULT' }],
+          OR: [{ tenantId: ORG_ID }, { type: 'DEFAULT' }],
         },
         take: DEFAULT_PAGE_LIMIT,
         skip: undefined,
@@ -308,7 +308,7 @@ describe('did.repository', () => {
       });
       expect(mockDid.count).toHaveBeenCalledWith({
         where: {
-          OR: [{ tenantId: ORG_ID }, { isDefault: true, type: 'DEFAULT' }],
+          OR: [{ tenantId: ORG_ID }, { type: 'DEFAULT' }],
         },
       });
       expect(result).toEqual({ data: [DID_RECORD], total: 1 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -99,7 +99,7 @@ export async function getDidById(id: string, tenantId: string): Promise<Did | nu
   const did = await prisma.did.findFirst({
     where: {
       id,
-      OR: [{ tenantId }, { isDefault: true, type: 'DEFAULT' }],
+      OR: [{ tenantId }, { type: 'DEFAULT' }],
     },
   });
 
@@ -116,7 +116,7 @@ export async function getDidByDid(didString: string, tenantId: string): Promise<
   const did = await prisma.did.findFirst({
     where: {
       did: didString,
-      OR: [{ tenantId }, { isDefault: true, type: 'DEFAULT' }],
+      OR: [{ tenantId }, { type: 'DEFAULT' }],
     },
   });
 
@@ -134,7 +134,7 @@ export async function listDids(
   const { type, status, serviceInstanceId, limit, offset } = options;
 
   const where: Prisma.DidWhereInput = {
-    OR: [{ tenantId }, { isDefault: true, type: 'DEFAULT' }],
+    OR: [{ tenantId }, { type: 'DEFAULT' }],
   };
 
   if (type !== undefined) {

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -30,10 +30,6 @@ import { paginationMetaSchema } from '@/lib/api/pagination';
 // Credential Schemas (remain local — no credential service directory yet)
 // ============================================================================
 
-const signingOptionsSchema = z.object({
-  serviceInstanceId: z.string().optional().describe('Signing service instance ID'),
-});
-
 const storageOptionsSchema = z.object({
   serviceInstanceId: z.string().optional().describe('Storage service instance ID'),
   encrypt: z.boolean().optional().describe('Whether to encrypt the stored credential'),
@@ -58,7 +54,6 @@ export const credentialIssueRequestSchema = z.object({
     .string()
     .describe('Type of credential to issue (e.g. DigitalProductPassport, DigitalLivestockPassport)'),
   version: z.string().describe('Data model version'),
-  signingOptions: signingOptionsSchema.optional().describe('Signing service options'),
   storageOptions: storageOptionsSchema.optional().describe('Storage service options'),
   publishingOptions: publishingOptionsSchema.optional().describe('IDR publishing options'),
 });


### PR DESCRIPTION
This PR closes a security gap where tenants could issue credentials using
any DID, including DIDs belonging to other tenants. The credential issuance
pipeline now enforces:

1. The `issuer.id` in the credential payload must be a DID registered to the
   authenticated tenant or a system default DID.
2. The DID must have an associated VC service instance. The VC service is
   resolved from the DID's association, ensuring signing always happens on
   the service that holds the DID's key material. This works for both
   tenant-owned and system default DIDs without special-casing.
3. `signingOptions.serviceInstanceId` has been removed from the request body
   — the DID uniquely determines which VC service to use.

Also fixes DID repository queries (`getDidById`, `getDidByDid`, `listDids`)
to match all system DIDs by `{ type: 'DEFAULT' }` rather than requiring
`{ isDefault: true, type: 'DEFAULT' }`, making them robust against future
multi-DID system configurations.

## Test plan
- [x] Credential issuance with system default DID succeeds
- [x] Credential issuance with tenant-owned DID succeeds
- [x] Credential issuance with DID on non-primary VC service instance succeeds
- [x] Credential issuance with another tenant's DID rejected (400)
- [x] Credential issuance with fabricated DID rejected (400)
- [x] Credential issuance with DID that has no service association rejected (400)
- [x] Issuer as object without `id` field rejected (400)
- [x] `getDidByDid` database error propagates as 500, issuance blocked
- [x] String-form issuer DID extracted correctly
- [x] Missing issuer.id rejected (400)
- [x] System default DID resolves the system VC service instance (not the tenant's)
- [x] E2E tests cover all happy and unhappy paths across local, CI, and deployed environments
- [x] 103 unit tests pass (37 repository + 66 credential route)