### PR TITLE
fix(ci): install documentation deps with --ignore-workspace in Pages workflow

### DIFF
--- a/.github/workflows/buld_publish_docs.yml
+++ b/.github/workflows/buld_publish_docs.yml
@@ -20,7 +20,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: cd documentation && pnpm install --frozen-lockfile
+        run: cd documentation && pnpm install --ignore-workspace --frozen-lockfile
 
       - name: Build website
         run: cd documentation && pnpm build


### PR DESCRIPTION
This PR adds `--ignore-workspace` to the documentation install step in the Pages deploy workflow, which lets docusaurus resolve from `documentation/node_modules` at build time and unblocks deploys to GitHub Pages on every push to `next`.

The pnpm migration (#619) added the same flag to `docs_build.yml` (the PR-trigger workflow) but missed the deploy-on-push companion in `buld_publish_docs.yml`. Without it, `cd documentation && pnpm install --frozen-lockfile` is treated as a workspace install ("Scope: all 9 workspace projects"), and the subsequent build step fails with `sh: 1: docusaurus: not found`. The most recent push to `next` (run 25793262938) is the first concrete failure.

## Test plan
- [x] Diff matches the pattern already used by `docs_build.yml` line 43.
- [ ] Verified by the next push-to-next run of the workflow; this is the first signal we can act on.