### PR TITLE
perf(docker): exclude packages/*/e2e from image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,8 +15,10 @@ docker-compose.e2e-closed.yml
 # Per-app E2E suites live at packages/<app>/e2e/. None of their
 # contents (Cypress specs, fixtures, support helpers, .env.e2e) belong
 # in any production image, and including them invalidates the builder
-# stage's COPY layer on every spec change. Exclude all e2e/ dirs.
-**/e2e
+# stage's COPY layer on every spec change. Exclude all e2e/ dirs;
+# the trailing slash keeps the rule directory-only so a hypothetical
+# file named `e2e` in source would not be filtered.
+**/e2e/
 .git
 .gitignore
 .github

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 docker-compose.yaml
 docker-compose.e2e.yml
+docker-compose.e2e-closed.yml
 .dockerignore
 **/Dockerfile
 **/node_modules
@@ -11,6 +12,11 @@ docker-compose.e2e.yml
 **/build
 **/.next
 **/tsconfig.tsbuildinfo
+# Per-app E2E suites live at packages/<app>/e2e/. None of their
+# contents (Cypress specs, fixtures, support helpers, .env.e2e) belong
+# in any production image, and including them invalidates the builder
+# stage's COPY layer on every spec change. Exclude all e2e/ dirs.
+**/e2e
 .git
 .gitignore
 .github
@@ -31,16 +37,11 @@ logs
 aws
 .DS_Store
 .storybook
-e2e/package.json
-e2e/yarn.lock
-e2e/node_modules
 minio_data
 documentation
 local.env
 
-packages/untp-test-suite
 packages/untp-test-suite-mocha
-packages/vc-test-suite
 
 packages/reference-implementation/src/constants/app-config.json
 packages/components/src/constants/app-config.json


### PR DESCRIPTION
Adds `**/e2e` to `.dockerignore` so the per-app Cypress suites (`packages/reference-implementation/e2e/`, `packages/untp-playground/e2e/`) are excluded from the Docker build context. None of those files are needed at runtime, and including them was the dominant source of unnecessary image rebuilds.

Verified locally with a probe image: a `find /context -name e2e -type d` against a fresh build context returns nothing under `packages/*/e2e/`.

## Why this matters

The RI builder stage's `COPY packages/reference-implementation/. ./packages/reference-implementation/` pulled in the entire `e2e/` subtree on every build. Any Cypress spec edit, fixture tweak, or config change invalidated the COPY layer and forced `yarn install` plus the workspace builds to rerun even though nothing about the production image changed. After this PR, only true source/dep changes in `src/`, `prisma/`, `public/`, or `package.json` invalidate the builder stage.

The same goes for the playground Dockerfile: `COPY packages/untp-playground/. .` no longer pulls in its e2e suite.

## Also cleaned up

Stale `.dockerignore` entries pointing at directories that no longer exist on `next`:

- `e2e/package.json`, `e2e/yarn.lock`, `e2e/node_modules` — the root `e2e/` workspace was removed by #607.
- `packages/untp-test-suite`, `packages/vc-test-suite` — both removed by #608.

Added `docker-compose.e2e-closed.yml` to match the existing entries for the other two compose files.

## Test plan
- [x] Probe image confirms `**/e2e` excludes both `packages/reference-implementation/e2e/` and `packages/untp-playground/e2e/` from the build context
- [ ] CI's `Build E2E image (RI)` and `Build E2E image (playground)` steps both green on the new branch
- [ ] Cache behaviour: a follow-up PR that only touches `packages/reference-implementation/e2e/cypress/...` should NOT trigger a real image rebuild (cache hit instead). Measurable in subsequent runs, not this PR.