### PR TITLE
Feat/add untp 0.7.0 render templates

### DIFF
--- a/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/example-data.json
@@ -1,31 +1,19 @@
 {
-  "type": [
-    "DigitalConformityCredential",
-    "VerifiableCredential"
-  ],
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
-  ],
+  "type": ["DigitalConformityCredential", "VerifiableCredential"],
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vocabulary.uncefact.org/untp/0.7.0/context/"],
   "id": "https://credentials.sample-cab.example.com/dcc/mine-001",
   "issuer": {
-    "type": [
-      "CredentialIssuer"
-    ],
+    "type": ["CredentialIssuer"],
     "id": "did:web:sample-cab.example.com",
     "name": "Sample Conformity Assessment Body",
     "issuerAlsoKnownAs": [
       {
-        "type": [
-          "Party"
-        ],
+        "type": ["Party"],
         "id": "https://sample-register.example.com/companies/CAB-001",
         "name": "Sample Conformity Assessment Services Pty Ltd",
         "registeredId": "CAB-001",
         "idScheme": {
-          "type": [
-            "IdentifierScheme"
-          ],
+          "type": ["IdentifierScheme"],
           "id": "https://sample-register.example.com",
           "name": "Swiss Central Business Name Index (ZEFIX)"
         }
@@ -36,9 +24,7 @@
   "validUntil": "2028-01-15T00:00:00Z",
   "name": "Coppermark Certification — Sample Copper Mine",
   "credentialSubject": {
-    "type": [
-      "ConformityAttestation"
-    ],
+    "type": ["ConformityAttestation"],
     "id": "https://coppermark-cab.example.com/attestation/CM-KM-2025-001",
     "name": "Coppermark Responsible Production Certificate — Sample Mine",
     "description": "Third-party conformity assessment of Sample Copper Mine against Coppermark Responsible Risk Assessment (RRA) v3.0, covering environmental, social, and governance criteria for responsible copper production.",
@@ -46,16 +32,12 @@
     "assessmentLevel": "authority-benchmark",
     "attestationType": "certification",
     "issuedToParty": {
-      "type": [
-        "Party"
-      ],
+      "type": ["Party"],
       "id": "did:web:sample-mine.example.com",
       "name": "Sample Copper Mine Pty Ltd",
       "registeredId": "MINE-001",
       "idScheme": {
-        "type": [
-          "IdentifierScheme"
-        ],
+        "type": ["IdentifierScheme"],
         "id": "https://sample-register.example.com",
         "name": "Patents and Companies Registration Agency (Zambia)"
       }
@@ -70,16 +52,12 @@
           "mediaType": "image/png"
         },
         "issuingAuthority": {
-          "type": [
-            "Party"
-          ],
+          "type": ["Party"],
           "id": "https://coppermark.org",
           "name": "The Copper Mark Company",
           "registeredId": "CM-AUTH-001",
           "idScheme": {
-            "type": [
-              "IdentifierScheme"
-            ],
+            "type": ["IdentifierScheme"],
             "id": "https://coppermark.org",
             "name": "Coppermark Registry"
           }
@@ -93,16 +71,12 @@
       }
     ],
     "referenceScheme": {
-      "type": [
-        "ConformityScheme"
-      ],
+      "type": ["ConformityScheme"],
       "id": "https://coppermark.org",
       "name": "Coppermark"
     },
     "referenceProfile": {
-      "type": [
-        "ConformityProfile"
-      ],
+      "type": ["ConformityProfile"],
       "id": "https://coppermark.org/rra/v3.0",
       "name": "Coppermark Responsible Risk Assessment (RRA) v3.0"
     },
@@ -131,24 +105,18 @@
     },
     "conformityAssessment": [
       {
-        "type": [
-          "ConformityAssessment"
-        ],
+        "type": ["ConformityAssessment"],
         "id": "https://coppermark-cab.example.com/assessment/CM-KM-2025-001-GHG",
         "name": "GHG Emissions Assessment (Criteria 26, 27)",
         "description": "Assessment of greenhouse gas emissions management, measurement, and reduction initiatives at Sample Copper Mine against Coppermark criteria 26 (GHG Emissions) and 27 (Energy Use and Efficiency).",
         "assessmentCriteria": [
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://coppermark.org/rra/v3.0/criterion/26",
             "name": "GHG Emissions — Coppermark Criterion 26",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
                 "name": "Greenhouse Gas Emissions",
                 "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
@@ -156,16 +124,12 @@
             ]
           },
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://coppermark.org/rra/v3.0/criterion/27",
             "name": "Energy Use and Efficiency — Coppermark Criterion 27",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/renewable-energy-use",
                 "name": "Renewable Energy Use",
                 "definition": "Adoption and integration of renewable energy sources to reduce reliance on fossil fuels and lower the carbon footprint of operations and products."
@@ -177,9 +141,7 @@
         "assessedPerformance": [
           {
             "metric": {
-              "type": [
-                "PerformanceMetric"
-              ],
+              "type": ["PerformanceMetric"],
               "id": "https://vocabulary.uncefact.org/performance-metric/scope-1-ghg-emissions",
               "name": "Scope 1 GHG Emissions"
             },
@@ -192,9 +154,7 @@
         "assessedFacility": [
           {
             "facility": {
-              "type": [
-                "Facility"
-              ],
+              "type": ["Facility"],
               "id": "https://facility-register.example.com/fac-001",
               "name": "Sample Copper Mine",
               "registeredId": "fac-001"
@@ -203,17 +163,13 @@
           }
         ],
         "assessedOrganisation": {
-          "type": [
-            "Party"
-          ],
+          "type": ["Party"],
           "id": "did:web:sample-mine.example.com",
           "name": "Sample Copper Mine Pty Ltd"
         },
         "conformityTopic": [
           {
-            "type": [
-              "ConformityTopic"
-            ],
+            "type": ["ConformityTopic"],
             "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
             "name": "Greenhouse Gas Emissions"
           }
@@ -221,24 +177,18 @@
         "conformance": true
       },
       {
-        "type": [
-          "ConformityAssessment"
-        ],
+        "type": ["ConformityAssessment"],
         "id": "https://coppermark-cab.example.com/assessment/CM-KM-2025-001-FL",
         "name": "No Forced Labor Assessment (Criterion 12)",
         "description": "Assessment of forced labor elimination practices at Sample Copper Mine against Coppermark criterion 12 (Forced Labour).",
         "assessmentCriteria": [
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://coppermark.org/rra/v3.0/criterion/12",
             "name": "Forced Labour — Coppermark Criterion 12",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/forced-labor-elimination",
                 "name": "Forced Labor Elimination",
                 "definition": "Policies and practices to identify, prevent, and remediate forced labor, including debt bondage, trafficking, and involuntary work, throughout the supply chain."
@@ -250,9 +200,7 @@
         "assessedPerformance": [
           {
             "metric": {
-              "type": [
-                "PerformanceMetric"
-              ],
+              "type": ["PerformanceMetric"],
               "id": "https://vocabulary.uncefact.org/performance-metric/forced-labor-incidents",
               "name": "Forced Labor Incidents"
             },
@@ -265,9 +213,7 @@
         "assessedFacility": [
           {
             "facility": {
-              "type": [
-                "Facility"
-              ],
+              "type": ["Facility"],
               "id": "https://facility-register.example.com/fac-001",
               "name": "Sample Copper Mine",
               "registeredId": "fac-001"
@@ -276,17 +222,13 @@
           }
         ],
         "assessedOrganisation": {
-          "type": [
-            "Party"
-          ],
+          "type": ["Party"],
           "id": "did:web:sample-mine.example.com",
           "name": "Sample Copper Mine Pty Ltd"
         },
         "conformityTopic": [
           {
-            "type": [
-              "ConformityTopic"
-            ],
+            "type": ["ConformityTopic"],
             "id": "https://vocabulary.uncefact.org/conformity-topic/forced-labor-elimination",
             "name": "Forced Labor Elimination"
           }
@@ -294,24 +236,18 @@
         "conformance": true
       },
       {
-        "type": [
-          "ConformityAssessment"
-        ],
+        "type": ["ConformityAssessment"],
         "id": "https://coppermark-cab.example.com/assessment/CM-KM-2025-001-WS",
         "name": "Water Stewardship Assessment (Criterion 28)",
         "description": "Assessment of water stewardship practices at Sample Copper Mine against Coppermark criterion 28 (Water Stewardship).",
         "assessmentCriteria": [
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://coppermark.org/rra/v3.0/criterion/28",
             "name": "Water Stewardship — Coppermark Criterion 28",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
                 "name": "Water Conservation",
                 "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
@@ -323,9 +259,7 @@
         "assessedPerformance": [
           {
             "metric": {
-              "type": [
-                "PerformanceMetric"
-              ],
+              "type": ["PerformanceMetric"],
               "id": "https://vocabulary.uncefact.org/performance-metric/water-intensity",
               "name": "Water Intensity"
             },
@@ -338,9 +272,7 @@
         "assessedFacility": [
           {
             "facility": {
-              "type": [
-                "Facility"
-              ],
+              "type": ["Facility"],
               "id": "https://facility-register.example.com/fac-001",
               "name": "Sample Copper Mine",
               "registeredId": "fac-001"
@@ -349,17 +281,13 @@
           }
         ],
         "assessedOrganisation": {
-          "type": [
-            "Party"
-          ],
+          "type": ["Party"],
           "id": "did:web:sample-mine.example.com",
           "name": "Sample Copper Mine Pty Ltd"
         },
         "conformityTopic": [
           {
-            "type": [
-              "ConformityTopic"
-            ],
+            "type": ["ConformityTopic"],
             "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
             "name": "Water Conservation"
           }

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/example-data.json
@@ -1,0 +1,371 @@
+{
+  "type": [
+    "DigitalConformityCredential",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
+  ],
+  "id": "https://credentials.sample-cab.example.com/dcc/mine-001",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:sample-cab.example.com",
+    "name": "Sample Conformity Assessment Body",
+    "issuerAlsoKnownAs": [
+      {
+        "type": [
+          "Party"
+        ],
+        "id": "https://sample-register.example.com/companies/CAB-001",
+        "name": "Sample Conformity Assessment Services Pty Ltd",
+        "registeredId": "CAB-001",
+        "idScheme": {
+          "type": [
+            "IdentifierScheme"
+          ],
+          "id": "https://sample-register.example.com",
+          "name": "Swiss Central Business Name Index (ZEFIX)"
+        }
+      }
+    ]
+  },
+  "validFrom": "2025-01-15T00:00:00Z",
+  "validUntil": "2028-01-15T00:00:00Z",
+  "name": "Coppermark Certification — Sample Copper Mine",
+  "credentialSubject": {
+    "type": [
+      "ConformityAttestation"
+    ],
+    "id": "https://coppermark-cab.example.com/attestation/CM-KM-2025-001",
+    "name": "Coppermark Responsible Production Certificate — Sample Mine",
+    "description": "Third-party conformity assessment of Sample Copper Mine against Coppermark Responsible Risk Assessment (RRA) v3.0, covering environmental, social, and governance criteria for responsible copper production.",
+    "assessorLevel": "3rdParty",
+    "assessmentLevel": "authority-benchmark",
+    "attestationType": "certification",
+    "issuedToParty": {
+      "type": [
+        "Party"
+      ],
+      "id": "did:web:sample-mine.example.com",
+      "name": "Sample Copper Mine Pty Ltd",
+      "registeredId": "MINE-001",
+      "idScheme": {
+        "type": [
+          "IdentifierScheme"
+        ],
+        "id": "https://sample-register.example.com",
+        "name": "Patents and Companies Registration Agency (Zambia)"
+      }
+    },
+    "authorisation": [
+      {
+        "name": "Accreditation of Sample Conformity Assessment Body as a Coppermark Approved Assessment Firm.",
+        "trustmark": {
+          "name": "Coppermark Approved Assessor",
+          "description": "Trust mark issued by The Copper Mark Company to accredited assessment firms.",
+          "imageData": "Y29wcGVybWFyay1sb2dv",
+          "mediaType": "image/png"
+        },
+        "issuingAuthority": {
+          "type": [
+            "Party"
+          ],
+          "id": "https://coppermark.org",
+          "name": "The Copper Mark Company",
+          "registeredId": "CM-AUTH-001",
+          "idScheme": {
+            "type": [
+              "IdentifierScheme"
+            ],
+            "id": "https://coppermark.org",
+            "name": "Coppermark Registry"
+          }
+        },
+        "endorsementEvidence": {
+          "linkURL": "https://coppermark.org/approved-assessors/sgs",
+          "linkName": "Sample CAB Coppermark Accreditation",
+          "mediaType": "text/html",
+          "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+        }
+      }
+    ],
+    "referenceScheme": {
+      "type": [
+        "ConformityScheme"
+      ],
+      "id": "https://coppermark.org",
+      "name": "Coppermark"
+    },
+    "referenceProfile": {
+      "type": [
+        "ConformityProfile"
+      ],
+      "id": "https://coppermark.org/rra/v3.0",
+      "name": "Coppermark Responsible Risk Assessment (RRA) v3.0"
+    },
+    "profileScore": {
+      "code": "fully-meets",
+      "rank": 3,
+      "definition": "The site fully meets all applicable Coppermark criteria with no significant non-conformances."
+    },
+    "conformityCertificate": {
+      "linkURL": "https://coppermark.org/participants/kansanshi-mining",
+      "linkName": "Coppermark Public Certificate — Sample Copper Mine Pty Ltd",
+      "mediaType": "text/html",
+      "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+    },
+    "auditableEvidence": {
+      "linkURL": "https://coppermark-cab.example.com/reports/CM-KM-2025-001-full.pdf",
+      "linkName": "Full Assessment Report — Sample Mine (Restricted)",
+      "mediaType": "application/pdf",
+      "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+    },
+    "trustmark": {
+      "name": "Coppermark Certified",
+      "description": "The Copper Mark — responsible production trust mark for copper, molybdenum, nickel, and zinc.",
+      "imageData": "Y29wcGVybWFyay1jZXJ0aWZpZWQ=",
+      "mediaType": "image/png"
+    },
+    "conformityAssessment": [
+      {
+        "type": [
+          "ConformityAssessment"
+        ],
+        "id": "https://coppermark-cab.example.com/assessment/CM-KM-2025-001-GHG",
+        "name": "GHG Emissions Assessment (Criteria 26, 27)",
+        "description": "Assessment of greenhouse gas emissions management, measurement, and reduction initiatives at Sample Copper Mine against Coppermark criteria 26 (GHG Emissions) and 27 (Energy Use and Efficiency).",
+        "assessmentCriteria": [
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://coppermark.org/rra/v3.0/criterion/26",
+            "name": "GHG Emissions — Coppermark Criterion 26",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
+                "name": "Greenhouse Gas Emissions",
+                "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
+              }
+            ]
+          },
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://coppermark.org/rra/v3.0/criterion/27",
+            "name": "Energy Use and Efficiency — Coppermark Criterion 27",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/renewable-energy-use",
+                "name": "Renewable Energy Use",
+                "definition": "Adoption and integration of renewable energy sources to reduce reliance on fossil fuels and lower the carbon footprint of operations and products."
+              }
+            ]
+          }
+        ],
+        "assessmentDate": "2025-01-10",
+        "assessedPerformance": [
+          {
+            "metric": {
+              "type": [
+                "PerformanceMetric"
+              ],
+              "id": "https://vocabulary.uncefact.org/performance-metric/scope-1-ghg-emissions",
+              "name": "Scope 1 GHG Emissions"
+            },
+            "measure": {
+              "value": 45000,
+              "unit": "TNE"
+            }
+          }
+        ],
+        "assessedFacility": [
+          {
+            "facility": {
+              "type": [
+                "Facility"
+              ],
+              "id": "https://facility-register.example.com/fac-001",
+              "name": "Sample Copper Mine",
+              "registeredId": "fac-001"
+            },
+            "idVerifiedByCAB": true
+          }
+        ],
+        "assessedOrganisation": {
+          "type": [
+            "Party"
+          ],
+          "id": "did:web:sample-mine.example.com",
+          "name": "Sample Copper Mine Pty Ltd"
+        },
+        "conformityTopic": [
+          {
+            "type": [
+              "ConformityTopic"
+            ],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
+            "name": "Greenhouse Gas Emissions"
+          }
+        ],
+        "conformance": true
+      },
+      {
+        "type": [
+          "ConformityAssessment"
+        ],
+        "id": "https://coppermark-cab.example.com/assessment/CM-KM-2025-001-FL",
+        "name": "No Forced Labor Assessment (Criterion 12)",
+        "description": "Assessment of forced labor elimination practices at Sample Copper Mine against Coppermark criterion 12 (Forced Labour).",
+        "assessmentCriteria": [
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://coppermark.org/rra/v3.0/criterion/12",
+            "name": "Forced Labour — Coppermark Criterion 12",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/forced-labor-elimination",
+                "name": "Forced Labor Elimination",
+                "definition": "Policies and practices to identify, prevent, and remediate forced labor, including debt bondage, trafficking, and involuntary work, throughout the supply chain."
+              }
+            ]
+          }
+        ],
+        "assessmentDate": "2025-01-10",
+        "assessedPerformance": [
+          {
+            "metric": {
+              "type": [
+                "PerformanceMetric"
+              ],
+              "id": "https://vocabulary.uncefact.org/performance-metric/forced-labor-incidents",
+              "name": "Forced Labor Incidents"
+            },
+            "measure": {
+              "value": 0,
+              "unit": "C62"
+            }
+          }
+        ],
+        "assessedFacility": [
+          {
+            "facility": {
+              "type": [
+                "Facility"
+              ],
+              "id": "https://facility-register.example.com/fac-001",
+              "name": "Sample Copper Mine",
+              "registeredId": "fac-001"
+            },
+            "idVerifiedByCAB": true
+          }
+        ],
+        "assessedOrganisation": {
+          "type": [
+            "Party"
+          ],
+          "id": "did:web:sample-mine.example.com",
+          "name": "Sample Copper Mine Pty Ltd"
+        },
+        "conformityTopic": [
+          {
+            "type": [
+              "ConformityTopic"
+            ],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/forced-labor-elimination",
+            "name": "Forced Labor Elimination"
+          }
+        ],
+        "conformance": true
+      },
+      {
+        "type": [
+          "ConformityAssessment"
+        ],
+        "id": "https://coppermark-cab.example.com/assessment/CM-KM-2025-001-WS",
+        "name": "Water Stewardship Assessment (Criterion 28)",
+        "description": "Assessment of water stewardship practices at Sample Copper Mine against Coppermark criterion 28 (Water Stewardship).",
+        "assessmentCriteria": [
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://coppermark.org/rra/v3.0/criterion/28",
+            "name": "Water Stewardship — Coppermark Criterion 28",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
+                "name": "Water Conservation",
+                "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
+              }
+            ]
+          }
+        ],
+        "assessmentDate": "2025-01-10",
+        "assessedPerformance": [
+          {
+            "metric": {
+              "type": [
+                "PerformanceMetric"
+              ],
+              "id": "https://vocabulary.uncefact.org/performance-metric/water-intensity",
+              "name": "Water Intensity"
+            },
+            "measure": {
+              "value": 2.1,
+              "unit": "MTQ"
+            }
+          }
+        ],
+        "assessedFacility": [
+          {
+            "facility": {
+              "type": [
+                "Facility"
+              ],
+              "id": "https://facility-register.example.com/fac-001",
+              "name": "Sample Copper Mine",
+              "registeredId": "fac-001"
+            },
+            "idVerifiedByCAB": true
+          }
+        ],
+        "assessedOrganisation": {
+          "type": [
+            "Party"
+          ],
+          "id": "did:web:sample-mine.example.com",
+          "name": "Sample Copper Mine Pty Ltd"
+        },
+        "conformityTopic": [
+          {
+            "type": [
+              "ConformityTopic"
+            ],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
+            "name": "Water Conservation"
+          }
+        ],
+        "conformance": true
+      }
+    ]
+  }
+}

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/template.hbs
@@ -711,16 +711,6 @@
               </div>
               {{/if}}
 
-              {{#if conformance}}
-              <div>
-                <span class="badge-conformant">Conformant</span>
-              </div>
-              {{else}}
-              <div>
-                <span class="badge-nonconformant">Non-conformant</span>
-              </div>
-              {{/if}}
-
               {{#if assessedPerformance}}
               <section class="assessment-details">
                 <header class="assessment-subheader">
@@ -774,9 +764,6 @@
                   <div class="data-row">
                     <p class="facility-name">
                       {{facility.name}}
-                      {{#if idVerifiedByCAB}}
-                        <span style="font-size:12px;color:var(--color-primary);margin-left:6px;">(ID verified by CAB)</span>
-                      {{/if}}
                     </p>
                     <div class="link-container">
                       <a href="{{facility.id}}" class="link-text" target="_blank">
@@ -811,7 +798,23 @@
                 </div>
               </section>
               {{/if}}
-
+              {{#if assessedOrganisation}}
+              <section class="product-section">
+                <header class="product-header">
+                  <h4 class="data-text">Assessed organisation</h4>
+                </header>
+                <div class="values-container">
+                  <div class="data-row">
+                    <p class="product-name">{{assessedOrganisation.name}}</p>
+                    <div class="link-container">
+                      <a href="{{assessedOrganisation.id}}" class="link-text" target="_blank">
+                        <div class="view-link">View</div>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              {{/if}}
               <section class="assessment-details">
                 <header class="assessment-subheader">
                   <h4 class="subheader-title">Other details</h4>
@@ -824,14 +827,6 @@
                       <div class="data-value">
                         <div class="data-text">{{assessmentDate}}</div>
                       </div>
-                    </div>
-                    {{/if}}
-                    {{#if assessedOrganisation}}
-                    <div class="data-row-details">
-                      <div class="data-label">Organisation assessed</div>
-                      <a href="{{assessedOrganisation.id}}" class="link-text" target="_blank">
-                        <div class="data-text">{{assessedOrganisation.name}}</div>
-                      </a>
                     </div>
                     {{/if}}
                     {{#if referenceStandard}}
@@ -915,21 +910,6 @@
               </a>
             </div>
           </div>
-          {{#if issuer.issuerAlsoKnownAs}}
-          {{#each issuer.issuerAlsoKnownAs}}
-          {{#if idScheme.name}}
-          <div class="data-row-alt">
-            <div class="data-label">Issuer registry</div>
-            <div class="issuing-value">
-              <div class="data-text">
-                <a href="{{idScheme.id}}" class="link-text" target="_blank">{{idScheme.name}}</a>
-                {{#if registeredId}} · {{registeredId}}{{/if}}
-              </div>
-            </div>
-          </div>
-          {{/if}}
-          {{/each}}
-          {{/if}}
           {{#if validFrom}}
           <div class="data-row-alt">
             <div class="data-label">Valid from</div>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_conformity_credential/template.hbs
@@ -1,0 +1,953 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Digital Conformity Credential</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+      rel="stylesheet" />
+    <style>
+      :root {
+        --color-primary: rgba(31, 90, 149, 1);
+        --color-secondary: rgba(247, 250, 253, 1);
+        --color-white: rgba(255, 255, 255, 1);
+        --color-black: rgba(0, 0, 0, 1);
+        --color-gray-700: rgba(35, 46, 61, 1);
+        --color-gray-600: rgba(85, 96, 110, 1);
+        --color-gray-400: rgba(212, 214, 216, 1);
+        --color-gray-300: rgba(237, 239, 240, 1);
+        --color-link-underline: rgba(79, 149, 221, 1);
+        --color-icon: #94c4f5;
+        --font-family: 'Lato', sans-serif;
+        --font-weight-light: 300;
+        --font-weight-regular: 400;
+        --font-weight-medium: 500;
+        --font-weight-semi-bold: 600;
+        --font-weight-bold: 700;
+        --font-weight-black: 900;
+      }
+
+      * { margin: 0; box-sizing: border-box; }
+      body { font-family: var(--font-family); }
+      a { text-decoration: none; }
+
+      .conformity-attestation {
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+        word-break: break-word;
+      }
+
+      .attestation-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 32px;
+        background-color: var(--color-white);
+      }
+
+      .content-section {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        width: 100%;
+      }
+
+      .credential-header-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+      }
+
+      .credential-header {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 24px;
+        padding: 20px 16px;
+        background-color: var(--color-gray-700);
+        width: 100%;
+      }
+
+      .credential-details {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        width: 100%;
+      }
+
+      .credential-title-group {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+        align-self: stretch;
+      }
+
+      .credential-label {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-white);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .credential-title {
+        font-weight: var(--font-weight-black);
+        color: var(--color-white);
+        font-size: 30px;
+        line-height: 32.5px;
+        margin: 0;
+      }
+
+      .credential-info {
+        display: flex;
+        flex-direction: column;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-white);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .credential-info span {
+        font-size: 14px;
+        font-weight: var(--font-weight-regular);
+        line-height: 19.25px;
+      }
+
+      .credential-info a {
+        font-size: 16px;
+        font-weight: var(--font-weight-bold);
+        line-height: 22px;
+      }
+
+      .credential-info p {
+        color: var(--color-gray-400);
+        font-size: 14px;
+        font-weight: var(--font-weight-regular);
+        line-height: 19.25px;
+      }
+
+      .credential-info div {
+        font-size: 16px;
+        font-weight: var(--font-weight-bold);
+        line-height: 22px;
+        color: var(--color-white);
+        text-transform: capitalize;
+      }
+
+      .credential-link {
+        color: var(--color-white);
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: var(--color-white);
+        text-underline-offset: 3px;
+      }
+
+      .credential-description {
+        align-self: stretch;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-white);
+        font-size: 16px;
+        line-height: 18.9px;
+      }
+
+      /* Profile score badge */
+      .profile-score-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 12px;
+        background-color: rgba(255,255,255,0.15);
+        border-radius: 4px;
+        color: var(--color-white);
+        font-size: 15px;
+        font-weight: var(--font-weight-semi-bold);
+      }
+
+      /* Evidence links */
+      .evidence-links {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        align-self: stretch;
+        padding: 8px 0;
+      }
+
+      .evidence-link-group {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .evidence-name-container {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+      }
+
+      .evidence-name {
+        align-self: stretch;
+        font-weight: var(--font-weight-semi-bold);
+        color: var(--color-white);
+        font-size: 16px;
+        line-height: 17.4px;
+      }
+
+      .evidence-arrow {
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      /* Assessment section */
+      .assessment-section {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 32px;
+        align-self: stretch;
+        padding: 0 16px;
+      }
+
+      .credential-details-inner {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        width: 100%;
+      }
+
+      .assessment-title {
+        font-weight: var(--font-weight-bold);
+        color: var(--color-black);
+        font-size: 20px;
+        line-height: 21.8px;
+      }
+
+      .assessment-description {
+        align-self: stretch;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-black);
+        font-size: 16px;
+        line-height: 18.9px;
+      }
+
+      .assessment-card {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 16px;
+        padding: 16px;
+        align-self: stretch;
+        background-color: var(--color-secondary);
+        border-radius: 4px;
+      }
+
+      .assessment-topic {
+        align-self: stretch;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-primary);
+        font-size: 18px;
+        line-height: 21.2px;
+        margin: 0;
+      }
+
+      .assessment-details {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+        width: 100%;
+      }
+
+      .assessment-subheader {
+        display: flex;
+        height: 20px;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .subheader-title {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 16px;
+      }
+
+      .assessment-values {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+        width: 100%;
+      }
+
+      .values-container {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        align-self: stretch;
+        width: 100%;
+      }
+
+      .data-row-alt {
+        display: grid;
+        grid-template-columns: 1fr 3fr;
+        gap: 16px;
+        padding: 10px 0 12px;
+        border-bottom: 1px solid var(--color-gray-400);
+        width: 100%;
+      }
+
+      .data-row-details {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 16px;
+        padding: 10px 0 12px;
+        border-bottom: 1px solid var(--color-gray-400);
+        width: 100%;
+      }
+
+      .data-label {
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-600);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .data-value {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex: 1;
+      }
+
+      .data-text {
+        flex: 1;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .conformity-topic-tag {
+        display: inline-block;
+        padding: 2px 8px;
+        background-color: rgba(31, 90, 149, 0.1);
+        border-radius: 4px;
+        font-size: 13px;
+        color: var(--color-primary);
+        margin-right: 4px;
+        margin-bottom: 4px;
+      }
+
+      .badge-conformant {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 10px;
+        border-radius: 8px;
+        font-size: 13px;
+        font-weight: var(--font-weight-semi-bold);
+        background-color: rgba(184, 236, 182, 1);
+        color: rgba(8, 50, 0, 1);
+      }
+
+      .badge-nonconformant {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 10px;
+        border-radius: 8px;
+        font-size: 13px;
+        font-weight: var(--font-weight-semi-bold);
+        background-color: rgba(255, 188, 183, 1);
+        color: rgba(50, 0, 0, 1);
+      }
+
+      .criteria-list {
+        margin: 0;
+        padding-left: 25px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .criteria-name {
+        font-weight: var(--font-weight-light);
+        color: var(--color-black);
+        font-size: 16px;
+        line-height: 18.88px;
+      }
+
+      .link-text {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        width: fit-content;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: var(--color-link-underline);
+        text-underline-offset: 3px;
+      }
+
+      .link-label {
+        color: var(--color-black);
+        font-weight: var(--font-weight-regular);
+        font-size: 14px;
+        line-height: 15.3px;
+      }
+
+      .criteria-link {
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 6px;
+        display: flex;
+      }
+
+      .facility-section,
+      .product-section {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+        align-self: stretch;
+      }
+
+      .facility-header,
+      .product-header {
+        display: flex;
+        align-self: stretch;
+        align-items: flex-start;
+        justify-content: center;
+        gap: 10px;
+      }
+
+      .facility-name,
+      .product-name {
+        font-weight: var(--font-weight-regular);
+        font-size: 16px;
+        line-height: 17.4px;
+        color: var(--color-gray-700);
+      }
+
+      .data-row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 16px;
+        padding: 10px 0 12px;
+        border-bottom: 1px solid var(--color-gray-400);
+        width: 100%;
+      }
+
+      .link-container {
+        display: flex;
+        flex-direction: column;
+        align-items: self-end;
+        gap: 6px;
+      }
+
+      .view-link {
+        font-weight: var(--font-weight-medium);
+        font-size: 16px;
+        line-height: 17.4px;
+        color: var(--color-gray-700);
+      }
+
+      /* Issuer endorsement */
+      .issuer-endorsement-section {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+        width: 100%;
+      }
+
+      .endorsement-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .endorsement-title {
+        font-weight: var(--font-weight-bold);
+        color: var(--color-black);
+        font-size: 20px;
+        line-height: 21.8px;
+      }
+
+      .endorsement-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+        align-self: stretch;
+      }
+
+      .endorsement-wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        align-self: stretch;
+      }
+
+      .accreditation-list {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+      }
+
+      .accreditation-item {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+        position: relative;
+      }
+
+      .accreditation-image {
+        height: 50px;
+        width: auto;
+        max-width: 100%;
+        object-fit: contain;
+      }
+
+      .accreditation-details {
+        color: var(--color-gray-700);
+        font-weight: var(--font-weight-medium);
+        font-size: 16px;
+        line-height: 17.4px;
+      }
+
+      .accreditation-details a {
+        color: var(--color-gray-700);
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 3px;
+      }
+
+      /* Issuing details */
+      .issuing-details-section {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+        padding: 24px 16px 36px;
+        background-color: var(--color-gray-300);
+        width: 100%;
+      }
+
+      .issuing-details-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        width: 100%;
+      }
+
+      .issuing-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .issuing-title {
+        font-weight: var(--font-weight-bold);
+        color: var(--color-black);
+        font-size: 20px;
+        line-height: 21.8px;
+      }
+
+      .issuing-link {
+        display: flex;
+        flex: 1;
+        align-self: stretch;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+      }
+
+      .issuing-value {
+        align-items: center;
+        gap: 10px;
+        flex: 1;
+        display: flex;
+        align-self: stretch;
+      }
+
+      .issuer-link {
+        width: fit-content;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .evidence-link-group svg { fill: var(--color-icon); }
+      .evidence-arrow svg { stroke: var(--color-icon); }
+
+      @media (min-width: 1200px) {
+        .conformity-attestation { max-width: 1200px; }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="conformity-attestation">
+      <div class="attestation-content">
+        <div class="content-section">
+          <header class="credential-header-container">
+            <div class="credential-header">
+              <div class="credential-details">
+                <div class="credential-title-group">
+                  <div class="credential-label">CONFORMITY CREDENTIAL</div>
+                  <h1 class="credential-title">{{credentialSubject.name}}</h1>
+                </div>
+                {{#if credentialSubject.issuedToParty}}
+                <div class="credential-info">
+                  <span>Issued to:</span>
+                  <a href="{{credentialSubject.issuedToParty.id}}" class="credential-link" target="_blank">{{credentialSubject.issuedToParty.name}}</a>
+                </div>
+                {{/if}}
+                {{#if credentialSubject.description}}
+                <p class="credential-description">{{credentialSubject.description}}</p>
+                {{/if}}
+                {{#if credentialSubject.assessorLevel}}
+                <div class="credential-info">
+                  <p>Level of independent assurance:</p>
+                  <div>{{credentialSubject.assessorLevel}}</div>
+                </div>
+                {{/if}}
+                {{#if credentialSubject.assessmentLevel}}
+                <div class="credential-info">
+                  <p>Type of authority endorsement:</p>
+                  <div>{{credentialSubject.assessmentLevel}}</div>
+                </div>
+                {{/if}}
+                {{#if credentialSubject.attestationType}}
+                <div class="credential-info">
+                  <p>Attestation type:</p>
+                  <div>{{credentialSubject.attestationType}}</div>
+                </div>
+                {{/if}}
+                {{#if credentialSubject.referenceScheme}}
+                <div class="credential-info">
+                  <p>Conformity scheme:</p>
+                  <a href="{{credentialSubject.referenceScheme.id}}" class="credential-link" target="_blank">{{credentialSubject.referenceScheme.name}}</a>
+                </div>
+                {{/if}}
+                {{#if credentialSubject.referenceProfile}}
+                <div class="credential-info">
+                  <p>Assessment profile:</p>
+                  <a href="{{credentialSubject.referenceProfile.id}}" class="credential-link" target="_blank">{{credentialSubject.referenceProfile.name}}</a>
+                </div>
+                {{/if}}
+                {{#if credentialSubject.profileScore}}
+                <div>
+                  <span class="profile-score-badge">{{credentialSubject.profileScore.code}}{{#if credentialSubject.profileScore.rank}} · rank {{credentialSubject.profileScore.rank}}{{/if}}</span>
+                </div>
+                {{/if}}
+              </div>
+              <div class="credential-details">
+                {{#if credentialSubject.auditableEvidence.linkURL}}
+                <a href="{{credentialSubject.auditableEvidence.linkURL}}" class="evidence-links" target="_blank">
+                  <div class="evidence-link-group">
+                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M2 18C1.45 18 0.979333 17.8043 0.588 17.413C0.196667 17.0217 0.000666667 16.5507 0 16V2C0 1.45 0.196 0.979333 0.588 0.588C0.98 0.196667 1.45067 0.000666667 2 0H16C16.55 0 17.021 0.196 17.413 0.588C17.805 0.98 18.0007 1.45067 18 2V16C18 16.55 17.8043 17.021 17.413 17.413C17.0217 17.805 16.5507 18.0007 16 18H2ZM2 2V16H16V2H14V9L11.5 7.5L9 9V2H2Z" fill="var(--color-icon)" />
+                    </svg>
+                    <div class="evidence-name-container">
+                      <div class="evidence-name">Auditable Evidence</div>
+                    </div>
+                  </div>
+                  <div class="evidence-arrow">
+                    <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M1 1L8 8L1 15" stroke="var(--color-icon)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </div>
+                </a>
+                {{/if}}
+                {{#if credentialSubject.conformityCertificate.linkURL}}
+                <a href="{{credentialSubject.conformityCertificate.linkURL}}" class="evidence-links" target="_blank">
+                  <div class="evidence-link-group">
+                    <svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M16 4H4V0H16V4ZM16 9.5C16.2833 9.5 16.521 9.404 16.713 9.212C16.905 9.02 17.0007 8.78267 17 8.5C16.9993 8.21733 16.9033 7.98 16.712 7.788C16.5207 7.596 16.2833 7.5 16 7.5C15.7167 7.5 15.4793 7.596 15.288 7.788C15.0967 7.98 15.0007 8.21733 15 8.5C14.9993 8.78267 15.0953 9.02033 15.288 9.213C15.4807 9.40567 15.718 9.50133 16 9.5ZM14 16V12H6V16H14ZM16 18H4V14H0V8C0 7.15 0.291667 6.43767 0.875 5.863C1.45833 5.28833 2.16667 5.00067 3 5H17C17.85 5 18.5627 5.28767 19.138 5.863C19.7133 6.43833 20.0007 7.15067 20 8V14H16V18Z" fill="var(--color-icon)" />
+                    </svg>
+                    <div class="evidence-name-container">
+                      <div class="evidence-name">Printable Certificate</div>
+                    </div>
+                  </div>
+                  <div class="evidence-arrow">
+                    <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M1 1L8 8L1 15" stroke="var(--color-icon)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </div>
+                </a>
+                {{/if}}
+              </div>
+            </div>
+          </header>
+        </div>
+
+        <div class="assessment-section">
+          {{#if credentialSubject.conformityAssessment}}
+          <section class="credential-details-inner">
+            <header>
+              <h2 class="assessment-title">Assessments</h2>
+              <p class="assessment-description">The list of specific assessments made within this conformity attestation.</p>
+            </header>
+            {{#each credentialSubject.conformityAssessment}}
+            <article class="assessment-card">
+              <h3 class="assessment-topic">{{name}}</h3>
+              {{#if description}}
+              <p style="font-size:14px;color:var(--color-gray-600);">{{description}}</p>
+              {{/if}}
+
+              {{#if conformityTopic}}
+              <div>
+                {{#each conformityTopic}}
+                <span class="conformity-topic-tag">{{name}}</span>
+                {{/each}}
+              </div>
+              {{/if}}
+
+              {{#if conformance}}
+              <div>
+                <span class="badge-conformant">Conformant</span>
+              </div>
+              {{else}}
+              <div>
+                <span class="badge-nonconformant">Non-conformant</span>
+              </div>
+              {{/if}}
+
+              {{#if assessedPerformance}}
+              <section class="assessment-details">
+                <header class="assessment-subheader">
+                  <h4 class="subheader-title">Assessed performance</h4>
+                </header>
+                <div class="assessment-values">
+                  <div class="values-container">
+                    {{#each assessedPerformance}}
+                    {{#if metric}}
+                    <div class="data-row-alt">
+                      <div class="data-label">{{metric.name}}</div>
+                      <div class="data-value">
+                        <div class="data-text">
+                          {{#if measure}}{{measure.value}} {{measure.unit}}{{/if}}
+                        </div>
+                      </div>
+                    </div>
+                    {{/if}}
+                    {{/each}}
+                  </div>
+                </div>
+              </section>
+              {{/if}}
+
+              {{#if assessmentCriteria}}
+              <section class="assessment-details">
+                <header class="assessment-subheader">
+                  <h4 class="subheader-title">Assessment Criteria</h4>
+                </header>
+                {{#each assessmentCriteria}}
+                <div class="criteria-name">{{name}}</div>
+                {{#if id}}
+                <div class="criteria-link">
+                  <div class="link-text">
+                    <a href="{{id}}" class="link-label" target="_blank">Assessment criteria</a>
+                  </div>
+                </div>
+                {{/if}}
+                {{/each}}
+              </section>
+              {{/if}}
+
+              {{#if assessedFacility}}
+              <section class="facility-section">
+                <header class="facility-header">
+                  <h4 class="data-text">Assessed facilities</h4>
+                </header>
+                <div class="values-container">
+                  {{#each assessedFacility}}
+                  {{#if facility}}
+                  <div class="data-row">
+                    <p class="facility-name">
+                      {{facility.name}}
+                      {{#if idVerifiedByCAB}}
+                        <span style="font-size:12px;color:var(--color-primary);margin-left:6px;">(ID verified by CAB)</span>
+                      {{/if}}
+                    </p>
+                    <div class="link-container">
+                      <a href="{{facility.id}}" class="link-text" target="_blank">
+                        <div class="view-link">View</div>
+                      </a>
+                    </div>
+                  </div>
+                  {{/if}}
+                  {{/each}}
+                </div>
+              </section>
+              {{/if}}
+
+              {{#if assessedProduct}}
+              <section class="product-section">
+                <header class="product-header">
+                  <h4 class="data-text">Assessed products</h4>
+                </header>
+                <div class="values-container">
+                  {{#each assessedProduct}}
+                  {{#if product}}
+                  <div class="data-row">
+                    <p class="product-name">{{product.name}}</p>
+                    <div class="link-container">
+                      <a href="{{product.id}}" class="link-text" target="_blank">
+                        <div class="view-link">View</div>
+                      </a>
+                    </div>
+                  </div>
+                  {{/if}}
+                  {{/each}}
+                </div>
+              </section>
+              {{/if}}
+
+              <section class="assessment-details">
+                <header class="assessment-subheader">
+                  <h4 class="subheader-title">Other details</h4>
+                </header>
+                <div class="assessment-values">
+                  <div class="values-container">
+                    {{#if assessmentDate}}
+                    <div class="data-row-details">
+                      <div class="data-label">Assessed</div>
+                      <div class="data-value">
+                        <div class="data-text">{{assessmentDate}}</div>
+                      </div>
+                    </div>
+                    {{/if}}
+                    {{#if assessedOrganisation}}
+                    <div class="data-row-details">
+                      <div class="data-label">Organisation assessed</div>
+                      <a href="{{assessedOrganisation.id}}" class="link-text" target="_blank">
+                        <div class="data-text">{{assessedOrganisation.name}}</div>
+                      </a>
+                    </div>
+                    {{/if}}
+                    {{#if referenceStandard}}
+                    <div class="data-row-details">
+                      <div class="data-label">Standard</div>
+                      <a href="{{referenceStandard.id}}" class="link-text" target="_blank">
+                        <div class="data-text">{{referenceStandard.name}}</div>
+                      </a>
+                    </div>
+                    {{/if}}
+                    {{#if referenceRegulation}}
+                    <div class="data-row-details">
+                      <div class="data-label">Regulation</div>
+                      <a href="{{referenceRegulation.id}}" class="link-text" target="_blank">
+                        <div class="data-text">{{referenceRegulation.name}}</div>
+                      </a>
+                    </div>
+                    {{/if}}
+                  </div>
+                </div>
+              </section>
+            </article>
+            {{/each}}
+          </section>
+          {{/if}}
+
+          {{#if credentialSubject.trustmark}}
+          <section class="issuer-endorsement-section" style="padding: 0 16px;">
+            {{#if credentialSubject.trustmark.imageData}}
+            <img src="data:{{credentialSubject.trustmark.mediaType}};base64,{{credentialSubject.trustmark.imageData}}" alt="{{credentialSubject.trustmark.name}}" class="accreditation-image" style="max-height:64px;" />
+            {{/if}}
+            {{#if credentialSubject.trustmark.name}}
+            <p style="font-size:14px;color:var(--color-gray-600);margin-top:4px;">{{credentialSubject.trustmark.name}}{{#if credentialSubject.trustmark.description}} — {{credentialSubject.trustmark.description}}{{/if}}</p>
+            {{/if}}
+          </section>
+          {{/if}}
+
+          {{#if credentialSubject.authorisation}}
+          <section class="issuer-endorsement-section">
+            <header class="endorsement-header">
+              <h2 class="endorsement-title">Issuer endorsement</h2>
+            </header>
+            <div class="endorsement-content">
+              <div class="endorsement-wrapper">
+                <div class="accreditation-list">
+                  {{#each credentialSubject.authorisation}}
+                  <div class="accreditation-item">
+                    {{#if trustmark.imageData}}
+                    <img src="data:{{trustmark.mediaType}};base64,{{trustmark.imageData}}" alt="{{trustmark.name}}" class="accreditation-image" />
+                    {{/if}}
+                    <div class="accreditation-details">
+                      {{name}}
+                      {{#if issuingAuthority}}
+                        — accredited by
+                        <a href="{{issuingAuthority.id}}" target="_blank">{{issuingAuthority.name}}</a>
+                      {{/if}}.
+                    </div>
+                    {{#if endorsementEvidence.linkURL}}
+                    <a href="{{endorsementEvidence.linkURL}}" target="_blank" style="font-size:13px;color:var(--color-primary);text-decoration:underline;">{{endorsementEvidence.linkName}}</a>
+                    {{/if}}
+                  </div>
+                  {{/each}}
+                </div>
+              </div>
+            </div>
+          </section>
+          {{/if}}
+        </div>
+      </div>
+
+      <section class="issuing-details-section">
+        <header class="issuing-header">
+          <h2 class="issuing-title">Issuing details</h2>
+        </header>
+        <div class="issuing-details-content">
+          <div class="data-row-alt">
+            <div class="data-label">Issued by</div>
+            <div class="issuing-link">
+              <a href="{{issuer.id}}" class="link-text" target="_blank">
+                <div class="issuer-link">{{issuer.name}}</div>
+              </a>
+            </div>
+          </div>
+          {{#if issuer.issuerAlsoKnownAs}}
+          {{#each issuer.issuerAlsoKnownAs}}
+          {{#if idScheme.name}}
+          <div class="data-row-alt">
+            <div class="data-label">Issuer registry</div>
+            <div class="issuing-value">
+              <div class="data-text">
+                <a href="{{idScheme.id}}" class="link-text" target="_blank">{{idScheme.name}}</a>
+                {{#if registeredId}} · {{registeredId}}{{/if}}
+              </div>
+            </div>
+          </div>
+          {{/if}}
+          {{/each}}
+          {{/if}}
+          {{#if validFrom}}
+          <div class="data-row-alt">
+            <div class="data-label">Valid from</div>
+            <div class="issuing-value">
+              <div class="data-text">{{validFrom}}</div>
+            </div>
+          </div>
+          {{/if}}
+          {{#if validUntil}}
+          <div class="data-row-alt">
+            <div class="data-label">Valid until</div>
+            <div class="issuing-value">
+              <div class="data-text">{{validUntil}}</div>
+            </div>
+          </div>
+          {{/if}}
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/example-data.json
@@ -1,0 +1,354 @@
+{
+  "type": [
+    "DigitalFacilityRecord",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
+  ],
+  "id": "https://credentials.sample-mine.example.com/dfr/mine-001",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:sample-mine.example.com",
+    "name": "Sample Copper Mine Pty Ltd",
+    "issuerAlsoKnownAs": [
+      {
+        "type": [
+          "Party"
+        ],
+        "id": "https://sample-register.example.com/companies/MINE-001",
+        "name": "Sample Copper Mine Pty Ltd",
+        "registeredId": "MINE-001",
+        "idScheme": {
+          "type": [
+            "IdentifierScheme"
+          ],
+          "id": "https://sample-register.example.com",
+          "name": "Patents and Companies Registration Agency (Zambia)"
+        }
+      }
+    ]
+  },
+  "validFrom": "2025-01-15T00:00:00Z",
+  "validUntil": "2028-01-15T00:00:00Z",
+  "name": "Digital Facility Record — Sample Copper Mine",
+  "credentialSubject": {
+    "type": [
+      "Facility"
+    ],
+    "id": "https://facility-register.example.com/fac-001",
+    "name": "Sample Copper Mine",
+    "description": "Open-pit and underground copper-gold mine located in Solwezi, North-Western Province, Zambia. Annual production capacity of approximately 250,000 tonnes of copper in concentrate.",
+    "registeredId": "fac-001",
+    "idScheme": {
+      "type": [
+        "IdentifierScheme"
+      ],
+      "id": "https://facility-register.example.com",
+      "name": "UNTP Sample Facility Register"
+    },
+    "countryOfOperation": {
+      "countryCode": "ZM",
+      "countryName": "Zambia"
+    },
+    "processCategory": [
+      {
+        "code": "14110",
+        "name": "Copper ores and concentrates",
+        "definition": "Copper ores and concentrates obtained from mining operations.",
+        "schemeId": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+        "schemeName": "UN Central Product Classification (CPC)"
+      }
+    ],
+    "relatedParty": [
+      {
+        "role": "owner",
+        "party": {
+          "type": [
+            "Party"
+          ],
+          "id": "did:web:sample-mine.example.com",
+          "name": "Sample Copper Mine Pty Ltd",
+          "description": "Zambian copper mining company operating the Sample mine, one of the largest copper mines in Africa.",
+          "registeredId": "MINE-001",
+          "idScheme": {
+            "type": [
+              "IdentifierScheme"
+            ],
+            "id": "https://sample-register.example.com",
+            "name": "Patents and Companies Registration Agency (Zambia)"
+          },
+          "registrationCountry": {
+            "countryCode": "ZM",
+            "countryName": "Zambia"
+          },
+          "partyAddress": {
+            "streetAddress": "Plot 123, Sample Road",
+            "postalCode": "10101",
+            "addressLocality": "Solwezi",
+            "addressRegion": "North-Western Province",
+            "addressCountry": {
+              "countryCode": "ZM",
+              "countryName": "Zambia"
+            }
+          },
+          "organisationWebsite": "https://sample-mine.example.com",
+          "industryCategory": [
+            {
+              "code": "14110",
+              "name": "Copper ores and concentrates",
+              "definition": "Copper ores and concentrates obtained from mining operations.",
+              "schemeId": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+              "schemeName": "UN Central Product Classification (CPC)"
+            }
+          ]
+        }
+      }
+    ],
+    "relatedDocument": [
+      {
+        "linkURL": "https://credentials.sample-cab.example.com/dcc/mine-001",
+        "linkName": "Coppermark Certification — Sample Copper Mine",
+        "mediaType": "application/ld+json",
+        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+      }
+    ],
+    "facilityAlsoKnownAs": [
+      {
+        "type": [
+          "Facility"
+        ],
+        "id": "https://mining-register.gov.zm/facilities/ZM-NW-CU-0012",
+        "name": "Sample Copper Mine",
+        "registeredId": "ZM-NW-CU-0012",
+        "idScheme": {
+          "type": [
+            "IdentifierScheme"
+          ],
+          "id": "https://mining-register.gov.zm",
+          "name": "Zambia Mining Cadastre"
+        }
+      }
+    ],
+    "locationInformation": {
+      "plusCode": "https://plus.codes/6F2M2222+22",
+      "geoLocation": {
+        "latitude": -12.17,
+        "longitude": 26.4
+      },
+      "geoBoundary": [
+        {
+          "latitude": -12.14,
+          "longitude": 26.37
+        },
+        {
+          "latitude": -12.2,
+          "longitude": 26.43
+        }
+      ]
+    },
+    "address": {
+      "streetAddress": "Sample Mine Road",
+      "postalCode": "10101",
+      "addressLocality": "Solwezi",
+      "addressRegion": "North-Western Province",
+      "addressCountry": {
+        "countryCode": "ZM",
+        "countryName": "Zambia"
+      }
+    },
+    "materialUsage": {
+      "applicablePeriod": {
+        "startDate": "2024-01-01",
+        "endDate": "2024-12-31",
+        "periodInformation": "Calendar year 2024 reporting period."
+      },
+      "materialConsumed": [
+        {
+          "name": "Copper ore",
+          "originCountry": {
+            "countryCode": "ZM",
+            "countryName": "Zambia"
+          },
+          "materialType": {
+            "code": "14110",
+            "name": "Copper ores and concentrates",
+            "definition": "Copper ores and concentrates obtained from mining operations.",
+            "schemeId": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+            "schemeName": "UN Central Product Classification (CPC)"
+          },
+          "massFraction": 1,
+          "mass": {
+            "value": 25000000,
+            "unit": "KGM"
+          },
+          "recycledMassFraction": 0,
+          "hazardous": false
+        },
+        {
+          "name": "ANFO explosives",
+          "originCountry": {
+            "countryCode": "ZA",
+            "countryName": "South Africa"
+          },
+          "materialType": {
+            "code": "35440",
+            "name": "Explosives",
+            "definition": "Prepared explosives for mining and construction.",
+            "schemeId": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+            "schemeName": "UN Central Product Classification (CPC)"
+          },
+          "massFraction": 0.002,
+          "mass": {
+            "value": 50000,
+            "unit": "KGM"
+          },
+          "recycledMassFraction": 0,
+          "hazardous": true
+        },
+        {
+          "name": "Process water",
+          "originCountry": {
+            "countryCode": "ZM",
+            "countryName": "Zambia"
+          },
+          "materialType": {
+            "code": "18000",
+            "name": "Natural water",
+            "definition": "Natural water for industrial processing.",
+            "schemeId": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+            "schemeName": "UN Central Product Classification (CPC)"
+          },
+          "massFraction": 0,
+          "mass": {
+            "value": 525000000,
+            "unit": "KGM"
+          },
+          "recycledMassFraction": 0.65,
+          "hazardous": false
+        }
+      ]
+    },
+    "performanceClaim": [
+      {
+        "type": [
+          "Claim"
+        ],
+        "id": "https://sample-mine.example.com/claims/ghg-2024",
+        "name": "GHG Emissions — Scope 1",
+        "description": "Annual Scope 1 greenhouse gas emissions from the Sample Copper Mine for the 2024 reporting year.",
+        "referenceCriteria": [
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://sample-scheme.coppermark.org/criteria/ghg-management/v3",
+            "name": "GHG Emissions Management (Coppermark RRA Criterion 26)",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
+                "name": "Greenhouse Gas Emissions",
+                "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
+              }
+            ]
+          }
+        ],
+        "claimDate": "2025-03-01",
+        "applicablePeriod": {
+          "startDate": "2024-01-01",
+          "endDate": "2024-12-31",
+          "periodInformation": "Calendar year 2024 reporting period."
+        },
+        "claimedPerformance": [
+          {
+            "metric": {
+              "type": [
+                "PerformanceMetric"
+              ],
+              "id": "https://vocabulary.uncefact.org/performance-metric/scope-1-ghg-emissions",
+              "name": "Scope 1 GHG Emissions"
+            },
+            "measure": {
+              "value": 45000,
+              "unit": "TNE"
+            }
+          }
+        ],
+        "conformityTopic": [
+          {
+            "type": [
+              "ConformityTopic"
+            ],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
+            "name": "Greenhouse Gas Emissions",
+            "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
+          }
+        ]
+      },
+      {
+        "type": [
+          "Claim"
+        ],
+        "id": "https://sample-mine.example.com/claims/water-2024",
+        "name": "Water Withdrawal Intensity",
+        "description": "Water withdrawal intensity per tonne of copper produced at Sample mine for 2024.",
+        "referenceCriteria": [
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://sample-scheme.coppermark.org/criteria/water-stewardship/v3",
+            "name": "Water Stewardship (Coppermark RRA Criterion 27)",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
+                "name": "Water Conservation",
+                "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
+              }
+            ]
+          }
+        ],
+        "claimDate": "2025-03-01",
+        "applicablePeriod": {
+          "startDate": "2024-01-01",
+          "endDate": "2024-12-31",
+          "periodInformation": "Calendar year 2024 reporting period."
+        },
+        "claimedPerformance": [
+          {
+            "metric": {
+              "type": [
+                "PerformanceMetric"
+              ],
+              "id": "https://vocabulary.uncefact.org/performance-metric/water-intensity",
+              "name": "Water Intensity"
+            },
+            "measure": {
+              "value": 2.1,
+              "unit": "MTQ"
+            }
+          }
+        ],
+        "conformityTopic": [
+          {
+            "type": [
+              "ConformityTopic"
+            ],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
+            "name": "Water Conservation",
+            "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/example-data.json
@@ -1,31 +1,19 @@
 {
-  "type": [
-    "DigitalFacilityRecord",
-    "VerifiableCredential"
-  ],
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
-  ],
+  "type": ["DigitalFacilityRecord", "VerifiableCredential"],
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vocabulary.uncefact.org/untp/0.7.0/context/"],
   "id": "https://credentials.sample-mine.example.com/dfr/mine-001",
   "issuer": {
-    "type": [
-      "CredentialIssuer"
-    ],
+    "type": ["CredentialIssuer"],
     "id": "did:web:sample-mine.example.com",
     "name": "Sample Copper Mine Pty Ltd",
     "issuerAlsoKnownAs": [
       {
-        "type": [
-          "Party"
-        ],
+        "type": ["Party"],
         "id": "https://sample-register.example.com/companies/MINE-001",
         "name": "Sample Copper Mine Pty Ltd",
         "registeredId": "MINE-001",
         "idScheme": {
-          "type": [
-            "IdentifierScheme"
-          ],
+          "type": ["IdentifierScheme"],
           "id": "https://sample-register.example.com",
           "name": "Patents and Companies Registration Agency (Zambia)"
         }
@@ -36,17 +24,13 @@
   "validUntil": "2028-01-15T00:00:00Z",
   "name": "Digital Facility Record — Sample Copper Mine",
   "credentialSubject": {
-    "type": [
-      "Facility"
-    ],
+    "type": ["Facility"],
     "id": "https://facility-register.example.com/fac-001",
     "name": "Sample Copper Mine",
     "description": "Open-pit and underground copper-gold mine located in Solwezi, North-Western Province, Zambia. Annual production capacity of approximately 250,000 tonnes of copper in concentrate.",
     "registeredId": "fac-001",
     "idScheme": {
-      "type": [
-        "IdentifierScheme"
-      ],
+      "type": ["IdentifierScheme"],
       "id": "https://facility-register.example.com",
       "name": "UNTP Sample Facility Register"
     },
@@ -67,17 +51,13 @@
       {
         "role": "owner",
         "party": {
-          "type": [
-            "Party"
-          ],
+          "type": ["Party"],
           "id": "did:web:sample-mine.example.com",
           "name": "Sample Copper Mine Pty Ltd",
           "description": "Zambian copper mining company operating the Sample mine, one of the largest copper mines in Africa.",
           "registeredId": "MINE-001",
           "idScheme": {
-            "type": [
-              "IdentifierScheme"
-            ],
+            "type": ["IdentifierScheme"],
             "id": "https://sample-register.example.com",
             "name": "Patents and Companies Registration Agency (Zambia)"
           },
@@ -118,16 +98,12 @@
     ],
     "facilityAlsoKnownAs": [
       {
-        "type": [
-          "Facility"
-        ],
+        "type": ["Facility"],
         "id": "https://mining-register.gov.zm/facilities/ZM-NW-CU-0012",
         "name": "Sample Copper Mine",
         "registeredId": "ZM-NW-CU-0012",
         "idScheme": {
-          "type": [
-            "IdentifierScheme"
-          ],
+          "type": ["IdentifierScheme"],
           "id": "https://mining-register.gov.zm",
           "name": "Zambia Mining Cadastre"
         }
@@ -234,24 +210,18 @@
     },
     "performanceClaim": [
       {
-        "type": [
-          "Claim"
-        ],
+        "type": ["Claim"],
         "id": "https://sample-mine.example.com/claims/ghg-2024",
         "name": "GHG Emissions — Scope 1",
         "description": "Annual Scope 1 greenhouse gas emissions from the Sample Copper Mine for the 2024 reporting year.",
         "referenceCriteria": [
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://sample-scheme.coppermark.org/criteria/ghg-management/v3",
             "name": "GHG Emissions Management (Coppermark RRA Criterion 26)",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
                 "name": "Greenhouse Gas Emissions",
                 "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
@@ -268,9 +238,7 @@
         "claimedPerformance": [
           {
             "metric": {
-              "type": [
-                "PerformanceMetric"
-              ],
+              "type": ["PerformanceMetric"],
               "id": "https://vocabulary.uncefact.org/performance-metric/scope-1-ghg-emissions",
               "name": "Scope 1 GHG Emissions"
             },
@@ -282,9 +250,7 @@
         ],
         "conformityTopic": [
           {
-            "type": [
-              "ConformityTopic"
-            ],
+            "type": ["ConformityTopic"],
             "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
             "name": "Greenhouse Gas Emissions",
             "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
@@ -292,24 +258,18 @@
         ]
       },
       {
-        "type": [
-          "Claim"
-        ],
+        "type": ["Claim"],
         "id": "https://sample-mine.example.com/claims/water-2024",
         "name": "Water Withdrawal Intensity",
         "description": "Water withdrawal intensity per tonne of copper produced at Sample mine for 2024.",
         "referenceCriteria": [
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://sample-scheme.coppermark.org/criteria/water-stewardship/v3",
             "name": "Water Stewardship (Coppermark RRA Criterion 27)",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
                 "name": "Water Conservation",
                 "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
@@ -326,9 +286,7 @@
         "claimedPerformance": [
           {
             "metric": {
-              "type": [
-                "PerformanceMetric"
-              ],
+              "type": ["PerformanceMetric"],
               "id": "https://vocabulary.uncefact.org/performance-metric/water-intensity",
               "name": "Water Intensity"
             },
@@ -340,9 +298,7 @@
         ],
         "conformityTopic": [
           {
-            "type": [
-              "ConformityTopic"
-            ],
+            "type": ["ConformityTopic"],
             "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
             "name": "Water Conservation",
             "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/template.hbs
@@ -38,6 +38,10 @@
       section { padding: 0 16px; }
       a { text-decoration: none; }
 
+      .capitalize-first {
+        text-transform: capitalize;
+      }
+
       .facility-record {
         width: 100%;
         margin: 0 auto;
@@ -430,13 +434,21 @@
             {{#each credentialSubject.relatedParty}}
             {{#if party}}
             <div class="grid-row border-bottom-gray-500">
-              <div class="label">{{role}}</div>
+              <div class="label capitalize-first">{{role}}</div>
               <div class="grid-value">
                 <a href="{{party.id}}" class="blue-bottom-line-2" aria-label="Visit {{party.name}}" target="_blank">{{party.name}}</a>
               </div>
             </div>
             {{/if}}
             {{/each}}
+                        {{#if credentialSubject.registeredId}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">Registered ID</div>
+              <div class="grid-value">
+                <div class="grid-value-text">{{credentialSubject.registeredId}}</div>
+              </div>
+            </div>
+            {{/if}}
             {{#if credentialSubject.countryOfOperation}}
             <div class="grid-row border-bottom-gray-500">
               <div class="label">Country</div>
@@ -474,18 +486,6 @@
               </div>
             </div>
             {{/if}}
-            {{#if credentialSubject.processCategory}}
-            <div class="grid-row border-bottom-gray-500">
-              <div class="label">Processes</div>
-              <div class="grid-value">
-                <div class="grid-value-list">
-                  {{#each credentialSubject.processCategory}}
-                  <a href="{{schemeId}}" class="blue-bottom-line-2" target="_blank">{{name}}</a>
-                  {{/each}}
-                </div>
-              </div>
-            </div>
-            {{/if}}
             {{#if credentialSubject.locationInformation.geoLocation}}
             <div class="grid-row border-bottom-gray-500">
               <div class="label">Geolocation</div>
@@ -499,39 +499,17 @@
               </div>
             </div>
             {{/if}}
-            {{#if credentialSubject.registeredId}}
+            {{#if credentialSubject.processCategory}}
             <div class="grid-row border-bottom-gray-500">
-              <div class="label">Registered ID</div>
+              <div class="label">Processes</div>
               <div class="grid-value">
-                <div class="grid-value-text">{{credentialSubject.registeredId}}</div>
-              </div>
-            </div>
-            {{/if}}
-            {{#if credentialSubject.idScheme}}
-            <div class="grid-row border-bottom-gray-500">
-              <div class="label">ID Scheme</div>
-              <div class="grid-value">
-                <a href="{{credentialSubject.idScheme.id}}" class="blue-bottom-line-2" target="_blank">{{credentialSubject.idScheme.name}}</a>
-              </div>
-            </div>
-            {{/if}}
-            {{#if credentialSubject.facilityAlsoKnownAs}}
-            {{#each credentialSubject.facilityAlsoKnownAs}}
-            <div class="grid-row border-bottom-gray-500">
-              <div class="label">Also known as</div>
-              <div class="grid-value">
-                {{#if idScheme.name}}
-                <div class="grid-value-text">
-                  <a href="{{id}}" class="blue-bottom-line-2" target="_blank">{{name}}</a>
-                  {{#if registeredId}} · {{registeredId}}{{/if}}
-                  {{#if idScheme.name}} ({{idScheme.name}}){{/if}}
+                <div class="grid-value-list">
+                  {{#each credentialSubject.processCategory}}
+                  <a href="{{schemeId}}" class="blue-bottom-line-2" target="_blank">{{name}}</a>
+                  {{/each}}
                 </div>
-                {{else}}
-                <a href="{{id}}" class="blue-bottom-line-2" target="_blank">{{name}}</a>
-                {{/if}}
               </div>
             </div>
-            {{/each}}
             {{/if}}
           </div>
         </section>
@@ -655,21 +633,6 @@
               </div>
             </div>
           </div>
-          {{#if issuer.issuerAlsoKnownAs}}
-          {{#each issuer.issuerAlsoKnownAs}}
-          {{#if idScheme.name}}
-          <div class="grid-row-alt border-bottom-gray-400">
-            <div class="label-alt">Issuer registry</div>
-            <div class="grid-value">
-              <div class="grid-value-text-alt">
-                <a href="{{idScheme.id}}" style="text-decoration:underline;color:var(--color-gray-700);" target="_blank">{{idScheme.name}}</a>
-                {{#if registeredId}} · {{registeredId}}{{/if}}
-              </div>
-            </div>
-          </div>
-          {{/if}}
-          {{/each}}
-          {{/if}}
           {{#if validFrom}}
           <div class="grid-row-alt border-bottom-gray-400">
             <div class="label-alt">Valid from</div>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_facility_record/template.hbs
@@ -1,0 +1,693 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+      rel="stylesheet" />
+    <title>Digital Facility Record</title>
+    <style>
+      :root {
+        --color-primary: rgba(35, 46, 61, 1);
+        --color-secondary: rgba(31, 90, 149, 1);
+        --color-white: rgba(255, 255, 255, 1);
+        --color-black: rgba(0, 0, 0, 1);
+        --color-gray-700: rgba(35, 46, 61, 1);
+        --color-gray-600: rgba(85, 96, 110, 1);
+        --color-gray-500: rgba(169, 177, 183, 1);
+        --color-gray-400: rgba(212, 214, 216, 1);
+        --color-gray-300: rgba(237, 239, 240, 1);
+        --color-success-bg: rgba(184, 236, 182, 1);
+        --color-success-text: rgba(8, 50, 0, 1);
+        --color-error-bg: rgba(255, 188, 183, 1);
+        --color-error-text: rgba(50, 0, 0, 1);
+        --color-link-underline-dark: rgba(79, 149, 221, 1);
+        --color-link-underline-light: rgba(148, 196, 245, 1);
+        --color-icon: #1f5a95;
+        --font-family: 'Lato', sans-serif;
+        --font-weight-regular: 400;
+        --font-weight-medium: 500;
+        --font-weight-semi-bold: 600;
+        --font-weight-bold: 700;
+        --font-weight-black: 900;
+      }
+
+      * { margin: 0; box-sizing: border-box; }
+      body { font-family: var(--font-family); }
+      section { padding: 0 16px; }
+      a { text-decoration: none; }
+
+      .facility-record {
+        width: 100%;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+
+      .facility-record-header {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        align-items: center;
+      }
+
+      .facility-header {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 32px 16px 20px 16px;
+        background-color: var(--color-primary);
+      }
+
+      .facility-record .facility-title {
+        width: 100%;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-white);
+        font-size: 16px;
+        line-height: 22px;
+        text-transform: uppercase;
+      }
+
+      .facility-record .name-description {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .facility-record .name-description h1 {
+        font-weight: var(--font-weight-black);
+        color: var(--color-white);
+        font-size: 30px;
+        line-height: 32.5px;
+      }
+
+      .facility-record .name-description p {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-white);
+        font-size: 16px;
+        line-height: 17.4px;
+      }
+
+      .facility-record .facility-details-section {
+        padding: 0 16px 16px;
+        align-self: stretch;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+        background-color: var(--color-gray-600);
+      }
+
+      .facility-record .grid-row {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 16px;
+        padding: 10px 0 12px;
+        width: 100%;
+        border-bottom: 1px solid;
+      }
+
+      .facility-record .grid-row:last-child { border-bottom: none; }
+
+      .facility-record .border-bottom-gray-500 { border-color: var(--color-gray-500); }
+
+      .facility-record .label {
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-300);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .facility-record .grid-value {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        align-self: stretch;
+        flex: 1;
+      }
+
+      .facility-record .grid-value-text {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-white);
+        font-size: 16px;
+        line-height: 17.4px;
+        flex: 1;
+      }
+
+      .facility-record .grid-value-list {
+        display: flex;
+        flex-wrap: wrap;
+        row-gap: 4px;
+        max-width: 100%;
+      }
+
+      .facility-record .grid-value-list a { margin-right: 10px; }
+
+      .blue-bottom-line-2,
+      .blue-bottom-line-2:link {
+        width: fit-content;
+        color: var(--color-white);
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: var(--color-link-underline-light);
+        text-underline-offset: 3px;
+      }
+
+      .white-text { color: var(--color-white); }
+
+      /* Declarations / Performance Claims */
+      .facility-record .declarations {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 0 16px;
+        width: 100%;
+      }
+
+      .facility-record .declaration-title {
+        font-size: 20px;
+        font-weight: var(--font-weight-bold);
+        line-height: 21.8px;
+        color: var(--color-gray-700);
+      }
+
+      .facility-record .conformities-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .facility-record .conformity-card {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+        padding: 16px 18px 16px 16px;
+        background-color: var(--color-white);
+        border-radius: 4px;
+        border: 1px solid var(--color-gray-400);
+      }
+
+      .facility-record .claim-name {
+        position: relative;
+        align-self: stretch;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-secondary);
+        font-size: 18px;
+        line-height: 21.2px;
+      }
+
+      .facility-record .regulation-details {
+        color: var(--color-gray-600);
+        font-size: 14px;
+        line-height: 19.2px;
+        align-self: stretch;
+        font-weight: var(--font-weight-regular);
+      }
+
+      .facility-record .metric-value {
+        flex: 1;
+        color: var(--color-gray-700);
+        font-size: 16px;
+        font-weight: var(--font-weight-regular);
+        line-height: 17.44px;
+      }
+
+      .facility-record .conformity-topic-tag {
+        display: inline-block;
+        padding: 2px 8px;
+        background-color: rgba(31, 90, 149, 0.1);
+        border-radius: 4px;
+        font-size: 13px;
+        color: var(--color-secondary);
+        margin-right: 4px;
+        margin-bottom: 4px;
+      }
+
+      .facility-record .period-info {
+        font-size: 13px;
+        color: var(--color-gray-600);
+      }
+
+      /* Material Usage section */
+      .facility-record .material-usage {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 0 16px;
+        width: 100%;
+      }
+
+      .facility-record .material-table {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .facility-record .material-item {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        border: 1px solid var(--color-gray-400);
+        border-radius: 4px;
+        padding: 12px 16px;
+        gap: 12px;
+        align-items: start;
+      }
+
+      .facility-record .material-left {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .facility-record .material-name {
+        font-size: 16px;
+        font-weight: var(--font-weight-semi-bold);
+        color: var(--color-black);
+      }
+
+      .facility-record .material-type {
+        font-size: 13px;
+        color: var(--color-gray-600);
+      }
+
+      .facility-record .material-tags {
+        display: flex;
+        gap: 4px;
+        flex-wrap: wrap;
+        margin-top: 4px;
+      }
+
+      .facility-record .material-tag {
+        font-size: 12px;
+        background-color: rgba(247, 250, 253, 1);
+        color: var(--color-gray-600);
+        padding: 2px 6px;
+        border-radius: 3px;
+      }
+
+      .facility-record .material-right {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 4px;
+      }
+
+      .facility-record .material-mass {
+        font-size: 16px;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+      }
+
+      .facility-record .material-country {
+        font-size: 13px;
+        color: var(--color-gray-600);
+      }
+
+      /* Related documents */
+      .facility-record .related-docs {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 0 16px;
+        width: 100%;
+      }
+
+      .facility-record .doc-link {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--color-gray-400);
+        text-decoration: none;
+        color: var(--color-gray-700);
+        font-size: 16px;
+        font-weight: var(--font-weight-regular);
+      }
+
+      /* Issuing details */
+      .facility-record .issuing-details {
+        width: 100%;
+        padding: 24px 16px 36px;
+        background-color: var(--color-gray-300);
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+      }
+
+      .facility-record .issuing-title {
+        font-weight: var(--font-weight-bold);
+        color: var(--color-black);
+        font-size: 20px;
+        line-height: 21.8px;
+      }
+
+      .facility-record .facility-details {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        width: 100%;
+      }
+
+      .facility-record .grid-row-alt {
+        display: grid;
+        grid-template-columns: 1.4fr 3fr;
+        gap: 16px;
+        padding: 10px 0 12px;
+        width: 100%;
+        border-bottom: 1px solid;
+      }
+
+      .facility-record .border-bottom-gray-400 { border-color: var(--color-gray-400); }
+
+      .facility-record .label-alt {
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-600);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .facility-record .grid-value-link {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+        align-self: stretch;
+        display: flex;
+        flex: 1;
+      }
+
+      .facility-record .div-wrapper {
+        gap: 10px;
+        display: inline-flex;
+        align-items: flex-start;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: var(--color-link-underline-dark);
+        text-underline-offset: 3px;
+      }
+
+      .facility-record .issuer-link {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 16px;
+        line-height: 22px;
+      }
+
+      .facility-record .grid-value-text-alt {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 16px;
+        line-height: 17.4px;
+        flex: 1;
+      }
+
+      @media (min-width: 1200px) {
+        .facility-record { max-width: 1200px; }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="facility-record">
+      <div class="facility-record-header">
+        <header class="facility-header">
+          <div class="facility-title">FACILITY RECORD</div>
+          <div class="name-description">
+            <h1>{{credentialSubject.name}}</h1>
+            {{#if credentialSubject.description}}
+            <p>{{credentialSubject.description}}</p>
+            {{/if}}
+          </div>
+        </header>
+        <section class="facility-details-section">
+          <div class="facility-details">
+            {{#each credentialSubject.relatedParty}}
+            {{#if party}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">{{role}}</div>
+              <div class="grid-value">
+                <a href="{{party.id}}" class="blue-bottom-line-2" aria-label="Visit {{party.name}}" target="_blank">{{party.name}}</a>
+              </div>
+            </div>
+            {{/if}}
+            {{/each}}
+            {{#if credentialSubject.countryOfOperation}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">Country</div>
+              <div class="grid-value">
+                <div class="grid-value-text">
+                  {{#if credentialSubject.countryOfOperation.countryName}}
+                    {{credentialSubject.countryOfOperation.countryName}}
+                    {{#if credentialSubject.countryOfOperation.countryCode}}({{credentialSubject.countryOfOperation.countryCode}}){{/if}}
+                  {{else}}
+                    {{credentialSubject.countryOfOperation}}
+                  {{/if}}
+                </div>
+              </div>
+            </div>
+            {{/if}}
+            {{#if credentialSubject.address}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">Address</div>
+              <div class="grid-value">
+                {{#if credentialSubject.locationInformation.plusCode}}
+                <a href="{{credentialSubject.locationInformation.plusCode}}" class="blue-bottom-line-2" target="_blank">
+                  {{#if credentialSubject.address.streetAddress}}{{credentialSubject.address.streetAddress}}, {{/if}}
+                  {{#if credentialSubject.address.addressLocality}}{{credentialSubject.address.addressLocality}}, {{/if}}
+                  {{#if credentialSubject.address.addressRegion}}{{credentialSubject.address.addressRegion}} {{/if}}
+                  {{#if credentialSubject.address.postalCode}}{{credentialSubject.address.postalCode}}{{/if}}
+                </a>
+                {{else}}
+                <span class="white-text">
+                  {{#if credentialSubject.address.streetAddress}}{{credentialSubject.address.streetAddress}}, {{/if}}
+                  {{#if credentialSubject.address.addressLocality}}{{credentialSubject.address.addressLocality}}, {{/if}}
+                  {{#if credentialSubject.address.addressRegion}}{{credentialSubject.address.addressRegion}} {{/if}}
+                  {{#if credentialSubject.address.postalCode}}{{credentialSubject.address.postalCode}}{{/if}}
+                </span>
+                {{/if}}
+              </div>
+            </div>
+            {{/if}}
+            {{#if credentialSubject.processCategory}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">Processes</div>
+              <div class="grid-value">
+                <div class="grid-value-list">
+                  {{#each credentialSubject.processCategory}}
+                  <a href="{{schemeId}}" class="blue-bottom-line-2" target="_blank">{{name}}</a>
+                  {{/each}}
+                </div>
+              </div>
+            </div>
+            {{/if}}
+            {{#if credentialSubject.locationInformation.geoLocation}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">Geolocation</div>
+              <div class="grid-value">
+                {{#if credentialSubject.locationInformation.geoLocation.latitude}}
+                <a
+                  href="https://www.google.com/maps?q={{credentialSubject.locationInformation.geoLocation.latitude}},{{credentialSubject.locationInformation.geoLocation.longitude}}"
+                  class="blue-bottom-line-2"
+                  target="_blank">Show on map</a>
+                {{/if}}
+              </div>
+            </div>
+            {{/if}}
+            {{#if credentialSubject.registeredId}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">Registered ID</div>
+              <div class="grid-value">
+                <div class="grid-value-text">{{credentialSubject.registeredId}}</div>
+              </div>
+            </div>
+            {{/if}}
+            {{#if credentialSubject.idScheme}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">ID Scheme</div>
+              <div class="grid-value">
+                <a href="{{credentialSubject.idScheme.id}}" class="blue-bottom-line-2" target="_blank">{{credentialSubject.idScheme.name}}</a>
+              </div>
+            </div>
+            {{/if}}
+            {{#if credentialSubject.facilityAlsoKnownAs}}
+            {{#each credentialSubject.facilityAlsoKnownAs}}
+            <div class="grid-row border-bottom-gray-500">
+              <div class="label">Also known as</div>
+              <div class="grid-value">
+                {{#if idScheme.name}}
+                <div class="grid-value-text">
+                  <a href="{{id}}" class="blue-bottom-line-2" target="_blank">{{name}}</a>
+                  {{#if registeredId}} · {{registeredId}}{{/if}}
+                  {{#if idScheme.name}} ({{idScheme.name}}){{/if}}
+                </div>
+                {{else}}
+                <a href="{{id}}" class="blue-bottom-line-2" target="_blank">{{name}}</a>
+                {{/if}}
+              </div>
+            </div>
+            {{/each}}
+            {{/if}}
+          </div>
+        </section>
+      </div>
+
+      {{#if credentialSubject.materialUsage}}
+      <section class="material-usage">
+        <h2 class="declaration-title">Material Usage</h2>
+        {{#if credentialSubject.materialUsage.applicablePeriod}}
+        <p class="period-info">
+          Period: {{credentialSubject.materialUsage.applicablePeriod.startDate}} — {{credentialSubject.materialUsage.applicablePeriod.endDate}}
+          {{#if credentialSubject.materialUsage.applicablePeriod.periodInformation}}
+            · {{credentialSubject.materialUsage.applicablePeriod.periodInformation}}
+          {{/if}}
+        </p>
+        {{/if}}
+        {{#if credentialSubject.materialUsage.materialConsumed}}
+        <div class="material-table">
+          {{#each credentialSubject.materialUsage.materialConsumed}}
+          <div class="material-item">
+            <div class="material-left">
+              <div class="material-name">{{name}}</div>
+              {{#if materialType}}
+              <div class="material-type">{{materialType.name}}</div>
+              {{/if}}
+              <div class="material-tags">
+                {{#if recycledMassFraction}}
+                <span class="material-tag">Recycled {{recycledMassFraction}}</span>
+                {{/if}}
+                <span class="material-tag">Hazard {{#if hazardous}}Yes{{else}}No{{/if}}</span>
+              </div>
+            </div>
+            <div class="material-right">
+              {{#if mass}}
+              <div class="material-mass">{{mass.value}} {{mass.unit}}</div>
+              {{/if}}
+              {{#if originCountry}}
+              <div class="material-country">
+                {{#if originCountry.countryCode}}{{originCountry.countryCode}}{{else}}{{originCountry}}{{/if}}
+              </div>
+              {{/if}}
+            </div>
+          </div>
+          {{/each}}
+        </div>
+        {{/if}}
+      </section>
+      {{/if}}
+
+      {{#if credentialSubject.performanceClaim}}
+      <section class="declarations">
+        <h2 class="declaration-title">Performance Claims</h2>
+        <div class="conformities-list">
+          {{#each credentialSubject.performanceClaim}}
+          <article class="conformity-card">
+            <div class="claim-name">{{name}}</div>
+            {{#if description}}
+            <p class="regulation-details">{{description}}</p>
+            {{/if}}
+            {{#if conformityTopic}}
+            <div>
+              {{#each conformityTopic}}
+              <span class="conformity-topic-tag">{{name}}</span>
+              {{/each}}
+            </div>
+            {{/if}}
+            {{#if claimedPerformance}}
+            <div style="display:flex;flex-direction:column;gap:4px;">
+              {{#each claimedPerformance}}
+              {{#if metric}}
+              <p class="metric-value">{{metric.name}}: {{#if measure}}{{measure.value}} {{measure.unit}}{{/if}}</p>
+              {{/if}}
+              {{/each}}
+            </div>
+            {{/if}}
+            {{#if applicablePeriod}}
+            <p class="period-info">Period: {{applicablePeriod.startDate}} — {{applicablePeriod.endDate}}</p>
+            {{/if}}
+            {{#if claimDate}}
+            <p class="regulation-details">Claim date: {{claimDate}}</p>
+            {{/if}}
+            {{#if referenceCriteria}}
+            <div style="display:flex;flex-direction:column;gap:4px;">
+              {{#each referenceCriteria}}
+              <a href="{{id}}" target="_blank" style="font-size:13px;color:var(--color-secondary);text-decoration:underline;">{{name}}</a>
+              {{/each}}
+            </div>
+            {{/if}}
+          </article>
+          {{/each}}
+        </div>
+      </section>
+      {{/if}}
+
+      {{#if credentialSubject.relatedDocument}}
+      <section class="related-docs">
+        <h2 class="declaration-title">Related Documents</h2>
+        {{#each credentialSubject.relatedDocument}}
+        {{#if linkURL}}
+        <a href="{{linkURL}}" class="doc-link" target="_blank">
+          <span>{{#if linkName}}{{linkName}}{{else}}{{linkURL}}{{/if}}</span>
+          <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 1L8 8L1 15" stroke="var(--color-icon)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </a>
+        {{/if}}
+        {{/each}}
+      </section>
+      {{/if}}
+
+      <section class="issuing-details">
+        <div class="typography-heading">
+          <h2 class="issuing-title">Issuing details</h2>
+        </div>
+        <div class="facility-details">
+          <div class="grid-row-alt border-bottom-gray-400">
+            <div class="label-alt">Issued by</div>
+            <div class="grid-value-link">
+              <div class="div-wrapper">
+                <a href="{{issuer.id}}" class="issuer-link" target="_blank">{{issuer.name}}</a>
+              </div>
+            </div>
+          </div>
+          {{#if issuer.issuerAlsoKnownAs}}
+          {{#each issuer.issuerAlsoKnownAs}}
+          {{#if idScheme.name}}
+          <div class="grid-row-alt border-bottom-gray-400">
+            <div class="label-alt">Issuer registry</div>
+            <div class="grid-value">
+              <div class="grid-value-text-alt">
+                <a href="{{idScheme.id}}" style="text-decoration:underline;color:var(--color-gray-700);" target="_blank">{{idScheme.name}}</a>
+                {{#if registeredId}} · {{registeredId}}{{/if}}
+              </div>
+            </div>
+          </div>
+          {{/if}}
+          {{/each}}
+          {{/if}}
+          {{#if validFrom}}
+          <div class="grid-row-alt border-bottom-gray-400">
+            <div class="label-alt">Valid from</div>
+            <div class="grid-value">
+              <div class="grid-value-text-alt">{{validFrom}}</div>
+            </div>
+          </div>
+          {{/if}}
+          {{#if validUntil}}
+          <div class="grid-row-alt border-bottom-gray-400">
+            <div class="label-alt">Valid until</div>
+            <div class="grid-value">
+              <div class="grid-value-text-alt">{{validUntil}}</div>
+            </div>
+          </div>
+          {{/if}}
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/example-data.json
@@ -1,46 +1,30 @@
 {
-  "type": [
-    "DigitalIdentityAnchor",
-    "VerifiableCredential"
-  ],
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
-  ],
+  "type": ["DigitalIdentityAnchor", "VerifiableCredential"],
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vocabulary.uncefact.org/untp/0.7.0/context/"],
   "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
   "issuer": {
-    "type": [
-      "CredentialIssuer"
-    ],
+    "type": ["CredentialIssuer"],
     "id": "did:web:identifiers.example-company.com:12345",
     "name": "Example Company Pty Ltd",
     "issuerAlsoKnownAs": [
       {
-        "type": [
-          "Party"
-        ],
+        "type": ["Party"],
         "id": "https://sample-business-register.gov/123456789",
         "name": "Sample Company Ltd",
         "registeredId": "90664869327",
         "idScheme": {
-          "type": [
-            "IdentifierScheme"
-          ],
+          "type": ["IdentifierScheme"],
           "id": "https://jargon.sh",
           "name": "Global Identifier Scheme Name"
         }
       },
       {
-        "type": [
-          "Party"
-        ],
+        "type": ["Party"],
         "id": "https://sample-business-register.gov/123456789",
         "name": "Sample Company Ltd",
         "registeredId": "90664869327",
         "idScheme": {
-          "type": [
-            "IdentifierScheme"
-          ],
+          "type": ["IdentifierScheme"],
           "id": "https://jargon.sh",
           "name": "Global Identifier Scheme Name"
         }
@@ -66,32 +50,23 @@
     "digestMultibase": "The quick brown fox jumps over the lazy dog."
   },
   "credentialSubject": {
-    "type": [
-      "RegisteredIdentity"
-    ],
+    "type": ["RegisteredIdentity"],
     "id": "did:web:samplecompany.com/123456789",
     "registeredName": "Sample business Ltd",
     "registeredId": "123456789",
     "registeredDate": "1970-01-01",
     "publicInformation": "https://jargon.sh",
     "idScheme": {
-      "type": [
-        "IdentifierScheme"
-      ],
+      "type": ["IdentifierScheme"],
       "id": "https://jargon.sh",
       "name": "Global Identifier Scheme Name"
     },
     "registrar": {
-      "type": [
-        "Party"
-      ],
+      "type": ["Party"],
       "id": "https://sample-business-register.gov/123456789",
       "name": "Sample Company Ltd"
     },
     "registerType": "business",
-    "registrationScope": [
-      "https://jargon.sh",
-      "https://jargon.sh"
-    ]
+    "registrationScope": ["https://jargon.sh", "https://jargon.sh"]
   }
 }

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/example-data.json
@@ -1,0 +1,97 @@
+{
+  "type": [
+    "DigitalIdentityAnchor",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
+  ],
+  "id": "https://example-company.com/credentials/2a423366-a0d6-4855-ba65-2e0c926d09b0",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:identifiers.example-company.com:12345",
+    "name": "Example Company Pty Ltd",
+    "issuerAlsoKnownAs": [
+      {
+        "type": [
+          "Party"
+        ],
+        "id": "https://sample-business-register.gov/123456789",
+        "name": "Sample Company Ltd",
+        "registeredId": "90664869327",
+        "idScheme": {
+          "type": [
+            "IdentifierScheme"
+          ],
+          "id": "https://jargon.sh",
+          "name": "Global Identifier Scheme Name"
+        }
+      },
+      {
+        "type": [
+          "Party"
+        ],
+        "id": "https://sample-business-register.gov/123456789",
+        "name": "Sample Company Ltd",
+        "registeredId": "90664869327",
+        "idScheme": {
+          "type": [
+            "IdentifierScheme"
+          ],
+          "id": "https://jargon.sh",
+          "name": "Global Identifier Scheme Name"
+        }
+      }
+    ]
+  },
+  "validFrom": "2024-03-15T12:00:00Z",
+  "validUntil": "2034-03-15T12:00:00Z",
+  "name": "Some name",
+  "credentialStatus": {
+    "id": "https://example-cab.com/credentials/status/3#94567",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "refresh",
+    "statusListIndex": 94567,
+    "statusListCredential": "https://example-cab.com/credentials/status/4"
+  },
+  "renderTemplate2024": {
+    "name": "The quick brown fox jumps over the lazy dog.",
+    "mediaQuery": "The quick brown fox jumps over the lazy dog.",
+    "template": "The quick brown fox jumps over the lazy dog.",
+    "url": "https://jargon.sh",
+    "mediaType": "The quick brown fox jumps over the lazy dog.",
+    "digestMultibase": "The quick brown fox jumps over the lazy dog."
+  },
+  "credentialSubject": {
+    "type": [
+      "RegisteredIdentity"
+    ],
+    "id": "did:web:samplecompany.com/123456789",
+    "registeredName": "Sample business Ltd",
+    "registeredId": "123456789",
+    "registeredDate": "1970-01-01",
+    "publicInformation": "https://jargon.sh",
+    "idScheme": {
+      "type": [
+        "IdentifierScheme"
+      ],
+      "id": "https://jargon.sh",
+      "name": "Global Identifier Scheme Name"
+    },
+    "registrar": {
+      "type": [
+        "Party"
+      ],
+      "id": "https://sample-business-register.gov/123456789",
+      "name": "Sample Company Ltd"
+    },
+    "registerType": "business",
+    "registrationScope": [
+      "https://jargon.sh",
+      "https://jargon.sh"
+    ]
+  }
+}

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/template.hbs
@@ -30,6 +30,10 @@
     section { padding: 0 16px; }
     a { text-decoration: none; }
 
+    .capitalize-first {
+      text-transform: capitalize;
+    }
+
     .identity-anchor {
       width: 100%;
       margin: 0 auto;
@@ -292,7 +296,7 @@
           <div class="grid-row border-bottom-gray-500">
             <div class="label">Register Type</div>
             <div class="grid-value">
-              <div class="grid-value-text">{{credentialSubject.registerType}}</div>
+              <div class="grid-value-text capitalize-first">{{credentialSubject.registerType}}</div>
             </div>
           </div>
           {{/if}}
@@ -345,21 +349,6 @@
             </div>
           </div>
         </div>
-        {{#if issuer.issuerAlsoKnownAs}}
-        {{#each issuer.issuerAlsoKnownAs}}
-        {{#if idScheme.name}}
-        <div class="grid-row-alt border-bottom-gray-400">
-          <div class="label-alt">Issuer Registry</div>
-          <div class="grid-value">
-            <div class="grid-value-text-alt">
-              <a href="{{idScheme.id}}" style="text-decoration:underline;color:var(--color-gray-700);" target="_blank">{{idScheme.name}}</a>
-              {{#if registeredId}} · {{registeredId}}{{/if}}
-            </div>
-          </div>
-        </div>
-        {{/if}}
-        {{/each}}
-        {{/if}}
         {{#if validFrom}}
         <div class="grid-row-alt border-bottom-gray-400">
           <div class="label-alt">Valid from</div>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_identity_anchor/template.hbs
@@ -1,0 +1,384 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet">
+  <title>Digital Identity Anchor</title>
+  <style>
+    :root {
+      --color-primary: rgba(35, 46, 61, 1);
+      --color-white: rgba(255, 255, 255, 1);
+      --color-black: rgba(0, 0, 0, 1);
+      --color-gray-700: rgba(35, 46, 61, 1);
+      --color-gray-600: rgba(85, 96, 110, 1);
+      --color-gray-500: rgba(169, 177, 183, 1);
+      --color-gray-400: rgba(212, 214, 216, 1);
+      --color-gray-300: rgba(237, 239, 240, 1);
+      --color-link-underline-dark: rgba(79, 149, 221, 1);
+      --color-link-underline-light: rgba(148, 196, 245, 1);
+      --font-family: "Lato", sans-serif;
+      --font-weight-regular: 400;
+      --font-weight-medium: 500;
+      --font-weight-bold: 700;
+      --font-weight-black: 900;
+    }
+
+    * { margin: 0; box-sizing: border-box; }
+    body { font-family: var(--font-family); }
+    section { padding: 0 16px; }
+    a { text-decoration: none; }
+
+    .identity-anchor {
+      width: 100%;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .identity-anchor-header {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      align-items: center;
+    }
+
+    .identity-header {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 32px 16px 20px;
+      background-color: var(--color-primary);
+    }
+
+    .identity-anchor .identity-title {
+      width: 100%;
+      font-weight: var(--font-weight-medium);
+      color: var(--color-white);
+      font-size: 16px;
+      line-height: 22px;
+      text-transform: uppercase;
+    }
+
+    .identity-anchor .name-description {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .identity-anchor .name-description h1 {
+      font-weight: var(--font-weight-black);
+      color: var(--color-white);
+      font-size: 30px;
+      line-height: 32.5px;
+    }
+
+    .identity-anchor .name-description p {
+      font-weight: var(--font-weight-medium);
+      color: var(--color-white);
+      font-size: 16px;
+      line-height: 17.4px;
+      word-break: break-all;
+    }
+
+    .identity-anchor .identity-details-section {
+      padding: 0 16px 16px;
+      align-self: stretch;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+      background-color: var(--color-gray-600);
+    }
+
+    .identity-anchor .grid-row {
+      display: grid;
+      grid-template-columns: 1fr 2fr;
+      gap: 16px;
+      padding: 10px 0 12px;
+      width: 100%;
+      border-bottom: 1px solid;
+    }
+
+    .identity-anchor .grid-row:last-child { border-bottom: none; }
+    .identity-anchor .border-bottom-gray-500 { border-color: var(--color-gray-500); }
+
+    .identity-anchor .label {
+      font-weight: var(--font-weight-regular);
+      color: var(--color-gray-300);
+      font-size: 16px;
+      line-height: 22px;
+    }
+
+    .identity-anchor .grid-value {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      align-self: stretch;
+      flex: 1;
+    }
+
+    .identity-anchor .grid-value-text {
+      font-weight: var(--font-weight-medium);
+      color: var(--color-white);
+      font-size: 16px;
+      line-height: 17.4px;
+      flex: 1;
+      word-break: break-all;
+    }
+
+    .blue-bottom-line-2,
+    .blue-bottom-line-2:link {
+      width: fit-content;
+      color: var(--color-white);
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
+      text-decoration-color: var(--color-link-underline-light);
+      text-underline-offset: 3px;
+    }
+
+    /* Registration scope tags */
+    .scope-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+
+    .scope-tag {
+      display: inline-block;
+      padding: 2px 8px;
+      background-color: rgba(255,255,255,0.15);
+      border-radius: 4px;
+      font-size: 13px;
+      color: var(--color-white);
+      word-break: break-all;
+    }
+
+    /* Issuing details */
+    .identity-anchor .issuing-details {
+      width: 100%;
+      padding: 24px 16px 36px;
+      background-color: var(--color-white);
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+    }
+
+    .identity-anchor .typography-heading {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .identity-anchor .issuing-title {
+      font-weight: var(--font-weight-bold);
+      color: var(--color-black);
+      font-size: 20px;
+      line-height: 21.8px;
+    }
+
+    .identity-anchor .identity-details {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: flex-start;
+      width: 100%;
+    }
+
+    .identity-anchor .grid-row-alt {
+      display: grid;
+      grid-template-columns: 1.4fr 3fr;
+      gap: 16px;
+      padding: 10px 0 12px;
+      width: 100%;
+      border-bottom: 1px solid;
+    }
+
+    .identity-anchor .border-bottom-gray-400 { border-color: var(--color-gray-400); }
+
+    .identity-anchor .label-alt {
+      font-weight: var(--font-weight-regular);
+      color: var(--color-gray-600);
+      font-size: 16px;
+      line-height: 22px;
+    }
+
+    .identity-anchor .grid-value-link {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 6px;
+      align-self: stretch;
+      display: flex;
+      flex: 1;
+    }
+
+    .identity-anchor .div-wrapper {
+      gap: 10px;
+      display: inline-flex;
+      align-items: flex-start;
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
+      text-decoration-color: var(--color-link-underline-dark);
+      text-underline-offset: 3px;
+    }
+
+    .identity-anchor .issuer-link {
+      font-weight: var(--font-weight-medium);
+      color: var(--color-gray-700);
+      font-size: 16px;
+      line-height: 22px;
+    }
+
+    .identity-anchor .grid-value-text-alt {
+      font-weight: var(--font-weight-medium);
+      color: var(--color-gray-700);
+      font-size: 16px;
+      line-height: 17.4px;
+      flex: 1;
+      word-break: break-all;
+    }
+
+    @media (min-width: 1200px) {
+      .identity-anchor { max-width: 1200px; }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="identity-anchor">
+    <div class="identity-anchor-header">
+      <header class="identity-header">
+        <div class="identity-title">DIGITAL IDENTITY ANCHOR</div>
+        <div class="name-description">
+          <h1>{{credentialSubject.registeredName}}</h1>
+          <p>{{credentialSubject.id}}</p>
+        </div>
+      </header>
+      <section class="identity-details-section">
+        <div class="identity-details">
+          {{#if credentialSubject.idScheme.name}}
+          <div class="grid-row border-bottom-gray-500">
+            <div class="label">Identifier Scheme</div>
+            <div class="grid-value">
+              {{#if credentialSubject.idScheme.id}}
+              <a href="{{credentialSubject.idScheme.id}}" class="blue-bottom-line-2" target="_blank">{{credentialSubject.idScheme.name}}</a>
+              {{else}}
+              <div class="grid-value-text">{{credentialSubject.idScheme.name}}</div>
+              {{/if}}
+            </div>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.registeredId}}
+          <div class="grid-row border-bottom-gray-500">
+            <div class="label">Registered ID</div>
+            <div class="grid-value">
+              <div class="grid-value-text">{{credentialSubject.registeredId}}</div>
+            </div>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.registeredDate}}
+          <div class="grid-row border-bottom-gray-500">
+            <div class="label">Registered Date</div>
+            <div class="grid-value">
+              <div class="grid-value-text">{{credentialSubject.registeredDate}}</div>
+            </div>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.registerType}}
+          <div class="grid-row border-bottom-gray-500">
+            <div class="label">Register Type</div>
+            <div class="grid-value">
+              <div class="grid-value-text">{{credentialSubject.registerType}}</div>
+            </div>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.registrar}}
+          <div class="grid-row border-bottom-gray-500">
+            <div class="label">Registrar</div>
+            <div class="grid-value">
+              {{#if credentialSubject.registrar.id}}
+              <a href="{{credentialSubject.registrar.id}}" class="blue-bottom-line-2" target="_blank">{{credentialSubject.registrar.name}}</a>
+              {{else}}
+              <div class="grid-value-text">{{credentialSubject.registrar.name}}</div>
+              {{/if}}
+            </div>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.publicInformation}}
+          <div class="grid-row border-bottom-gray-500">
+            <div class="label">Public Info</div>
+            <div class="grid-value">
+              <a href="{{credentialSubject.publicInformation}}" class="blue-bottom-line-2" target="_blank">{{credentialSubject.publicInformation}}</a>
+            </div>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.registrationScope}}
+          <div class="grid-row border-bottom-gray-500">
+            <div class="label">Registration Scope</div>
+            <div class="grid-value">
+              <div class="scope-tags">
+                {{#each credentialSubject.registrationScope}}
+                <a href="{{this}}" class="scope-tag" target="_blank">{{this}}</a>
+                {{/each}}
+              </div>
+            </div>
+          </div>
+          {{/if}}
+        </div>
+      </section>
+    </div>
+
+    <section class="issuing-details">
+      <div class="typography-heading">
+        <h2 class="issuing-title">Issuing Details</h2>
+      </div>
+      <div class="identity-details">
+        <div class="grid-row-alt border-bottom-gray-400">
+          <div class="label-alt">Issued by</div>
+          <div class="grid-value-link">
+            <div class="div-wrapper">
+              <a href="{{issuer.id}}" class="issuer-link" target="_blank">{{issuer.name}}</a>
+            </div>
+          </div>
+        </div>
+        {{#if issuer.issuerAlsoKnownAs}}
+        {{#each issuer.issuerAlsoKnownAs}}
+        {{#if idScheme.name}}
+        <div class="grid-row-alt border-bottom-gray-400">
+          <div class="label-alt">Issuer Registry</div>
+          <div class="grid-value">
+            <div class="grid-value-text-alt">
+              <a href="{{idScheme.id}}" style="text-decoration:underline;color:var(--color-gray-700);" target="_blank">{{idScheme.name}}</a>
+              {{#if registeredId}} · {{registeredId}}{{/if}}
+            </div>
+          </div>
+        </div>
+        {{/if}}
+        {{/each}}
+        {{/if}}
+        {{#if validFrom}}
+        <div class="grid-row-alt border-bottom-gray-400">
+          <div class="label-alt">Valid from</div>
+          <div class="grid-value">
+            <div class="grid-value-text-alt">{{validFrom}}</div>
+          </div>
+        </div>
+        {{/if}}
+        {{#if validUntil}}
+        <div class="grid-row-alt border-bottom-gray-400">
+          <div class="label-alt">Valid until</div>
+          <div class="grid-value">
+            <div class="grid-value-text-alt">{{validUntil}}</div>
+          </div>
+        </div>
+        {{/if}}
+      </div>
+    </section>
+  </div>
+</body>
+
+</html>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/example-data.json
@@ -1,31 +1,19 @@
 {
-  "type": [
-    "DigitalProductPassport",
-    "VerifiableCredential"
-  ],
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
-  ],
+  "type": ["DigitalProductPassport", "VerifiableCredential"],
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vocabulary.uncefact.org/untp/0.7.0/context/"],
   "id": "https://credentials.sample-mine.example.com/dpp/cu-conc-2025",
   "issuer": {
-    "type": [
-      "CredentialIssuer"
-    ],
+    "type": ["CredentialIssuer"],
     "id": "did:web:sample-mine.example.com",
     "name": "Sample Copper Mine Pty Ltd",
     "issuerAlsoKnownAs": [
       {
-        "type": [
-          "Party"
-        ],
+        "type": ["Party"],
         "id": "https://sample-register.example.com/companies/MINE-001",
         "name": "Sample Copper Mine Pty Ltd",
         "registeredId": "MINE-001",
         "idScheme": {
-          "type": [
-            "IdentifierScheme"
-          ],
+          "type": ["IdentifierScheme"],
           "id": "https://sample-register.example.com",
           "name": "Patents and Companies Registration Agency (Zambia)"
         }
@@ -36,16 +24,12 @@
   "validUntil": "2026-03-01T00:00:00Z",
   "name": "Digital Product Passport — Copper Concentrate (Cu 30%)",
   "credentialSubject": {
-    "type": [
-      "Product"
-    ],
+    "type": ["Product"],
     "id": "https://id.sample-mine.example.com/product/cu-conc-2025",
     "name": "Copper Concentrate (Cu 30%)",
     "description": "Copper sulphide flotation concentrate with approximately 30% copper content, produced at Sample Copper Mine. Suitable for smelting to produce refined copper cathode.",
     "idScheme": {
-      "type": [
-        "IdentifierScheme"
-      ],
+      "type": ["IdentifierScheme"],
       "id": "https://id.sample-mine.example.com",
       "name": "Sample Product Identifier Scheme"
     },
@@ -73,16 +57,12 @@
       {
         "role": "manufacturer",
         "party": {
-          "type": [
-            "Party"
-          ],
+          "type": ["Party"],
           "id": "did:web:sample-mine.example.com",
           "name": "Sample Copper Mine Pty Ltd",
           "registeredId": "MINE-001",
           "idScheme": {
-            "type": [
-              "IdentifierScheme"
-            ],
+            "type": ["IdentifierScheme"],
             "id": "https://sample-register.example.com",
             "name": "Patents and Companies Registration Agency (Zambia)"
           },
@@ -94,16 +74,12 @@
       }
     ],
     "producedAtFacility": {
-      "type": [
-        "Facility"
-      ],
+      "type": ["Facility"],
       "id": "https://facility-register.example.com/fac-001",
       "name": "Sample Copper Mine",
       "registeredId": "fac-001",
       "idScheme": {
-        "type": [
-          "IdentifierScheme"
-        ],
+        "type": ["IdentifierScheme"],
         "id": "https://facility-register.example.com",
         "name": "UNTP Sample Facility Register"
       }
@@ -144,24 +120,18 @@
     ],
     "performanceClaim": [
       {
-        "type": [
-          "Claim"
-        ],
+        "type": ["Claim"],
         "id": "https://sample-mine.example.com/claims/product-carbon-2025",
         "name": "Product Carbon Footprint — Copper Concentrate",
         "description": "Cradle-to-gate carbon footprint of copper concentrate per tonne produced at Sample mine.",
         "referenceCriteria": [
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://sample-scheme.coppermark.org/criteria/ghg-management/v3",
             "name": "GHG Emissions Management (Coppermark RRA Criterion 26)",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
                 "name": "Greenhouse Gas Emissions",
                 "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
@@ -173,9 +143,7 @@
         "claimedPerformance": [
           {
             "metric": {
-              "type": [
-                "PerformanceMetric"
-              ],
+              "type": ["PerformanceMetric"],
               "id": "https://vocabulary.uncefact.org/performance-metric/product-carbon-footprint",
               "name": "Product Carbon Footprint"
             },
@@ -187,9 +155,7 @@
         ],
         "conformityTopic": [
           {
-            "type": [
-              "ConformityTopic"
-            ],
+            "type": ["ConformityTopic"],
             "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
             "name": "Greenhouse Gas Emissions",
             "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
@@ -197,24 +163,18 @@
         ]
       },
       {
-        "type": [
-          "Claim"
-        ],
+        "type": ["Claim"],
         "id": "https://sample-mine.example.com/claims/product-water-2025",
         "name": "Water Intensity — Copper Concentrate",
         "description": "Water consumption per tonne of copper concentrate produced at Sample mine.",
         "referenceCriteria": [
           {
-            "type": [
-              "Criterion"
-            ],
+            "type": ["Criterion"],
             "id": "https://sample-scheme.coppermark.org/criteria/water-stewardship/v3",
             "name": "Water Stewardship (Coppermark RRA Criterion 27)",
             "conformityTopic": [
               {
-                "type": [
-                  "ConformityTopic"
-                ],
+                "type": ["ConformityTopic"],
                 "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
                 "name": "Water Conservation",
                 "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
@@ -226,9 +186,7 @@
         "claimedPerformance": [
           {
             "metric": {
-              "type": [
-                "PerformanceMetric"
-              ],
+              "type": ["PerformanceMetric"],
               "id": "https://vocabulary.uncefact.org/performance-metric/water-intensity",
               "name": "Water Intensity"
             },
@@ -240,9 +198,7 @@
         ],
         "conformityTopic": [
           {
-            "type": [
-              "ConformityTopic"
-            ],
+            "type": ["ConformityTopic"],
             "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
             "name": "Water Conservation",
             "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/example-data.json
@@ -1,0 +1,254 @@
+{
+  "type": [
+    "DigitalProductPassport",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
+  ],
+  "id": "https://credentials.sample-mine.example.com/dpp/cu-conc-2025",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:sample-mine.example.com",
+    "name": "Sample Copper Mine Pty Ltd",
+    "issuerAlsoKnownAs": [
+      {
+        "type": [
+          "Party"
+        ],
+        "id": "https://sample-register.example.com/companies/MINE-001",
+        "name": "Sample Copper Mine Pty Ltd",
+        "registeredId": "MINE-001",
+        "idScheme": {
+          "type": [
+            "IdentifierScheme"
+          ],
+          "id": "https://sample-register.example.com",
+          "name": "Patents and Companies Registration Agency (Zambia)"
+        }
+      }
+    ]
+  },
+  "validFrom": "2025-03-01T00:00:00Z",
+  "validUntil": "2026-03-01T00:00:00Z",
+  "name": "Digital Product Passport — Copper Concentrate (Cu 30%)",
+  "credentialSubject": {
+    "type": [
+      "Product"
+    ],
+    "id": "https://id.sample-mine.example.com/product/cu-conc-2025",
+    "name": "Copper Concentrate (Cu 30%)",
+    "description": "Copper sulphide flotation concentrate with approximately 30% copper content, produced at Sample Copper Mine. Suitable for smelting to produce refined copper cathode.",
+    "idScheme": {
+      "type": [
+        "IdentifierScheme"
+      ],
+      "id": "https://id.sample-mine.example.com",
+      "name": "Sample Product Identifier Scheme"
+    },
+    "modelNumber": "SM-CU-CONC-30",
+    "batchNumber": "2025-Q1-4501",
+    "idGranularity": "model",
+    "productCategory": [
+      {
+        "code": "14110",
+        "name": "Copper ores and concentrates",
+        "definition": "Copper ores and concentrates obtained from mining operations.",
+        "schemeId": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+        "schemeName": "UN Central Product Classification (CPC)"
+      }
+    ],
+    "relatedDocument": [
+      {
+        "linkURL": "https://credentials.sample-cab.example.com/dcc/mine-001",
+        "linkName": "Coppermark Certification — Sample Copper Mine",
+        "mediaType": "application/ld+json",
+        "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dcc"
+      }
+    ],
+    "relatedParty": [
+      {
+        "role": "manufacturer",
+        "party": {
+          "type": [
+            "Party"
+          ],
+          "id": "did:web:sample-mine.example.com",
+          "name": "Sample Copper Mine Pty Ltd",
+          "registeredId": "MINE-001",
+          "idScheme": {
+            "type": [
+              "IdentifierScheme"
+            ],
+            "id": "https://sample-register.example.com",
+            "name": "Patents and Companies Registration Agency (Zambia)"
+          },
+          "registrationCountry": {
+            "countryCode": "ZM",
+            "countryName": "Zambia"
+          }
+        }
+      }
+    ],
+    "producedAtFacility": {
+      "type": [
+        "Facility"
+      ],
+      "id": "https://facility-register.example.com/fac-001",
+      "name": "Sample Copper Mine",
+      "registeredId": "fac-001",
+      "idScheme": {
+        "type": [
+          "IdentifierScheme"
+        ],
+        "id": "https://facility-register.example.com",
+        "name": "UNTP Sample Facility Register"
+      }
+    },
+    "productionDate": "2025-03-01",
+    "countryOfProduction": {
+      "countryCode": "ZM",
+      "countryName": "Zambia"
+    },
+    "dimensions": {
+      "weight": {
+        "value": 1000,
+        "unit": "KGM"
+      }
+    },
+    "materialProvenance": [
+      {
+        "name": "Copper ore",
+        "originCountry": {
+          "countryCode": "ZM",
+          "countryName": "Zambia"
+        },
+        "materialType": {
+          "code": "14110",
+          "name": "Copper ores and concentrates",
+          "definition": "Copper ores and concentrates obtained from mining operations.",
+          "schemeId": "https://unstats.un.org/unsd/classifications/Econ/cpc/",
+          "schemeName": "UN Central Product Classification (CPC)"
+        },
+        "massFraction": 0.3,
+        "mass": {
+          "value": 300,
+          "unit": "KGM"
+        },
+        "recycledMassFraction": 0,
+        "hazardous": false
+      }
+    ],
+    "performanceClaim": [
+      {
+        "type": [
+          "Claim"
+        ],
+        "id": "https://sample-mine.example.com/claims/product-carbon-2025",
+        "name": "Product Carbon Footprint — Copper Concentrate",
+        "description": "Cradle-to-gate carbon footprint of copper concentrate per tonne produced at Sample mine.",
+        "referenceCriteria": [
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://sample-scheme.coppermark.org/criteria/ghg-management/v3",
+            "name": "GHG Emissions Management (Coppermark RRA Criterion 26)",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
+                "name": "Greenhouse Gas Emissions",
+                "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
+              }
+            ]
+          }
+        ],
+        "claimDate": "2025-03-01",
+        "claimedPerformance": [
+          {
+            "metric": {
+              "type": [
+                "PerformanceMetric"
+              ],
+              "id": "https://vocabulary.uncefact.org/performance-metric/product-carbon-footprint",
+              "name": "Product Carbon Footprint"
+            },
+            "measure": {
+              "value": 2.1,
+              "unit": "KGM"
+            }
+          }
+        ],
+        "conformityTopic": [
+          {
+            "type": [
+              "ConformityTopic"
+            ],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions",
+            "name": "Greenhouse Gas Emissions",
+            "definition": "Assessment of direct and indirect greenhouse gas emissions across scopes 1, 2, and 3, including measurement, reporting, and reduction targets aligned with climate science."
+          }
+        ]
+      },
+      {
+        "type": [
+          "Claim"
+        ],
+        "id": "https://sample-mine.example.com/claims/product-water-2025",
+        "name": "Water Intensity — Copper Concentrate",
+        "description": "Water consumption per tonne of copper concentrate produced at Sample mine.",
+        "referenceCriteria": [
+          {
+            "type": [
+              "Criterion"
+            ],
+            "id": "https://sample-scheme.coppermark.org/criteria/water-stewardship/v3",
+            "name": "Water Stewardship (Coppermark RRA Criterion 27)",
+            "conformityTopic": [
+              {
+                "type": [
+                  "ConformityTopic"
+                ],
+                "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
+                "name": "Water Conservation",
+                "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
+              }
+            ]
+          }
+        ],
+        "claimDate": "2025-03-01",
+        "claimedPerformance": [
+          {
+            "metric": {
+              "type": [
+                "PerformanceMetric"
+              ],
+              "id": "https://vocabulary.uncefact.org/performance-metric/water-intensity",
+              "name": "Water Intensity"
+            },
+            "measure": {
+              "value": 15,
+              "unit": "MTQ"
+            }
+          }
+        ],
+        "conformityTopic": [
+          {
+            "type": [
+              "ConformityTopic"
+            ],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/water-conservation",
+            "name": "Water Conservation",
+            "definition": "Efficient and responsible management of water resources, including reduction of water consumption, recycling, and protection of water quality in operations and supply chains."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
@@ -34,6 +34,9 @@
         --font-weight-medium: 500;
         --font-weight-bold: 600;
         --font-weight-black: 900;
+
+        --image-src: url("{{credentialSubject.productImage.linkURL}}");
+        /* Background image for header image; Default: url("{{credentialSubject.product.productImage.linkURL}}") */
       }
 
       * {
@@ -75,6 +78,10 @@
 
       .header-image {
         background-color: var(--color-gray-600);
+        background-image: var(--image-src, none), linear-gradient(248.36deg, rgba(0, 0, 0, 0.18) 7.6%, rgba(0, 0, 0, 0.6) 70.52%);
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
         height: 232px;
         position: relative;
       }

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
@@ -522,61 +522,6 @@
         </div>
       </section>
 
-      {{#if credentialSubject.performanceClaim}}
-      <section class="declarations">
-        <div>
-          <h3 class="section-title">Performance Claims</h3>
-        </div>
-        <div class="cards-conformities">
-          {{#each credentialSubject.performanceClaim}}
-          <article class="cards-conformity">
-            <div class="claim-name">{{name}}</div>
-            {{#if description}}
-            <div class="conformity-info">
-              <p>{{description}}</p>
-            </div>
-            {{/if}}
-            {{#if conformityTopic}}
-            <div>
-              {{#each conformityTopic}}
-              <span class="conformity-topic-tag">{{name}}</span>
-              {{/each}}
-            </div>
-            {{/if}}
-            {{#if claimedPerformance}}
-            <div class="conformity-info">
-              {{#each claimedPerformance}}
-              {{#if metric}}
-              <p class="performance-item">
-                {{metric.name}}:
-                {{#if measure}}
-                  {{measure.value}} {{measure.unit}}
-                {{/if}}
-              </p>
-              {{/if}}
-              {{/each}}
-            </div>
-            {{/if}}
-            {{#if referenceCriteria}}
-            <div class="conformity-info">
-              {{#each referenceCriteria}}
-              <p>
-                <a href="{{id}}" class="gray-bottom-line" target="_blank">{{name}}</a>
-              </p>
-              {{/each}}
-            </div>
-            {{/if}}
-            {{#if claimDate}}
-            <div class="conformity-info">
-              <p>Claim date: {{claimDate}}</p>
-            </div>
-            {{/if}}
-          </article>
-          {{/each}}
-        </div>
-      </section>
-      {{/if}}
-
       {{#if credentialSubject.materialProvenance}}
       {{#if credentialSubject.materialProvenance.0.name}}
       <section class="composition">

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
@@ -42,6 +42,10 @@
         box-sizing: border-box;
       }
 
+      .capitalize-first {
+        text-transform: capitalize;
+      }
+
       body {
         font-family: var(--font-family);
         color: var(--color-gray-600);
@@ -436,17 +440,6 @@
         {{#if credentialSubject.description}}
         <div class="information-text">{{credentialSubject.description}}</div>
         {{/if}}
-        {{#if credentialSubject.relatedDocument}}
-        <div class="information-show-more">
-          {{#each credentialSubject.relatedDocument}}
-          {{#if linkURL}}
-          {{#if linkName}}
-          <a href="{{linkURL}}" class="blue-bottom-line-thick" target="_blank">{{linkName}}</a>
-          {{/if}}
-          {{/if}}
-          {{/each}}
-        </div>
-        {{/if}}
       </section>
 
       <section class="production">
@@ -463,7 +456,7 @@
           {{#each credentialSubject.relatedParty}}
           {{#if party}}
           <div class="table-item">
-            <span>{{role}}</span>
+            <span class="capitalize-first">{{role}}</span>
             <a href="{{party.id}}" class="blue-bottom-line-thick" target="_blank">{{party.name}}</a>
           </div>
           {{/if}}
@@ -495,20 +488,6 @@
                 {{credentialSubject.countryOfProduction}}
               {{/if}}
             </p>
-          </div>
-          {{/if}}
-          {{#if credentialSubject.idScheme}}
-          <div class="table-item">
-            <span>ID scheme</span>
-            <p class="item-value">
-              <a href="{{credentialSubject.idScheme.id}}" class="blue-bottom-line-thick" target="_blank">{{credentialSubject.idScheme.name}}</a>
-            </p>
-          </div>
-          {{/if}}
-          {{#if credentialSubject.idGranularity}}
-          <div class="table-item">
-            <span>ID granularity</span>
-            <p class="item-value">{{credentialSubject.idGranularity}}</p>
           </div>
           {{/if}}
           {{#if credentialSubject.dimensions}}
@@ -663,18 +642,6 @@
             <span>Registered ID</span>
             <a href="{{issuer.id}}" class="blue-bottom-line-thick" target="_blank">{{issuer.id}}</a>
           </div>
-          {{#if issuer.issuerAlsoKnownAs}}
-          {{#each issuer.issuerAlsoKnownAs}}
-          {{#if idScheme.name}}
-          <div class="table-item">
-            <span>Registry</span>
-            <p class="item-value">
-              <a href="{{idScheme.id}}" class="blue-bottom-line-thick" target="_blank">{{idScheme.name}}</a>
-            </p>
-          </div>
-          {{/if}}
-          {{/each}}
-          {{/if}}
           {{#if validFrom}}
           <div class="table-item">
             <span>Valid from</span>
@@ -693,7 +660,7 @@
       <footer>
         <p>
           This Digital Product Passport (DPP) is a digital record of the product's sustainability and environmental performance, ensuring transparency and accountability in line with UNTP standards. For more information visit
-          <a href="https://uncefact.github.io/spec-untp/" class="gray-bottom-line" target="_blank">uncefact.github.io/spec-untp/</a>.
+          <a href="https://untp.unece.org" class="gray-bottom-line" target="_blank">untp.unece.org</a>.
         </p>
       </footer>
     </div>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_product_passport/template.hbs
@@ -1,0 +1,701 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+      rel="stylesheet"
+    />
+    <title>Digital Product Passport</title>
+    <style>
+      :root {
+        /* Brand Colors */
+        --color-primary: rgba(31, 90, 149, 1);
+
+        /* Neutrals */
+        --color-white: rgba(255, 255, 255, 1);
+        --color-black: rgba(0, 0, 0, 1);
+        --color-gray-700: rgba(35, 46, 61, 1);
+        --color-gray-600: rgba(85, 96, 110, 1);
+        --color-gray-400: rgba(212, 214, 216, 1);
+        --color-gray-100: rgba(247, 250, 253, 1);
+
+        /* Semantic Colors */
+        --color-link-underline-dark: rgba(79, 149, 221, 1);
+        --color-accent-success: rgba(184, 236, 182, 1);
+        --color-accent-error: rgba(255, 188, 183, 1);
+        --color-icon: rgba(31, 90, 149, 1);
+
+        /* Font Variables */
+        --font-family: "Lato", sans-serif;
+        --font-weight-light: 300;
+        --font-weight-regular: 400;
+        --font-weight-medium: 500;
+        --font-weight-bold: 600;
+        --font-weight-black: 900;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: var(--font-family);
+        color: var(--color-gray-600);
+        font-weight: var(--font-weight-regular);
+      }
+
+      .container {
+        min-width: 150px;
+        width: 100%;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+        word-break: break-word;
+        background-color: var(--color-white);
+      }
+
+      section,
+      header,
+      footer {
+        padding: 0 16px;
+      }
+
+      section header {
+        margin: 0;
+      }
+
+      .header-image {
+        background-color: var(--color-gray-600);
+        height: 232px;
+        position: relative;
+      }
+
+      .header-image-top-left {
+        position: absolute;
+        top: 25px;
+        left: 15px;
+        font-weight: var(--font-weight-medium);
+        font-size: 16px;
+        line-height: 22px;
+        color: var(--color-white);
+      }
+
+      .header-image-bottom-left {
+        position: absolute;
+        bottom: 18px;
+        left: 15px;
+        color: var(--color-white);
+      }
+
+      .header-image-bottom-left h1 {
+        font-size: 30px;
+        font-weight: var(--font-weight-black);
+        line-height: 32.5px;
+      }
+
+      .header-batch {
+        padding: 12px 16px;
+        background-color: var(--color-gray-100);
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .header-batch-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        flex-grow: 1;
+        min-width: 0;
+      }
+
+      .header-batch-item a {
+        color: var(--color-gray-700);
+        font-size: 14px;
+        font-weight: var(--font-weight-medium);
+      }
+
+      .header-batch-item svg {
+        fill: var(--color-icon);
+        stroke: var(--color-icon);
+      }
+
+      .section-title {
+        font-size: 18px;
+        font-weight: var(--font-weight-bold);
+        line-height: 19.62px;
+        color: var(--color-gray-700);
+      }
+
+      .section-description {
+        margin-top: 12px;
+        font-size: 16px;
+        line-height: 18.88px;
+        color: var(--color-black);
+        font-weight: var(--font-weight-regular);
+      }
+
+      .table {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .table-item {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        column-gap: 16px;
+        align-items: center;
+        padding-bottom: 10px;
+        border-bottom: 1px solid var(--color-gray-400);
+      }
+
+      .table-item span {
+        font-size: 16px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-600);
+      }
+
+      .table-item p,
+      .table-item a {
+        font-size: 16px;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+      }
+
+      .item-value {
+        display: flex;
+        flex-direction: column;
+        font-size: 16px;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-600);
+      }
+
+      .item-value span {
+        color: var(--color-gray-700);
+      }
+
+      .information-text {
+        font-size: 19px;
+        padding-bottom: 8px;
+        font-weight: var(--font-weight-light);
+        color: var(--color-black);
+        line-height: 22.42px;
+      }
+
+      .information-show-more {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        font-size: 14px;
+        font-weight: var(--font-weight-medium);
+      }
+
+      .production {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      /* Claims / Performance Section */
+      .declarations {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .cards-conformities {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .cards-conformity {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 16px;
+        background-color: var(--color-white);
+        border: 1px solid var(--color-gray-400);
+        border-radius: 4px;
+      }
+
+      .claim-name {
+        font-size: 18px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-primary);
+      }
+
+      .conformity-info {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .conformity-info p {
+        font-size: 14px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-600);
+      }
+
+      .conformity-topic-tag {
+        display: inline-block;
+        padding: 2px 8px;
+        background-color: var(--color-gray-100);
+        border-radius: 4px;
+        font-size: 13px;
+        color: var(--color-primary);
+        margin-right: 4px;
+        margin-bottom: 4px;
+      }
+
+      .performance-item {
+        font-size: 16px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-700);
+      }
+
+      /* Composition */
+      .composition-box {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      .composition-box-item {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        border: 1px solid var(--color-gray-400);
+        border-radius: 4px;
+        padding: 16px;
+      }
+
+      .composition-first-column {
+        display: grid;
+        grid-template-columns: 40px 1fr;
+        gap: 12px;
+      }
+
+      .composition-percent {
+        font-size: 16px;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-black);
+      }
+
+      .composition-title {
+        font-size: 16px;
+        font-weight: var(--font-weight-bold);
+        color: var(--color-black);
+      }
+
+      .composition-tag {
+        display: flex;
+        gap: 4px;
+        flex-wrap: wrap;
+      }
+
+      .composition-tag-item {
+        font-size: 14px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-black);
+        background-color: var(--color-gray-100);
+        padding: 2px 4px;
+      }
+
+      .country-code {
+        font-size: 14px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-600);
+      }
+
+      /* Related documents / links */
+      .traceability-cards {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .traceability-card {
+        display: grid;
+        grid-template-columns: 3fr 1fr;
+        align-items: center;
+        text-decoration: none;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--color-gray-400);
+      }
+
+      .traceability-card-text {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 16px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-black);
+      }
+
+      .traceability-card-view-details {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+      }
+
+      /* Issued By */
+      .issued-by {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      /* Footer */
+      footer {
+        padding: 16px 16px 32px;
+        background-color: var(--color-gray-100);
+      }
+
+      footer p {
+        font-size: 14px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-600);
+      }
+
+      /* Links */
+      .blue-bottom-line-thick {
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: var(--color-link-underline-dark);
+        text-underline-offset: 3px;
+        color: var(--color-gray-700);
+      }
+
+      .gray-bottom-line {
+        border-bottom: 1px solid var(--color-gray-600);
+        text-decoration: none;
+        color: var(--color-gray-600);
+      }
+
+      @media (min-width: 1200px) {
+        .container {
+          max-width: 1200px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header class="header">
+        <div class="header-image">
+          <p class="header-image-top-left">PRODUCT PASSPORT</p>
+          <div class="header-image-bottom-left">
+            <h1>{{credentialSubject.name}}</h1>
+          </div>
+        </div>
+        <div class="header-batch">
+          {{#if credentialSubject.registeredId}}
+          <div class="header-batch-item">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z" fill="var(--color-icon)" stroke="var(--color-icon)" />
+            </svg>
+            <a href="{{credentialSubject.id}}" class="blue-bottom-line-thick" target="_blank">ID: {{credentialSubject.registeredId}}</a>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.batchNumber}}
+          <div class="header-batch-item">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z" fill="var(--color-icon)" stroke="var(--color-icon)" />
+            </svg>
+            <a>Batch: {{credentialSubject.batchNumber}}</a>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.itemNumber}}
+          <div class="header-batch-item">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z" fill="var(--color-icon)" stroke="var(--color-icon)" />
+            </svg>
+            <a>Item: {{credentialSubject.itemNumber}}</a>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.modelNumber}}
+          <div class="header-batch-item">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M2.45 3.5C2.17152 3.5 1.90445 3.38938 1.70754 3.19246C1.51062 2.99555 1.4 2.72848 1.4 2.45C1.4 2.17152 1.51062 1.90445 1.70754 1.70754C1.90445 1.51062 2.17152 1.4 2.45 1.4C2.72848 1.4 2.99555 1.51062 3.19246 1.70754C3.38938 1.90445 3.5 2.17152 3.5 2.45C3.5 2.72848 3.38938 2.99555 3.19246 3.19246C2.99555 3.38938 2.72848 3.5 2.45 3.5ZM13.587 6.706L7.287 0.406C7.035 0.154 6.685 0 6.3 0H1.4C0.623 0 0 0.623 0 1.4V6.3C0 6.685 0.154 7.035 0.413 7.287L6.706 13.587C6.965 13.839 7.315 14 7.7 14C8.085 14 8.435 13.839 8.687 13.587L13.587 8.687C13.846 8.435 14 8.085 14 7.7C14 7.308 13.839 6.958 13.587 6.706Z" fill="var(--color-icon)" stroke="var(--color-icon)" />
+            </svg>
+            <a>Model: {{credentialSubject.modelNumber}}</a>
+          </div>
+          {{/if}}
+        </div>
+      </header>
+
+      <section>
+        {{#if credentialSubject.description}}
+        <div class="information-text">{{credentialSubject.description}}</div>
+        {{/if}}
+        {{#if credentialSubject.relatedDocument}}
+        <div class="information-show-more">
+          {{#each credentialSubject.relatedDocument}}
+          {{#if linkURL}}
+          {{#if linkName}}
+          <a href="{{linkURL}}" class="blue-bottom-line-thick" target="_blank">{{linkName}}</a>
+          {{/if}}
+          {{/if}}
+          {{/each}}
+        </div>
+        {{/if}}
+      </section>
+
+      <section class="production">
+        <div class="section-title">Production</div>
+        <div class="table">
+          {{#if credentialSubject.productCategory}}
+          <div class="table-item">
+            <span>Product category</span>
+            <p class="item-value">
+              {{#each credentialSubject.productCategory}}{{name}}{{#unless @last}}, {{/unless}}{{/each}}
+            </p>
+          </div>
+          {{/if}}
+          {{#each credentialSubject.relatedParty}}
+          {{#if party}}
+          <div class="table-item">
+            <span>{{role}}</span>
+            <a href="{{party.id}}" class="blue-bottom-line-thick" target="_blank">{{party.name}}</a>
+          </div>
+          {{/if}}
+          {{/each}}
+          {{#if credentialSubject.producedAtFacility}}
+          <div class="table-item">
+            <span>Produced at</span>
+            <p class="item-value">
+              <a href="{{credentialSubject.producedAtFacility.id}}" class="blue-bottom-line-thick" target="_blank">{{credentialSubject.producedAtFacility.name}}</a>
+            </p>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.productionDate}}
+          <div class="table-item">
+            <span>Date produced</span>
+            <p class="item-value">{{credentialSubject.productionDate}}</p>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.countryOfProduction}}
+          <div class="table-item">
+            <span>Country</span>
+            <p class="item-value">
+              {{#if credentialSubject.countryOfProduction.countryName}}
+                {{credentialSubject.countryOfProduction.countryName}}
+                {{#if credentialSubject.countryOfProduction.countryCode}}
+                  ({{credentialSubject.countryOfProduction.countryCode}})
+                {{/if}}
+              {{else}}
+                {{credentialSubject.countryOfProduction}}
+              {{/if}}
+            </p>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.idScheme}}
+          <div class="table-item">
+            <span>ID scheme</span>
+            <p class="item-value">
+              <a href="{{credentialSubject.idScheme.id}}" class="blue-bottom-line-thick" target="_blank">{{credentialSubject.idScheme.name}}</a>
+            </p>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.idGranularity}}
+          <div class="table-item">
+            <span>ID granularity</span>
+            <p class="item-value">{{credentialSubject.idGranularity}}</p>
+          </div>
+          {{/if}}
+          {{#if credentialSubject.dimensions}}
+          <div class="table-item">
+            <span>Dimensions</span>
+            <p class="item-value">
+              {{#if credentialSubject.dimensions.weight}}
+              <span>Weight: {{credentialSubject.dimensions.weight.value}} {{credentialSubject.dimensions.weight.unit}}</span>
+              {{/if}}
+              {{#if credentialSubject.dimensions.length}}
+              <span>Length: {{credentialSubject.dimensions.length.value}} {{credentialSubject.dimensions.length.unit}}</span>
+              {{/if}}
+              {{#if credentialSubject.dimensions.width}}
+              <span>Width: {{credentialSubject.dimensions.width.value}} {{credentialSubject.dimensions.width.unit}}</span>
+              {{/if}}
+              {{#if credentialSubject.dimensions.height}}
+              <span>Height: {{credentialSubject.dimensions.height.value}} {{credentialSubject.dimensions.height.unit}}</span>
+              {{/if}}
+              {{#if credentialSubject.dimensions.volume}}
+              <span>Volume: {{credentialSubject.dimensions.volume.value}} {{credentialSubject.dimensions.volume.unit}}</span>
+              {{/if}}
+            </p>
+          </div>
+          {{/if}}
+        </div>
+      </section>
+
+      {{#if credentialSubject.performanceClaim}}
+      <section class="declarations">
+        <div>
+          <h3 class="section-title">Performance Claims</h3>
+        </div>
+        <div class="cards-conformities">
+          {{#each credentialSubject.performanceClaim}}
+          <article class="cards-conformity">
+            <div class="claim-name">{{name}}</div>
+            {{#if description}}
+            <div class="conformity-info">
+              <p>{{description}}</p>
+            </div>
+            {{/if}}
+            {{#if conformityTopic}}
+            <div>
+              {{#each conformityTopic}}
+              <span class="conformity-topic-tag">{{name}}</span>
+              {{/each}}
+            </div>
+            {{/if}}
+            {{#if claimedPerformance}}
+            <div class="conformity-info">
+              {{#each claimedPerformance}}
+              {{#if metric}}
+              <p class="performance-item">
+                {{metric.name}}:
+                {{#if measure}}
+                  {{measure.value}} {{measure.unit}}
+                {{/if}}
+              </p>
+              {{/if}}
+              {{/each}}
+            </div>
+            {{/if}}
+            {{#if referenceCriteria}}
+            <div class="conformity-info">
+              {{#each referenceCriteria}}
+              <p>
+                <a href="{{id}}" class="gray-bottom-line" target="_blank">{{name}}</a>
+              </p>
+              {{/each}}
+            </div>
+            {{/if}}
+            {{#if claimDate}}
+            <div class="conformity-info">
+              <p>Claim date: {{claimDate}}</p>
+            </div>
+            {{/if}}
+          </article>
+          {{/each}}
+        </div>
+      </section>
+      {{/if}}
+
+      {{#if credentialSubject.materialProvenance}}
+      {{#if credentialSubject.materialProvenance.0.name}}
+      <section class="composition">
+        <div>
+          <h3 class="section-title">Material Provenance</h3>
+          <p class="section-description">Origin and composition of materials used in this product.</p>
+        </div>
+        <div class="composition-box">
+          {{#each credentialSubject.materialProvenance}}
+          <article class="composition-box-item">
+            <div class="composition-first-column">
+              {{#if massFraction}}
+              <p class="composition-percent">{{massFraction}}</p>
+              {{else}}
+              <p class="composition-percent">—</p>
+              {{/if}}
+              <div>
+                <p class="composition-title">
+                  {{#if mass}}{{mass.value}} {{mass.unit}} {{/if}}{{name}}
+                </p>
+                {{#if materialType}}
+                <p style="font-size:13px;color:var(--color-gray-600);">{{materialType.name}}</p>
+                {{/if}}
+                <div class="composition-tag">
+                  {{#if recycledMassFraction}}
+                  <p class="composition-tag-item">Recycled {{recycledMassFraction}}</p>
+                  {{/if}}
+                  <p class="composition-tag-item">Hazard {{#if hazardous}}Yes{{else}}No{{/if}}</p>
+                </div>
+              </div>
+            </div>
+            {{#if originCountry}}
+            <div class="country-code">
+              {{#if originCountry.countryCode}}{{originCountry.countryCode}}{{else}}{{originCountry}}{{/if}}
+            </div>
+            {{/if}}
+          </article>
+          {{/each}}
+        </div>
+      </section>
+      {{/if}}
+      {{/if}}
+
+      {{#if credentialSubject.characteristics}}
+      <section class="production">
+        <div>
+          <h3 class="section-title">Characteristics</h3>
+        </div>
+        <div class="table">
+          {{#each credentialSubject.characteristics}}
+          <div class="table-item">
+            <span>{{@key}}</span>
+            <p class="item-value">{{this}}</p>
+          </div>
+          {{/each}}
+        </div>
+      </section>
+      {{/if}}
+
+      <section class="issued-by">
+        <div>
+          <h3 class="section-title">Passport Issued By</h3>
+        </div>
+        <div class="table">
+          <div class="table-item">
+            <span>Organisation</span>
+            <p class="item-value">{{issuer.name}}</p>
+          </div>
+          <div class="table-item">
+            <span>Registered ID</span>
+            <a href="{{issuer.id}}" class="blue-bottom-line-thick" target="_blank">{{issuer.id}}</a>
+          </div>
+          {{#if issuer.issuerAlsoKnownAs}}
+          {{#each issuer.issuerAlsoKnownAs}}
+          {{#if idScheme.name}}
+          <div class="table-item">
+            <span>Registry</span>
+            <p class="item-value">
+              <a href="{{idScheme.id}}" class="blue-bottom-line-thick" target="_blank">{{idScheme.name}}</a>
+            </p>
+          </div>
+          {{/if}}
+          {{/each}}
+          {{/if}}
+          {{#if validFrom}}
+          <div class="table-item">
+            <span>Valid from</span>
+            <p class="item-value">{{validFrom}}</p>
+          </div>
+          {{/if}}
+          {{#if validUntil}}
+          <div class="table-item">
+            <span>Valid to</span>
+            <p class="item-value">{{validUntil}}</p>
+          </div>
+          {{/if}}
+        </div>
+      </section>
+
+      <footer>
+        <p>
+          This Digital Product Passport (DPP) is a digital record of the product's sustainability and environmental performance, ensuring transparency and accountability in line with UNTP standards. For more information visit
+          <a href="https://uncefact.github.io/spec-untp/" class="gray-bottom-line" target="_blank">uncefact.github.io/spec-untp/</a>.
+        </p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/example-data.json
@@ -1,0 +1,139 @@
+{
+  "type": [
+    "DigitalTraceabilityEvent",
+    "VerifiableCredential"
+  ],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
+  ],
+  "id": "https://credentials.sample-mine.example.com/dte/move-conc-2025-0301",
+  "issuer": {
+    "type": [
+      "CredentialIssuer"
+    ],
+    "id": "did:web:sample-mine.example.com",
+    "name": "Sample Copper Mine Pty Ltd",
+    "issuerAlsoKnownAs": [
+      {
+        "type": [
+          "Party"
+        ],
+        "id": "https://sample-register.example.com/companies/MINE-001",
+        "name": "Sample Copper Mine Pty Ltd",
+        "registeredId": "MINE-001",
+        "idScheme": {
+          "type": [
+            "IdentifierScheme"
+          ],
+          "id": "https://sample-register.example.com",
+          "name": "Patents and Companies Registration Agency (Zambia)"
+        }
+      }
+    ]
+  },
+  "validFrom": "2025-03-01T00:00:00Z",
+  "validUntil": "2026-03-01T00:00:00Z",
+  "name": "Shipment of Copper Concentrate — Sample Mine to Sample Smelter",
+  "credentialSubject": [
+    {
+      "type": [
+        "MoveEvent",
+        "LifecycleEvent"
+      ],
+      "id": "https://sample-mine.example.com/events/move-conc-2025-0301",
+      "name": "Copper concentrate shipment to Sample",
+      "description": "Shipment of 100 tonnes of copper concentrate (Cu 30%) from Sample Copper Mine to Sample Copper Refinery via sea freight.",
+      "eventDate": "2025-03-01T08:00:00Z",
+      "activityType": {
+        "code": "shipping",
+        "name": "Shipping",
+        "definition": "The movement of goods from one location to another.",
+        "schemeId": "https://ref.gs1.org/cbv/BizStep",
+        "schemeName": "GS1 CBV Business Step"
+      },
+      "relatedParty": [
+        {
+          "role": "consignor",
+          "party": {
+            "type": [
+              "Party"
+            ],
+            "id": "did:web:sample-mine.example.com",
+            "name": "Sample Copper Mine Pty Ltd",
+            "registeredId": "MINE-001",
+            "idScheme": {
+              "type": [
+                "IdentifierScheme"
+              ],
+              "id": "https://sample-register.example.com",
+              "name": "Patents and Companies Registration Agency (Zambia)"
+            }
+          }
+        },
+        {
+          "role": "consignee",
+          "party": {
+            "type": [
+              "Party"
+            ],
+            "id": "did:web:sample-refinery.example.com",
+            "name": "Sample Copper Refinery Co. Ltd",
+            "registeredId": "REF-001",
+            "idScheme": {
+              "type": [
+                "IdentifierScheme"
+              ],
+              "id": "https://www.sample-register.example.com",
+              "name": "Japan Corporate Number (Houjin Bangou)"
+            }
+          }
+        }
+      ],
+      "movedProduct": [
+        {
+          "product": {
+            "type": [
+              "Product"
+            ],
+            "id": "https://id.sample-mine.example.com/product/cu-conc-2025",
+            "name": "Copper Concentrate (Cu 30%)",
+            "modelNumber": "SM-CU-CONC-30",
+            "batchNumber": "2025-Q1-4501",
+            "idGranularity": "model"
+          },
+          "quantity": {
+            "value": 100000,
+            "unit": "KGM"
+          },
+          "disposition": "new"
+        }
+      ],
+      "fromFacility": {
+        "type": [
+          "Facility"
+        ],
+        "id": "https://facility-register.example.com/fac-001",
+        "name": "Sample Copper Mine",
+        "registeredId": "fac-001"
+      },
+      "toFacility": {
+        "type": [
+          "Facility"
+        ],
+        "id": "https://facility-register.example.com/fac-002",
+        "name": "Sample Copper Refinery",
+        "registeredId": "fac-002"
+      },
+      "consignmentId": "urn:carrier:zm-road:WB-2025-KM-CS-0301",
+      "relatedDocument": [
+        {
+          "linkURL": "https://credentials.sample-mine.example.com/dpp/cu-conc-2025",
+          "linkName": "Digital Product Passport — Copper Concentrate (Cu 30%)",
+          "mediaType": "application/ld+json",
+          "linkType": "https://test.uncefact.org/vocabulary/linkTypes/dpp"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/example-data.json
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/example-data.json
@@ -1,31 +1,19 @@
 {
-  "type": [
-    "DigitalTraceabilityEvent",
-    "VerifiableCredential"
-  ],
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://vocabulary.uncefact.org/untp/0.7.0/context/"
-  ],
+  "type": ["DigitalTraceabilityEvent", "VerifiableCredential"],
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vocabulary.uncefact.org/untp/0.7.0/context/"],
   "id": "https://credentials.sample-mine.example.com/dte/move-conc-2025-0301",
   "issuer": {
-    "type": [
-      "CredentialIssuer"
-    ],
+    "type": ["CredentialIssuer"],
     "id": "did:web:sample-mine.example.com",
     "name": "Sample Copper Mine Pty Ltd",
     "issuerAlsoKnownAs": [
       {
-        "type": [
-          "Party"
-        ],
+        "type": ["Party"],
         "id": "https://sample-register.example.com/companies/MINE-001",
         "name": "Sample Copper Mine Pty Ltd",
         "registeredId": "MINE-001",
         "idScheme": {
-          "type": [
-            "IdentifierScheme"
-          ],
+          "type": ["IdentifierScheme"],
           "id": "https://sample-register.example.com",
           "name": "Patents and Companies Registration Agency (Zambia)"
         }
@@ -37,10 +25,7 @@
   "name": "Shipment of Copper Concentrate — Sample Mine to Sample Smelter",
   "credentialSubject": [
     {
-      "type": [
-        "MoveEvent",
-        "LifecycleEvent"
-      ],
+      "type": ["MoveEvent", "LifecycleEvent"],
       "id": "https://sample-mine.example.com/events/move-conc-2025-0301",
       "name": "Copper concentrate shipment to Sample",
       "description": "Shipment of 100 tonnes of copper concentrate (Cu 30%) from Sample Copper Mine to Sample Copper Refinery via sea freight.",
@@ -56,16 +41,12 @@
         {
           "role": "consignor",
           "party": {
-            "type": [
-              "Party"
-            ],
+            "type": ["Party"],
             "id": "did:web:sample-mine.example.com",
             "name": "Sample Copper Mine Pty Ltd",
             "registeredId": "MINE-001",
             "idScheme": {
-              "type": [
-                "IdentifierScheme"
-              ],
+              "type": ["IdentifierScheme"],
               "id": "https://sample-register.example.com",
               "name": "Patents and Companies Registration Agency (Zambia)"
             }
@@ -74,16 +55,12 @@
         {
           "role": "consignee",
           "party": {
-            "type": [
-              "Party"
-            ],
+            "type": ["Party"],
             "id": "did:web:sample-refinery.example.com",
             "name": "Sample Copper Refinery Co. Ltd",
             "registeredId": "REF-001",
             "idScheme": {
-              "type": [
-                "IdentifierScheme"
-              ],
+              "type": ["IdentifierScheme"],
               "id": "https://www.sample-register.example.com",
               "name": "Japan Corporate Number (Houjin Bangou)"
             }
@@ -93,9 +70,7 @@
       "movedProduct": [
         {
           "product": {
-            "type": [
-              "Product"
-            ],
+            "type": ["Product"],
             "id": "https://id.sample-mine.example.com/product/cu-conc-2025",
             "name": "Copper Concentrate (Cu 30%)",
             "modelNumber": "SM-CU-CONC-30",
@@ -110,17 +85,13 @@
         }
       ],
       "fromFacility": {
-        "type": [
-          "Facility"
-        ],
+        "type": ["Facility"],
         "id": "https://facility-register.example.com/fac-001",
         "name": "Sample Copper Mine",
         "registeredId": "fac-001"
       },
       "toFacility": {
-        "type": [
-          "Facility"
-        ],
+        "type": ["Facility"],
         "id": "https://facility-register.example.com/fac-002",
         "name": "Sample Copper Refinery",
         "registeredId": "fac-002"

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/template.hbs
@@ -528,7 +528,7 @@
                   {{/if}}
                   {{#each measure}}
                   <div class="item-row">
-                    <div class="item-name">{{metric.name}}</div>
+                    <div class="item-name">{{../metric.name}}</div>
                     <div class="item-quantity">{{value}} {{unit}}</div>
                   </div>
                   {{/each}}

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/template.hbs
@@ -641,21 +641,6 @@
               </a>
             </div>
           </div>
-          {{#if issuer.issuerAlsoKnownAs}}
-          {{#each issuer.issuerAlsoKnownAs}}
-          {{#if idScheme.name}}
-          <div class="data-row-standard">
-            <div class="data-label">Issuer registry</div>
-            <div class="data-value">
-              <a href="{{idScheme.id}}" class="link-highlight" target="_blank">
-                <span class="link-text">{{idScheme.name}}</span>
-              </a>
-              {{#if registeredId}} · {{registeredId}}{{/if}}
-            </div>
-          </div>
-          {{/if}}
-          {{/each}}
-          {{/if}}
           {{#if validFrom}}
           <div class="data-row-standard">
             <div class="data-label">Valid from</div>

--- a/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/template.hbs
+++ b/packages/reference-implementation/src/templates/v0.7.0/digital_traceability_event/template.hbs
@@ -1,0 +1,675 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+      rel="stylesheet" />
+    <style>
+      :root {
+        --color-primary: rgba(31, 90, 149, 1);
+        --color-secondary: rgba(181, 213, 245, 0.5);
+        --color-white: rgba(255, 255, 255, 1);
+        --color-black: rgba(0, 0, 0, 1);
+        --color-gray-700: rgba(35, 46, 61, 1);
+        --color-gray-600: rgba(85, 96, 110, 1);
+        --color-gray-400: rgba(212, 214, 216, 1);
+        --color-gray-300: rgba(237, 239, 240, 1);
+        --color-gray-100: rgba(250, 250, 250, 1);
+        --color-link-underline: rgba(79, 149, 221, 1);
+        --color-icon: rgba(31, 90, 149, 1);
+        --font-family: 'Lato', sans-serif;
+        --font-weight-regular: 400;
+        --font-weight-medium: 500;
+        --font-weight-semi-bold: 600;
+        --font-weight-bold: 700;
+        --font-weight-black: 900;
+      }
+
+      * { margin: 0; box-sizing: border-box; }
+      body { font-family: var(--font-family); }
+      a { text-decoration: none; }
+
+      .traceability-container {
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+        word-break: break-word;
+        background-color: var(--color-gray-100);
+      }
+
+      .traceability-content {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .header-section {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 16px 0 0 16px;
+      }
+
+      .credential-title {
+        width: 100%;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 16px;
+        line-height: 22px;
+        text-transform: uppercase;
+      }
+
+      .main-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 32px;
+        padding: 0 16px;
+        align-self: stretch;
+        width: 100%;
+      }
+
+      /* Event card */
+      .event-card {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        width: 100%;
+        background-color: var(--color-white);
+        border: 1px solid var(--color-gray-400);
+        border-radius: 4px;
+        padding: 16px;
+      }
+
+      .event-header {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .event-type-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 10px;
+        background-color: var(--color-secondary);
+        border: 1px solid var(--color-primary);
+        border-radius: 4px;
+        color: var(--color-primary);
+        font-size: 14px;
+        font-weight: var(--font-weight-semi-bold);
+        width: fit-content;
+      }
+
+      /* Hide Lifecycle Event type badge */
+      .event-type-LifecycleEvent {
+        display: none;
+      }
+
+      .event-name {
+        font-size: 22px;
+        font-weight: var(--font-weight-black);
+        color: var(--color-primary);
+        line-height: 26px;
+      }
+
+      .event-description {
+        font-size: 15px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-600);
+        line-height: 18px;
+      }
+
+      .event-date {
+        font-size: 14px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-black);
+      }
+
+      .event-date span {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+      }
+
+      /* Section heading */
+      .section-heading {
+        font-weight: var(--font-weight-bold);
+        color: var(--color-black);
+        font-size: 18px;
+        line-height: 21.8px;
+        margin-bottom: 8px;
+      }
+
+      /* Data rows */
+      .data-section {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        width: 100%;
+      }
+
+      .data-row {
+        display: grid;
+        grid-template-columns: 1.2fr 2fr;
+        gap: 16px;
+        padding: 10px 0 12px;
+        width: 100%;
+        border-bottom: 1px solid var(--color-gray-400);
+      }
+
+      .data-label {
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-700);
+        font-size: 15px;
+        line-height: 17.4px;
+      }
+
+      .data-value {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 15px;
+        line-height: 17.4px;
+      }
+
+      .data-link {
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-decoration-color: var(--color-link-underline);
+        text-underline-offset: 3px;
+        color: var(--color-gray-700);
+        font-size: 15px;
+        font-weight: var(--font-weight-medium);
+      }
+
+      /* Product list */
+      .item-list-container {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        width: 100%;
+        background-color: var(--color-gray-100);
+        padding: 12px 16px;
+        border-radius: 4px;
+        border: 1px solid var(--color-gray-400);
+      }
+
+      .list-title {
+        font-size: 15px;
+        font-weight: var(--font-weight-semi-bold);
+        color: var(--color-primary);
+        margin-bottom: 4px;
+      }
+
+      .item-row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 16px;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--color-gray-400);
+        align-items: center;
+      }
+
+      .item-row:last-child { border-bottom: none; }
+
+      .item-name {
+        font-size: 15px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-black);
+      }
+
+      .item-detail {
+        font-size: 13px;
+        color: var(--color-gray-600);
+      }
+
+      .item-quantity {
+        font-size: 15px;
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        white-space: nowrap;
+      }
+
+      /* Party list */
+      .party-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        width: 100%;
+      }
+
+      .party-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--color-gray-400);
+      }
+
+      .party-role {
+        font-size: 13px;
+        font-weight: var(--font-weight-semi-bold);
+        color: var(--color-gray-600);
+        text-transform: capitalize;
+        min-width: 80px;
+      }
+
+      .party-name {
+        font-size: 15px;
+        font-weight: var(--font-weight-regular);
+        color: var(--color-gray-700);
+      }
+
+      /* Related docs */
+      .traceability-link {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--color-gray-400);
+      }
+
+      .link-group {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .organization-name {
+        font-weight: var(--font-weight-regular);
+        color: var(--color-black);
+        font-size: 15px;
+      }
+
+      /* Issuing details section */
+      .issuing-details-section {
+        width: 100%;
+        padding: 24px 16px 36px;
+        background-color: var(--color-gray-300);
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+      }
+
+      .issuing-title {
+        font-weight: var(--font-weight-bold);
+        color: var(--color-black);
+        font-size: 20px;
+        line-height: 21.8px;
+        margin-bottom: 8px;
+      }
+
+      .data-row-standard {
+        display: grid;
+        grid-template-columns: 1.4fr 3fr;
+        gap: 16px;
+        padding: 10px 0 12px;
+        width: 100%;
+        border-bottom: 1px solid var(--color-gray-400);
+      }
+
+      .link-highlight {
+        display: inline-flex;
+        align-items: flex-start;
+        gap: 10px;
+        border-bottom: 2px solid var(--color-link-underline);
+      }
+
+      .link-text {
+        font-weight: var(--font-weight-medium);
+        color: var(--color-gray-700);
+        font-size: 16px;
+        line-height: 17.4px;
+      }
+
+      @media (min-width: 1200px) {
+        .traceability-container { max-width: 1200px; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="traceability-container">
+      <div class="traceability-content">
+        <header class="header-section">
+          <div class="credential-title">DIGITAL TRACEABILITY EVENT</div>
+        </header>
+        <section class="main-content">
+          {{#each credentialSubject}}
+          <article class="event-card">
+            <!-- Event header -->
+            <div class="event-header">
+              {{#each type}}
+              <div class="event-type-badge event-type-{{this}}">{{this}}</div>
+              {{/each}}
+              {{#if name}}
+              <h2 class="event-name">{{name}}</h2>
+              {{/if}}
+              {{#if description}}
+              <p class="event-description">{{description}}</p>
+              {{/if}}
+              {{#if eventDate}}
+              <p class="event-date">Event date: <span>{{eventDate}}</span></p>
+              {{/if}}
+              {{#if activityType}}
+              <p class="event-date">Activity: <span>{{activityType.name}}</span></p>
+              {{/if}}
+              {{#if consignmentId}}
+              <p class="event-date">Consignment ID: <span>{{consignmentId}}</span></p>
+              {{/if}}
+            </div>
+
+            <!-- Parties -->
+            {{#if relatedParty}}
+            <div>
+              <h3 class="section-heading">Parties</h3>
+              <div class="party-list">
+                {{#each relatedParty}}
+                {{#if party}}
+                <div class="party-item">
+                  <span class="party-role">{{role}}</span>
+                  {{#if party.id}}
+                  <a href="{{party.id}}" class="data-link" target="_blank">{{party.name}}</a>
+                  {{else}}
+                  <span class="party-name">{{party.name}}</span>
+                  {{/if}}
+                </div>
+                {{/if}}
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- Moved products -->
+            {{#if movedProduct}}
+            <div>
+              <h3 class="section-heading">Products</h3>
+              <div class="item-list-container">
+                <div class="list-title">Moved</div>
+                {{#each movedProduct}}
+                {{#if product}}
+                <div class="item-row">
+                  <div>
+                    <div class="item-name">
+                      {{#if product.id}}
+                      <a href="{{product.id}}" class="data-link" target="_blank">{{product.name}}</a>
+                      {{else}}
+                      {{product.name}}
+                      {{/if}}
+                    </div>
+                    {{#if product.batchNumber}}
+                    <div class="item-detail">Batch: {{product.batchNumber}}</div>
+                    {{/if}}
+                    {{#if product.modelNumber}}
+                    <div class="item-detail">Model: {{product.modelNumber}}</div>
+                    {{/if}}
+                    {{#if disposition}}
+                    <div class="item-detail">Disposition: {{disposition}}</div>
+                    {{/if}}
+                  </div>
+                  {{#if quantity}}
+                  <div class="item-quantity">{{quantity.value}} {{quantity.unit}}</div>
+                  {{/if}}
+                </div>
+                {{/if}}
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- Input products (MakeEvent) -->
+            {{#if inputProduct}}
+            <div>
+              <h3 class="section-heading">Input Products</h3>
+              <div class="item-list-container">
+                <div class="list-title">Input</div>
+                {{#each inputProduct}}
+                {{#if product}}
+                <div class="item-row">
+                  <div>
+                    <div class="item-name">
+                      {{#if product.id}}
+                      <a href="{{product.id}}" class="data-link" target="_blank">{{product.name}}</a>
+                      {{else}}
+                      {{product.name}}
+                      {{/if}}
+                    </div>
+                    {{#if product.batchNumber}}
+                    <div class="item-detail">Batch: {{product.batchNumber}}</div>
+                    {{/if}}
+                  </div>
+                  {{#if quantity}}
+                  <div class="item-quantity">{{quantity.value}} {{quantity.unit}}</div>
+                  {{/if}}
+                </div>
+                {{/if}}
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- Output products (MakeEvent) -->
+            {{#if outputProduct}}
+            <div>
+              <h3 class="section-heading">Output Products</h3>
+              <div class="item-list-container">
+                <div class="list-title">Output</div>
+                {{#each outputProduct}}
+                {{#if product}}
+                <div class="item-row">
+                  <div>
+                    <div class="item-name">
+                      {{#if product.id}}
+                      <a href="{{product.id}}" class="data-link" target="_blank">{{product.name}}</a>
+                      {{else}}
+                      {{product.name}}
+                      {{/if}}
+                    </div>
+                    {{#if product.batchNumber}}
+                    <div class="item-detail">Batch: {{product.batchNumber}}</div>
+                    {{/if}}
+                  </div>
+                  {{#if quantity}}
+                  <div class="item-quantity">{{quantity.value}} {{quantity.unit}}</div>
+                  {{/if}}
+                </div>
+                {{/if}}
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- Modified products (ModifyEvent) -->
+            {{#if modifiedProduct}}
+            <div>
+              <h3 class="section-heading">Modified Products</h3>
+              <div class="item-list-container">
+                <div class="list-title">Modified</div>
+                {{#each modifiedProduct}}
+                {{#if product}}
+                <div class="item-row">
+                  <div>
+                    <div class="item-name">
+                      {{#if product.id}}
+                      <a href="{{product.id}}" class="data-link" target="_blank">{{product.name}}</a>
+                      {{else}}
+                      {{product.name}}
+                      {{/if}}
+                    </div>
+                    {{#if product.batchNumber}}
+                    <div class="item-detail">Batch: {{product.batchNumber}}</div>
+                    {{/if}}
+                  </div>
+                  {{#if quantity}}
+                  <div class="item-quantity">{{quantity.value}} {{quantity.unit}}</div>
+                  {{/if}}
+                </div>
+                {{/if}}
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- Sensor data -->
+            {{#if sensorData}}
+            <div>
+              <h3 class="section-heading">Sensor Data</h3>
+              <div class="data-section">
+                {{#each sensorData}}
+                <div class="item-list-container" style="margin-bottom:8px;">
+                  {{#if metric}}
+                  <div class="list-title">{{metric.name}}</div>
+                  {{/if}}
+                  {{#each measure}}
+                  <div class="item-row">
+                    <div class="item-name">{{metric.name}}</div>
+                    <div class="item-quantity">{{value}} {{unit}}</div>
+                  </div>
+                  {{/each}}
+                  {{#if sensor}}
+                  <div class="item-detail" style="padding:4px 0;">Sensor: {{sensor.name}}</div>
+                  {{/if}}
+                </div>
+                {{/each}}
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- From / To facilities (MoveEvent) -->
+            {{#if fromFacility}}
+            <div class="data-section">
+              <h3 class="section-heading">Movement</h3>
+              <div class="data-row">
+                <div class="data-label">From</div>
+                <div class="data-value">
+                  {{#if fromFacility.id}}
+                  <a href="{{fromFacility.id}}" class="data-link" target="_blank">{{fromFacility.name}}</a>
+                  {{else}}
+                  {{fromFacility.name}}
+                  {{/if}}
+                </div>
+              </div>
+              {{#if toFacility}}
+              <div class="data-row">
+                <div class="data-label">To</div>
+                <div class="data-value">
+                  {{#if toFacility.id}}
+                  <a href="{{toFacility.id}}" class="data-link" target="_blank">{{toFacility.name}}</a>
+                  {{else}}
+                  {{toFacility.name}}
+                  {{/if}}
+                </div>
+              </div>
+              {{/if}}
+            </div>
+            {{/if}}
+
+            <!-- Made at facility (MakeEvent) -->
+            {{#if madeAtFacility}}
+            <div class="data-section">
+              <h3 class="section-heading">Production Facility</h3>
+              <div class="data-row">
+                <div class="data-label">Made at</div>
+                <div class="data-value">
+                  {{#if madeAtFacility.id}}
+                  <a href="{{madeAtFacility.id}}" class="data-link" target="_blank">{{madeAtFacility.name}}</a>
+                  {{else}}
+                  {{madeAtFacility.name}}
+                  {{/if}}
+                </div>
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- Modified at facility (ModifyEvent) -->
+            {{#if modifiedAtFacility}}
+            <div class="data-section">
+              <h3 class="section-heading">Modification Facility</h3>
+              <div class="data-row">
+                <div class="data-label">Modified at</div>
+                <div class="data-value">
+                  {{#if modifiedAtFacility.id}}
+                  <a href="{{modifiedAtFacility.id}}" class="data-link" target="_blank">{{modifiedAtFacility.name}}</a>
+                  {{else}}
+                  {{modifiedAtFacility.name}}
+                  {{/if}}
+                </div>
+              </div>
+            </div>
+            {{/if}}
+
+            <!-- Related documents -->
+            {{#if relatedDocument}}
+            <div>
+              <h3 class="section-heading">Related Documents</h3>
+              {{#each relatedDocument}}
+              {{#if linkURL}}
+              <a href="{{linkURL}}" class="traceability-link" target="_blank">
+                <div class="link-group">
+                  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M2 18C1.45 18 0.979333 17.8043 0.588 17.413C0.196667 17.0217 0.000666667 16.5507 0 16V2C0 1.45 0.196 0.979333 0.588 0.588C0.98 0.196667 1.45067 0.000666667 2 0H16C16.55 0 17.021 0.196 17.413 0.588C17.805 0.98 18.0007 1.45067 18 2V16C18 16.55 17.8043 17.021 17.413 17.413C17.0217 17.805 16.5507 18.0007 16 18H2ZM2 2V16H16V2H14V9L11.5 7.5L9 9V2H2Z" fill="var(--color-icon)" />
+                  </svg>
+                  <div class="organization-name">{{#if linkName}}{{linkName}}{{else}}{{linkURL}}{{/if}}</div>
+                </div>
+                <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M1 1L8 8L1 15" stroke="var(--color-icon)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </a>
+              {{/if}}
+              {{/each}}
+            </div>
+            {{/if}}
+          </article>
+          {{/each}}
+        </section>
+      </div>
+
+      <section class="issuing-details-section">
+        <h2 class="issuing-title">Issuing Details</h2>
+        <div class="data-section">
+          <div class="data-row-standard">
+            <div class="data-label">Issued by</div>
+            <div>
+              <a href="{{issuer.id}}" class="link-highlight" target="_blank">
+                <span class="link-text">{{issuer.name}}</span>
+              </a>
+            </div>
+          </div>
+          {{#if issuer.issuerAlsoKnownAs}}
+          {{#each issuer.issuerAlsoKnownAs}}
+          {{#if idScheme.name}}
+          <div class="data-row-standard">
+            <div class="data-label">Issuer registry</div>
+            <div class="data-value">
+              <a href="{{idScheme.id}}" class="link-highlight" target="_blank">
+                <span class="link-text">{{idScheme.name}}</span>
+              </a>
+              {{#if registeredId}} · {{registeredId}}{{/if}}
+            </div>
+          </div>
+          {{/if}}
+          {{/each}}
+          {{/if}}
+          {{#if validFrom}}
+          <div class="data-row-standard">
+            <div class="data-label">Valid from</div>
+            <div class="data-value">{{validFrom}}</div>
+          </div>
+          {{/if}}
+          {{#if validUntil}}
+          <div class="data-row-standard">
+            <div class="data-label">Valid until</div>
+            <div class="data-value">{{validUntil}}</div>
+          </div>
+          {{/if}}
+        </div>
+      </section>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR adds Handlebars render templates and matching example data for each of the UNTP v0.7.0 core credential types.
The examples are taken from the `spec-untp` repository.

## Related Tickets & Documents
Implements #512 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Reference Implementation docs site](https://uncefact.github.io/tests-untp/docs/reference-implementation/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## API Documentation Updated?

- [ ] 📚 Updated Swagger schemas in `schemas.ts`
- [ ] ✅ Verified Zod schemas match Prisma database schema
- [x] 🙅 No API changes in this PR