### PR TITLE
feat: add untp v0.7.0 data model bridges

### DIFF
--- a/packages/services/src/data-model-bridges/bridge-registry.test.ts
+++ b/packages/services/src/data-model-bridges/bridge-registry.test.ts
@@ -22,6 +22,16 @@ describe('bridge-registry', () => {
       expect(getBridge(dataModelType, '0.6.1')).toBeDefined();
     });
 
+    it.each([
+      'DigitalProductPassport',
+      'DigitalConformityCredential',
+      'DigitalFacilityRecord',
+      'DigitalIdentityAnchor',
+      'DigitalTraceabilityEvent',
+    ])('returns a bridge for %s at version 0.7.0', (dataModelType) => {
+      expect(getBridge(dataModelType, '0.7.0')).toBeDefined();
+    });
+
     it('returns undefined for an unknown type', () => {
       expect(getBridge('UnknownType', '0.6.0')).toBeUndefined();
     });
@@ -39,6 +49,7 @@ describe('bridge-registry', () => {
     ])('each bridge for %s has buildSubject and extractRefs methods', (dataModelType) => {
       const bridge060 = getBridge(dataModelType, '0.6.0');
       const bridge061 = getBridge(dataModelType, '0.6.1');
+      const bridge070 = getBridge(dataModelType, '0.7.0');
 
       expect(bridge060).toHaveProperty('buildSubject');
       expect(bridge060).toHaveProperty('extractRefs');
@@ -49,6 +60,11 @@ describe('bridge-registry', () => {
       expect(bridge061).toHaveProperty('extractRefs');
       expect(typeof bridge061!.buildSubject).toBe('function');
       expect(typeof bridge061!.extractRefs).toBe('function');
+
+      expect(bridge070).toHaveProperty('buildSubject');
+      expect(bridge070).toHaveProperty('extractRefs');
+      expect(typeof bridge070!.buildSubject).toBe('function');
+      expect(typeof bridge070!.extractRefs).toBe('function');
     });
   });
 });

--- a/packages/services/src/data-model-bridges/bridge-registry.ts
+++ b/packages/services/src/data-model-bridges/bridge-registry.ts
@@ -2,35 +2,45 @@ import { makeBridge } from './make-bridge.js';
 import type { IDataModelBridge } from './types.js';
 import { dppV060Spec } from './data-models/dpp/versions/v060/index.js';
 import { dppV061Spec } from './data-models/dpp/versions/v061/index.js';
+import { dppV070Spec } from './data-models/dpp/versions/v070/index.js';
 import { dccV060Spec } from './data-models/dcc/versions/v060/index.js';
 import { dccV061Spec } from './data-models/dcc/versions/v061/index.js';
+import { dccV070Spec } from './data-models/dcc/versions/v070/index.js';
 import { dfrV060Spec } from './data-models/dfr/versions/v060/index.js';
 import { dfrV061Spec } from './data-models/dfr/versions/v061/index.js';
+import { dfrV070Spec } from './data-models/dfr/versions/v070/index.js';
 import { diaV060Spec } from './data-models/dia/versions/v060/index.js';
 import { diaV061Spec } from './data-models/dia/versions/v061/index.js';
+import { diaV070Spec } from './data-models/dia/versions/v070/index.js';
 import { dteV060Spec } from './data-models/dte/versions/v060/index.js';
 import { dteV061Spec } from './data-models/dte/versions/v061/index.js';
+import { dteV070Spec } from './data-models/dte/versions/v070/index.js';
 
 const registry: Record<string, Record<string, IDataModelBridge>> = {
   DigitalProductPassport: {
     '0.6.0': makeBridge(dppV060Spec),
     '0.6.1': makeBridge(dppV061Spec),
+    '0.7.0': makeBridge(dppV070Spec),
   },
   DigitalConformityCredential: {
     '0.6.0': makeBridge(dccV060Spec),
     '0.6.1': makeBridge(dccV061Spec),
+    '0.7.0': makeBridge(dccV070Spec),
   },
   DigitalFacilityRecord: {
     '0.6.0': makeBridge(dfrV060Spec),
     '0.6.1': makeBridge(dfrV061Spec),
+    '0.7.0': makeBridge(dfrV070Spec),
   },
   DigitalIdentityAnchor: {
     '0.6.0': makeBridge(diaV060Spec),
     '0.6.1': makeBridge(diaV061Spec),
+    '0.7.0': makeBridge(diaV070Spec),
   },
   DigitalTraceabilityEvent: {
     '0.6.0': makeBridge(dteV060Spec),
     '0.6.1': makeBridge(dteV061Spec),
+    '0.7.0': makeBridge(dteV070Spec),
   },
 };
 

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/builder.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/builder.test.ts
@@ -1,0 +1,310 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dccV070Spec } from './index.js';
+import {
+  createOrganisation,
+  createProduct,
+  createConformityInput,
+  createBridgeEntities,
+} from '../../../../__fixtures__/entities.js';
+
+describe('buildDccSubject (v0.7.0)', () => {
+  const bridge = makeBridge(dccV070Spec);
+
+  // ── credentialSubject root structure ─────────────────────────────────────────
+
+  describe('credentialSubject root', () => {
+    it('sets type to ConformityAttestation and Attestation', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.type).toEqual(['ConformityAttestation', 'Attestation']);
+    });
+
+    it('includes issuedToParty field', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.issuedToParty).toBeDefined();
+    });
+
+    it('does not emit legacy scope key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      expect(subject.scope).toBeUndefined();
+    });
+
+    it('does not emit legacy assessment key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      expect(subject.assessment).toBeUndefined();
+    });
+
+    it('omits conformityAssessment when conformity is absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: undefined }));
+      expect(subject.conformityAssessment).toBeUndefined();
+    });
+
+    it('omits conformityAssessment when conformity is an empty array', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [] }));
+      expect(subject.conformityAssessment).toBeUndefined();
+    });
+
+    it('omits referenceScheme when conformity is absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: undefined }));
+      expect(subject.referenceScheme).toBeUndefined();
+    });
+
+    it('omits referenceScheme when first conformity input has no scheme', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ conformity: [createConformityInput({ scheme: undefined })] }),
+      );
+      expect(subject.referenceScheme).toBeUndefined();
+    });
+  });
+
+  // ── issuedToParty ─────────────────────────────────────────────────────────────
+
+  describe('issuedToParty', () => {
+    it('maps organisation to issuedToParty with all fields', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const party = subject.issuedToParty as Record<string, unknown>;
+
+      expect(party).toEqual({
+        id: 'did:web:example.com:org:1',
+        name: 'Test Organisation',
+        description: 'A test organisation for unit tests',
+        registeredId: '9520123456788',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'https://id.gs1.org/01/',
+          name: 'Global Trade Item Number (GTIN)',
+        },
+      });
+    });
+
+    it('omits registeredId and idScheme when organisation has no primaryIdentifier', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: createOrganisation({ primaryIdentifier: null }) }),
+      );
+      const party = subject.issuedToParty as Record<string, unknown>;
+      expect(party.registeredId).toBeUndefined();
+      expect(party.idScheme).toBeUndefined();
+    });
+
+    it('handles missing organisation gracefully', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ organisation: undefined }));
+      const party = subject.issuedToParty as Record<string, unknown>;
+      expect(party.id).toBeUndefined();
+      expect(party.name).toBeUndefined();
+    });
+  });
+
+  // ── referenceScheme (replaces scope) ────────────────────────────────────────
+
+  describe('referenceScheme', () => {
+    it('sets referenceScheme type to ConformityScheme', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const scheme = subject.referenceScheme as Record<string, unknown>;
+      expect(scheme.type).toEqual(['ConformityScheme']);
+    });
+
+    it('builds referenceScheme from first conformity input scheme', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              scheme: { id: 'https://example.org/conformity-scheme', name: 'Test Conformity Scheme' },
+            }),
+          ],
+        }),
+      );
+      const scheme = subject.referenceScheme as Record<string, unknown>;
+
+      expect(scheme).toEqual({
+        type: ['ConformityScheme'],
+        id: 'https://example.org/conformity-scheme',
+        name: 'Test Conformity Scheme',
+      });
+    });
+
+    it('uses first conformity input scheme when multiple inputs are present', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({ scheme: { id: 'https://example.org/scheme-first' } }),
+            createConformityInput({ scheme: { id: 'https://example.org/scheme-second' } }),
+          ],
+        }),
+      );
+      const scheme = subject.referenceScheme as Record<string, unknown>;
+      expect(scheme.id).toBe('https://example.org/scheme-first');
+    });
+
+    it('omits name from referenceScheme when scheme has no name', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [createConformityInput({ scheme: { id: 'https://example.org/scheme' } })],
+        }),
+      );
+      const scheme = subject.referenceScheme as Record<string, unknown>;
+      expect(scheme.name).toBeUndefined();
+    });
+  });
+
+  // ── conformityAssessment array (renamed from assessment) ───────────────────
+
+  describe('conformityAssessment', () => {
+    it('builds one conformityAssessment per conformity input', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ conformity: [createConformityInput(), createConformityInput()] }),
+      );
+      const assessments = subject.conformityAssessment as unknown[];
+      expect(assessments).toHaveLength(2);
+    });
+
+    it('sets assessment type to ConformityAssessment and Declaration', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      expect(assessment.type).toEqual(['ConformityAssessment', 'Declaration']);
+    });
+
+    it('builds referenceStandard as an array (v0.7.0 shape)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              standard: { id: 'https://example.org/standard/1.0', name: 'Test Standard 1.0' },
+            }),
+          ],
+        }),
+      );
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      expect(assessment.referenceStandard).toEqual([
+        {
+          type: ['Standard'],
+          id: 'https://example.org/standard/1.0',
+          name: 'Test Standard 1.0',
+        },
+      ]);
+    });
+
+    it('builds referenceRegulation as an array (v0.7.0 shape)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              regulation: { id: 'https://example.org/regulation/1.0', name: 'Test Regulation 1.0' },
+            }),
+          ],
+        }),
+      );
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      expect(assessment.referenceRegulation).toEqual([
+        {
+          type: ['Regulation'],
+          id: 'https://example.org/regulation/1.0',
+          name: 'Test Regulation 1.0',
+        },
+      ]);
+    });
+
+    it('builds assessmentCriteria from criteria input', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              criteria: [
+                { id: 'https://example.org/criteria/1', name: 'Criterion 1', conformityTopic: 'environment.emissions' },
+              ],
+            }),
+          ],
+        }),
+      );
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      expect(assessment.assessmentCriteria).toEqual([
+        {
+          type: ['Criterion'],
+          id: 'https://example.org/criteria/1',
+          name: 'Criterion 1',
+          conformityTopic: 'environment.emissions',
+        },
+      ]);
+    });
+
+    it('filters out criteria with empty-string id', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              criteria: [
+                { id: '', name: 'Empty ID Criterion' },
+                { id: 'https://example.org/criteria/1', name: 'Valid Criterion' },
+              ],
+            }),
+          ],
+        }),
+      );
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      const criteria = assessment.assessmentCriteria as Record<string, unknown>[];
+      expect(criteria).toHaveLength(1);
+      expect(criteria[0].id).toBe('https://example.org/criteria/1');
+    });
+
+    it('each assessment includes assessedProduct with Product using itemNumber (renamed field)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          product: createProduct({ batchNumber: 'BATCH-001', serialNumber: 'SN-999' }),
+          conformity: [createConformityInput()],
+        }),
+      );
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      const assessedProduct = assessment.assessedProduct as Record<string, unknown>[];
+
+      expect(assessedProduct).toHaveLength(1);
+      const product = assessedProduct[0].product as Record<string, unknown>;
+      expect(product.type).toEqual(['Product']);
+      expect(product.registeredId).toBe('9520123456788');
+      expect(product.batchNumber).toBe('BATCH-001');
+      expect(product.itemNumber).toBe('SN-999');
+      expect(product.serialNumber).toBeUndefined();
+    });
+
+    it('each assessment includes assessedFacility when facility is provided', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      const assessedFacility = assessment.assessedFacility as Record<string, unknown>[];
+
+      expect(assessedFacility).toHaveLength(1);
+      expect(assessedFacility[0]).toMatchObject({
+        type: ['FacilityVerification'],
+        facility: { type: ['Facility'], registeredId: '4012345000009' },
+      });
+    });
+
+    it('each assessment includes assessedOrganisation when organisation is provided', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      const assessedOrg = assessment.assessedOrganisation as Record<string, unknown>;
+      expect(assessedOrg).toMatchObject({ registeredId: '9520123456788', name: 'Test Organisation' });
+    });
+
+    it('omits assessedProduct when product is not provided', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ product: undefined, conformity: [createConformityInput()] }),
+      );
+      const assessment = (subject.conformityAssessment as Record<string, unknown>[])[0];
+      expect(assessment.assessedProduct).toBeUndefined();
+    });
+
+    it('builds multiple assessments from multiple conformity inputs', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({ standard: { id: 'https://example.org/std/1' } }),
+            createConformityInput({ standard: { id: 'https://example.org/std/2' } }),
+          ],
+        }),
+      );
+      const assessments = subject.conformityAssessment as Record<string, unknown>[];
+      expect(assessments).toHaveLength(2);
+      const firstStd = (assessments[0].referenceStandard as Record<string, unknown>[])[0];
+      const secondStd = (assessments[1].referenceStandard as Record<string, unknown>[])[0];
+      expect(firstStd.id).toBe('https://example.org/std/1');
+      expect(secondStd.id).toBe('https://example.org/std/2');
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/builder.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/builder.ts
@@ -1,0 +1,151 @@
+import type { BridgeEntities, CredentialSubject, ConformityInput } from '../../../../types.js';
+import { buildParty } from '../../../../primitives/party.js';
+import { buildIdentifierScheme } from '../../../../primitives/identifier.js';
+
+// ── Internal types ─────────────────────────────────────────────────────────────
+
+type DccProduct = {
+  type: ['Product'];
+  id: string | undefined;
+  name: string | undefined;
+  registeredId?: string;
+  idScheme?: ReturnType<typeof buildIdentifierScheme>;
+  batchNumber?: string;
+  itemNumber?: string;
+};
+
+type DccFacility = {
+  type: ['Facility'];
+  id: string | undefined;
+  name: string | undefined;
+  registeredId?: string;
+  idScheme?: ReturnType<typeof buildIdentifierScheme>;
+};
+
+type DccProductVerification = {
+  type: ['ProductVerification'];
+  product: DccProduct;
+};
+
+type DccFacilityVerification = {
+  type: ['FacilityVerification'];
+  facility: DccFacility;
+};
+
+type DccReferenceScheme = {
+  type: ['ConformityScheme'];
+  id: string;
+  name?: string;
+};
+
+type ReferenceItem = { type: [string]; id: string; name: string };
+
+type DccConformityAssessment = {
+  type: ['ConformityAssessment', 'Declaration'];
+  referenceStandard?: ReferenceItem[];
+  referenceRegulation?: ReferenceItem[];
+  assessmentCriteria?: { type: ['Criterion']; id: string; name: string; conformityTopic?: string }[];
+  assessedProduct?: DccProductVerification[];
+  assessedFacility?: DccFacilityVerification[];
+  assessedOrganisation?: ReturnType<typeof buildParty>;
+};
+
+// ── Private helpers ────────────────────────────────────────────────────────────
+
+function buildDccProduct(product: NonNullable<BridgeEntities['product']>): DccProduct {
+  return {
+    type: ['Product'],
+    id: product.id,
+    name: product.name,
+    ...(product.primaryIdentifier && {
+      registeredId: product.primaryIdentifier.value,
+      idScheme: buildIdentifierScheme(product.primaryIdentifier.scheme),
+    }),
+    ...(product.batchNumber && { batchNumber: product.batchNumber }),
+    ...(product.serialNumber && { itemNumber: product.serialNumber }),
+  };
+}
+
+function buildDccFacility(facility: NonNullable<BridgeEntities['facility']>): DccFacility {
+  return {
+    type: ['Facility'],
+    id: facility.id,
+    name: facility.name,
+    ...(facility.primaryIdentifier && {
+      registeredId: facility.primaryIdentifier.value,
+      idScheme: buildIdentifierScheme(facility.primaryIdentifier.scheme),
+    }),
+  };
+}
+
+function buildAssessment(conformityInput: ConformityInput, entities: BridgeEntities): DccConformityAssessment {
+  const { organisation, facility, product } = entities;
+  const assessment: DccConformityAssessment = { type: ['ConformityAssessment', 'Declaration'] };
+
+  if (conformityInput.standard?.id) {
+    assessment.referenceStandard = [
+      { type: ['Standard'], id: conformityInput.standard.id, name: conformityInput.standard.name ?? '' },
+    ];
+  }
+
+  if (conformityInput.regulation?.id) {
+    assessment.referenceRegulation = [
+      { type: ['Regulation'], id: conformityInput.regulation.id, name: conformityInput.regulation.name ?? '' },
+    ];
+  }
+
+  if (conformityInput.criteria && conformityInput.criteria.length > 0) {
+    const filteredCriteria = conformityInput.criteria
+      .filter((c) => c.id !== '')
+      .map((c) => ({
+        type: ['Criterion'] as ['Criterion'],
+        id: c.id,
+        name: c.name,
+        ...(c.conformityTopic && { conformityTopic: c.conformityTopic }),
+      }));
+
+    if (filteredCriteria.length > 0) {
+      assessment.assessmentCriteria = filteredCriteria;
+    }
+  }
+
+  if (product) {
+    assessment.assessedProduct = [{ type: ['ProductVerification'], product: buildDccProduct(product) }];
+  }
+
+  if (facility) {
+    assessment.assessedFacility = [{ type: ['FacilityVerification'], facility: buildDccFacility(facility) }];
+  }
+
+  if (organisation) {
+    assessment.assessedOrganisation = buildParty(organisation);
+  }
+
+  return assessment;
+}
+
+// ── Public builder ─────────────────────────────────────────────────────────────
+
+export function buildDccSubject(entities: BridgeEntities): CredentialSubject {
+  const { organisation, conformity } = entities;
+
+  // referenceScheme is derived from the first conformity input's scheme
+  const firstScheme = conformity?.[0]?.scheme;
+  const referenceScheme: DccReferenceScheme | undefined = firstScheme?.id
+    ? {
+        type: ['ConformityScheme'],
+        id: firstScheme.id,
+        ...(firstScheme.name && { name: firstScheme.name }),
+      }
+    : undefined;
+
+  const conformityAssessment =
+    conformity && conformity.length > 0 ? conformity.map((input) => buildAssessment(input, entities)) : undefined;
+
+  return {
+    type: ['ConformityAttestation', 'Attestation'],
+    issuedToParty: buildParty(organisation),
+    ...(referenceScheme && { referenceScheme }),
+    ...(conformityAssessment && { conformityAssessment }),
+  };
+}

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/extractor.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/extractor.test.ts
@@ -1,0 +1,301 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dccV070Spec } from './index.js';
+import {
+  createOrganisation,
+  createFacility,
+  createProduct,
+  createConformityInput,
+  createBridgeEntities,
+} from '../../../../__fixtures__/entities.js';
+import type { CredentialSubject } from '../../../../types.js';
+
+const EMPTY_ARRAYS = { organisations: [], facilities: [], products: [] };
+
+describe('extractDccRefs (v0.7.0)', () => {
+  const bridge = makeBridge(dccV070Spec);
+
+  // ── edge cases ───────────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('returns empty arrays for null subject', () => {
+      const refs = bridge.extractRefs(null as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays for undefined subject', () => {
+      const refs = bridge.extractRefs(undefined as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays for minimal subject with no extractable refs', () => {
+      const refs = bridge.extractRefs({ type: ['ConformityAttestation', 'Attestation'] });
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('omits conformity when no conformityAssessment is present', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        issuedToParty: { registeredId: '1234567890' },
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+
+    it('extracts schemeUrl from referenceScheme.id when no assessments are present', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        referenceScheme: { id: 'https://example.org/scheme' },
+      });
+      expect(refs.conformity).toEqual({
+        schemeUrl: 'https://example.org/scheme',
+        standardUrls: [],
+        regulationUrls: [],
+        criteriaUrls: [],
+      });
+    });
+  });
+
+  // ── organisation refs ────────────────────────────────────────────────────────
+
+  describe('organisation refs', () => {
+    it('extracts organisations[0].id from issuedToParty.registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        issuedToParty: { registeredId: '1234567890' },
+      });
+      expect(refs.organisations).toEqual([{ id: '1234567890' }]);
+    });
+
+    it('falls back to assessedOrganisation.registeredId when issuedToParty has no registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        issuedToParty: { name: 'Some org' },
+        conformityAssessment: [{ assessedOrganisation: { registeredId: '9999999999' } }],
+      });
+      expect(refs.organisations).toEqual([{ id: '9999999999' }]);
+    });
+
+    it('uses issuedToParty.registeredId over assessedOrganisation.registeredId when both are present', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        issuedToParty: { registeredId: '1111111111' },
+        conformityAssessment: [{ assessedOrganisation: { registeredId: '9999999999' } }],
+      });
+      expect(refs.organisations).toEqual([{ id: '1111111111' }]);
+    });
+  });
+
+  // ── product refs ─────────────────────────────────────────────────────────────
+
+  describe('product refs', () => {
+    it('extracts products from conformityAssessment[].assessedProduct[].product.registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [{ assessedProduct: [{ product: { registeredId: '01234567890123' } }] }],
+      });
+      expect(refs.products).toEqual([{ id: '01234567890123' }]);
+    });
+
+    it('includes batchNumber when present', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [
+          { assessedProduct: [{ product: { registeredId: '01234567890123', batchNumber: 'BATCH-001' } }] },
+        ],
+      });
+      expect(refs.products).toEqual([{ id: '01234567890123', batchNumber: 'BATCH-001' }]);
+    });
+
+    it('extracts serialNumber from itemNumber (renamed field in v0.7.0)', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [
+          { assessedProduct: [{ product: { registeredId: '01234567890123', itemNumber: 'SN-12345' } }] },
+        ],
+      });
+      expect(refs.products).toEqual([{ id: '01234567890123', serialNumber: 'SN-12345' }]);
+    });
+
+    it('extracts products from ALL assessments and deduplicates', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [
+          { assessedProduct: [{ product: { registeredId: 'PROD-001' } }] },
+          { assessedProduct: [{ product: { registeredId: 'PROD-002' } }] },
+          { assessedProduct: [{ product: { registeredId: 'PROD-001' } }] },
+        ],
+      });
+      expect(refs.products).toEqual([{ id: 'PROD-001' }, { id: 'PROD-002' }]);
+    });
+  });
+
+  // ── facility refs ────────────────────────────────────────────────────────────
+
+  describe('facility refs', () => {
+    it('extracts facilities from conformityAssessment[].assessedFacility[].facility.registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [{ assessedFacility: [{ facility: { registeredId: '9876543210' } }] }],
+      });
+      expect(refs.facilities).toEqual([{ id: '9876543210' }]);
+    });
+
+    it('extracts facilities from ALL assessments and deduplicates', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [
+          { assessedFacility: [{ facility: { registeredId: 'FAC-001' } }] },
+          { assessedFacility: [{ facility: { registeredId: 'FAC-002' } }] },
+          { assessedFacility: [{ facility: { registeredId: 'FAC-001' } }] },
+        ],
+      });
+      expect(refs.facilities).toEqual([{ id: 'FAC-001' }, { id: 'FAC-002' }]);
+    });
+  });
+
+  // ── conformity refs ──────────────────────────────────────────────────────────
+
+  describe('conformity refs', () => {
+    it('extracts schemeUrl from referenceScheme.id (renamed from scope)', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        referenceScheme: { id: 'https://example.org/conformity-scheme' },
+        conformityAssessment: [{}],
+      });
+      expect(refs.conformity?.schemeUrl).toBe('https://example.org/conformity-scheme');
+    });
+
+    it('extracts standardUrls from conformityAssessment[].referenceStandard[] (array shape)', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [{ referenceStandard: [{ id: 'https://example.org/standard/1.0' }] }],
+      });
+      expect(refs.conformity?.standardUrls).toEqual(['https://example.org/standard/1.0']);
+    });
+
+    it('extracts regulationUrls from conformityAssessment[].referenceRegulation[] (array shape)', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [{ referenceRegulation: [{ id: 'https://example.org/regulation/1.0' }] }],
+      });
+      expect(refs.conformity?.regulationUrls).toEqual(['https://example.org/regulation/1.0']);
+    });
+
+    it('extracts criteriaUrls from conformityAssessment[].assessmentCriteria[].id', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [
+          {
+            assessmentCriteria: [{ id: 'https://example.org/criteria/1' }, { id: 'https://example.org/criteria/2' }],
+          },
+        ],
+      });
+      expect(refs.conformity?.criteriaUrls).toEqual([
+        'https://example.org/criteria/1',
+        'https://example.org/criteria/2',
+      ]);
+    });
+
+    it('deduplicates criteriaUrls across assessments', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [
+          { assessmentCriteria: [{ id: 'https://example.org/criteria/1' }] },
+          { assessmentCriteria: [{ id: 'https://example.org/criteria/1' }] },
+        ],
+      });
+      expect(refs.conformity?.criteriaUrls).toEqual(['https://example.org/criteria/1']);
+    });
+
+    it('aggregates standardUrls across multiple assessments', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [
+          { referenceStandard: [{ id: 'https://example.org/std/1' }] },
+          { referenceStandard: [{ id: 'https://example.org/std/2' }] },
+        ],
+      });
+      expect(refs.conformity?.standardUrls).toEqual(['https://example.org/std/1', 'https://example.org/std/2']);
+    });
+
+    it('omits conformity when assessments have no extractable refs', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [{}],
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+
+    it('always includes all three url arrays when conformity is present', () => {
+      const refs = bridge.extractRefs({
+        type: ['ConformityAttestation', 'Attestation'],
+        conformityAssessment: [{ referenceStandard: [{ id: 'https://example.org/std/1' }] }],
+      });
+      expect(refs.conformity?.standardUrls).toBeDefined();
+      expect(refs.conformity?.regulationUrls).toBeDefined();
+      expect(refs.conformity?.criteriaUrls).toBeDefined();
+    });
+  });
+
+  // ── round-trip (build → extract) ─────────────────────────────────────────────
+
+  describe('round-trip (build → extract)', () => {
+    it('extracts all refs from a fully built subject', () => {
+      const entities = createBridgeEntities({ conformity: [createConformityInput()] });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.organisations).toEqual([{ id: '9520123456788' }]);
+      expect(refs.products).toEqual([{ id: '9520123456788', batchNumber: 'BATCH-001' }]);
+      expect(refs.facilities).toEqual([{ id: '4012345000009' }]);
+      expect(refs.conformity?.schemeUrl).toBe('https://example.org/conformity-scheme');
+      expect(refs.conformity?.standardUrls).toContain('https://example.org/standard/1.0');
+      expect(refs.conformity?.regulationUrls).toContain('https://example.org/regulation/1.0');
+      expect(refs.conformity?.criteriaUrls).toContain('https://example.org/criteria/1');
+      expect(refs.conformity?.criteriaUrls).toContain('https://example.org/criteria/2');
+    });
+
+    it('handles multiple conformity inputs in round-trip', () => {
+      const entities = createBridgeEntities({
+        conformity: [
+          createConformityInput({
+            scheme: { id: 'https://example.org/scheme-first' },
+            standard: { id: 'https://example.org/std/1' },
+          }),
+          createConformityInput({ standard: { id: 'https://example.org/std/2' } }),
+        ],
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.conformity?.schemeUrl).toBe('https://example.org/scheme-first');
+      expect(refs.conformity?.standardUrls).toEqual(['https://example.org/std/1', 'https://example.org/std/2']);
+    });
+
+    it('round-trips serialNumber via itemNumber field', () => {
+      const entities = createBridgeEntities({
+        product: createProduct({ serialNumber: 'SN-777', batchNumber: undefined }),
+        conformity: [createConformityInput()],
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.products).toEqual([{ id: '9520123456788', serialNumber: 'SN-777' }]);
+    });
+
+    it('extracts empty refs from a minimal built subject with no conformity', () => {
+      const entities = createBridgeEntities({
+        organisation: createOrganisation({ primaryIdentifier: null }),
+        facility: createFacility({ primaryIdentifier: null }),
+        product: createProduct({ primaryIdentifier: null }),
+        conformity: undefined,
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.organisations).toEqual([]);
+      expect(refs.products).toEqual([]);
+      expect(refs.facilities).toEqual([]);
+      expect(refs.conformity).toBeUndefined();
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/extractor.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/extractor.ts
@@ -1,0 +1,122 @@
+import type { CredentialSubject, ExtractedRefs } from '../../../../types.js';
+
+// ── Internal types (mirrors builder output shape) ─────────────────────────────
+
+type DccProduct = {
+  registeredId?: string;
+  batchNumber?: string;
+  itemNumber?: string;
+};
+
+type DccProductVerification = { product?: DccProduct };
+type DccFacilityVerification = { facility?: { registeredId?: string } };
+
+type DccConformityAssessment = {
+  referenceStandard?: { id?: string }[];
+  referenceRegulation?: { id?: string }[];
+  assessmentCriteria?: { id?: string }[];
+  assessedProduct?: DccProductVerification[];
+  assessedFacility?: DccFacilityVerification[];
+  assessedOrganisation?: { registeredId?: string };
+};
+
+type DccSubject = {
+  issuedToParty?: { registeredId?: string };
+  referenceScheme?: { id?: string };
+  conformityAssessment?: DccConformityAssessment[];
+};
+
+// ── Public extractor ──────────────────────────────────────────────────────────
+
+const EMPTY_REFS: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+export function extractDccRefs(subject: CredentialSubject): ExtractedRefs {
+  if (!subject) return { ...EMPTY_REFS };
+
+  const dcc = subject as DccSubject;
+  const refs: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+  // Organisation: issuedToParty is primary; assessedOrganisation is fallback.
+  if (dcc.issuedToParty?.registeredId) {
+    refs.organisations.push({ id: dcc.issuedToParty.registeredId });
+  } else if (dcc.conformityAssessment?.[0]?.assessedOrganisation?.registeredId) {
+    refs.organisations.push({ id: dcc.conformityAssessment[0].assessedOrganisation.registeredId });
+  }
+
+  const seenProductIds = new Set<string>();
+  const seenFacilityIds = new Set<string>();
+
+  if (dcc.conformityAssessment) {
+    for (const assessment of dcc.conformityAssessment) {
+      if (assessment.assessedProduct) {
+        for (const pv of assessment.assessedProduct) {
+          const p = pv.product;
+          if (p?.registeredId && !seenProductIds.has(p.registeredId)) {
+            seenProductIds.add(p.registeredId);
+            refs.products.push({
+              id: p.registeredId,
+              ...(p.batchNumber && { batchNumber: p.batchNumber }),
+              ...(p.itemNumber && { serialNumber: p.itemNumber }),
+            });
+          }
+        }
+      }
+
+      if (assessment.assessedFacility) {
+        for (const fv of assessment.assessedFacility) {
+          if (fv.facility?.registeredId && !seenFacilityIds.has(fv.facility.registeredId)) {
+            seenFacilityIds.add(fv.facility.registeredId);
+            refs.facilities.push({ id: fv.facility.registeredId });
+          }
+        }
+      }
+    }
+  }
+
+  if (dcc.conformityAssessment && dcc.conformityAssessment.length > 0) {
+    const schemeUrl = dcc.referenceScheme?.id;
+    const standardUrls: string[] = [];
+    const regulationUrls: string[] = [];
+    const criteriaUrls: string[] = [];
+    const seenCriteria = new Set<string>();
+
+    for (const assessment of dcc.conformityAssessment) {
+      if (assessment.referenceStandard) {
+        for (const s of assessment.referenceStandard) {
+          if (s.id) standardUrls.push(s.id);
+        }
+      }
+      if (assessment.referenceRegulation) {
+        for (const r of assessment.referenceRegulation) {
+          if (r.id) regulationUrls.push(r.id);
+        }
+      }
+      if (assessment.assessmentCriteria) {
+        for (const criterion of assessment.assessmentCriteria) {
+          if (criterion.id && !seenCriteria.has(criterion.id)) {
+            seenCriteria.add(criterion.id);
+            criteriaUrls.push(criterion.id);
+          }
+        }
+      }
+    }
+
+    if (schemeUrl || standardUrls.length > 0 || regulationUrls.length > 0 || criteriaUrls.length > 0) {
+      refs.conformity = {
+        ...(schemeUrl && { schemeUrl }),
+        standardUrls,
+        regulationUrls,
+        criteriaUrls,
+      };
+    }
+  } else if (dcc.referenceScheme?.id) {
+    refs.conformity = {
+      schemeUrl: dcc.referenceScheme.id,
+      standardUrls: [],
+      regulationUrls: [],
+      criteriaUrls: [],
+    };
+  }
+
+  return refs;
+}

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/index.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/index.ts
@@ -1,0 +1,8 @@
+import type { VersionSpec } from '../../../../types.js';
+import { buildDccSubject } from './builder.js';
+import { extractDccRefs } from './extractor.js';
+
+export const dccV070Spec: VersionSpec = {
+  builder: buildDccSubject,
+  extractor: extractDccRefs,
+};

--- a/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/builder.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/builder.test.ts
@@ -1,0 +1,265 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dfrV070Spec } from './index.js';
+import {
+  createFacility,
+  createProduct,
+  createConformityInput,
+  createBridgeEntities,
+} from '../../../../__fixtures__/entities.js';
+
+describe('buildDfrSubject (v0.7.0)', () => {
+  const bridge = makeBridge(dfrV070Spec);
+
+  // ── credentialSubject root structure ─────────────────────────────────────────
+
+  describe('credentialSubject root', () => {
+    it('sets type to Facility (no FacilityRecord wrapper)', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.type).toEqual(['Facility']);
+    });
+
+    it('does not emit a nested facility wrapper', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.facility).toBeUndefined();
+    });
+
+    it('does not emit legacy conformityClaim key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      expect(subject.conformityClaim).toBeUndefined();
+    });
+
+    it('omits performanceClaim when conformity is absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: undefined }));
+      expect(subject.performanceClaim).toBeUndefined();
+    });
+
+    it('omits performanceClaim when conformity is an empty array', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [] }));
+      expect(subject.performanceClaim).toBeUndefined();
+    });
+
+    it('silently ignores entities.product', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct() }));
+      expect(subject.product).toBeUndefined();
+    });
+  });
+
+  // ── facility fields ──────────────────────────────────────────────────────────
+
+  describe('facility fields', () => {
+    it('maps facility id and name at top level', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          facility: createFacility({ id: 'did:web:example.com:facility:1', name: 'My Facility' }),
+        }),
+      );
+      expect(subject.id).toBe('did:web:example.com:facility:1');
+      expect(subject.name).toBe('My Facility');
+    });
+
+    it('includes description when present', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ facility: createFacility({ description: 'A fine facility' }) }),
+      );
+      expect(subject.description).toBe('A fine facility');
+    });
+
+    it('omits description when absent', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ facility: createFacility({ description: undefined }) }),
+      );
+      expect(subject.description).toBeUndefined();
+    });
+
+    it('includes registeredId and idScheme at top level when primaryIdentifier is present', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.registeredId).toBe('4012345000009');
+      expect(subject.idScheme).toEqual({
+        type: ['IdentifierScheme'],
+        id: 'https://id.gs1.org/414/',
+        name: 'Global Location Number (GLN)',
+      });
+    });
+
+    it('omits registeredId and idScheme when primaryIdentifier is absent', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ facility: createFacility({ primaryIdentifier: null }) }),
+      );
+      expect(subject.registeredId).toBeUndefined();
+      expect(subject.idScheme).toBeUndefined();
+    });
+
+    it('maps locationInformation when geo fields are present', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.locationInformation).toEqual({
+        type: ['Location'],
+        plusCode: '4RRH469X+VF',
+        geoLocation: { type: 'Point', coordinates: [151.2093, -33.8688] },
+      });
+    });
+
+    it('maps address when present', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.address).toEqual({
+        type: ['Address'],
+        streetAddress: '123 Test Street',
+        postalCode: '2000',
+        addressLocality: 'Sydney',
+        addressRegion: 'NSW',
+        addressCountry: 'AU',
+      });
+    });
+
+    it('omits both location and address when facility has no location data', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ facility: createFacility({ location: null }) }));
+      expect(subject.locationInformation).toBeUndefined();
+      expect(subject.address).toBeUndefined();
+    });
+  });
+
+  // ── relatedParty (replaces operatedByParty) ─────────────────────────────────
+
+  describe('relatedParty', () => {
+    it('emits a single PartyRole entry with role=operator', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const parties = subject.relatedParty as Record<string, unknown>[];
+      expect(Array.isArray(parties)).toBe(true);
+      expect(parties).toHaveLength(1);
+      expect(parties[0].type).toEqual(['PartyRole']);
+      expect(parties[0].role).toBe('operator');
+    });
+
+    it('maps organisation to the embedded party', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const parties = subject.relatedParty as Record<string, unknown>[];
+      const party = parties[0].party as Record<string, unknown>;
+
+      expect(party).toEqual({
+        id: 'did:web:example.com:org:1',
+        name: 'Test Organisation',
+        description: 'A test organisation for unit tests',
+        registeredId: '9520123456788',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'https://id.gs1.org/01/',
+          name: 'Global Trade Item Number (GTIN)',
+        },
+      });
+    });
+
+    it('does not emit legacy operatedByParty key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.operatedByParty).toBeUndefined();
+    });
+
+    it('handles missing organisation gracefully', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ organisation: undefined }));
+      const parties = subject.relatedParty as Record<string, unknown>[];
+      const party = parties[0].party as Record<string, unknown>;
+      expect(party.id).toBeUndefined();
+      expect(party.name).toBeUndefined();
+    });
+  });
+
+  // ── performanceClaim (replaces conformityClaim) ─────────────────────────────
+
+  describe('performanceClaim', () => {
+    it('builds performanceClaim array from conformity inputs', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const claims = subject.performanceClaim as unknown[];
+      expect(Array.isArray(claims)).toBe(true);
+      expect(claims).toHaveLength(1);
+    });
+
+    it('sets claim type to Claim and Declaration', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.type).toEqual(['Claim', 'Declaration']);
+    });
+
+    it('builds referenceStandard as an array (v0.7.0 shape)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              standard: { id: 'https://example.org/standard/1.0', name: 'Test Standard 1.0' },
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.referenceStandard).toEqual([
+        { type: ['Standard'], id: 'https://example.org/standard/1.0', name: 'Test Standard 1.0' },
+      ]);
+    });
+
+    it('builds referenceRegulation as an array (v0.7.0 shape)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              regulation: { id: 'https://example.org/regulation/1.0', name: 'Test Regulation 1.0' },
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.referenceRegulation).toEqual([
+        { type: ['Regulation'], id: 'https://example.org/regulation/1.0', name: 'Test Regulation 1.0' },
+      ]);
+    });
+
+    it('builds referenceCriteria (renamed from assessmentCriteria)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              criteria: [
+                { id: 'https://example.org/criteria/1', name: 'Criterion 1', conformityTopic: 'environment.emissions' },
+              ],
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.referenceCriteria).toEqual([
+        {
+          type: ['Criterion'],
+          id: 'https://example.org/criteria/1',
+          name: 'Criterion 1',
+          conformityTopic: 'environment.emissions',
+        },
+      ]);
+      expect(claim.assessmentCriteria).toBeUndefined();
+    });
+
+    it('filters out criteria with empty-string id', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              criteria: [
+                { id: '', name: 'Empty ID Criterion' },
+                { id: 'https://example.org/criteria/1', name: 'Valid Criterion' },
+              ],
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      const criteria = claim.referenceCriteria as Record<string, unknown>[];
+      expect(criteria).toHaveLength(1);
+      expect(criteria[0].id).toBe('https://example.org/criteria/1');
+    });
+
+    it('builds multiple performance claims', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [createConformityInput(), createConformityInput({ standard: { id: 'https://other.org/std' } })],
+        }),
+      );
+      const claims = subject.performanceClaim as unknown[];
+      expect(claims).toHaveLength(2);
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/builder.ts
+++ b/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/builder.ts
@@ -1,0 +1,107 @@
+import type { BridgeEntities, CredentialSubject, ConformityInput, FacilityEntity } from '../../../../types.js';
+import { buildParty } from '../../../../primitives/party.js';
+import { buildIdentifierScheme } from '../../../../primitives/identifier.js';
+import { buildLocationInformation, buildAddress } from '../../../../primitives/location.js';
+
+// ── Internal types ─────────────────────────────────────────────────────────────
+
+type PartyRole = {
+  type: ['PartyRole'];
+  role: string;
+  party: ReturnType<typeof buildParty>;
+};
+
+type ReferenceItem = { type: [string]; id: string; name: string };
+
+type PerformanceClaim = {
+  type: ['Claim', 'Declaration'];
+  referenceStandard?: ReferenceItem[];
+  referenceRegulation?: ReferenceItem[];
+  referenceCriteria?: { type: ['Criterion']; id: string; name: string; conformityTopic?: string }[];
+};
+
+type DfrFacility = {
+  type: ['Facility'];
+  id: string | undefined;
+  name: string | undefined;
+  description?: string;
+  registeredId?: string;
+  idScheme?: ReturnType<typeof buildIdentifierScheme>;
+  relatedParty: PartyRole[];
+  locationInformation?: ReturnType<typeof buildLocationInformation>;
+  address?: ReturnType<typeof buildAddress>;
+  performanceClaim?: PerformanceClaim[];
+};
+
+// ── Private helpers ────────────────────────────────────────────────────────────
+
+function buildPerformanceClaim(input: ConformityInput): PerformanceClaim {
+  const claim: PerformanceClaim = { type: ['Claim', 'Declaration'] };
+
+  if (input.standard?.id) {
+    claim.referenceStandard = [{ type: ['Standard'], id: input.standard.id, name: input.standard.name ?? '' }];
+  }
+
+  if (input.regulation?.id) {
+    claim.referenceRegulation = [{ type: ['Regulation'], id: input.regulation.id, name: input.regulation.name ?? '' }];
+  }
+
+  if (input.criteria && input.criteria.length > 0) {
+    const filteredCriteria = input.criteria
+      .filter((c) => c.id !== '')
+      .map((c) => ({
+        type: ['Criterion'] as ['Criterion'],
+        id: c.id,
+        name: c.name,
+        ...(c.conformityTopic && { conformityTopic: c.conformityTopic }),
+      }));
+
+    if (filteredCriteria.length > 0) {
+      claim.referenceCriteria = filteredCriteria;
+    }
+  }
+
+  return claim;
+}
+
+function buildFacility(
+  facility: FacilityEntity | undefined,
+  organisation: BridgeEntities['organisation'],
+  performanceClaim: PerformanceClaim[] | undefined,
+): DfrFacility {
+  const location = facility?.location;
+  const locationInformation = buildLocationInformation(location);
+  const address = buildAddress(location?.address);
+
+  return {
+    type: ['Facility'],
+    id: facility?.id,
+    name: facility?.name,
+    ...(facility?.description && { description: facility.description }),
+    ...(facility?.primaryIdentifier && {
+      registeredId: facility.primaryIdentifier.value,
+      idScheme: buildIdentifierScheme(facility.primaryIdentifier.scheme),
+    }),
+    relatedParty: [
+      {
+        type: ['PartyRole'],
+        role: 'operator',
+        party: buildParty(organisation),
+      },
+    ],
+    ...(locationInformation && { locationInformation }),
+    ...(address && { address }),
+    ...(performanceClaim && { performanceClaim }),
+  };
+}
+
+// ── Public builder ─────────────────────────────────────────────────────────────
+
+export function buildDfrSubject(entities: BridgeEntities): CredentialSubject {
+  // entities.product is silently ignored — DFR is facility-scoped
+  const { organisation, facility, conformity } = entities;
+
+  const performanceClaims = conformity && conformity.length > 0 ? conformity.map(buildPerformanceClaim) : undefined;
+
+  return buildFacility(facility, organisation, performanceClaims);
+}

--- a/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/extractor.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/extractor.test.ts
@@ -1,0 +1,184 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dfrV070Spec } from './index.js';
+import { createFacility, createConformityInput, createBridgeEntities } from '../../../../__fixtures__/entities.js';
+import type { CredentialSubject } from '../../../../types.js';
+
+const EMPTY_ARRAYS = { organisations: [], facilities: [], products: [] };
+
+describe('extractDfrRefs (v0.7.0)', () => {
+  const bridge = makeBridge(dfrV070Spec);
+
+  // ── edge cases ───────────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('returns empty arrays for null subject', () => {
+      const refs = bridge.extractRefs(null as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays for undefined subject', () => {
+      const refs = bridge.extractRefs(undefined as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays for a subject with no ids (no wrapper in v0.7.0)', () => {
+      const refs = bridge.extractRefs({ type: ['Facility'] });
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+  });
+
+  // ── facility refs ─────────────────────────────────────────────────────────────
+
+  describe('facility refs', () => {
+    it('extracts facilities[0].id from top-level registeredId', () => {
+      const refs = bridge.extractRefs({ type: ['Facility'], registeredId: '4012345000009' });
+      expect(refs.facilities).toEqual([{ id: '4012345000009' }]);
+    });
+
+    it('returns empty facilities array when registeredId is absent', () => {
+      const refs = bridge.extractRefs({ type: ['Facility'], id: 'did:web:example.com:facility:1' });
+      expect(refs.facilities).toEqual([]);
+    });
+  });
+
+  // ── organisation refs ────────────────────────────────────────────────────────
+
+  describe('organisation refs', () => {
+    it('extracts organisations from relatedParty[].party.registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        relatedParty: [{ type: ['PartyRole'], role: 'operator', party: { registeredId: '9520123456788' } }],
+      });
+      expect(refs.organisations).toEqual([{ id: '9520123456788' }]);
+    });
+
+    it('returns empty organisations array when relatedParty is absent', () => {
+      const refs = bridge.extractRefs({ type: ['Facility'], registeredId: '4012345000009' });
+      expect(refs.organisations).toEqual([]);
+    });
+
+    it('returns empty organisations array when party has no registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        relatedParty: [{ role: 'operator', party: { name: 'An org' } }],
+      });
+      expect(refs.organisations).toEqual([]);
+    });
+  });
+
+  // ── conformity refs ──────────────────────────────────────────────────────────
+
+  describe('conformity refs', () => {
+    it('omits conformity when performanceClaim is absent', () => {
+      const refs = bridge.extractRefs({ type: ['Facility'], registeredId: '4012345000009' });
+      expect(refs.conformity).toBeUndefined();
+    });
+
+    it('omits conformity when performanceClaim is an empty array', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        performanceClaim: [],
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+
+    it('extracts standardUrls from performanceClaim[].referenceStandard[].id (array shape)', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        performanceClaim: [{ referenceStandard: [{ id: 'https://example.org/standard/1.0' }] }],
+      });
+      expect(refs.conformity?.standardUrls).toEqual(['https://example.org/standard/1.0']);
+    });
+
+    it('extracts regulationUrls from performanceClaim[].referenceRegulation[].id (array shape)', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        performanceClaim: [{ referenceRegulation: [{ id: 'https://example.org/regulation/1.0' }] }],
+      });
+      expect(refs.conformity?.regulationUrls).toEqual(['https://example.org/regulation/1.0']);
+    });
+
+    it('extracts criteriaUrls from performanceClaim[].referenceCriteria[].id', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        performanceClaim: [
+          {
+            referenceCriteria: [{ id: 'https://example.org/criteria/1' }, { id: 'https://example.org/criteria/2' }],
+          },
+        ],
+      });
+      expect(refs.conformity?.criteriaUrls).toEqual([
+        'https://example.org/criteria/1',
+        'https://example.org/criteria/2',
+      ]);
+    });
+
+    it('aggregates urls across multiple claims', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        performanceClaim: [
+          { referenceStandard: [{ id: 'https://example.org/standard/1.0' }] },
+          { referenceStandard: [{ id: 'https://example.org/standard/2.0' }] },
+        ],
+      });
+      expect(refs.conformity?.standardUrls).toEqual([
+        'https://example.org/standard/1.0',
+        'https://example.org/standard/2.0',
+      ]);
+    });
+
+    it('omits conformity when all claims have no extractable urls', () => {
+      const refs = bridge.extractRefs({
+        type: ['Facility'],
+        registeredId: '4012345000009',
+        performanceClaim: [{ type: ['Claim', 'Declaration'] }],
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+  });
+
+  // ── round-trip ───────────────────────────────────────────────────────────────
+
+  describe('round-trip (build → extract)', () => {
+    it('extracts all refs from a fully built subject', () => {
+      const entities = createBridgeEntities({ conformity: [createConformityInput()] });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.facilities).toEqual([{ id: '4012345000009' }]);
+      expect(refs.organisations).toEqual([{ id: '9520123456788' }]);
+      expect(refs.conformity?.standardUrls).toContain('https://example.org/standard/1.0');
+      expect(refs.conformity?.regulationUrls).toContain('https://example.org/regulation/1.0');
+      expect(refs.conformity?.criteriaUrls).toContain('https://example.org/criteria/1');
+      expect(refs.conformity?.criteriaUrls).toContain('https://example.org/criteria/2');
+    });
+
+    it('extracts no product ref from a built subject (DFR has no product)', () => {
+      const entities = createBridgeEntities();
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+      expect(refs.products).toEqual([]);
+    });
+
+    it('extracts empty refs from a minimal built subject', () => {
+      const entities = createBridgeEntities({
+        facility: createFacility({ primaryIdentifier: null }),
+        organisation: undefined,
+        conformity: undefined,
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.facilities).toEqual([]);
+      expect(refs.organisations).toEqual([]);
+      expect(refs.conformity).toBeUndefined();
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/extractor.ts
+++ b/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/extractor.ts
@@ -1,0 +1,75 @@
+import type { CredentialSubject, ExtractedRefs } from '../../../../types.js';
+
+// ── Internal types ─────────────────────────────────────────────────────────────
+
+type PartyRole = {
+  role?: string;
+  party?: { registeredId?: string };
+};
+
+type PerformanceClaim = {
+  referenceStandard?: { id?: string }[];
+  referenceRegulation?: { id?: string }[];
+  referenceCriteria?: { id?: string }[];
+};
+
+type DfrSubject = {
+  type?: string[];
+  registeredId?: string;
+  relatedParty?: PartyRole[];
+  performanceClaim?: PerformanceClaim[];
+};
+
+// ── Public extractor ──────────────────────────────────────────────────────────
+
+const EMPTY_REFS: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+export function extractDfrRefs(subject: CredentialSubject): ExtractedRefs {
+  if (!subject) return { ...EMPTY_REFS };
+
+  // In v0.7.0 the credentialSubject IS the Facility directly (no wrapper).
+  const dfr = subject as DfrSubject;
+  const refs: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+  if (dfr.registeredId) {
+    refs.facilities.push({ id: dfr.registeredId });
+  }
+
+  if (dfr.relatedParty && dfr.relatedParty.length > 0) {
+    for (const pr of dfr.relatedParty) {
+      if (pr.party?.registeredId) {
+        refs.organisations.push({ id: pr.party.registeredId });
+      }
+    }
+  }
+
+  if (dfr.performanceClaim && dfr.performanceClaim.length > 0) {
+    const standardUrls: string[] = [];
+    const regulationUrls: string[] = [];
+    const criteriaUrls: string[] = [];
+
+    for (const claim of dfr.performanceClaim) {
+      if (claim.referenceStandard) {
+        for (const s of claim.referenceStandard) {
+          if (s.id) standardUrls.push(s.id);
+        }
+      }
+      if (claim.referenceRegulation) {
+        for (const r of claim.referenceRegulation) {
+          if (r.id) regulationUrls.push(r.id);
+        }
+      }
+      if (claim.referenceCriteria) {
+        for (const c of claim.referenceCriteria) {
+          if (c.id) criteriaUrls.push(c.id);
+        }
+      }
+    }
+
+    if (standardUrls.length > 0 || regulationUrls.length > 0 || criteriaUrls.length > 0) {
+      refs.conformity = { standardUrls, regulationUrls, criteriaUrls };
+    }
+  }
+
+  return refs;
+}

--- a/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/index.ts
+++ b/packages/services/src/data-model-bridges/data-models/dfr/versions/v070/index.ts
@@ -1,0 +1,8 @@
+import type { VersionSpec } from '../../../../types.js';
+import { buildDfrSubject } from './builder.js';
+import { extractDfrRefs } from './extractor.js';
+
+export const dfrV070Spec: VersionSpec = {
+  builder: buildDfrSubject,
+  extractor: extractDfrRefs,
+};

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.test.ts
@@ -1,0 +1,142 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { diaV070Spec } from './index.js';
+import {
+  createOrganisation,
+  createProduct,
+  createFacility,
+  createConformityInput,
+  createBridgeEntities,
+} from '../../../../__fixtures__/entities.js';
+
+describe('buildDiaSubject (v0.7.0)', () => {
+  const bridge = makeBridge(diaV070Spec);
+
+  // ── credentialSubject root structure ─────────────────────────────────────────
+
+  describe('credentialSubject root', () => {
+    it('sets type to RegisteredIdentity', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.type).toEqual(['RegisteredIdentity']);
+    });
+
+    it('maps organisation id', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: createOrganisation({ id: 'did:web:example.com:org:1' }) }),
+      );
+      expect(subject.id).toBe('did:web:example.com:org:1');
+    });
+
+    it('maps organisation name to registeredName (renamed from name)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: createOrganisation({ name: 'ACME Corp' }) }),
+      );
+      expect(subject.registeredName).toBe('ACME Corp');
+      expect(subject.name).toBeUndefined();
+    });
+
+    it('includes registeredId and idScheme when primaryIdentifier is present', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.registeredId).toBe('9520123456788');
+      expect(subject.idScheme).toEqual({
+        type: ['IdentifierScheme'],
+        id: 'https://id.gs1.org/01/',
+        name: 'Global Trade Item Number (GTIN)',
+      });
+    });
+
+    it('omits registeredId and idScheme when primaryIdentifier is absent', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: createOrganisation({ primaryIdentifier: null }) }),
+      );
+      expect(subject.registeredId).toBeUndefined();
+      expect(subject.idScheme).toBeUndefined();
+    });
+
+    it('maps undefined id and registeredName when no entity is provided', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: undefined, facility: undefined, product: undefined }),
+      );
+      expect(subject.id).toBeUndefined();
+      expect(subject.registeredName).toBeUndefined();
+    });
+  });
+
+  // ── entity fallback priority ───────────────────────────────────────────────
+
+  describe('entity fallback priority', () => {
+    it('uses facility when organisation is absent', () => {
+      const facility = createFacility({ id: 'did:web:example.com:facility:99', name: 'My Facility' });
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: undefined, facility, product: undefined }),
+      );
+      expect(subject.id).toBe('did:web:example.com:facility:99');
+      expect(subject.registeredName).toBe('My Facility');
+      expect(subject.registeredId).toBe('4012345000009');
+    });
+
+    it('uses product when organisation and facility are absent', () => {
+      const product = createProduct({ id: 'did:web:example.com:product:42', name: 'My Product' });
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: undefined, facility: undefined, product }),
+      );
+      expect(subject.id).toBe('did:web:example.com:product:42');
+      expect(subject.registeredName).toBe('My Product');
+      expect(subject.registeredId).toBe('9520123456788');
+    });
+
+    it('prefers organisation over facility when both are provided', () => {
+      const organisation = createOrganisation({ id: 'did:web:org', name: 'Org' });
+      const facility = createFacility({ id: 'did:web:facility', name: 'Facility' });
+      const subject = bridge.buildSubject(createBridgeEntities({ organisation, facility }));
+      expect(subject.id).toBe('did:web:org');
+      expect(subject.registeredName).toBe('Org');
+    });
+
+    it('prefers facility over product when organisation is absent', () => {
+      const facility = createFacility({ id: 'did:web:facility', name: 'Facility' });
+      const product = createProduct({ id: 'did:web:product', name: 'Product' });
+      const subject = bridge.buildSubject(createBridgeEntities({ organisation: undefined, facility, product }));
+      expect(subject.id).toBe('did:web:facility');
+      expect(subject.registeredName).toBe('Facility');
+    });
+  });
+
+  // ── registerType mapping ────────────────────────────────────────────────────
+
+  describe('registerType mapping', () => {
+    it('sets registerType to Business when built from organisation', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.registerType).toBe('Business');
+    });
+
+    it('sets registerType to Facility when built from facility', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: undefined, facility: createFacility(), product: undefined }),
+      );
+      expect(subject.registerType).toBe('Facility');
+    });
+
+    it('sets registerType to Product when built from product', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: undefined, facility: undefined, product: createProduct() }),
+      );
+      expect(subject.registerType).toBe('Product');
+    });
+
+    it('omits registerType when no entity is provided', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ organisation: undefined, facility: undefined, product: undefined }),
+      );
+      expect(subject.registerType).toBeUndefined();
+    });
+  });
+
+  // ── silently ignored fields ──────────────────────────────────────────────────
+
+  describe('silently ignored inputs', () => {
+    it('does not include conformityClaim in subject', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      expect(subject.conformityClaim).toBeUndefined();
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.ts
@@ -1,0 +1,29 @@
+import type { BridgeEntities, CredentialSubject } from '../../../../types.js';
+import { buildIdentifierScheme } from '../../../../primitives/identifier.js';
+
+// ── Public builder ─────────────────────────────────────────────────────────────
+
+export function buildDiaSubject(entities: BridgeEntities): CredentialSubject {
+  // DIA anchors a single entity identity. Priority: organisation > facility > product.
+  // entities.conformity is silently ignored.
+  const entity = entities.organisation ?? entities.facility ?? entities.product;
+
+  const registerType = entities.organisation
+    ? 'Business'
+    : entities.facility
+      ? 'Facility'
+      : entities.product
+        ? 'Product'
+        : undefined;
+
+  return {
+    type: ['RegisteredIdentity'],
+    id: entity?.id,
+    registeredName: entity?.name,
+    ...(registerType && { registerType }),
+    ...(entity?.primaryIdentifier && {
+      registeredId: entity.primaryIdentifier.value,
+      idScheme: buildIdentifierScheme(entity.primaryIdentifier.scheme),
+    }),
+  };
+}

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.test.ts
@@ -1,0 +1,158 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { diaV070Spec } from './index.js';
+import {
+  createOrganisation,
+  createFacility,
+  createProduct,
+  createConformityInput,
+  createBridgeEntities,
+} from '../../../../__fixtures__/entities.js';
+import type { CredentialSubject } from '../../../../types.js';
+
+const EMPTY_ARRAYS = { organisations: [], facilities: [], products: [] };
+
+describe('extractDiaRefs (v0.7.0)', () => {
+  const bridge = makeBridge(diaV070Spec);
+
+  // ── edge cases ───────────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('returns empty arrays for null subject', () => {
+      const refs = bridge.extractRefs(null as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays for undefined subject', () => {
+      const refs = bridge.extractRefs(undefined as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays when registeredId is absent', () => {
+      const refs = bridge.extractRefs({ type: ['RegisteredIdentity'], id: 'did:web:example.com:org:1' });
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+  });
+
+  // ── registerType routing ───────────────────────────────────────────────────
+
+  describe('registerType routing', () => {
+    it('places ref in organisations when registerType is Business', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: '9520123456788',
+        registerType: 'Business',
+      });
+      expect(refs.organisations).toEqual([{ id: '9520123456788' }]);
+      expect(refs.facilities).toEqual([]);
+      expect(refs.products).toEqual([]);
+    });
+
+    it('places ref in facilities when registerType is Facility', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: '4012345000009',
+        registerType: 'Facility',
+      });
+      expect(refs.facilities).toEqual([{ id: '4012345000009' }]);
+    });
+
+    it('places ref in products when registerType is Product', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: '9520123456788',
+        registerType: 'Product',
+      });
+      expect(refs.products).toEqual([{ id: '9520123456788' }]);
+    });
+
+    it('places ref in facilities when registerType is Land', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: 'LAND-001',
+        registerType: 'Land',
+      });
+      expect(refs.facilities).toEqual([{ id: 'LAND-001' }]);
+    });
+
+    it('returns empty arrays when registerType is absent', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: '9520123456788',
+      });
+      expect(refs.organisations).toEqual([]);
+      expect(refs.facilities).toEqual([]);
+      expect(refs.products).toEqual([]);
+    });
+
+    it('returns empty arrays when registerType is Trademark', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: 'TM-12345',
+        registerType: 'Trademark',
+      });
+      expect(refs.organisations).toEqual([]);
+      expect(refs.facilities).toEqual([]);
+      expect(refs.products).toEqual([]);
+    });
+  });
+
+  // ── absent fields ─────────────────────────────────────────────────────────────
+
+  describe('absent fields in result', () => {
+    it('does not include conformity in refs', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: '9520123456788',
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+  });
+
+  // ── round-trip ───────────────────────────────────────────────────────────────
+
+  describe('round-trip (build → extract)', () => {
+    it('extracts organisation ref from a subject built with organisation', () => {
+      const entities = createBridgeEntities({ conformity: [createConformityInput()] });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.organisations).toEqual([{ id: '9520123456788' }]);
+    });
+
+    it('extracts ref from a subject built with facility only', () => {
+      const entities = createBridgeEntities({
+        organisation: undefined,
+        facility: createFacility(),
+        product: undefined,
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.facilities).toEqual([{ id: '4012345000009' }]);
+      expect(refs.organisations).toEqual([]);
+    });
+
+    it('extracts ref from a subject built with product only', () => {
+      const entities = createBridgeEntities({
+        organisation: undefined,
+        facility: undefined,
+        product: createProduct(),
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.products).toEqual([{ id: '9520123456788' }]);
+      expect(refs.organisations).toEqual([]);
+    });
+
+    it('extracts empty refs from a subject built with no primaryIdentifier', () => {
+      const entities = createBridgeEntities({
+        organisation: createOrganisation({ primaryIdentifier: null }),
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.organisations).toEqual([]);
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.ts
@@ -1,0 +1,31 @@
+import type { CredentialSubject, ExtractedRefs } from '../../../../types.js';
+
+// ── Internal types (mirrors builder output shape) ─────────────────────────────
+
+type DiaSubject = {
+  id?: string;
+  registeredName?: string;
+  registeredId?: string;
+  registerType?: string;
+};
+
+// ── Public extractor ──────────────────────────────────────────────────────────
+
+const EMPTY_REFS: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+export function extractDiaRefs(subject: CredentialSubject): ExtractedRefs {
+  if (!subject) return { ...EMPTY_REFS };
+
+  const dia = subject as DiaSubject;
+
+  if (!dia.registeredId) return { ...EMPTY_REFS };
+
+  const ref = { id: dia.registeredId };
+  const registerType = dia.registerType;
+
+  return {
+    organisations: registerType === 'Business' ? [ref] : [],
+    facilities: registerType === 'Facility' || registerType === 'Land' ? [ref] : [],
+    products: registerType === 'Product' ? [ref] : [],
+  };
+}

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/index.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/index.ts
@@ -1,0 +1,8 @@
+import type { VersionSpec } from '../../../../types.js';
+import { buildDiaSubject } from './builder.js';
+import { extractDiaRefs } from './extractor.js';
+
+export const diaV070Spec: VersionSpec = {
+  builder: buildDiaSubject,
+  extractor: extractDiaRefs,
+};

--- a/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/builder.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/builder.test.ts
@@ -1,0 +1,356 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dppV070Spec } from './index.js';
+import {
+  createOrganisation,
+  createFacility,
+  createProduct,
+  createConformityInput,
+  createBridgeEntities,
+} from '../../../../__fixtures__/entities.js';
+
+describe('buildDppSubject (v0.7.0)', () => {
+  const bridge = makeBridge(dppV070Spec);
+
+  // ── credentialSubject root structure ─────────────────────────────────────────
+
+  describe('credentialSubject root', () => {
+    it('sets type to Product (no ProductPassport wrapper)', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.type).toEqual(['Product']);
+    });
+
+    it('maps product id and name to top-level', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          product: createProduct({ id: 'did:web:example.com:product:1', name: 'My Product' }),
+        }),
+      );
+      expect(subject.id).toBe('did:web:example.com:product:1');
+      expect(subject.name).toBe('My Product');
+    });
+
+    it('includes description when present', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ product: createProduct({ description: 'A fine product' }) }),
+      );
+      expect(subject.description).toBe('A fine product');
+    });
+
+    it('omits description when absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct({ description: undefined }) }));
+      expect(subject.description).toBeUndefined();
+    });
+
+    it('sets idGranularity to lowercased product.level when present', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct({ level: 'BATCH' }) }));
+      expect(subject.idGranularity).toBe('batch');
+    });
+
+    it('sets idGranularity to model when level is MODEL', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct({ level: 'MODEL' }) }));
+      expect(subject.idGranularity).toBe('model');
+    });
+
+    it('sets idGranularity to item when level is ITEM', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct({ level: 'ITEM' }) }));
+      expect(subject.idGranularity).toBe('item');
+    });
+
+    it('omits idGranularity when product.level is absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct({ level: undefined }) }));
+      expect(subject.idGranularity).toBeUndefined();
+    });
+
+    it('does not emit legacy granularityLevel key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct({ level: 'BATCH' }) }));
+      expect(subject.granularityLevel).toBeUndefined();
+    });
+
+    it('does not emit a nested product wrapper', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.product).toBeUndefined();
+    });
+
+    it('does not emit legacy conformityClaim key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      expect(subject.conformityClaim).toBeUndefined();
+    });
+
+    it('omits performanceClaim when conformity is absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: undefined }));
+      expect(subject.performanceClaim).toBeUndefined();
+    });
+
+    it('omits performanceClaim when conformity is an empty array', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [] }));
+      expect(subject.performanceClaim).toBeUndefined();
+    });
+  });
+
+  // ── product identifier fields ─────────────────────────────────────────────────
+
+  describe('product identifiers', () => {
+    it('includes idScheme inline (no top-level registeredId)', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.idScheme).toEqual({
+        type: ['IdentifierScheme'],
+        id: 'https://id.gs1.org/01/',
+        name: 'Global Trade Item Number (GTIN)',
+      });
+      expect(subject.registeredId).toBeUndefined();
+    });
+
+    it('omits idScheme when primaryIdentifier is absent', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ product: createProduct({ primaryIdentifier: null }) }),
+      );
+      expect(subject.idScheme).toBeUndefined();
+    });
+
+    it('includes batchNumber when present', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ product: createProduct({ batchNumber: 'BATCH-2024-001' }) }),
+      );
+      expect(subject.batchNumber).toBe('BATCH-2024-001');
+    });
+
+    it('omits batchNumber when absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct({ batchNumber: undefined }) }));
+      expect(subject.batchNumber).toBeUndefined();
+    });
+
+    it('maps product.serialNumber to itemNumber (renamed field)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ product: createProduct({ serialNumber: 'SN-12345' }) }),
+      );
+      expect(subject.itemNumber).toBe('SN-12345');
+      expect(subject.serialNumber).toBeUndefined();
+    });
+
+    it('omits itemNumber when serialNumber is absent', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({ product: createProduct({ serialNumber: undefined }) }),
+      );
+      expect(subject.itemNumber).toBeUndefined();
+    });
+  });
+
+  // ── relatedParty (replaces producedByParty) ─────────────────────────────────
+
+  describe('relatedParty', () => {
+    it('emits a single PartyRole entry with role=producer', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const parties = subject.relatedParty as Record<string, unknown>[];
+      expect(Array.isArray(parties)).toBe(true);
+      expect(parties).toHaveLength(1);
+      expect(parties[0].type).toEqual(['PartyRole']);
+      expect(parties[0].role).toBe('producer');
+    });
+
+    it('maps organisation to the embedded party', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const parties = subject.relatedParty as Record<string, unknown>[];
+      const party = parties[0].party as Record<string, unknown>;
+
+      expect(party).toEqual({
+        id: 'did:web:example.com:org:1',
+        name: 'Test Organisation',
+        description: 'A test organisation for unit tests',
+        registeredId: '9520123456788',
+        idScheme: {
+          type: ['IdentifierScheme'],
+          id: 'https://id.gs1.org/01/',
+          name: 'Global Trade Item Number (GTIN)',
+        },
+      });
+    });
+
+    it('does not emit legacy producedByParty key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.producedByParty).toBeUndefined();
+    });
+
+    it('handles missing organisation gracefully', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ organisation: undefined }));
+      const parties = subject.relatedParty as Record<string, unknown>[];
+      const party = parties[0].party as Record<string, unknown>;
+      expect(party.id).toBeUndefined();
+      expect(party.name).toBeUndefined();
+    });
+  });
+
+  // ── producedAtFacility ───────────────────────────────────────────────────────
+
+  describe('producedAtFacility', () => {
+    it('sets facility type to Facility', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const facility = subject.producedAtFacility as Record<string, unknown>;
+      expect(facility.type).toEqual(['Facility']);
+    });
+
+    it('maps full facility including id, name, description, registeredId, idScheme', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const facility = subject.producedAtFacility as Record<string, unknown>;
+
+      expect(facility.id).toBe('did:web:example.com:facility:1');
+      expect(facility.name).toBe('Test Facility');
+      expect(facility.description).toBe('A test facility for unit tests');
+      expect(facility.registeredId).toBe('4012345000009');
+      expect(facility.idScheme).toEqual({
+        type: ['IdentifierScheme'],
+        id: 'https://id.gs1.org/414/',
+        name: 'Global Location Number (GLN)',
+      });
+    });
+
+    it('maps locationInformation when geo fields are present', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const facility = subject.producedAtFacility as Record<string, unknown>;
+      expect(facility.locationInformation).toEqual({
+        type: ['Location'],
+        plusCode: '4RRH469X+VF',
+        geoLocation: { type: 'Point', coordinates: [151.2093, -33.8688] },
+      });
+    });
+
+    it('maps address when present', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      const facility = subject.producedAtFacility as Record<string, unknown>;
+      expect(facility.address).toEqual({
+        type: ['Address'],
+        streetAddress: '123 Test Street',
+        postalCode: '2000',
+        addressLocality: 'Sydney',
+        addressRegion: 'NSW',
+        addressCountry: 'AU',
+      });
+    });
+
+    it('omits both location and address when facility has no location data', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ facility: createFacility({ location: null }) }));
+      const facility = subject.producedAtFacility as Record<string, unknown>;
+      expect(facility.locationInformation).toBeUndefined();
+      expect(facility.address).toBeUndefined();
+    });
+  });
+
+  // ── performanceClaim (replaces conformityClaim) ─────────────────────────────
+
+  describe('performanceClaim', () => {
+    it('builds performanceClaim array from conformity inputs', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const claims = subject.performanceClaim as unknown[];
+      expect(Array.isArray(claims)).toBe(true);
+      expect(claims).toHaveLength(1);
+    });
+
+    it('sets claim type to Claim and Declaration', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ conformity: [createConformityInput()] }));
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.type).toEqual(['Claim', 'Declaration']);
+    });
+
+    it('builds referenceStandard as an array (v0.7.0 shape)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              standard: { id: 'https://example.org/standard/1.0', name: 'Test Standard 1.0' },
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.referenceStandard).toEqual([
+        {
+          type: ['Standard'],
+          id: 'https://example.org/standard/1.0',
+          name: 'Test Standard 1.0',
+        },
+      ]);
+    });
+
+    it('builds referenceRegulation as an array (v0.7.0 shape)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              regulation: { id: 'https://example.org/regulation/1.0', name: 'Test Regulation 1.0' },
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.referenceRegulation).toEqual([
+        {
+          type: ['Regulation'],
+          id: 'https://example.org/regulation/1.0',
+          name: 'Test Regulation 1.0',
+        },
+      ]);
+    });
+
+    it('builds referenceCriteria from criteria input (renamed from assessmentCriteria)', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              criteria: [
+                { id: 'https://example.org/criteria/1', name: 'Criterion 1', conformityTopic: 'environment.emissions' },
+              ],
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.referenceCriteria).toEqual([
+        {
+          type: ['Criterion'],
+          id: 'https://example.org/criteria/1',
+          name: 'Criterion 1',
+          conformityTopic: 'environment.emissions',
+        },
+      ]);
+      expect(claim.assessmentCriteria).toBeUndefined();
+    });
+
+    it('filters out criteria with empty-string id', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [
+            createConformityInput({
+              criteria: [
+                { id: '', name: 'Empty ID Criterion' },
+                { id: 'https://example.org/criteria/1', name: 'Valid Criterion' },
+              ],
+            }),
+          ],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      const criteria = claim.referenceCriteria as Record<string, unknown>[];
+      expect(criteria).toHaveLength(1);
+      expect(criteria[0].id).toBe('https://example.org/criteria/1');
+    });
+
+    it('omits referenceCriteria when all criteria have empty-string ids', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [createConformityInput({ criteria: [{ id: '', name: 'Empty' }] })],
+        }),
+      );
+      const claim = (subject.performanceClaim as Record<string, unknown>[])[0];
+      expect(claim.referenceCriteria).toBeUndefined();
+    });
+
+    it('builds multiple performance claims', () => {
+      const subject = bridge.buildSubject(
+        createBridgeEntities({
+          conformity: [createConformityInput(), createConformityInput({ standard: { id: 'https://other.org/std' } })],
+        }),
+      );
+      const claims = subject.performanceClaim as unknown[];
+      expect(claims).toHaveLength(2);
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/builder.ts
+++ b/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/builder.ts
@@ -1,0 +1,112 @@
+import type { BridgeEntities, CredentialSubject, ConformityInput, FacilityEntity } from '../../../../types.js';
+import { buildParty } from '../../../../primitives/party.js';
+import { buildIdentifierScheme } from '../../../../primitives/identifier.js';
+import { buildLocationInformation, buildAddress } from '../../../../primitives/location.js';
+
+// ── Internal types ─────────────────────────────────────────────────────────────
+
+type DppFacility = {
+  type: ['Facility'];
+  id: string | undefined;
+  name: string | undefined;
+  description?: string;
+  registeredId?: string;
+  idScheme?: ReturnType<typeof buildIdentifierScheme>;
+  locationInformation?: ReturnType<typeof buildLocationInformation>;
+  address?: ReturnType<typeof buildAddress>;
+};
+
+type PartyRole = {
+  type: ['PartyRole'];
+  role: string;
+  party: ReturnType<typeof buildParty>;
+};
+
+type ReferenceItem = { type: [string]; id: string; name: string };
+
+type PerformanceClaim = {
+  type: ['Claim', 'Declaration'];
+  referenceStandard?: ReferenceItem[];
+  referenceRegulation?: ReferenceItem[];
+  referenceCriteria?: { type: ['Criterion']; id: string; name: string; conformityTopic?: string }[];
+};
+
+// ── Private helpers ────────────────────────────────────────────────────────────
+
+function buildFacility(facility: FacilityEntity | undefined): DppFacility {
+  const location = facility?.location;
+  const locationInformation = buildLocationInformation(location);
+  const address = buildAddress(location?.address);
+
+  return {
+    type: ['Facility'],
+    id: facility?.id,
+    name: facility?.name,
+    ...(facility?.description && { description: facility.description }),
+    ...(facility?.primaryIdentifier && {
+      registeredId: facility.primaryIdentifier.value,
+      idScheme: buildIdentifierScheme(facility.primaryIdentifier.scheme),
+    }),
+    ...(locationInformation && { locationInformation }),
+    ...(address && { address }),
+  };
+}
+
+function buildPerformanceClaim(input: ConformityInput): PerformanceClaim {
+  const claim: PerformanceClaim = { type: ['Claim', 'Declaration'] };
+
+  if (input.standard?.id) {
+    claim.referenceStandard = [{ type: ['Standard'], id: input.standard.id, name: input.standard.name ?? '' }];
+  }
+
+  if (input.regulation?.id) {
+    claim.referenceRegulation = [{ type: ['Regulation'], id: input.regulation.id, name: input.regulation.name ?? '' }];
+  }
+
+  if (input.criteria && input.criteria.length > 0) {
+    const filteredCriteria = input.criteria
+      .filter((c) => c.id !== '')
+      .map((c) => ({
+        type: ['Criterion'] as ['Criterion'],
+        id: c.id,
+        name: c.name,
+        ...(c.conformityTopic && { conformityTopic: c.conformityTopic }),
+      }));
+
+    if (filteredCriteria.length > 0) {
+      claim.referenceCriteria = filteredCriteria;
+    }
+  }
+
+  return claim;
+}
+
+// ── Public builder ─────────────────────────────────────────────────────────────
+
+export function buildDppSubject(entities: BridgeEntities): CredentialSubject {
+  const { organisation, facility, product, conformity } = entities;
+
+  const performanceClaims = conformity && conformity.length > 0 ? conformity.map(buildPerformanceClaim) : undefined;
+
+  return {
+    type: ['Product'],
+    id: product?.id,
+    name: product?.name,
+    ...(product?.description && { description: product.description }),
+    ...(product?.primaryIdentifier && {
+      idScheme: buildIdentifierScheme(product.primaryIdentifier.scheme),
+    }),
+    ...(product?.batchNumber && { batchNumber: product.batchNumber }),
+    ...(product?.serialNumber && { itemNumber: product.serialNumber }),
+    ...(product?.level && { idGranularity: product.level.toLowerCase() }),
+    producedAtFacility: buildFacility(facility),
+    relatedParty: [
+      {
+        type: ['PartyRole'],
+        role: 'producer',
+        party: buildParty(organisation),
+      },
+    ],
+    ...(performanceClaims && { performanceClaim: performanceClaims }),
+  };
+}

--- a/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/extractor.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/extractor.test.ts
@@ -1,0 +1,260 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dppV070Spec } from './index.js';
+import {
+  createOrganisation,
+  createFacility,
+  createProduct,
+  createConformityInput,
+  createBridgeEntities,
+} from '../../../../__fixtures__/entities.js';
+import type { CredentialSubject } from '../../../../types.js';
+
+const EMPTY_ARRAYS = { organisations: [], facilities: [], products: [] };
+
+describe('extractDppRefs (v0.7.0)', () => {
+  const bridge = makeBridge(dppV070Spec);
+
+  // ── edge cases ───────────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('returns empty arrays for null subject', () => {
+      const refs = bridge.extractRefs(null as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays for undefined subject', () => {
+      const refs = bridge.extractRefs(undefined as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays when subject has no id (no wrapper in v0.7.0)', () => {
+      const refs = bridge.extractRefs({ type: ['Product'] });
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+  });
+
+  // ── product refs ─────────────────────────────────────────────────────────────
+
+  describe('product refs', () => {
+    it('extracts products[0].id from the top-level id field', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+      });
+      expect(refs.products).toEqual([{ id: 'https://id.gs1.org/01/09520123456788' }]);
+    });
+
+    it('includes batchNumber when present', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        batchNumber: 'BATCH-001',
+      });
+      expect(refs.products).toEqual([{ id: 'https://id.gs1.org/01/09520123456788', batchNumber: 'BATCH-001' }]);
+    });
+
+    it('extracts serialNumber from itemNumber (v0.7.0 field rename)', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        itemNumber: 'SN-999',
+      });
+      expect(refs.products).toEqual([{ id: 'https://id.gs1.org/01/09520123456788', serialNumber: 'SN-999' }]);
+    });
+
+    it('includes both batchNumber and serialNumber when present', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        batchNumber: 'BATCH-001',
+        itemNumber: 'SN-999',
+      });
+      expect(refs.products).toEqual([
+        { id: 'https://id.gs1.org/01/09520123456788', batchNumber: 'BATCH-001', serialNumber: 'SN-999' },
+      ]);
+    });
+  });
+
+  // ── organisation refs ────────────────────────────────────────────────────────
+
+  describe('organisation refs', () => {
+    it('extracts organisations from relatedParty[].party.registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        relatedParty: [{ type: ['PartyRole'], role: 'producer', party: { registeredId: '1234567890' } }],
+      });
+      expect(refs.organisations).toEqual([{ id: '1234567890' }]);
+    });
+
+    it('returns empty organisations array when relatedParty is absent', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+      });
+      expect(refs.organisations).toEqual([]);
+    });
+
+    it('returns empty organisations array when party has no registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        relatedParty: [{ role: 'producer', party: { name: 'An org' } }],
+      });
+      expect(refs.organisations).toEqual([]);
+    });
+  });
+
+  // ── facility refs ────────────────────────────────────────────────────────────
+
+  describe('facility refs', () => {
+    it('extracts facilities[0].id from producedAtFacility.registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        producedAtFacility: { registeredId: '9876543210' },
+      });
+      expect(refs.facilities).toEqual([{ id: '9876543210' }]);
+    });
+
+    it('returns empty facilities array when producedAtFacility has no registeredId', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        producedAtFacility: { name: 'A facility' },
+      });
+      expect(refs.facilities).toEqual([]);
+    });
+  });
+
+  // ── conformity refs ──────────────────────────────────────────────────────────
+
+  describe('conformity refs', () => {
+    it('omits conformity when performanceClaim is absent', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+
+    it('extracts standardUrls from performanceClaim[].referenceStandard[].id (array shape)', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        performanceClaim: [{ referenceStandard: [{ id: 'https://example.org/standard/1.0' }] }],
+      });
+      expect(refs.conformity?.standardUrls).toEqual(['https://example.org/standard/1.0']);
+    });
+
+    it('extracts regulationUrls from performanceClaim[].referenceRegulation[].id (array shape)', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        performanceClaim: [{ referenceRegulation: [{ id: 'https://example.org/regulation/1.0' }] }],
+      });
+      expect(refs.conformity?.regulationUrls).toEqual(['https://example.org/regulation/1.0']);
+    });
+
+    it('extracts criteriaUrls from performanceClaim[].referenceCriteria[].id', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        performanceClaim: [
+          {
+            referenceCriteria: [{ id: 'https://example.org/criteria/1' }, { id: 'https://example.org/criteria/2' }],
+          },
+        ],
+      });
+      expect(refs.conformity?.criteriaUrls).toEqual([
+        'https://example.org/criteria/1',
+        'https://example.org/criteria/2',
+      ]);
+    });
+
+    it('aggregates urls across multiple claims', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        performanceClaim: [
+          { referenceStandard: [{ id: 'https://example.org/standard/1.0' }] },
+          { referenceStandard: [{ id: 'https://example.org/standard/2.0' }] },
+        ],
+      });
+      expect(refs.conformity?.standardUrls).toEqual([
+        'https://example.org/standard/1.0',
+        'https://example.org/standard/2.0',
+      ]);
+    });
+
+    it('always includes all three url arrays when conformity is present', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        performanceClaim: [{ referenceStandard: [{ id: 'https://example.org/standard/1.0' }] }],
+      });
+      expect(refs.conformity?.standardUrls).toBeDefined();
+      expect(refs.conformity?.regulationUrls).toBeDefined();
+      expect(refs.conformity?.criteriaUrls).toBeDefined();
+    });
+
+    it('omits conformity when all claims have no extractable urls', () => {
+      const refs = bridge.extractRefs({
+        type: ['Product'],
+        id: 'https://id.gs1.org/01/09520123456788',
+        performanceClaim: [{ type: ['Claim', 'Declaration'] }],
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+  });
+
+  // ── round-trip ───────────────────────────────────────────────────────────────
+
+  describe('round-trip (build → extract)', () => {
+    it('extracts all refs from a fully built subject', () => {
+      const entities = createBridgeEntities({ conformity: [createConformityInput()] });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.products).toEqual([
+        {
+          id: 'did:web:example.com:product:1',
+          batchNumber: 'BATCH-001',
+        },
+      ]);
+      expect(refs.organisations).toEqual([{ id: '9520123456788' }]);
+      expect(refs.facilities).toEqual([{ id: '4012345000009' }]);
+      expect(refs.conformity?.standardUrls).toContain('https://example.org/standard/1.0');
+      expect(refs.conformity?.regulationUrls).toContain('https://example.org/regulation/1.0');
+      expect(refs.conformity?.criteriaUrls).toContain('https://example.org/criteria/1');
+      expect(refs.conformity?.criteriaUrls).toContain('https://example.org/criteria/2');
+    });
+
+    it('extracts empty organisation and facility refs from a minimal built subject', () => {
+      const entities = createBridgeEntities({
+        organisation: createOrganisation({ primaryIdentifier: null }),
+        facility: createFacility({ primaryIdentifier: null }),
+        conformity: undefined,
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.organisations).toEqual([]);
+      expect(refs.facilities).toEqual([]);
+      expect(refs.conformity).toBeUndefined();
+    });
+
+    it('extracts serialNumber in round-trip via itemNumber mapping', () => {
+      const entities = createBridgeEntities({
+        product: createProduct({ serialNumber: 'SN-42', batchNumber: undefined }),
+      });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.products[0]).toEqual({
+        id: 'did:web:example.com:product:1',
+        serialNumber: 'SN-42',
+      });
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/extractor.ts
+++ b/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/extractor.ts
@@ -1,0 +1,87 @@
+import type { CredentialSubject, ExtractedRefs } from '../../../../types.js';
+
+// ── Internal types (mirrors builder output shape) ─────────────────────────────
+
+type PartyRole = {
+  role?: string;
+  party?: { registeredId?: string };
+};
+
+type PerformanceClaim = {
+  referenceStandard?: { id?: string }[];
+  referenceRegulation?: { id?: string }[];
+  referenceCriteria?: { id?: string }[];
+};
+
+type DppSubject = {
+  type?: string[];
+  id?: string;
+  batchNumber?: string;
+  itemNumber?: string;
+  producedAtFacility?: { registeredId?: string };
+  relatedParty?: PartyRole[];
+  performanceClaim?: PerformanceClaim[];
+};
+
+// ── Public extractor ──────────────────────────────────────────────────────────
+
+const EMPTY_REFS: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+export function extractDppRefs(subject: CredentialSubject): ExtractedRefs {
+  if (!subject) return { ...EMPTY_REFS };
+
+  const dpp = subject as DppSubject;
+
+  // In v0.7.0 the credentialSubject IS the Product directly (no wrapper).
+  if (!dpp.id) return { ...EMPTY_REFS };
+
+  const refs: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+  refs.products.push({
+    id: dpp.id,
+    ...(dpp.batchNumber && { batchNumber: dpp.batchNumber }),
+    ...(dpp.itemNumber && { serialNumber: dpp.itemNumber }),
+  });
+
+  if (dpp.relatedParty && dpp.relatedParty.length > 0) {
+    for (const pr of dpp.relatedParty) {
+      if (pr.party?.registeredId) {
+        refs.organisations.push({ id: pr.party.registeredId });
+      }
+    }
+  }
+
+  if (dpp.producedAtFacility?.registeredId) {
+    refs.facilities.push({ id: dpp.producedAtFacility.registeredId });
+  }
+
+  if (dpp.performanceClaim && dpp.performanceClaim.length > 0) {
+    const standardUrls: string[] = [];
+    const regulationUrls: string[] = [];
+    const criteriaUrls: string[] = [];
+
+    for (const claim of dpp.performanceClaim) {
+      if (claim.referenceStandard) {
+        for (const s of claim.referenceStandard) {
+          if (s.id) standardUrls.push(s.id);
+        }
+      }
+      if (claim.referenceRegulation) {
+        for (const r of claim.referenceRegulation) {
+          if (r.id) regulationUrls.push(r.id);
+        }
+      }
+      if (claim.referenceCriteria) {
+        for (const c of claim.referenceCriteria) {
+          if (c.id) criteriaUrls.push(c.id);
+        }
+      }
+    }
+
+    if (standardUrls.length > 0 || regulationUrls.length > 0 || criteriaUrls.length > 0) {
+      refs.conformity = { standardUrls, regulationUrls, criteriaUrls };
+    }
+  }
+
+  return refs;
+}

--- a/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/index.ts
+++ b/packages/services/src/data-model-bridges/data-models/dpp/versions/v070/index.ts
@@ -1,0 +1,8 @@
+import type { VersionSpec } from '../../../../types.js';
+import { buildDppSubject } from './builder.js';
+import { extractDppRefs } from './extractor.js';
+
+export const dppV070Spec: VersionSpec = {
+  builder: buildDppSubject,
+  extractor: extractDppRefs,
+};

--- a/packages/services/src/data-model-bridges/data-models/dte/versions/v070/builder.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dte/versions/v070/builder.test.ts
@@ -1,0 +1,204 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dteV070Spec } from './index.js';
+import { createProduct, createBridgeEntities } from '../../../../__fixtures__/entities.js';
+
+describe('buildDteSubject (v0.7.0)', () => {
+  const bridge = makeBridge(dteV070Spec);
+
+  // ── legacy fallback (no event input) ────────────────────────────────────────
+
+  describe('legacy fallback (no event input)', () => {
+    it('sets type to Event', () => {
+      const subject = bridge.buildSubject(createBridgeEntities());
+      expect(subject.type).toEqual(['Event']);
+    });
+
+    it('builds movedProduct from product (v0.7.0 EventProduct shape)', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct() }));
+      const moved = subject.movedProduct as Record<string, unknown>[];
+      expect(moved).toHaveLength(1);
+      expect(moved[0].type).toEqual(['EventProduct']);
+      const wrapped = moved[0].product as Record<string, unknown>;
+      expect(wrapped.type).toEqual(['Product']);
+      expect(wrapped.id).toBe('did:web:example.com:product:1');
+    });
+
+    it('omits movedProduct when product is absent', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: undefined }));
+      expect(subject.movedProduct).toBeUndefined();
+    });
+
+    it('does not emit legacy epcList key', () => {
+      const subject = bridge.buildSubject(createBridgeEntities({ product: createProduct() }));
+      expect(subject.epcList).toBeUndefined();
+    });
+  });
+
+  // ── ModifyEvent (replaces ObjectEvent) ──────────────────────────────────────
+
+  describe('ModifyEvent (from object event)', () => {
+    it('sets type to ModifyEvent + Event', () => {
+      const subject = bridge.buildSubject({ event: { eventType: 'object', products: [createProduct()] } });
+      expect(subject.type).toEqual(['ModifyEvent', 'Event']);
+    });
+
+    it('builds modifiedProduct from event.products as EventProduct[]', () => {
+      const p1 = createProduct({ id: 'product-1', name: 'P1' });
+      const p2 = createProduct({ id: 'product-2', name: 'P2' });
+      const subject = bridge.buildSubject({ event: { eventType: 'object', products: [p1, p2] } });
+      const modified = subject.modifiedProduct as Record<string, unknown>[];
+      expect(modified).toHaveLength(2);
+      expect(modified[0].type).toEqual(['EventProduct']);
+      expect((modified[0].product as Record<string, unknown>).id).toBe('product-1');
+      expect((modified[1].product as Record<string, unknown>).id).toBe('product-2');
+    });
+
+    it('does not emit legacy epcList key', () => {
+      const subject = bridge.buildSubject({ event: { eventType: 'object', products: [createProduct()] } });
+      expect(subject.epcList).toBeUndefined();
+    });
+  });
+
+  // ── MakeEvent (replaces TransformationEvent) ────────────────────────────────
+
+  describe('MakeEvent (from transformation event)', () => {
+    it('sets type to MakeEvent + Event', () => {
+      const subject = bridge.buildSubject({ event: { eventType: 'transformation' } });
+      expect(subject.type).toEqual(['MakeEvent', 'Event']);
+    });
+
+    it('builds inputProduct and outputProduct as EventProduct arrays', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'transformation',
+          inputProducts: [createProduct({ id: 'input-1', name: 'In' })],
+          outputProducts: [createProduct({ id: 'output-1', name: 'Out' })],
+        },
+      });
+      const inputs = subject.inputProduct as Record<string, unknown>[];
+      const outputs = subject.outputProduct as Record<string, unknown>[];
+      expect(inputs).toHaveLength(1);
+      expect((inputs[0].product as Record<string, unknown>).id).toBe('input-1');
+      expect(outputs).toHaveLength(1);
+      expect((outputs[0].product as Record<string, unknown>).id).toBe('output-1');
+    });
+
+    it('does not emit legacy inputEPCList/outputEPCList keys', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'transformation',
+          inputProducts: [createProduct({ id: 'input-1', name: 'In' })],
+        },
+      });
+      expect(subject.inputEPCList).toBeUndefined();
+      expect(subject.outputEPCList).toBeUndefined();
+    });
+  });
+
+  // ── MoveEvent (replaces AggregationEvent) ───────────────────────────────────
+
+  describe('MoveEvent (from aggregation event)', () => {
+    it('sets type to MoveEvent + Event', () => {
+      const subject = bridge.buildSubject({ event: { eventType: 'aggregation' } });
+      expect(subject.type).toEqual(['MoveEvent', 'Event']);
+    });
+
+    it('merges parentProduct + childProducts into movedProduct', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'aggregation',
+          parentProduct: createProduct({ id: 'parent-1', name: 'Box' }),
+          childProducts: [
+            createProduct({ id: 'child-1', name: 'Item A' }),
+            createProduct({ id: 'child-2', name: 'Item B' }),
+          ],
+        },
+      });
+      const moved = subject.movedProduct as Record<string, unknown>[];
+      expect(moved).toHaveLength(3);
+      expect((moved[0].product as Record<string, unknown>).id).toBe('parent-1');
+      expect((moved[1].product as Record<string, unknown>).id).toBe('child-1');
+      expect((moved[2].product as Record<string, unknown>).id).toBe('child-2');
+    });
+
+    it('does not emit legacy parentEPC/childEPCList keys', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'aggregation',
+          parentProduct: createProduct({ id: 'parent-1' }),
+        },
+      });
+      expect(subject.parentEPC).toBeUndefined();
+      expect(subject.childEPCList).toBeUndefined();
+    });
+  });
+
+  // ── MoveEvent (replaces TransactionEvent) ───────────────────────────────────
+
+  describe('MoveEvent (from transaction event)', () => {
+    it('sets type to MoveEvent + Event', () => {
+      const subject = bridge.buildSubject({ event: { eventType: 'transaction' } });
+      expect(subject.type).toEqual(['MoveEvent', 'Event']);
+    });
+
+    it('maps sourceParty and destinationParty to relatedParty with PartyRole entries', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'transaction',
+          sourceParty: 'https://id.gs1.org/417/seller',
+          destinationParty: 'https://id.gs1.org/417/buyer',
+          products: [createProduct({ id: 'traded-1', name: 'Goods' })],
+        },
+      });
+      const parties = subject.relatedParty as Record<string, unknown>[];
+      expect(parties).toHaveLength(2);
+      expect(parties[0].role).toBe('source');
+      expect((parties[0].party as Record<string, unknown>).id).toBe('https://id.gs1.org/417/seller');
+      expect(parties[1].role).toBe('destination');
+      expect((parties[1].party as Record<string, unknown>).id).toBe('https://id.gs1.org/417/buyer');
+    });
+
+    it('builds movedProduct from event.products', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'transaction',
+          products: [createProduct({ id: 'traded-1', name: 'Goods' })],
+        },
+      });
+      const moved = subject.movedProduct as Record<string, unknown>[];
+      expect(moved).toHaveLength(1);
+      expect((moved[0].product as Record<string, unknown>).id).toBe('traded-1');
+    });
+
+    it('does not emit legacy sourceParty/destinationParty top-level keys', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'transaction',
+          sourceParty: 'https://id.gs1.org/417/seller',
+          destinationParty: 'https://id.gs1.org/417/buyer',
+        },
+      });
+      expect(subject.sourceParty).toBeUndefined();
+      expect(subject.destinationParty).toBeUndefined();
+    });
+  });
+
+  // ── AssociationEvent (removed in v0.7.0, mapped to MoveEvent) ──────────────
+
+  describe('association event (removed in v0.7.0)', () => {
+    it('maps association to a MoveEvent for back-compat', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'association',
+          parentProduct: createProduct({ id: 'assembly', name: 'Assembly' }),
+          childProducts: [createProduct({ id: 'component-1', name: 'Part' })],
+        },
+      });
+      expect(subject.type).toEqual(['MoveEvent', 'Event']);
+      const moved = subject.movedProduct as Record<string, unknown>[];
+      expect(moved).toHaveLength(2);
+      expect((moved[0].product as Record<string, unknown>).id).toBe('assembly');
+      expect((moved[1].product as Record<string, unknown>).id).toBe('component-1');
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dte/versions/v070/builder.ts
+++ b/packages/services/src/data-model-bridges/data-models/dte/versions/v070/builder.ts
@@ -1,0 +1,93 @@
+import type { BridgeEntities, CredentialSubject, ProductEntity } from '../../../../types.js';
+
+// v0.7.0 replaces EPCIS-derived event types with semantic ones:
+//   TransformationEvent → MakeEvent
+//   ObjectEvent        → ModifyEvent
+//   AggregationEvent   → MoveEvent
+//   TransactionEvent   → MoveEvent
+//   AssociationEvent   → removed (mapped here to MoveEvent for back-compat)
+
+// ── Private helpers ─────────────────────────────────────────────────────────────
+
+function buildEventProduct(product: ProductEntity) {
+  return {
+    type: ['EventProduct'] as const,
+    product: { type: ['Product'] as const, id: product.id, name: product.name },
+  };
+}
+
+function buildEventProductList(products: ProductEntity[] | undefined) {
+  if (!products || products.length === 0) return undefined;
+  return products.map(buildEventProduct);
+}
+
+function buildPartyRole(partyId: string, role: string) {
+  return {
+    type: ['PartyRole'] as const,
+    role,
+    party: { type: ['Party'] as const, id: partyId },
+  };
+}
+
+// ── Public builder ─────────────────────────────────────────────────────────────
+
+export function buildDteSubject(entities: BridgeEntities): CredentialSubject {
+  const { event, product } = entities;
+
+  if (!event) {
+    // Legacy fallback — no event: emit a bare Event with movedProduct (closest v0.7.0 equivalent)
+    return {
+      type: ['Event'],
+      ...(product ? { movedProduct: [buildEventProduct(product)] } : {}),
+    };
+  }
+
+  switch (event.eventType) {
+    case 'object':
+      return {
+        type: ['ModifyEvent', 'Event'],
+        ...(buildEventProductList(event.products) && { modifiedProduct: buildEventProductList(event.products) }),
+      };
+
+    case 'transformation':
+      return {
+        type: ['MakeEvent', 'Event'],
+        ...(buildEventProductList(event.inputProducts) && { inputProduct: buildEventProductList(event.inputProducts) }),
+        ...(buildEventProductList(event.outputProducts) && {
+          outputProduct: buildEventProductList(event.outputProducts),
+        }),
+      };
+
+    case 'aggregation': {
+      const movedProducts: ProductEntity[] = [];
+      if (event.parentProduct) movedProducts.push(event.parentProduct);
+      if (event.childProducts) movedProducts.push(...event.childProducts);
+      return {
+        type: ['MoveEvent', 'Event'],
+        ...(movedProducts.length > 0 && { movedProduct: movedProducts.map(buildEventProduct) }),
+      };
+    }
+
+    case 'transaction': {
+      const relatedParty = [];
+      if (event.sourceParty) relatedParty.push(buildPartyRole(event.sourceParty, 'source'));
+      if (event.destinationParty) relatedParty.push(buildPartyRole(event.destinationParty, 'destination'));
+      return {
+        type: ['MoveEvent', 'Event'],
+        ...(relatedParty.length > 0 && { relatedParty }),
+        ...(buildEventProductList(event.products) && { movedProduct: buildEventProductList(event.products) }),
+      };
+    }
+
+    case 'association': {
+      // AssociationEvent removed in v0.7.0; closest semantic mapping is MoveEvent
+      const movedProducts: ProductEntity[] = [];
+      if (event.parentProduct) movedProducts.push(event.parentProduct);
+      if (event.childProducts) movedProducts.push(...event.childProducts);
+      return {
+        type: ['MoveEvent', 'Event'],
+        ...(movedProducts.length > 0 && { movedProduct: movedProducts.map(buildEventProduct) }),
+      };
+    }
+  }
+}

--- a/packages/services/src/data-model-bridges/data-models/dte/versions/v070/extractor.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dte/versions/v070/extractor.test.ts
@@ -1,0 +1,265 @@
+import { makeBridge } from '../../../../make-bridge.js';
+import { dteV070Spec } from './index.js';
+import { createProduct, createConformityInput, createBridgeEntities } from '../../../../__fixtures__/entities.js';
+import type { CredentialSubject } from '../../../../types.js';
+
+const EMPTY_ARRAYS = { organisations: [], facilities: [], products: [] };
+
+describe('extractDteRefs (v0.7.0)', () => {
+  const bridge = makeBridge(dteV070Spec);
+
+  // ── edge cases ───────────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('returns empty arrays for null subject', () => {
+      const refs = bridge.extractRefs(null as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays for undefined subject', () => {
+      const refs = bridge.extractRefs(undefined as unknown as CredentialSubject);
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays when no event fields present', () => {
+      const refs = bridge.extractRefs({ type: ['Event'] });
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays when modifiedProduct is empty', () => {
+      const refs = bridge.extractRefs({ type: ['ModifyEvent', 'Event'], modifiedProduct: [] });
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+
+    it('returns empty arrays when EventProduct has no product.id', () => {
+      const refs = bridge.extractRefs({
+        type: ['ModifyEvent', 'Event'],
+        modifiedProduct: [{ type: ['EventProduct'], product: { name: 'A product' } }],
+      });
+      expect(refs).toEqual(EMPTY_ARRAYS);
+    });
+  });
+
+  // ── ModifyEvent: modifiedProduct ────────────────────────────────────────────
+
+  describe('ModifyEvent (modifiedProduct)', () => {
+    it('extracts product ids from modifiedProduct[].product.id', () => {
+      const refs = bridge.extractRefs({
+        type: ['ModifyEvent', 'Event'],
+        modifiedProduct: [
+          { product: { id: 'https://id.gs1.org/01/09520123456788' } },
+          { product: { id: 'https://id.gs1.org/01/09520123456799' } },
+        ],
+      });
+      expect(refs.products).toEqual([
+        { id: 'https://id.gs1.org/01/09520123456788' },
+        { id: 'https://id.gs1.org/01/09520123456799' },
+      ]);
+    });
+
+    it('deduplicates product ids', () => {
+      const refs = bridge.extractRefs({
+        type: ['ModifyEvent', 'Event'],
+        modifiedProduct: [
+          { product: { id: 'https://id.gs1.org/01/09520123456788' } },
+          { product: { id: 'https://id.gs1.org/01/09520123456788' } },
+        ],
+      });
+      expect(refs.products).toEqual([{ id: 'https://id.gs1.org/01/09520123456788' }]);
+    });
+
+    it('extracts modifiedAtFacility id', () => {
+      const refs = bridge.extractRefs({
+        type: ['ModifyEvent', 'Event'],
+        modifiedProduct: [{ product: { id: 'p-1' } }],
+        modifiedAtFacility: { id: 'https://example.org/facility/A' },
+      });
+      expect(refs.facilities).toEqual([{ id: 'https://example.org/facility/A' }]);
+    });
+  });
+
+  // ── MakeEvent: inputProduct + outputProduct ─────────────────────────────────
+
+  describe('MakeEvent (inputProduct + outputProduct)', () => {
+    it('extracts product ids from inputProduct', () => {
+      const refs = bridge.extractRefs({
+        type: ['MakeEvent', 'Event'],
+        inputProduct: [{ product: { id: 'https://id.gs1.org/01/input-1' } }],
+      });
+      expect(refs.products).toEqual([{ id: 'https://id.gs1.org/01/input-1' }]);
+    });
+
+    it('extracts product ids from outputProduct', () => {
+      const refs = bridge.extractRefs({
+        type: ['MakeEvent', 'Event'],
+        outputProduct: [{ product: { id: 'https://id.gs1.org/01/output-1' } }],
+      });
+      expect(refs.products).toEqual([{ id: 'https://id.gs1.org/01/output-1' }]);
+    });
+
+    it('extracts from both input and output, deduplicated', () => {
+      const refs = bridge.extractRefs({
+        type: ['MakeEvent', 'Event'],
+        inputProduct: [
+          { product: { id: 'https://id.gs1.org/01/input-1' } },
+          { product: { id: 'https://id.gs1.org/01/shared' } },
+        ],
+        outputProduct: [
+          { product: { id: 'https://id.gs1.org/01/output-1' } },
+          { product: { id: 'https://id.gs1.org/01/shared' } },
+        ],
+      });
+      expect(refs.products).toEqual([
+        { id: 'https://id.gs1.org/01/input-1' },
+        { id: 'https://id.gs1.org/01/shared' },
+        { id: 'https://id.gs1.org/01/output-1' },
+      ]);
+    });
+
+    it('extracts madeAtFacility id', () => {
+      const refs = bridge.extractRefs({
+        type: ['MakeEvent', 'Event'],
+        madeAtFacility: { registeredId: 'FAC-123' },
+      });
+      expect(refs.facilities).toEqual([{ id: 'FAC-123' }]);
+    });
+  });
+
+  // ── MoveEvent: movedProduct + from/toFacility + relatedParty ────────────────
+
+  describe('MoveEvent (movedProduct + facilities + relatedParty)', () => {
+    it('extracts product ids from movedProduct', () => {
+      const refs = bridge.extractRefs({
+        type: ['MoveEvent', 'Event'],
+        movedProduct: [
+          { product: { id: 'https://id.gs1.org/01/product-1' } },
+          { product: { id: 'https://id.gs1.org/01/product-2' } },
+        ],
+      });
+      expect(refs.products).toEqual([
+        { id: 'https://id.gs1.org/01/product-1' },
+        { id: 'https://id.gs1.org/01/product-2' },
+      ]);
+    });
+
+    it('extracts fromFacility and toFacility ids', () => {
+      const refs = bridge.extractRefs({
+        type: ['MoveEvent', 'Event'],
+        fromFacility: { id: 'facility-origin' },
+        toFacility: { registeredId: 'facility-dest' },
+      });
+      expect(refs.facilities).toEqual([{ id: 'facility-origin' }, { id: 'facility-dest' }]);
+    });
+
+    it('deduplicates facility ids across from/to fields', () => {
+      const refs = bridge.extractRefs({
+        type: ['MoveEvent', 'Event'],
+        fromFacility: { id: 'same-facility' },
+        toFacility: { id: 'same-facility' },
+      });
+      expect(refs.facilities).toEqual([{ id: 'same-facility' }]);
+    });
+
+    it('extracts organisation ids from relatedParty[].party', () => {
+      const refs = bridge.extractRefs({
+        type: ['MoveEvent', 'Event'],
+        relatedParty: [
+          { type: ['PartyRole'], role: 'source', party: { type: ['Party'], id: 'https://id.gs1.org/417/seller' } },
+          { type: ['PartyRole'], role: 'destination', party: { type: ['Party'], id: 'https://id.gs1.org/417/buyer' } },
+        ],
+      });
+      expect(refs.organisations).toEqual([
+        { id: 'https://id.gs1.org/417/seller' },
+        { id: 'https://id.gs1.org/417/buyer' },
+      ]);
+    });
+
+    it('prefers party.registeredId over party.id when both are present', () => {
+      const refs = bridge.extractRefs({
+        type: ['MoveEvent', 'Event'],
+        relatedParty: [{ role: 'source', party: { id: 'did:web:seller', registeredId: 'SELLER-REG' } }],
+      });
+      expect(refs.organisations).toEqual([{ id: 'SELLER-REG' }]);
+    });
+
+    it('deduplicates organisation ids', () => {
+      const refs = bridge.extractRefs({
+        type: ['MoveEvent', 'Event'],
+        relatedParty: [
+          { role: 'source', party: { id: 'https://id.gs1.org/417/same-party' } },
+          { role: 'destination', party: { id: 'https://id.gs1.org/417/same-party' } },
+        ],
+      });
+      expect(refs.organisations).toEqual([{ id: 'https://id.gs1.org/417/same-party' }]);
+    });
+  });
+
+  // ── absent fields ─────────────────────────────────────────────────────────────
+
+  describe('absent fields in result', () => {
+    it('returns empty facilities array when no facility fields present', () => {
+      const refs = bridge.extractRefs({
+        type: ['Event'],
+        movedProduct: [{ product: { id: 'p-1' } }],
+      });
+      expect(refs.facilities).toEqual([]);
+    });
+
+    it('does not include conformity in refs', () => {
+      const refs = bridge.extractRefs({
+        type: ['Event'],
+        movedProduct: [{ product: { id: 'p-1' } }],
+      });
+      expect(refs.conformity).toBeUndefined();
+    });
+  });
+
+  // ── round-trip ───────────────────────────────────────────────────────────────
+
+  describe('round-trip (build → extract)', () => {
+    it('extracts product ref from a fully built fallback subject', () => {
+      const entities = createBridgeEntities({ conformity: [createConformityInput()] });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+
+      expect(refs.products).toHaveLength(1);
+      expect(refs.products[0].id).toBe('did:web:example.com:product:1');
+    });
+
+    it('extracts empty refs when product is absent', () => {
+      const entities = createBridgeEntities({ product: undefined });
+      const subject = bridge.buildSubject(entities);
+      const refs = bridge.extractRefs(subject);
+      expect(refs.products).toEqual([]);
+    });
+
+    it('round-trips a transformation event through MakeEvent', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'transformation',
+          inputProducts: [createProduct({ id: 'input-a' })],
+          outputProducts: [createProduct({ id: 'output-b' })],
+        },
+      });
+      const refs = bridge.extractRefs(subject);
+      expect(refs.products).toEqual([{ id: 'input-a' }, { id: 'output-b' }]);
+    });
+
+    it('round-trips a transaction event through MoveEvent', () => {
+      const subject = bridge.buildSubject({
+        event: {
+          eventType: 'transaction',
+          sourceParty: 'https://id.gs1.org/417/seller',
+          destinationParty: 'https://id.gs1.org/417/buyer',
+          products: [createProduct({ id: 'traded-1' })],
+        },
+      });
+      const refs = bridge.extractRefs(subject);
+      expect(refs.products).toEqual([{ id: 'traded-1' }]);
+      expect(refs.organisations).toEqual([
+        { id: 'https://id.gs1.org/417/seller' },
+        { id: 'https://id.gs1.org/417/buyer' },
+      ]);
+    });
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dte/versions/v070/extractor.ts
+++ b/packages/services/src/data-model-bridges/data-models/dte/versions/v070/extractor.ts
@@ -1,0 +1,88 @@
+import type { CredentialSubject, ExtractedRefs } from '../../../../types.js';
+
+// ── Internal types (mirror builder output shape) ──────────────────────────────
+
+type EventProduct = {
+  product?: { id?: string };
+};
+
+type PartyRole = {
+  party?: { id?: string; registeredId?: string };
+};
+
+type FacilityRef = {
+  id?: string;
+  registeredId?: string;
+};
+
+type DteSubject = {
+  // MakeEvent
+  inputProduct?: EventProduct[];
+  outputProduct?: EventProduct[];
+  madeAtFacility?: FacilityRef;
+  // ModifyEvent
+  modifiedProduct?: EventProduct[];
+  modifiedAtFacility?: FacilityRef;
+  // MoveEvent
+  movedProduct?: EventProduct[];
+  fromFacility?: FacilityRef;
+  toFacility?: FacilityRef;
+  // shared
+  relatedParty?: PartyRole[];
+};
+
+// ── Public extractor ──────────────────────────────────────────────────────────
+
+const EMPTY_REFS: ExtractedRefs = { organisations: [], facilities: [], products: [] };
+
+function pushProductRefs(list: EventProduct[] | undefined, seen: Set<string>, products: { id: string }[]) {
+  if (!list) return;
+  for (const ep of list) {
+    const id = ep.product?.id;
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      products.push({ id });
+    }
+  }
+}
+
+function facilityId(f: FacilityRef | undefined): string | undefined {
+  return f?.registeredId ?? f?.id;
+}
+
+export function extractDteRefs(subject: CredentialSubject): ExtractedRefs {
+  if (!subject) return { ...EMPTY_REFS };
+
+  const dte = subject as DteSubject;
+  const products: { id: string }[] = [];
+  const organisations: { id: string }[] = [];
+  const facilities: { id: string }[] = [];
+  const seenProductIds = new Set<string>();
+  const seenOrgIds = new Set<string>();
+  const seenFacilityIds = new Set<string>();
+
+  pushProductRefs(dte.modifiedProduct, seenProductIds, products);
+  pushProductRefs(dte.inputProduct, seenProductIds, products);
+  pushProductRefs(dte.outputProduct, seenProductIds, products);
+  pushProductRefs(dte.movedProduct, seenProductIds, products);
+
+  if (dte.relatedParty) {
+    for (const pr of dte.relatedParty) {
+      const id = pr.party?.registeredId ?? pr.party?.id;
+      if (id && !seenOrgIds.has(id)) {
+        seenOrgIds.add(id);
+        organisations.push({ id });
+      }
+    }
+  }
+
+  for (const f of [dte.madeAtFacility, dte.modifiedAtFacility, dte.fromFacility, dte.toFacility]) {
+    const id = facilityId(f);
+    if (id && !seenFacilityIds.has(id)) {
+      seenFacilityIds.add(id);
+      facilities.push({ id });
+    }
+  }
+
+  return { organisations, facilities, products };
+}

--- a/packages/services/src/data-model-bridges/data-models/dte/versions/v070/index.ts
+++ b/packages/services/src/data-model-bridges/data-models/dte/versions/v070/index.ts
@@ -1,0 +1,8 @@
+import type { VersionSpec } from '../../../../types.js';
+import { buildDteSubject } from './builder.js';
+import { extractDteRefs } from './extractor.js';
+
+export const dteV070Spec: VersionSpec = {
+  builder: buildDteSubject,
+  extractor: extractDteRefs,
+};


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR adds v0.7.0 builder/extractor bridges for each of the five UNTP core credential types and add them to the bridge registry

## Related Tickets & Documents
#513 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📖 [Reference Implementation docs site](https://uncefact.github.io/tests-untp/docs/reference-implementation/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## API Documentation Updated?

- [ ] 📚 Updated Swagger schemas in `schemas.ts`
- [ ] ✅ Verified Zod schemas match Prisma database schema
- [x] 🙅 No API changes in this PR