### PR TITLE
ci(docs): extract docs build into its own workflow with paths filter

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -437,25 +437,3 @@ jobs:
       - name: Stop playground stack
         if: steps.affected.outputs.result == 'true'
         run: docker compose -f docker-compose.e2e.yml --profile playground down -v
-
-  build_docs:
-    name: Docs build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install and build documentation
-        run: |
-          cd documentation
-          yarn install --frozen-lockfile
-          yarn build
-        env:
-          DOCS_BASE_URL: ${{ vars.DOCS_BASE_URL }}
-          DOCS_URL: ${{ vars.DOCS_URL }}

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,0 +1,44 @@
+name: Docs build
+
+# Only fires when files relevant to the Docusaurus build change. PRs that do
+# not touch any of these paths will not run this workflow and the "Docs build"
+# check will not appear on the PR; branch protection's run-and-pass rule
+# treats an absent check as non-blocking.
+on:
+  pull_request:
+    branches:
+      - next
+    paths:
+      - 'documentation/**'
+      - '.github/workflows/docs_build.yml'
+      - '.nvmrc'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-build-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build_docs:
+    name: Docs build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install and build documentation
+        run: |
+          cd documentation
+          yarn install --frozen-lockfile
+          yarn build
+        env:
+          DOCS_BASE_URL: ${{ vars.DOCS_BASE_URL }}
+          DOCS_URL: ${{ vars.DOCS_URL }}


### PR DESCRIPTION
The `build_docs` job moves out of `build_test.yml` into a new `.github/workflows/docs_build.yml` with `on: pull_request: paths: [documentation/**, .github/workflows/docs_build.yml, .nvmrc]`. PRs that don't touch those paths skip the docs build entirely, no install + Docusaurus build cost.

The job name and body are unchanged so branch protection sees the same `Docs build` check when it does run. The run-and-pass branch-protection rule means an absent check on a non-docs PR isn't a blocker.

Closes #605
Part of #556.