### PR TITLE
feat(playground): add support for UNTP v0.7.0 credentials

### DIFF
--- a/packages/untp-playground/__tests__/lib/credentialService.test.ts
+++ b/packages/untp-playground/__tests__/lib/credentialService.test.ts
@@ -101,7 +101,7 @@ describe('credentialService', () => {
     it('should detect version from UNTP context', () => {
       const credential = {
         type: ['DigitalProductPassport'],
-        '@context': ['https://test.uncefact.org/vocabulary/untp/dpp/0.5.0'],
+        '@context': ['https://www.w3.org/ns/credentials/v2', 'https://test.uncefact.org/vocabulary/untp/dpp/0.5.0'],
       };
 
       expect(detectVersion(credential)).toBe('0.5.0');
@@ -110,10 +110,34 @@ describe('credentialService', () => {
     it('should detect pre-release version from UNTP context', () => {
       const credential = {
         type: ['DigitalProductPassport'],
-        '@context': ['https://test.uncefact.org/vocabulary/untp/dpp/0.6.0-alpha2'],
+        '@context': [
+          'https://www.w3.org/ns/credentials/v2',
+          'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0-alpha2',
+        ],
       };
 
       expect(detectVersion(credential)).toBe('0.6.0-alpha2');
+    });
+
+    it('should detect version from v0.7.0 vocabulary.uncefact.org context', () => {
+      const credential = {
+        type: ['DigitalProductPassport', 'VerifiableCredential'],
+        '@context': ['https://www.w3.org/ns/credentials/v2', 'https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+      };
+
+      expect(detectVersion(credential)).toBe('0.7.0');
+    });
+
+    it('should detect pre-release version from vocabulary.uncefact.org context', () => {
+      const credential = {
+        type: ['DigitalConformityCredential', 'VerifiableCredential'],
+        '@context': [
+          'https://www.w3.org/ns/credentials/v2',
+          'https://vocabulary.uncefact.org/untp/0.7.0-beta1/context/',
+        ],
+      };
+
+      expect(detectVersion(credential)).toBe('0.7.0-beta1');
     });
 
     it('should detect version from custom domain', () => {
@@ -141,6 +165,45 @@ describe('credentialService', () => {
       };
 
       expect(detectVersion(credential)).toBe('unknown');
+    });
+
+    it('should return unknown when the second context is not a UNTP domain', () => {
+      const credential = {
+        type: ['DigitalProductPassport'],
+        '@context': ['https://www.w3.org/ns/credentials/v2', 'https://example.com/other/1.2.3'],
+      };
+
+      expect(detectVersion(credential)).toBe('unknown');
+    });
+
+    it('should return unknown when @context is not an array', () => {
+      const credential = {
+        type: ['DigitalProductPassport'],
+        '@context': 'https://vocabulary.uncefact.org/untp/0.7.0/context/',
+      } as unknown as Parameters<typeof detectVersion>[0];
+
+      expect(detectVersion(credential)).toBe('unknown');
+    });
+
+    it('should return unknown when @context is missing', () => {
+      const credential = {
+        type: ['DigitalProductPassport'],
+      } as unknown as Parameters<typeof detectVersion>[0];
+
+      expect(detectVersion(credential)).toBe('unknown');
+    });
+
+    it('should ignore non-string entries when searching by domain', () => {
+      const credential = {
+        type: ['DigitalLivestockPassport'],
+        '@context': [
+          'https://www.w3.org/ns/credentials/v2',
+          { '@vocab': 'https://aatp.foodagility.com/terms/' },
+          'https://aatp.foodagility.com/vocabulary/aatp/dlp/0.4.0',
+        ],
+      } as unknown as Parameters<typeof detectVersion>[0];
+
+      expect(detectVersion(credential, 'aatp.foodagility.com')).toBe('0.4.0');
     });
   });
 

--- a/packages/untp-playground/__tests__/lib/schemaValidation.test.ts
+++ b/packages/untp-playground/__tests__/lib/schemaValidation.test.ts
@@ -55,6 +55,158 @@ describe('schemaValidation', () => {
       expect(result.errors).toEqual([]);
     });
 
+    it('should construct the legacy schema URL for a v0.6.0 DPP credential', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ $schema: 'https://json-schema.org/draft/2020-12/schema', properties: {} }),
+      });
+
+      (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+      (detectVersion as jest.Mock).mockReturnValue('0.6.0');
+
+      await validateCredentialSchema({ type: 'DigitalProductPassport' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/schema?url=${encodeURIComponent(
+          'https://test.uncefact.org/vocabulary/untp/dpp/untp-dpp-schema-0.6.0.json',
+        )}`,
+      );
+    });
+
+    it('should construct the v0.7.0 schema URL for a DPP credential', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ $schema: 'https://json-schema.org/draft/2020-12/schema', properties: {} }),
+      });
+
+      (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+      (detectVersion as jest.Mock).mockReturnValue('0.7.0');
+
+      await validateCredentialSchema({ type: 'DigitalProductPassport' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/schema?url=${encodeURIComponent(
+          'https://untp.unece.org/artefacts/schema/v0.7.0/dpp/DigitalProductPassport.json',
+        )}`,
+      );
+    });
+
+    it('should use the renamed ConformityCredential schema filename for a v0.7.0 DCC credential', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ $schema: 'https://json-schema.org/draft/2020-12/schema', properties: {} }),
+      });
+
+      (detectCredentialType as jest.Mock).mockReturnValue('DigitalConformityCredential');
+      (detectVersion as jest.Mock).mockReturnValue('0.7.0');
+
+      await validateCredentialSchema({ type: 'DigitalConformityCredential' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/schema?url=${encodeURIComponent(
+          'https://untp.unece.org/artefacts/schema/v0.7.0/dcc/ConformityCredential.json',
+        )}`,
+      );
+    });
+
+    describe('with real detectCredentialType and detectVersion (integration)', () => {
+      const realCredentialService =
+        jest.requireActual<typeof import('@/lib/credentialService')>('@/lib/credentialService');
+
+      beforeEach(() => {
+        (detectCredentialType as jest.Mock).mockImplementation(realCredentialService.detectCredentialType);
+        (detectVersion as jest.Mock).mockImplementation(realCredentialService.detectVersion);
+      });
+
+      it('constructs the legacy schema URL from a real v0.6.0 DPP credential', async () => {
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ $schema: 'https://json-schema.org/draft/2020-12/schema', properties: {} }),
+        });
+
+        const credential = {
+          type: ['DigitalProductPassport', 'VerifiableCredential'],
+          '@context': ['https://www.w3.org/ns/credentials/v2', 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/'],
+        };
+
+        await validateCredentialSchema(credential);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          `/api/schema?url=${encodeURIComponent(
+            'https://test.uncefact.org/vocabulary/untp/dpp/untp-dpp-schema-0.6.0.json',
+          )}`,
+        );
+      });
+
+      it('constructs the v0.7.0 schema URL from a real v0.7.0 DPP credential', async () => {
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ $schema: 'https://json-schema.org/draft/2020-12/schema', properties: {} }),
+        });
+
+        const credential = {
+          type: ['DigitalProductPassport', 'VerifiableCredential'],
+          '@context': ['https://www.w3.org/ns/credentials/v2', 'https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+        };
+
+        await validateCredentialSchema(credential);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          `/api/schema?url=${encodeURIComponent(
+            'https://untp.unece.org/artefacts/schema/v0.7.0/dpp/DigitalProductPassport.json',
+          )}`,
+        );
+      });
+
+      it('constructs the renamed v0.7.0 DCC schema URL from a real v0.7.0 DCC credential', async () => {
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ $schema: 'https://json-schema.org/draft/2020-12/schema', properties: {} }),
+        });
+
+        const credential = {
+          type: ['DigitalConformityCredential', 'VerifiableCredential'],
+          '@context': ['https://www.w3.org/ns/credentials/v2', 'https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+        };
+
+        await validateCredentialSchema(credential);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          `/api/schema?url=${encodeURIComponent(
+            'https://untp.unece.org/artefacts/schema/v0.7.0/dcc/ConformityCredential.json',
+          )}`,
+        );
+      });
+    });
+
+    it('should construct v0.7.0 schema URLs for the remaining core credential types', async () => {
+      const cases: Array<{ type: string; short: string; file: string }> = [
+        { type: 'DigitalTraceabilityEvent', short: 'dte', file: 'DigitalTraceabilityEvent' },
+        { type: 'DigitalFacilityRecord', short: 'dfr', file: 'DigitalFacilityRecord' },
+        { type: 'DigitalIdentityAnchor', short: 'dia', file: 'DigitalIdentityAnchor' },
+      ];
+
+      for (const { type, short, file } of cases) {
+        (global.fetch as jest.Mock).mockClear();
+        schemaCache.clear();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ $schema: 'https://json-schema.org/draft/2020-12/schema', properties: {} }),
+        });
+
+        (detectCredentialType as jest.Mock).mockReturnValue(type);
+        (detectVersion as jest.Mock).mockReturnValue('0.7.0');
+
+        await validateCredentialSchema({ type });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          `/api/schema?url=${encodeURIComponent(
+            `https://untp.unece.org/artefacts/schema/v0.7.0/${short}/${file}.json`,
+          )}`,
+        );
+      }
+    });
+
     it('should validate a valid DLP credential', async () => {
       const mockSchema = {
         $schema: 'https://json-schema.org/draft/2020-12/schema',

--- a/packages/untp-playground/__tests__/lib/utils.test.ts
+++ b/packages/untp-playground/__tests__/lib/utils.test.ts
@@ -2,6 +2,7 @@ import {
   detectVcdmVersion,
   downloadJson,
   isPermittedCredentialType,
+  isUntpV070OrAbove,
   validateNormalizedCredential,
   downloadHtml,
 } from '@/lib/utils';
@@ -117,6 +118,41 @@ describe('utils', () => {
     it('handles case sensitivity', () => {
       expect(isPermittedCredentialType('digitalproductpassport' as CredentialType)).toBeFalsy();
       expect(isPermittedCredentialType('DIGITALPRODUCTPASSPORT' as CredentialType)).toBeFalsy();
+    });
+  });
+
+  describe('isUntpV070OrAbove', () => {
+    it('returns true for v0.7.0', () => {
+      expect(isUntpV070OrAbove('0.7.0')).toBe(true);
+    });
+
+    it('returns true for v0.7.0 pre-release versions', () => {
+      expect(isUntpV070OrAbove('0.7.0-beta1')).toBe(true);
+      expect(isUntpV070OrAbove('0.7.0-rc2')).toBe(true);
+      expect(isUntpV070OrAbove('0.7.0-alpha10')).toBe(true);
+    });
+
+    it('returns true for minor versions above 0.7 on major 0', () => {
+      expect(isUntpV070OrAbove('0.8.0')).toBe(true);
+      expect(isUntpV070OrAbove('0.10.0')).toBe(true);
+    });
+
+    it('returns true for any major version above 0', () => {
+      expect(isUntpV070OrAbove('1.0.0')).toBe(true);
+      expect(isUntpV070OrAbove('2.3.4')).toBe(true);
+    });
+
+    it('returns false for v0.6.0 and below', () => {
+      expect(isUntpV070OrAbove('0.6.0')).toBe(false);
+      expect(isUntpV070OrAbove('0.6.0-alpha2')).toBe(false);
+      expect(isUntpV070OrAbove('0.5.0')).toBe(false);
+      expect(isUntpV070OrAbove('0.4.0')).toBe(false);
+    });
+
+    it('returns false for unparseable version strings', () => {
+      expect(isUntpV070OrAbove('unknown')).toBe(false);
+      expect(isUntpV070OrAbove('')).toBe(false);
+      expect(isUntpV070OrAbove('v0.7.0')).toBe(false);
     });
   });
 

--- a/packages/untp-playground/constants.ts
+++ b/packages/untp-playground/constants.ts
@@ -41,6 +41,30 @@ export const VCDM_SCHEMA_URLS = {
     'https://w3c.github.io/vc-data-model/schema/verifiable-credential/verifiable-credential-schema.json',
 };
 
+// Domains used in UNTP credential @context URIs. v0.7.0 introduced the
+// `vocabulary.uncefact.org` domain; earlier versions use `test.uncefact.org`.
+export const UNTP_CONTEXT_DOMAINS = ['vocabulary.uncefact.org', 'test.uncefact.org'] as const;
+
+// Short names (URL segment) for each UNTP core credential type.
+export const UNTP_SHORT_CREDENTIAL_TYPES: Record<string, string> = {
+  DigitalProductPassport: 'dpp',
+  DigitalConformityCredential: 'dcc',
+  DigitalTraceabilityEvent: 'dte',
+  DigitalFacilityRecord: 'dfr',
+  DigitalIdentityAnchor: 'dia',
+};
+
+// Schema filename (without `.json`) for each UNTP core credential type. Applies
+// to v0.7.0 and above — most types match their credential type name verbatim,
+// but DCC was renamed from `DigitalConformityCredential` to `ConformityCredential`.
+export const UNTP_CORE_SCHEMA_FILENAMES: Record<string, string> = {
+  DigitalProductPassport: 'DigitalProductPassport',
+  DigitalConformityCredential: 'ConformityCredential',
+  DigitalTraceabilityEvent: 'DigitalTraceabilityEvent',
+  DigitalFacilityRecord: 'DigitalFacilityRecord',
+  DigitalIdentityAnchor: 'DigitalIdentityAnchor',
+};
+
 export enum TestCaseStatus {
   PENDING = 'pending',
   IN_PROGRESS = 'in-progress',

--- a/packages/untp-playground/src/lib/credentialService.ts
+++ b/packages/untp-playground/src/lib/credentialService.ts
@@ -1,6 +1,6 @@
 import type { Credential } from '@/types/credential';
 import { jwtDecode } from 'jwt-decode';
-import { CredentialType } from '../../constants';
+import { CredentialType, UNTP_CONTEXT_DOMAINS } from '../../constants';
 
 export function decodeEnvelopedCredential(credential: any): Credential {
   if (!isEnvelopedProof(credential)) {
@@ -34,11 +34,24 @@ export function detectCredentialType(credential: Credential): string {
 }
 
 export function detectVersion(credential: Credential, domain?: string): string {
-  const contextUrl = credential['@context']?.find((ctx) => ctx.includes(domain || 'test.uncefact.org'));
+  const contexts = credential['@context'];
+  if (!Array.isArray(contexts)) return 'unknown';
 
-  if (!contextUrl) return 'unknown';
+  let contextUri: string | undefined;
+  if (domain) {
+    contextUri = contexts.find((ctx): ctx is string => typeof ctx === 'string' && ctx.includes(domain));
+  } else {
+    // By convention, the core UNTP context URI is the second entry of @context
+    // (after the required VCDM context).
+    const candidate = contexts[1];
+    if (typeof candidate === 'string' && UNTP_CONTEXT_DOMAINS.some((d) => candidate.includes(d))) {
+      contextUri = candidate;
+    }
+  }
 
-  const versionMatch = contextUrl.match(/(\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)?)/);
+  if (!contextUri) return 'unknown';
+
+  const versionMatch = contextUri.match(/(\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+)?)/);
   return versionMatch ? versionMatch[1] : 'unknown';
 }
 

--- a/packages/untp-playground/src/lib/schemaValidation.ts
+++ b/packages/untp-playground/src/lib/schemaValidation.ts
@@ -1,7 +1,13 @@
 import addFormats from 'ajv-formats';
 import Ajv2020 from 'ajv/dist/2020';
-import { VCDM_SCHEMA_URLS, VCDMVersion } from '../../constants';
+import {
+  UNTP_CORE_SCHEMA_FILENAMES,
+  UNTP_SHORT_CREDENTIAL_TYPES,
+  VCDM_SCHEMA_URLS,
+  VCDMVersion,
+} from '../../constants';
 import { detectCredentialType, detectVersion } from './credentialService';
+import { isUntpV070OrAbove } from './utils';
 
 const ajv = new Ajv2020({
   allErrors: true,
@@ -52,14 +58,14 @@ export const EXTENSION_VERSIONS: Record<string, ExtensionConfig> = {
 };
 
 const schemaURLConstructor = (type: string, version: string) => {
-  const shortCredentialTypes: Record<string, string> = {
-    DigitalProductPassport: 'dpp',
-    DigitalConformityCredential: 'dcc',
-    DigitalTraceabilityEvent: 'dte',
-    DigitalFacilityRecord: 'dfr',
-    DigitalIdentityAnchor: 'dia',
-  };
-  return `https://test.uncefact.org/vocabulary/untp/${shortCredentialTypes[type]}/untp-${shortCredentialTypes[type]}-schema-${version}.json`;
+  const shortType = UNTP_SHORT_CREDENTIAL_TYPES[type];
+
+  if (isUntpV070OrAbove(version)) {
+    const fileName = UNTP_CORE_SCHEMA_FILENAMES[type];
+    return `https://untp.unece.org/artefacts/schema/v${version}/${shortType}/${fileName}.json`;
+  }
+
+  return `https://test.uncefact.org/vocabulary/untp/${shortType}/untp-${shortType}-schema-${version}.json`;
 };
 
 const findExtensionSchemaURL = (type: string, version: string) => {

--- a/packages/untp-playground/src/lib/utils.ts
+++ b/packages/untp-playground/src/lib/utils.ts
@@ -38,6 +38,18 @@ export function isPermittedCredentialType(type: CredentialType): type is Permitt
   return permittedCredentialTypes.includes(type as PermittedCredentialType);
 }
 
+/**
+ * Returns true when the given UNTP version string is v0.7.0 or newer.
+ * Used to switch between legacy and current schema URL formats.
+ */
+export function isUntpV070OrAbove(version: string): boolean {
+  const match = version.match(/^(\d+)\.(\d+)/);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return major > 0 || (major === 0 && minor >= 7);
+}
+
 const downloadFile = (content: string, filename: string, mimeType: string) => {
   const blob = new Blob([content], { type: mimeType });
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
This PR adds UNTP v0.7.0 credential support to the playground, so uploading a v0.7.0 credential now detects the correct version from the new `https://vocabulary.uncefact.org/untp/0.7.0/context/` context URI and fetches the schema from `https://untp.unece.org/artefacts/schema/v0.7.0/<short>/<FileName>.json` instead of the legacy `https://test.uncefact.org/vocabulary/untp/<short>/untp-<short>-schema-<version>.json` URL. v0.6.0 and earlier credentials continue to use the legacy URL format, so there is no regression.

Two v0.7.0-specific quirks are handled:
- The `@context` domain changed from `test.uncefact.org` to `vocabulary.uncefact.org`. A new `UNTP_CONTEXT_DOMAINS` constant drives version detection across both domains.
- The DCC schema file was renamed from `DigitalConformityCredential.json` to `ConformityCredential.json`. A new `UNTP_CORE_SCHEMA_FILENAMES` map records the v0.7.0+ filename for each credential type.

`detectVersion` was refactored to read `@context[1]` by convention (guarded by `Array.isArray`, type checks, and UNTP-domain membership) rather than substring-matching across the array. This eliminates false positives from unrelated contexts on the same domain and handles the new v0.7.0 URI structure uniformly.

Closes #504

### Known limitation
JSON-LD context validation of v0.7.0 credentials in the browser currently fails because the upstream `vocabulary.uncefact.org` host returns `403 Forbidden` on CORS preflight (`OPTIONS`) requests. This is unrelated to the changes in this PR. Upstream ticket: [uncefact/spec-untp#637](https://opensource.unicc.org/un/unece/uncefact/spec-untp/-/issues/637).

## Test plan
- [x] Uploading a v0.7.0 credential is correctly identified as v0.7.0 in the playground
- [x] The playground fetches and validates the correct v0.7.0 schema for each core credential type (DPP, DCC, DTE, DFR, DIA)
- [x] Uploading a v0.6.0 (or earlier) credential continues to be identified at its correct version and validated against its existing schema