### PR TITLE
fix(api): use entity description for IDR item description when publishing

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -207,6 +207,8 @@ Publishing requires the primary entity to have:
 
 If any of these are missing, publishing is silently skipped and a `PUBLISH_SKIPPED` warning is included in the response.
 
+The IDR entry's `description` field is taken from the primary entity's `description`, falling back to the entity's `name` if no description is set.
+
 | Publishing Option | Type | Description |
 |-------------------|------|-------------|
 | `publish` | boolean | Whether to publish to the identity resolver |

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -820,6 +820,8 @@ describe('POST /api/v1/credentials', () => {
         schemePrimaryKey: 'gtin',
         schemeNamespace: 'gs1',
         schemeIdrServiceInstanceId: 'idr-scheme-1',
+        entityName: 'Test Product',
+        entityDescription: 'A test product for E2E',
       };
       const primaryEntity = { ...defaults, ...overrides };
 
@@ -864,7 +866,7 @@ describe('POST /api/v1/credentials', () => {
       // idrService.publishLinks called
       expect(mockPublishLinks).toHaveBeenCalledWith('gtin', '09506000134352', expect.any(Array), '/', {
         namespace: 'gs1',
-        description: 'Digital Product Passport',
+        description: 'A test product for E2E',
       });
 
       // updateCredentialPublished called
@@ -896,7 +898,7 @@ describe('POST /api/v1/credentials', () => {
         expect.any(String),
         expect.any(Array),
         '/',
-        expect.objectContaining({ description: 'Custom Title' }),
+        expect.objectContaining({ description: 'A test product for E2E' }),
       );
     });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -282,7 +282,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
           publishingOptions.qualifierPath || '/',
           {
             namespace: primaryEntity.schemeNamespace,
-            description: linkTitle,
+            description: primaryEntity.entityDescription || primaryEntity.entityName,
           },
         );
       } catch (error) {

--- a/packages/reference-implementation/src/lib/entities/resolve-primary-entity.test.ts
+++ b/packages/reference-implementation/src/lib/entities/resolve-primary-entity.test.ts
@@ -29,9 +29,11 @@ const SCHEME_INFO = {
   registrar: { namespace: 'gs1' },
 };
 
-function makeEntity(id: string) {
+function makeEntity(id: string, name = 'Test Entity', description: string | null = 'Test entity description') {
   return {
     id,
+    name,
+    description,
     primaryIdentifier: {
       scheme: SCHEME_INFO,
     },
@@ -70,6 +72,8 @@ describe('resolvePrimaryEntity', () => {
     expect(result).toEqual<PrimaryEntityResult>({
       primaryIdentifier: '09506000134352',
       productId: 'prod-1',
+      entityName: 'Test Entity',
+      entityDescription: 'Test entity description',
       schemeNamespace: 'gs1',
       schemePrimaryKey: 'gtin',
       schemeIdrServiceInstanceId: 'idr-svc-1',
@@ -92,6 +96,8 @@ describe('resolvePrimaryEntity', () => {
     expect(result).toEqual<PrimaryEntityResult>({
       primaryIdentifier: '9506000134',
       facilityId: 'fac-1',
+      entityName: 'Test Entity',
+      entityDescription: 'Test entity description',
       schemeNamespace: 'gs1',
       schemePrimaryKey: 'gtin',
       schemeIdrServiceInstanceId: 'idr-svc-1',
@@ -114,10 +120,28 @@ describe('resolvePrimaryEntity', () => {
     expect(result).toEqual<PrimaryEntityResult>({
       primaryIdentifier: '9506000100',
       organisationId: 'org-1',
+      entityName: 'Test Entity',
+      entityDescription: 'Test entity description',
       schemeNamespace: 'gs1',
       schemePrimaryKey: 'gtin',
       schemeIdrServiceInstanceId: 'idr-svc-1',
     });
+  });
+
+  it('omits entityDescription when entity description is null', async () => {
+    const entity = makeEntity('prod-1', 'My Product', null);
+    mockGetProductByIdentifierValue.mockResolvedValue(entity);
+
+    const result = await resolvePrimaryEntity(
+      {
+        ...EMPTY_REFS,
+        products: [{ id: '09506000134352' }],
+      },
+      TENANT_ID,
+    );
+
+    expect(result.entityName).toBe('My Product');
+    expect(result.entityDescription).toBeUndefined();
   });
 
   it('returns empty result when entity not found in DB', async () => {
@@ -154,6 +178,8 @@ describe('resolvePrimaryEntity', () => {
     expect(result).toEqual<PrimaryEntityResult>({
       primaryIdentifier: 'product-id',
       productId: 'prod-1',
+      entityName: 'Test Entity',
+      entityDescription: 'Test entity description',
       schemeNamespace: 'gs1',
       schemePrimaryKey: 'gtin',
       schemeIdrServiceInstanceId: 'idr-svc-1',

--- a/packages/reference-implementation/src/lib/entities/resolve-primary-entity.ts
+++ b/packages/reference-implementation/src/lib/entities/resolve-primary-entity.ts
@@ -13,10 +13,39 @@ export type PrimaryEntityResult = {
   organisationId?: string;
   facilityId?: string;
   productId?: string;
+  entityName?: string;
+  entityDescription?: string;
   schemeNamespace?: string;
   schemePrimaryKey?: string;
   schemeIdrServiceInstanceId?: string | null;
 };
+
+/** Extracts common fields from a resolved entity. */
+function buildResult(
+  identifier: string,
+  entity: {
+    name: string;
+    description?: string | null;
+    primaryIdentifier?: {
+      scheme?: {
+        primaryKey: string;
+        idrServiceInstanceId?: string | null;
+        registrar?: { namespace: string } | null;
+      } | null;
+    } | null;
+  },
+  entityIdField: Partial<Pick<PrimaryEntityResult, 'productId' | 'facilityId' | 'organisationId'>>,
+): PrimaryEntityResult {
+  return {
+    primaryIdentifier: identifier,
+    ...entityIdField,
+    entityName: entity.name,
+    entityDescription: entity.description ?? undefined,
+    schemeNamespace: entity.primaryIdentifier?.scheme?.registrar?.namespace ?? undefined,
+    schemePrimaryKey: entity.primaryIdentifier?.scheme?.primaryKey,
+    schemeIdrServiceInstanceId: entity.primaryIdentifier?.scheme?.idrServiceInstanceId,
+  };
+}
 
 /**
  * Resolves a primary entity from extracted credential references.
@@ -31,13 +60,7 @@ export async function resolvePrimaryEntity(refs: ExtractedRefs, tenantId: string
       logger.warn({ identifierValue: refs.products[0].id, tenantId }, 'Product not found for identifier');
       return {};
     }
-    return {
-      primaryIdentifier: refs.products[0].id,
-      productId: entity.id,
-      schemeNamespace: entity.primaryIdentifier?.scheme?.registrar?.namespace ?? undefined,
-      schemePrimaryKey: entity.primaryIdentifier?.scheme?.primaryKey,
-      schemeIdrServiceInstanceId: entity.primaryIdentifier?.scheme?.idrServiceInstanceId,
-    };
+    return buildResult(refs.products[0].id, entity, { productId: entity.id });
   }
 
   if (refs.facilities[0]?.id) {
@@ -46,13 +69,7 @@ export async function resolvePrimaryEntity(refs: ExtractedRefs, tenantId: string
       logger.warn({ identifierValue: refs.facilities[0].id, tenantId }, 'Facility not found for identifier');
       return {};
     }
-    return {
-      primaryIdentifier: refs.facilities[0].id,
-      facilityId: entity.id,
-      schemeNamespace: entity.primaryIdentifier?.scheme?.registrar?.namespace ?? undefined,
-      schemePrimaryKey: entity.primaryIdentifier?.scheme?.primaryKey,
-      schemeIdrServiceInstanceId: entity.primaryIdentifier?.scheme?.idrServiceInstanceId,
-    };
+    return buildResult(refs.facilities[0].id, entity, { facilityId: entity.id });
   }
 
   if (refs.organisations[0]?.id) {
@@ -61,13 +78,7 @@ export async function resolvePrimaryEntity(refs: ExtractedRefs, tenantId: string
       logger.warn({ identifierValue: refs.organisations[0].id, tenantId }, 'Organisation not found for identifier');
       return {};
     }
-    return {
-      primaryIdentifier: refs.organisations[0].id,
-      organisationId: entity.id,
-      schemeNamespace: entity.primaryIdentifier?.scheme?.registrar?.namespace ?? undefined,
-      schemePrimaryKey: entity.primaryIdentifier?.scheme?.primaryKey,
-      schemeIdrServiceInstanceId: entity.primaryIdentifier?.scheme?.idrServiceInstanceId,
-    };
+    return buildResult(refs.organisations[0].id, entity, { organisationId: entity.id });
   }
 
   return {};


### PR DESCRIPTION
This PR fixes the IDR `description` field to use the entity's own description (or name as fallback) instead of the credential type name. When publishing a credential to the IDR, the `description` describes the item being identified, not the credential.

Closes #495

## Test plan
- [x] Entity description used when present (7 resolve-primary-entity tests)
- [x] Falls back to entity name when description is null
- [x] Publishing passes entity description to IDR service (66 credential route tests)
- [x] Documentation updated