### PR TITLE
fix(playground): prefix verify request with NEXT_PUBLIC_BASE_PATH

### DIFF
--- a/packages/untp-playground/__tests__/lib/verificationService.test.ts
+++ b/packages/untp-playground/__tests__/lib/verificationService.test.ts
@@ -1,9 +1,21 @@
 describe('verifyCredential', () => {
+  const originalBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+
   beforeEach(() => {
     jest.resetAllMocks();
+    jest.resetModules();
   });
 
-  it('sends credential to local API route', async () => {
+  afterEach(() => {
+    if (originalBasePath === undefined) {
+      delete process.env.NEXT_PUBLIC_BASE_PATH;
+    } else {
+      process.env.NEXT_PUBLIC_BASE_PATH = originalBasePath;
+    }
+  });
+
+  it('sends credential to local API route when no base path is set', async () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
     const mockResponse = { verified: true };
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -19,6 +31,22 @@ describe('verifyCredential', () => {
       body: JSON.stringify({ credential: { type: 'VerifiableCredential' } }),
     });
     expect(result).toEqual(mockResponse);
+  });
+
+  it('prefixes the request with NEXT_PUBLIC_BASE_PATH when set', async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = '/test-untp-playground';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ verified: true }),
+    });
+
+    const { verifyCredential } = await import('@/lib/verificationService');
+    await verifyCredential({ type: 'VerifiableCredential' });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/test-untp-playground/api/verify',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 
   it('throws on non-ok response', async () => {

--- a/packages/untp-playground/__tests__/lib/verificationService.test.ts
+++ b/packages/untp-playground/__tests__/lib/verificationService.test.ts
@@ -43,10 +43,11 @@ describe('verifyCredential', () => {
     const { verifyCredential } = await import('@/lib/verificationService');
     await verifyCredential({ type: 'VerifiableCredential' });
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      '/test-untp-playground/api/verify',
-      expect.objectContaining({ method: 'POST' }),
-    );
+    expect(global.fetch).toHaveBeenCalledWith('/test-untp-playground/api/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ credential: { type: 'VerifiableCredential' } }),
+    });
   });
 
   it('throws on non-ok response', async () => {

--- a/packages/untp-playground/src/lib/verificationService.ts
+++ b/packages/untp-playground/src/lib/verificationService.ts
@@ -1,6 +1,7 @@
 export async function verifyCredential(credential: any) {
   try {
-    const response = await fetch('/api/verify', {
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+    const response = await fetch(`${basePath}/api/verify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
This PR prefixes the playground's verify request with `NEXT_PUBLIC_BASE_PATH`, so verification works in environments deployed under a non-empty base path (test and prod) behind CloudFront. Previously the request was sent to `/api/verify` without the environment prefix, so CloudFront returned 403 because the path did not match the playground's distribution route.

The fix mirrors the existing pattern already used by the schema proxy in `schemaValidation.ts`.

Closes #520

## Test plan
- [x] Unit test asserts the request goes to `/api/verify` when no base path is set (local dev)
- [x] Unit test asserts the request goes to `/<base-path>/api/verify` when `NEXT_PUBLIC_BASE_PATH` is set
- [ ] Verified end to end against the deployed test environment after merge and deploy