### PR TITLE
fix(ci): install playground infra deps with --ignore-workspace

### DIFF
--- a/.github/workflows/ci_cd-untp-playground.yml
+++ b/.github/workflows/ci_cd-untp-playground.yml
@@ -49,7 +49,7 @@ jobs:
           cache: pnpm
   
       - name: Installing dependencies 📦️
-        run: pnpm install
+        run: pnpm install --ignore-workspace
         working-directory: ./packages/untp-playground/infra
 
       - name: Deploy Stack
@@ -105,7 +105,7 @@ jobs:
           cache: pnpm
   
       - name: Installing dependencies 📦️
-        run: pnpm install
+        run: pnpm install --ignore-workspace
         working-directory: ./packages/untp-playground/infra
 
       - name: Deploy Stack


### PR DESCRIPTION
This PR adds `--ignore-workspace` to the `pnpm install` step in both deploy jobs of `ci_cd-untp-playground.yml`, which lets `@pulumi/pulumi` resolve from `packages/untp-playground/infra/node_modules` so the deploy step can find the Pulumi SDK and the workflow stops failing on push to `next`.

`packages/untp-playground/infra` is not a member of `pnpm-workspace.yaml` (which globs `packages/*` and `packages/*/e2e`). Without the flag, pnpm walks up to the workspace root and runs a workspace-wide install ("Scope: all 9 workspace projects" in the log), leaving infra's own `node_modules` empty and producing the "Pulumi SDK has not been installed" error seen on run [25797247858](https://github.com/uncefact/tests-untp/actions/runs/25797247858/job/75777578278). Same fix pattern applied to the Pages workflow in #621.

## Test plan
- [ ] Verified by the next push-to-`next` deploy_test run; the install step should now resolve infra-only and the Pulumi `up` step should reach a normal preview/apply.