### PR TITLE
feat(release): wire up npm publish via Changesets OIDC and semver Docker tags

### DIFF
--- a/.github/workflows/docker-playground.yml
+++ b/.github/workflows/docker-playground.yml
@@ -1,5 +1,13 @@
 name: Docker — UNTP Playground
 
+# Triggers:
+#   - push to `next` rebuilds the rolling `:next` image on every merge.
+#   - pushing an `untp-playground-v<X.Y.Z>` git tag (e.g.
+#     `untp-playground-v0.3.0`) builds a release image tagged with the
+#     semver tag and `:latest`.
+#   - workflow_dispatch lets a maintainer rebuild a release on demand
+#     without re-tagging git.
+
 on:
   push:
     branches:
@@ -8,7 +16,14 @@ on:
       - 'packages/untp-playground/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/docker-playground.yml'
+    tags:
+      - 'untp-playground-v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver version to tag this build with (e.g. 0.3.0). Omit to push only :next.'
+        required: false
+        type: string
 
 concurrency:
   group: docker-playground-${{ github.ref }}
@@ -45,8 +60,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/untp-playground
+          # Tag strategy mirrors docker-ri.yml.
           tags: |
-            type=raw,value=next
+            type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
+            type=match,pattern=untp-playground-v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/untp-playground-v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/untp-playground-v') }}
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-ri.yml
+++ b/.github/workflows/docker-ri.yml
@@ -1,5 +1,14 @@
 name: Docker — Reference Implementation
 
+# Triggers:
+#   - push to `next` rebuilds the rolling `:next` image on every merge.
+#   - pushing a `reference-implementation-v<X.Y.Z>` git tag (e.g.
+#     `reference-implementation-v0.3.0`) builds a release image tagged
+#     with the semver tag and `:latest`. The semver tag is consumed by
+#     downstream deployments to pin a specific release.
+#   - workflow_dispatch lets a maintainer rebuild a release on demand
+#     without re-tagging git.
+
 on:
   push:
     branches:
@@ -12,7 +21,14 @@ on:
       - 'package.json'
       - 'packages/reference-implementation/Dockerfile'
       - '.github/workflows/docker-ri.yml'
+    tags:
+      - 'reference-implementation-v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver version to tag this build with (e.g. 0.3.0). Omit to push only :next.'
+        required: false
+        type: string
 
 concurrency:
   group: docker-ri-${{ github.ref }}
@@ -49,8 +65,18 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/reference-implementation
+          # Tag strategy:
+          #   - On branch push to `next`: `:next`.
+          #   - On git tag `reference-implementation-vX.Y.Z`: pulls X.Y.Z
+          #     and emits semver tags `:X.Y.Z`, `:X.Y`, `:X`, plus `:latest`.
+          #   - On workflow_dispatch: emits `:next`; if `version` input is
+          #     supplied, also emits `:<version>` and `:latest`.
           tags: |
-            type=raw,value=next
+            type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
+            type=match,pattern=reference-implementation-v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/reference-implementation-v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/reference-implementation-v') }}
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,145 +1,126 @@
 name: Release
 
+# This workflow does two things on push to `next`:
+#   1. If unconsumed changesets exist in `.changeset/`, the changesets
+#      action opens (or updates) a "Version Packages" PR that bumps
+#      versions in package.json files and rewrites CHANGELOG entries.
+#   2. When that "Version Packages" PR merges, the same workflow re-runs
+#      and detects that no changesets remain; it then publishes the
+#      updated packages to npm using OIDC Trusted Publishing (no
+#      long-lived NPM_TOKEN required) and creates the corresponding
+#      GitHub releases.
+#
+# Per-package hold:
+#   The Version Packages PR can be labelled to skip publishing specific
+#   packages from this release. Labels are of the form:
+#     hold:<package-name>
+#   e.g. `hold:@uncefact/untp-utils` or `hold:@uncefact/untp-ri-services`.
+#   Each held package keeps its bumped version + changelog entry on the
+#   merged Version Packages PR (so the next release picks it up), but
+#   `npm publish` is skipped for it. The default with no labels is to
+#   publish every package the Version Packages PR bumped.
+#
+# OIDC publishing requires:
+#   - `id-token: write` permission on the job (set below).
+#   - `--provenance` on `npm publish` (handled by NPM_CONFIG_PROVENANCE
+#     env var below; npm 11+ pairs that with the workflow's OIDC token).
+#   - Each publishable package configured as a Trusted Publisher on
+#     npmjs.com under the `@uncefact` org, pointed at this workflow
+#     filename.
+
 on:
   push:
     branches:
-      - main
-  workflow_dispatch:
+      - next
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
+  pull-requests: write
+  id-token: write
 
 jobs:
-  test_and_build:
+  release:
+    name: Version or publish
     runs-on: ubuntu-latest
+    # Only run on the canonical org repo; forks should not be able to
+    # trigger version PRs or attempt npm publishes.
+    if: github.repository_owner == 'uncefact'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: |
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-
-      - name: Check linting
-        run: pnpm lint
-
-      - name: Run tests
-        run: pnpm test
-
-      # https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-      # https://github.com/uncefact/tests-untp/issues/410
-      - name: Free up space on ubuntu runner for E2E tests
-        run: |
-          sudo rm -rf \
-            "$AGENT_TOOLSDIRECTORY" \
-            /opt/google/chrome \
-            /opt/microsoft \
-            /opt/pipx \
-            /usr/local/.ghcup \
-            /usr/local/graalvm* \
-            /usr/local/julia* \
-            /usr/local/lib/android \
-            /usr/local/share/chromium \
-            /usr/local/share/powershell \
-            /usr/local/share/vcpkg \
-            /usr/share/dotnet \
-            /usr/share/miniconda \
-            /usr/share/swift
-          docker image prune -af
-
-      - name: Start E2E docker compose
-        run: docker compose -f docker-compose.e2e.yml up -d
-
-      - name: Run E2E tests
-        run: pnpm test:run-cypress
-
-      - name: Stop docker compose
-        run: docker compose -f docker-compose.e2e.yml down
-
-  build_docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
-
-      - name: Install and build documentation
-        run: |
-          cd documentation
-          pnpm install --frozen-lockfile
-          pnpm build
-        env:
-          DOCS_BASE_URL: ${{ vars.DOCS_BASE_URL }}
-          DOCS_URL: ${{ vars.DOCS_URL }}
-
-  release:
-    needs: [test_and_build, build_docs]
-    runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.retrieve_version.outputs.new_version }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      # Get the version from version.json file and store it in the output file
-      - name: Get version from version.json
-        id: retrieve_version
-        run: |
-          new_version=$(jq -r '.version' version.json)
-          if [ -z "$new_version" ]; then
-            echo "Error: version field is empty or not found in version.json!"
-            exit 1
-          fi
-          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
-
-      # Create tag to the repository by using the version from the output file
-      - name: Create tag
-        id: create-tag
-        run: |
-          new_version=${{ steps.retrieve_version.outputs.new_version }}
-
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git tag -a "$new_version" -m "Release version $new_version"
-          git push origin "$new_version"
-
-          echo "new_tag=$new_version" >> "$GITHUB_OUTPUT"
-
-      # Create GitHub release
-      - name: Create GitHub Release
+      # Resolve hold labels on the just-merged Version Packages PR. The
+      # 'release' npm script (root package.json) reads PUBLISH_IGNORE
+      # as a comma-separated list of package names to skip during
+      # `changeset publish`. When this workflow runs OUTSIDE of a
+      # Version-Packages-merge (i.e. it's only opening or updating the
+      # PR, not publishing) the lookup short-circuits and PUBLISH_IGNORE
+      # stays empty.
+      - name: Resolve hold labels from merged Version Packages PR
+        id: holds
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          new_version=${{ steps.retrieve_version.outputs.new_version }}
-          new_tag=${{ steps.create-tag.outputs.new_tag }}          
+          set -euo pipefail
+          ignore=""
+          # The latest commit on next is the merge of the Version
+          # Packages PR. Find the PR number via the commit SHA.
+          pr_number=$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state merged \
+              --search "${GITHUB_SHA}" \
+              --json number,title \
+              --jq '.[] | select(.title == "chore(release): version packages") | .number' \
+              | head -n1
+          )
+          if [ -n "${pr_number}" ]; then
+            ignore=$(
+              gh pr view "${pr_number}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json labels \
+                --jq '[.labels[].name | select(startswith("hold:")) | sub("^hold:"; "")] | join(",")'
+            )
+            echo "Found Version Packages PR #${pr_number}; hold list: '${ignore}'"
+          else
+            echo "No merged Version Packages PR for this commit; nothing to hold."
+          fi
+          echo "ignore=${ignore}" >> "$GITHUB_OUTPUT"
 
-          sed -n "/## \[$new_version\]/,/## \[/p" CHANGELOG.md | sed '$d' > release_notes.md
-
-          gh release create "$new_tag" \
-            --title "Release ${{ steps.retrieve_version.outputs.new_version }}" \
-            --notes-file release_notes.md \
-            --target ${{ github.ref_name }}
+      - name: Create release PR or publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          version: pnpm changeset version
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No NPM_TOKEN: publishing uses npm OIDC Trusted Publishing.
+          # NPM_CONFIG_PROVENANCE pairs the OIDC token with the publish
+          # action so each release ships a provenance attestation.
+          NPM_CONFIG_PROVENANCE: 'true'
+          # Comma-separated package names to skip during `changeset
+          # publish`. Read by scripts/release.mjs.
+          PUBLISH_IGNORE: ${{ steps.holds.outputs.ignore }}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "storybook:components": "pnpm --filter @reference-implementation/components run storybook",
     "storybook:reference-implementation": "pnpm --filter untp-reference-implementation run storybook",
     "changeset": "changeset",
+    "release": "node scripts/release.mjs",
     "prepare": "husky install",
     "lint:check": "cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint packages",
     "lint:fix": "cross-env NODE_OPTIONS=--max-old-space-size=8192 eslint packages --fix",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * Build the publishable libraries and invoke `changeset publish`, optionally
+ * skipping packages named in the `PUBLISH_IGNORE` env var.
+ *
+ * `PUBLISH_IGNORE` is a comma-separated list of fully-qualified package
+ * names (e.g. `@uncefact/untp-utils,@uncefact/untp-ri-services`). It is
+ * populated by `.github/workflows/release.yml` from `hold:<name>` labels
+ * applied to the Version Packages PR before merge.
+ *
+ * Each name becomes a `--ignore <name>` flag passed to changeset publish.
+ * Held packages keep their bumped version + changelog entry on `next`
+ * (since the Version Packages PR has already merged) but are not published
+ * to npm in this run. The next release will pick them up automatically
+ * because their changeset entries have already been consumed.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', shell: false, ...options });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+run('pnpm', ['--filter', '@uncefact/untp-utils', 'run', 'build']);
+run('pnpm', ['--filter', '@uncefact/untp-ri-services', 'run', 'build']);
+
+const rawIgnore = process.env.PUBLISH_IGNORE ?? '';
+const ignored = rawIgnore
+  .split(',')
+  .map((entry) => entry.trim())
+  .filter((entry) => entry.length > 0);
+
+const publishArgs = ['publish'];
+for (const name of ignored) {
+  publishArgs.push('--ignore', name);
+}
+
+if (ignored.length > 0) {
+  console.log(`Publishing with --ignore for: ${ignored.join(', ')}`);
+} else {
+  console.log('Publishing all bumped packages (no PUBLISH_IGNORE entries).');
+}
+
+run('pnpm', ['exec', 'changeset', ...publishArgs]);


### PR DESCRIPTION
This PR adds the publishing pipelines that the Changesets adoption in #610 sets up: npm publishing for the three publishable `@uncefact/*` libraries via Changesets + OIDC Trusted Publishing, semver-aware tagging for the reference implementation and playground Docker images, and a per-package hold mechanism so the Version Packages PR can publish some packages while holding back others.

Rebased onto current `next` (post pnpm migration) and updated all build/release scripts to use pnpm.

## npm publishing

`.github/workflows/release.yml` is replaced with a Changesets-action release flow:

- Triggers on push to `next`.
- If unconsumed changesets are present, opens (or updates) a `chore(release): version packages` PR that bumps versions and rewrites changelogs.
- When that PR merges, the workflow re-runs and publishes the updated packages to npm.
- Publishing uses **npm OIDC Trusted Publishing**: the job holds `id-token: write` and pairs that token with `--provenance` via `NPM_CONFIG_PROVENANCE=true`. No long-lived `NPM_TOKEN` is required. Each publishable package must be configured as a Trusted Publisher on npmjs.com under the `@uncefact` org, pointed at `.github/workflows/release.yml`.

The legacy `version.json`-driven release path is removed. `version.json` itself stays because `documentation/version-mapping/script.js` still reads it.

## Per-package hold labels

Applying labels of the form `hold:<package-name>` to the **merged** Version Packages PR skips `npm publish` for those specific packages during this release. Examples:

- `hold:@uncefact/untp-utils` → utils stays at its bumped version on `next` but is not pushed to npm
- `hold:@uncefact/untp-ri-services` → services stays at its bumped version on `next` but is not pushed to npm

The held package's bumped version and changelog entry remain on `next` (the Version Packages PR has already merged). The next release picks the package up automatically because its changeset has been consumed; if you want a deferred publish, push a new changeset bumping the same package at the right level when you're ready.

Mechanism:

1. `release.yml` resolves the merged Version Packages PR for the current commit and extracts every `hold:` label.
2. The labels are passed as `PUBLISH_IGNORE` (comma-separated package names) to the `release` npm script.
3. `scripts/release.mjs` builds the publishable libraries and invokes `changeset publish`, forwarding each held name as `--ignore <name>`.

Default behaviour (no labels) is unchanged: every bumped package publishes.

## Docker image tagging

`.github/workflows/docker-ri.yml` and `.github/workflows/docker-playground.yml` now support three trigger modes:

| Trigger | Tags produced |
| --- | --- |
| push to `next` | `:next` |
| push of `reference-implementation-v<X.Y.Z>` or `untp-playground-v<X.Y.Z>` git tag | `:X.Y.Z`, `:X.Y`, `:X`, `:latest` |
| `workflow_dispatch` with `version` input | `:<version>`, `:latest` |

`docker/metadata-action` extracts the semver from the tag via a `type=match,pattern=...,group=1` rule, so consumers can pin to a specific release.

## Test plan
- [x] yaml lint passes on all three workflow files
- [ ] Setup-side: each package needs to be configured as a Trusted Publisher on npmjs.com before the first publish; tracked outside this PR

Closes part of #556 (release pipelines + multi-arch Docker).