### PR TITLE
fix(ci): gate prod deploy and :latest image on stable release tags

### DIFF
--- a/.github/workflows/ci_cd-untp-playground.yml
+++ b/.github/workflows/ci_cd-untp-playground.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - next
       - 'cd/**'
+    tags:
+      - 'untp-playground-v*'
     paths:
       - 'packages/untp-playground/**'
       - '.github/workflows/ci_cd-untp-playground.yml'
@@ -69,7 +71,19 @@ jobs:
           STACK_NAME: test
 
   deploy_prod:
-    if: github.repository_owner == 'uncefact' && github.ref_type == 'tag' && github.event_name == 'workflow_dispatch'
+    # Stable releases only. A tag push for `untp-playground-v<X.Y.Z>` deploys
+    # to prod; pre-release tags carrying a `-rc` / `-alpha` / `-beta` / `-pre`
+    # suffix on the version do not. workflow_dispatch against a stable tag
+    # still works for a manual re-deploy.
+    if: >-
+      github.repository_owner == 'uncefact' &&
+      github.ref_type == 'tag' &&
+      startsWith(github.ref, 'refs/tags/untp-playground-v') &&
+      !contains(github.ref_name, '-rc') &&
+      !contains(github.ref_name, '-alpha') &&
+      !contains(github.ref_name, '-beta') &&
+      !contains(github.ref_name, '-pre') &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     concurrency:
       group: untp-plaground-${{github.ref}}
 

--- a/.github/workflows/docker-playground.yml
+++ b/.github/workflows/docker-playground.yml
@@ -64,7 +64,7 @@ jobs:
           tags: |
             type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
             type=match,pattern=untp-playground-v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/untp-playground-v') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/untp-playground-v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/untp-playground-v') && !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-pre') }}
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
 

--- a/.github/workflows/docker-ri.yml
+++ b/.github/workflows/docker-ri.yml
@@ -74,7 +74,7 @@ jobs:
           tags: |
             type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
             type=match,pattern=reference-implementation-v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/reference-implementation-v') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/reference-implementation-v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/reference-implementation-v') && !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-pre') }}
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
 


### PR DESCRIPTION
Two release-tag bugs surfaced when `untp-playground-v0.3.0` was pushed.

- `ci_cd-untp-playground.yml` did not subscribe to tag pushes, so the tag never started the workflow. The `deploy_prod` job's gate also required `workflow_dispatch`, which a tag push can never satisfy.
- `:latest` in both `docker-playground.yml` and `docker-ri.yml` was applied for any matching tag, including pre-releases.

This PR adds the tag pattern to the playground workflow's trigger, loosens the prod gate to accept tag pushes, and tightens both Docker workflows so `:latest` is reserved for stable semver. Tags carrying `-rc` / `-alpha` / `-beta` / `-pre` suffixes still produce a versioned image (so RC builds are installable) but do not claim `:latest` and do not deploy to prod.