### PR TITLE
fix(playground): prefix NEXT_PUBLIC_BASE_PATH on new /api callers

### DIFF
--- a/packages/untp-playground/constants.ts
+++ b/packages/untp-playground/constants.ts
@@ -108,3 +108,9 @@ export const allowedContextValue = {
 export const allowedExtensionValue = {
   '@context': [...commonContextUrls, 'https://{extension.domain}/{type}/{version}/'],
 };
+
+// Next.js inlines `NEXT_PUBLIC_*` at build time, so this constant captures
+// the deploy-time base path (e.g. `/test-untp-playground`) once and lets
+// every client-side `/api/*` caller prefix it consistently. The fallback
+// empty string keeps local dev (where the var is unset) working.
+export const API_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || '';

--- a/packages/untp-playground/src/components/ArtefactUploader.tsx
+++ b/packages/untp-playground/src/components/ArtefactUploader.tsx
@@ -9,6 +9,7 @@ import { Loader2, Upload } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { toast } from 'sonner';
+import { API_BASE_PATH } from '../../constants';
 
 const MAX_FETCH_BYTES = 10 * 1_048_576;
 
@@ -99,8 +100,7 @@ export function ArtefactUploader({
     setFetchError(null);
     setIsFetching(true);
     try {
-      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-      const response = await fetch(`${basePath}/api/fetch`, {
+      const response = await fetch(`${API_BASE_PATH}/api/fetch`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ url: trimmed }),

--- a/packages/untp-playground/src/components/ArtefactUploader.tsx
+++ b/packages/untp-playground/src/components/ArtefactUploader.tsx
@@ -99,7 +99,8 @@ export function ArtefactUploader({
     setFetchError(null);
     setIsFetching(true);
     try {
-      const response = await fetch('/api/fetch', {
+      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+      const response = await fetch(`${basePath}/api/fetch`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ url: trimmed }),

--- a/packages/untp-playground/src/lib/schemaValidation.ts
+++ b/packages/untp-playground/src/lib/schemaValidation.ts
@@ -1,6 +1,7 @@
 import addFormats from 'ajv-formats';
 import Ajv2020 from 'ajv/dist/2020';
 import {
+  API_BASE_PATH,
   UNTP_CORE_SCHEMA_FILENAMES,
   UNTP_SHORT_CREDENTIAL_TYPES,
   VCDM_SCHEMA_URLS,
@@ -31,8 +32,7 @@ async function fetchSchema(schemaUrl: string): Promise<any> {
   if (inflight) {
     return inflight;
   }
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_PATH || '';
-  const proxyUrl = `${baseUrl}/api/schema?url=${encodeURIComponent(schemaUrl)}`;
+  const proxyUrl = `${API_BASE_PATH}/api/schema?url=${encodeURIComponent(schemaUrl)}`;
   // Evict the in-flight entry once settled so a transient failure doesn't poison the cache.
   const promise = (async () => {
     try {

--- a/packages/untp-playground/src/lib/schemeValidation.ts
+++ b/packages/untp-playground/src/lib/schemeValidation.ts
@@ -1,6 +1,11 @@
 import addFormats from 'ajv-formats';
 import Ajv2020 from 'ajv/dist/2020';
-import { UNTP_CONTEXT_DOMAINS, UNTP_CORE_SCHEMA_FILENAMES, UNTP_SHORT_CREDENTIAL_TYPES } from '../../constants';
+import {
+  API_BASE_PATH,
+  UNTP_CONTEXT_DOMAINS,
+  UNTP_CORE_SCHEMA_FILENAMES,
+  UNTP_SHORT_CREDENTIAL_TYPES,
+} from '../../constants';
 import { schemaCache } from './schemaValidation';
 
 const ajv = new Ajv2020({
@@ -37,8 +42,7 @@ async function fetchSchema(schemaUrl: string): Promise<any> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), SCHEMA_FETCH_TIMEOUT_MS);
     try {
-      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-      const response = await fetch(`${basePath}/api/schema?url=${encodeURIComponent(schemaUrl)}`, {
+      const response = await fetch(`${API_BASE_PATH}/api/schema?url=${encodeURIComponent(schemaUrl)}`, {
         signal: controller.signal,
       });
       if (response.status === 404) {

--- a/packages/untp-playground/src/lib/schemeValidation.ts
+++ b/packages/untp-playground/src/lib/schemeValidation.ts
@@ -37,7 +37,8 @@ async function fetchSchema(schemaUrl: string): Promise<any> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), SCHEMA_FETCH_TIMEOUT_MS);
     try {
-      const response = await fetch(`/api/schema?url=${encodeURIComponent(schemaUrl)}`, {
+      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+      const response = await fetch(`${basePath}/api/schema?url=${encodeURIComponent(schemaUrl)}`, {
         signal: controller.signal,
       });
       if (response.status === 404) {


### PR DESCRIPTION
This PR prefixes the deployment base path onto the two `/api` calls added in #625, which means ConformityScheme validation and the artefact URL fetcher work on `test.uncefact.org/test-untp-playground` instead of returning 403 from the load balancer because the request never reaches the playground container.

## Cause

The deploy sets `NEXT_PUBLIC_BASE_PATH=/test-untp-playground` and Next.js mounts the API routes under that prefix. The DPP schema caller in `schemaValidation.ts` already constructs the URL as `${basePath}/api/schema?...` and works. The two new callers introduced by #625 do not:

- `src/lib/schemeValidation.ts:40` issued `/api/schema?url=...`
- `src/components/ArtefactUploader.tsx:102` issued `/api/fetch`

Both hit the ALB at `test.uncefact.org/api/...`, which is outside the playground's mount, and return 403.

## Fix

Both callers now read `process.env.NEXT_PUBLIC_BASE_PATH` (Next.js inlines `NEXT_PUBLIC_*` at build time) and prefix it onto the URL, mirroring the existing DPP pattern.

## Test plan
- [x] `pnpm --filter untp-playground build` clean on Node 22.22.2.
- [x] Playground Jest 239 tests pass.
- [ ] Verified by the next deploy_test run on `next`: ConformityScheme schema fetch and artefact URL fetch both succeed under `test.uncefact.org/test-untp-playground`.