### PR TITLE
fix(idr): rename itemDescription to description for IDR v3 compatibility

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -237,7 +237,7 @@ Validates, signs, stores, and optionally publishes a verifiable credential. Retu
 | `storageOptions.encrypt` | boolean | No | Whether to encrypt (default: `true`) |
 | `publishingOptions.publish` | boolean | No | Whether to publish to IDR |
 | `publishingOptions.linkType` | string | No | Link relation type |
-| `publishingOptions.linkTitle` | string | No | Link title |
+| `publishingOptions.linkTitle` | string | No | Link title (defaults to data model name) |
 | `publishingOptions.qualifierPath` | string | No | Qualifier path (default: `/`) |
 | `publishingOptions.machineVerificationUrl` | string | No | Machine verification URL |
 | `publishingOptions.humanVerificationUrl` | string | No | Human verification URL |

--- a/documentation/docs/reference-implementation/api/identifiers.md
+++ b/documentation/docs/reference-implementation/api/identifiers.md
@@ -313,7 +313,7 @@ Publishes one or more links for an identifier to the upstream IDR service. Each 
 | Optional Field | Description |
 |----------------|-------------|
 | `qualifierPath` | Qualifier path appended to the IDR link |
-| `itemDescription` | Human-readable description for the IDR entry |
+| `description` | Description of the item being identified |
 
 ```mermaid
 sequenceDiagram

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -864,7 +864,7 @@ describe('POST /api/v1/credentials', () => {
       // idrService.publishLinks called
       expect(mockPublishLinks).toHaveBeenCalledWith('gtin', '09506000134352', expect.any(Array), '/', {
         namespace: 'gs1',
-        itemDescription: 'Digital Product Passport',
+        description: 'Digital Product Passport',
       });
 
       // updateCredentialPublished called
@@ -896,7 +896,7 @@ describe('POST /api/v1/credentials', () => {
         expect.any(String),
         expect.any(Array),
         '/',
-        expect.objectContaining({ itemDescription: 'Custom Title' }),
+        expect.objectContaining({ description: 'Custom Title' }),
       );
     });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -282,7 +282,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
           publishingOptions.qualifierPath || '/',
           {
             namespace: primaryEntity.schemeNamespace,
-            itemDescription: linkTitle,
+            description: linkTitle,
           },
         );
       } catch (error) {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
@@ -54,9 +54,9 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links' });
  *               qualifierPath:
  *                 type: string
  *                 description: Optional qualifier path for the IDR link
- *               itemDescription:
+ *               description:
  *                 type: string
- *                 description: Optional human-readable description
+ *                 description: Description of the item being identified
  *     responses:
  *       201:
  *         description: Links published successfully
@@ -117,7 +117,7 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
   let body: {
     links?: Array<Record<string, unknown>>;
     qualifierPath?: string;
-    itemDescription?: string;
+    description?: string;
   };
   try {
     body = await req.json();
@@ -160,7 +160,7 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
     identifier.value,
     body.links as Link[],
     body.qualifierPath,
-    { namespace, itemDescription: body.itemDescription },
+    { namespace, description: body.description },
   );
 
   logger.info({ identifierId, publishedCount: registration.links.length }, 'Storing audit records');

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -38,7 +38,7 @@ const storageOptionsSchema = z.object({
 const publishingOptionsSchema = z.object({
   publish: z.boolean().optional().describe('Whether to publish the credential to the Identity Resolver'),
   linkType: z.string().optional().describe('UNTP link relation type (defaults to gs1:sustainabilityInfo)'),
-  linkTitle: z.string().optional().describe('Title for the published link'),
+  linkTitle: z.string().optional().describe('Title for the published link (defaults to data model name)'),
   qualifierPath: z
     .string()
     .optional()

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
@@ -155,7 +155,7 @@ describe('PyxIdentityResolverAdapter', () => {
       const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
       await adapter.publishLinks('abn', '51824753556', mockLinks, undefined, {
         ...mockOptions,
-        itemDescription: 'Test item',
+        description: 'Test item',
       });
 
       const callArgs = mockFetch.mock.calls[0];
@@ -164,7 +164,7 @@ describe('PyxIdentityResolverAdapter', () => {
         namespace: 'ato',
         identificationKey: '51824753556',
         identificationKeyType: 'abn',
-        itemDescription: 'Test item',
+        description: 'Test item',
         qualifierPath: '/',
         active: true,
       });

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
@@ -85,7 +85,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
       namespace,
       identificationKeyType: identifierScheme,
       identificationKey: identifier,
-      itemDescription: options.itemDescription ?? '',
+      description: options.description ?? '',
       qualifierPath: qualifierPath ?? '/',
       active: true,
       responses: links.map((link) => ({

--- a/packages/services/src/identity-resolver/types.ts
+++ b/packages/services/src/identity-resolver/types.ts
@@ -149,8 +149,8 @@ export type LinkRegistration = {
 export type PublishLinksOptions = {
   /** Namespace for the identifier scheme (e.g., "untp", "gs1") */
   namespace: string;
-  /** Human-readable description of the item being registered */
-  itemDescription?: string;
+  /** Human-readable description of the item being identified */
+  description?: string;
   /** IANA language tag override (e.g., "en") — falls back to service config */
   ianaLanguage?: string;
   /** Regional/market context override (e.g., "au") — falls back to service config */


### PR DESCRIPTION
This PR fixes credential publishing to the Identity Resolver, which was failing with HTTP 400 because the Pyx IDR adapter sent `itemDescription` but IDR v3.0.0 expects `description`. Verified locally against the IDR v3.0.0 Docker image.

Also adds `publishingOptions.description` to the credentials API so callers can provide a description for the identified item separately from the link title. Falls back to `linkTitle` when not provided.

Closes #486

## Test plan
- [x] IDR adapter sends `description` in payload (51 adapter tests pass)
- [x] Credential route passes `publishingOptions.description` or falls back to `linkTitle` (66 route tests pass)
- [x] Verified against local IDR v3.0.0 Docker image: `description` accepted, `itemDescription` alone rejected