### PR TITLE
ci: expose credential verification details to playground

### DIFF
--- a/.github/workflows/ci_cd-untp-playground.yml
+++ b/.github/workflows/ci_cd-untp-playground.yml
@@ -61,6 +61,8 @@ jobs:
           NEXT_PUBLIC_IMAGE_PATH: /test-untp-playground/_next/image
           NEXT_PUBLIC_REPORT_NAME:
           NEXT_PUBLIC_PLAYGROUND_VERSION: ${{ github.sha }}
+          VERIFICATION_SERVICE_URL: ${{env.PLAYGROUND_VERIFICATION_SERVICE_URL}}
+          VERIFICATION_SERVICE_TOKEN: ${{secrets.PLAYGROUND_VERIFICATION_SERVICE_TOKEN}}
           STACK_NAME: test
 
   deploy_prod:
@@ -112,4 +114,6 @@ jobs:
           NEXT_PUBLIC_IMAGE_PATH: /untp-playground/_next/image
           NEXT_PUBLIC_REPORT_NAME:
           NEXT_PUBLIC_PLAYGROUND_VERSION: ${{ github.ref_name }}
+          VERIFICATION_SERVICE_URL: ${{env.PLAYGROUND_VERIFICATION_SERVICE_URL}}
+          VERIFICATION_SERVICE_TOKEN: ${{secrets.PLAYGROUND_VERIFICATION_SERVICE_TOKEN}}
           STACK_NAME: prod

--- a/packages/untp-playground/infra/README.md
+++ b/packages/untp-playground/infra/README.md
@@ -25,22 +25,26 @@ The UNTP Playground has two environments:
 When code is pushed to the `next` or `cd/**` branch:
 
 1. GitHub Actions workflow triggers automatically
-2. Deploys with these environment variables (static - defined in [workflow file](../../../.github/workflows/ci_cd-untp-playground.yml)):
+2. Deploys with these environment variables (defined in [workflow file](../../../.github/workflows/ci_cd-untp-playground.yml)):
    - NEXT_PUBLIC_BASE_PATH = /test-untp-playground
    - NEXT_PUBLIC_ASSET_PREFIX = /test-untp-playground
    - NEXT_PUBLIC_IMAGE_PATH = /test-untp-playground/\_next/image
    - NEXT_PUBLIC_REPORT_NAME= AATP <!-- Abbreviated UNTP extension name (optional). Defaults to "UNTP". -->
+   - VERIFICATION_SERVICE_URL= ${{env.PLAYGROUND_VERIFICATION_SERVICE_URL}} <!-- The endpoint of the verification service used to verify the uploaded VC.-->
+   - VERIFICATION_SERVICE_TOKEN= ${{secrets.PLAYGROUND_VERIFICATION_SERVICE_TOKEN}} <!-- The API key used to authenticate with the verifiable credential service. -->
 
 ### Production Deployment
 
 When a tag is created, associated with the next branch and the workflow is [triggered manually](https://github.com/uncefact/tests-untp/actions/workflows/ci_cd-untp-playground.yml):
 
 1. GitHub Actions workflow triggers
-2. Deploys with these environment variables (static - defined in [workflow file](../../../.github/workflows/ci_cd-untp-playground.yml)):
+2. Deploys with these environment variables (defined in [workflow file](../../../.github/workflows/ci_cd-untp-playground.yml)):
    - NEXT_PUBLIC_BASE_PATH = /untp-playground
    - NEXT_PUBLIC_ASSET_PREFIX = /untp-playground
    - NEXT_PUBLIC_IMAGE_PATH = /untp-playground/\_next/image
-   - NEXT_PUBLIC_REPORT_NAME = AATP <!-- Abbreviated UNTP extension name (optional). Defaults to "UNTP". -->
+   - NEXT_PUBLIC_REPORT_NAME = AATP
+   - VERIFICATION_SERVICE_URL= ${{env.PLAYGROUND_VERIFICATION_SERVICE_URL}}
+   - VERIFICATION_SERVICE_TOKEN= ${{secrets.PLAYGROUND_VERIFICATION_SERVICE_TOKEN}}
 
 ## Infrastructure Details
 

--- a/packages/untp-playground/infra/infra/app.ts
+++ b/packages/untp-playground/infra/infra/app.ts
@@ -173,6 +173,14 @@ export function deployApp() {
               targetGroup: targetGroup,
             },
           ],
+          environment: [
+            ...(process.env.VERIFICATION_SERVICE_URL
+              ? [{ name: 'VERIFICATION_SERVICE_URL', value: process.env.VERIFICATION_SERVICE_URL }]
+              : []),
+            ...(process.env.VERIFICATION_SERVICE_TOKEN
+              ? [{ name: 'VERIFICATION_SERVICE_TOKEN', value: process.env.VERIFICATION_SERVICE_TOKEN }]
+              : []),
+          ],
         },
       },
       networkConfiguration: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes #505 by exposing the endpoint and api token of the credential verification service to the UNTP playground during deployment to each environment (test, prod).


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Reference Implementation docs site](https://uncefact.github.io/tests-untp/docs/reference-implementation/)
- [x] 📜 README.md
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## API Documentation Updated?


- [ ] 📚 Updated Swagger schemas in `schemas.ts`
- [ ] ✅ Verified Zod schemas match Prisma database schema
- [x] 🙅 No API changes in this PR

