### PR TITLE
docs(adr): per-package tag-triggered npm release (supersedes Changesets ADRs)

### DIFF
--- a/docs/adrs/004-changesets-for-version-management.md
+++ b/docs/adrs/004-changesets-for-version-management.md
@@ -1,7 +1,8 @@
 # ADR: Changesets for version management and publishing
 
 - **Date:** 2026-05-12
-- **Status:** accepted
+- **Status:** superseded by [031](./031-per-package-tag-triggered-npm-release.md)
+- **Update (2026-05-15):** Changesets is removed from the repository. Per-package tag-triggered npm publishing replaces it; see ADR 031 for the new model and the rationale for the change.
 
 ## Context
 

--- a/docs/adrs/005-changeset-enforcement-via-three-layers.md
+++ b/docs/adrs/005-changeset-enforcement-via-three-layers.md
@@ -1,7 +1,8 @@
 # ADR: Changeset enforcement via three layers
 
 - **Date:** 2026-05-12
-- **Status:** proposed
+- **Status:** superseded by [031](./031-per-package-tag-triggered-npm-release.md)
+- **Update (2026-05-15):** Changesets is removed from the repository, so per-PR changeset enforcement no longer applies. See ADR 031 for the replacement release model.
 
 ## Context
 

--- a/docs/adrs/013-release-workflow-correctness-measures.md
+++ b/docs/adrs/013-release-workflow-correctness-measures.md
@@ -1,8 +1,9 @@
 # ADR: Release workflow correctness measures
 
 - **Date:** 2026-05-12
-- **Status:** accepted
+- **Status:** superseded by [031](./031-per-package-tag-triggered-npm-release.md)
 - **Update (2026-05-13):** `release.yml` currently triggers on `push: branches: main`. PR #611 proposes switching it to `push: next` with Changesets-driven OIDC publishing, but is not yet merged. The pnpm migration on this branch converted the workflow's install step from yarn to pnpm without touching the trigger or the correctness measures (idempotency, single concurrency group, etc.), which are unchanged.
+- **Update (2026-05-15):** The single-workflow decision in this ADR is reversed by ADR 031. The portable correctness measures (SHA pin + verification, `cancel-in-progress: false`, npm provenance, `.nvmrc`) carry forward into the per-package publish workflows. The `GITHUB_TOKEN`-doesn't-trigger-downstream-workflows concern that justified the single-workflow design no longer applies because tag pushes are now deliberate human actions.
 
 ## Context
 

--- a/docs/adrs/022-rc-cycles-via-changesets-pre-mode.md
+++ b/docs/adrs/022-rc-cycles-via-changesets-pre-mode.md
@@ -1,7 +1,8 @@
 # ADR: Release candidate cycles via Changesets pre mode
 
 - **Date:** 2026-05-12
-- **Status:** proposed
+- **Status:** superseded by [031](./031-per-package-tag-triggered-npm-release.md)
+- **Update (2026-05-15):** Changesets pre mode is replaced by SemVer-suffixed tags. A tag of the form `<prefix>-v<X.Y.Z>-rc.N` publishes to the `rc` dist-tag; promotion to stable is a tag push without the suffix. See ADR 031.
 
 ## Context
 

--- a/docs/adrs/026-release-runbook-for-failure-recovery.md
+++ b/docs/adrs/026-release-runbook-for-failure-recovery.md
@@ -1,7 +1,8 @@
 # ADR: Release runbook for failure recovery
 
 - **Date:** 2026-05-12
-- **Status:** proposed
+- **Status:** superseded by [031](./031-per-package-tag-triggered-npm-release.md)
+- **Update (2026-05-15):** Failure recovery is now handled by the `unpublish-or-deprecate` workflow described in ADR 031. The two outcomes (npm unpublish within the 72 h window; npm deprecate beyond it) are wired into the same `workflow_dispatch`-only workflow that authenticates via OIDC Trusted Publishing.
 
 ## Context
 

--- a/docs/adrs/031-per-package-tag-triggered-npm-release.md
+++ b/docs/adrs/031-per-package-tag-triggered-npm-release.md
@@ -1,0 +1,103 @@
+# ADR: Per-package tag-triggered npm release
+
+- **Date:** 2026-05-15
+- **Status:** accepted
+- **Supersedes:** [004](./004-changesets-for-version-management.md), [005](./005-changeset-enforcement-via-three-layers.md), [013](./013-release-workflow-correctness-measures.md), [022](./022-rc-cycles-via-changesets-pre-mode.md), [026](./026-release-runbook-for-failure-recovery.md)
+
+## Context
+
+ADR 004 adopted Changesets for version management and publishing across the publishable npm surface (`@uncefact/untp-ri-services` and `@uncefact/untp-utils`). ADRs 005, 013, 022 and 026 build on that decision (per-PR enforcement, single-workflow correctness measures, RC cycles via pre mode, and the failure-recovery runbook respectively).
+
+In practice the Changesets model couples release cadence across packages. Each merge to `next` accumulates pending changesets into a single "Version Packages" PR; merging that PR fires `changeset publish` and ships every accumulated bump in lock-step. The per-package hold mechanism added in #611 papered over the symptom, but the root issue is the shared release event itself: shipping any single package requires either holding back the others or accepting that they ship at the same time.
+
+The reference implementation and the playground already solve the cadence problem in a different way. Each Docker image is built from a per-app tag (`reference-implementation-v<X.Y.Z>`, `untp-playground-v<X.Y.Z>`); the tag push is the release event; the workflow is scoped to that one artefact. The pattern is well-understood, easy to reason about, and lines up with how publishing actually feels (open a release, push a tag, ship a thing).
+
+This ADR brings the npm-publishable packages onto the same pattern.
+
+## Decision
+
+Each publishable npm package owns its own tag prefix and its own publish workflow. Release cycles decouple completely; one package ships when its maintainer pushes its tag.
+
+**Tag pattern.** Short package name (no `@uncefact/` scope) plus `-v<X.Y.Z>`:
+
+| Package | Tag prefix | Example tag |
+|---|---|---|
+| `@uncefact/untp-ri-services` | `untp-ri-services-v` | `untp-ri-services-v1.2.3` |
+| `@uncefact/untp-utils` | `untp-utils-v` | `untp-utils-v0.5.0-rc.1` |
+
+Pre-release tags carry an SemVer suffix (`-rc.N`, `-alpha.N`, `-beta.N`, `-pre.N`). Stable tags carry only `X.Y.Z`.
+
+**Workflow per package.** Two workflows are added, one per publishable package:
+
+- `.github/workflows/publish-untp-utils.yml`
+- `.github/workflows/publish-untp-ri-services.yml`
+
+Each workflow:
+
+1. Triggers on `push` of a tag matching its prefix.
+2. Checks out the tagged commit with `ref: ${{ github.sha }}` and a verification step that fails the workflow if the checked-out HEAD does not match (carrying forward the SHA-pin practice from ADR 013).
+3. Reads the package's `package.json`. Refuses to publish if the version in `package.json` does not match the version in the tag. This prevents the "tag says 1.2.3, package says 1.2.2" class of mismatch.
+4. Builds the package (and the workspace dependencies it transitively requires).
+5. Publishes to npm with `--provenance`. Stable tags publish with `--tag latest`; pre-release tags publish with `--tag rc`. Consumers that want pre-releases must opt in explicitly via `npm install @uncefact/<pkg>@rc`; `npm install @uncefact/<pkg>` always resolves to the latest stable.
+6. Authenticates with npm via OIDC Trusted Publishing (`id-token: write`, no long-lived `NPM_TOKEN`). Each package must be configured as a Trusted Publisher on npmjs.com under the `@uncefact` org, pointed at its specific workflow filename.
+
+**Rollback / archive workflow.** A single `workflow_dispatch`-only workflow (`unpublish-or-deprecate.yml`) handles withdrawal:
+
+- Inputs: `package` (dropdown of publishable packages), `version` (string), `action` (`unpublish` | `deprecate`), `message` (string).
+- `unpublish` runs `npm unpublish <pkg>@<version>`. npm only permits unpublish within 72 hours of the version's first publish (and only when no other versions depend on it). Outside that window the command fails loudly; that failure is the prompt to fall back to `deprecate`.
+- `deprecate` runs `npm deprecate <pkg>@<version> "<message>"`. The version remains installable but `npm install` emits a warning and the version is hidden from typical version listings. This is the long-term archive path for broken releases that cannot be unpublished.
+
+The same workflow authenticates via OIDC Trusted Publishing — no separate token surface for the rollback path.
+
+**Correctness measures inherited from ADR 013.** The portable practices stay in place:
+
+- Explicit SHA checkout with a verification step.
+- Per-package `concurrency` group with `cancel-in-progress: false` (a half-published release would be worse than a queued release).
+- npm `--provenance` and `id-token: write`.
+- `actions/setup-node` reads `.nvmrc`.
+
+The "single workflow" choice from ADR 013 is reversed. ADR 013 rejected the multi-workflow alternative on the grounds that a `GITHUB_TOKEN` cannot trigger downstream workflows. That concern only applied to workflow-created tags (the Changesets action creating tags from the release workflow). Under this ADR the tag push is a deliberate human action, and tag-triggered workflows fire from human pushes without restriction.
+
+**Changesets footprint removed.** The implementation PR that follows this ADR deletes `.changeset/`, `scripts/release.mjs`, `.github/workflows/release.yml`, the `@changesets/cli` devDep, and the `changeset` / `release` scripts from the root `package.json`.
+
+## Consequences
+
+**What becomes easier**
+
+- Releases decouple. Shipping `@uncefact/untp-utils@0.5.1` does not block on the state of `@uncefact/untp-ri-services`. The release cadence per package is no longer the slowest sibling's cadence.
+- The mental model is uniform across the four release surfaces (services, utils, reference implementation, playground). All four shape: bump version → push tag → workflow does the rest.
+- No PR-time changeset authoring burden. Version bumps happen at release time on a maintainer's machine (or via a small "bump and tag" GitHub UI flow), not on every merging PR.
+- Pre-releases are first-class. A tag of the form `<prefix>-v0.6.0-rc.1` publishes to `rc` without ceremony; promotion to stable is just another tag push with the suffix removed.
+- Rollback has a single documented path with two outcomes (unpublish vs deprecate), both wired into the same workflow.
+
+**What becomes harder**
+
+- No centralised release-notes aggregation across packages. Each package's release notes live in its own `CHANGELOG.md` and (where the package warrants one) `RELEASE_NOTES.md`. Maintainers write these by hand before tagging, the same way the playground does today.
+- Version bumps move from PR-time to release-time. The "did I forget a changeset?" check no longer exists; instead the workflow's `package.json` ↔ tag-version match check catches forgotten bumps at tag push.
+- Maintainers must remember the per-package tag prefixes. A `docs/RELEASES.md` runbook (added in the implementation PR) documents them.
+
+## Alternatives Considered
+
+### Keep Changesets, expand the per-package hold mechanism
+
+Rejected. The hold labels (PR #611) skip publishing for specific packages on a given release event, but the release event itself is still shared across the publishable surface. The cadence-coupling stays. The hold mechanism is a workaround for the symptom, not the cause.
+
+### Move to release-please
+
+Rejected. release-please solves a similar problem (per-package release PRs) and would technically be a fit, but it duplicates the operational model the repository already runs for the playground and reference implementation. Adopting the same pattern across all four release surfaces is simpler than running two release tools side by side.
+
+### Per-package "Version Packages" PRs via Changesets `fixed`/`linked` groups
+
+Rejected. Changesets supports grouping packages so that a single bump in one package automatically bumps the others. This is the opposite of the decoupling goal: it forces version lock-step. The Changesets config knobs that would help (one Version Packages PR per package) don't exist as first-class features and would need to be hacked in via multiple instances of Changesets at different paths, which is more complexity than the per-package workflow approach.
+
+### Single shared parameterised publish workflow
+
+Rejected. A parameterised workflow that detects the package from the tag prefix would reduce duplication but would push tag-pattern matching into workflow logic, making it harder to see at a glance which package each workflow ships. With only two publishable packages, the duplication is contained. Adopt the parameterised pattern only if the publishable surface grows to a point where duplication becomes painful.
+
+## References
+
+- ADR 011: Independent versioning across four release streams (the framing this ADR builds on)
+- npm Trusted Publishing: https://docs.npmjs.com/trusted-publishers
+- npm unpublish policy: https://docs.npmjs.com/policies/unpublish
+- npm deprecate: https://docs.npmjs.com/cli/v10/commands/npm-deprecate
+- PR #611: Changesets npm publish wiring (the implementation now being superseded)

--- a/docs/adrs/031-per-package-tag-triggered-npm-release.md
+++ b/docs/adrs/031-per-package-tag-triggered-npm-release.md
@@ -25,7 +25,7 @@ Each publishable npm package owns its own tag prefix and its own publish workflo
 | `@uncefact/untp-ri-services` | `untp-ri-services-v` | `untp-ri-services-v1.2.3` |
 | `@uncefact/untp-utils` | `untp-utils-v` | `untp-utils-v0.5.0-rc.1` |
 
-Pre-release tags carry an SemVer suffix (`-rc.N`, `-alpha.N`, `-beta.N`, `-pre.N`). Stable tags carry only `X.Y.Z`.
+Pre-release tags carry a SemVer suffix (`-rc.N`, `-alpha.N`, `-beta.N`, `-pre.N`). Stable tags carry only `X.Y.Z`.
 
 **Workflow per package.** Two workflows are added, one per publishable package:
 


### PR DESCRIPTION
Records the decision to drop Changesets and adopt a per-package tag-triggered npm publishing model (matching the existing pattern for the reference implementation and the playground Docker images). The implementation lands in a follow-up PR.

- **031** (new, `accepted`): per-package tag-triggered npm release. Each publishable package owns a tag prefix (`untp-ri-services-v*`, `untp-utils-v*`), a publish workflow scoped to that prefix, OIDC Trusted Publishing, stable → `latest` dist-tag, pre-release (`-rc.N` etc.) → `rc` dist-tag, and a shared `workflow_dispatch` rollback workflow that runs `npm unpublish` (within 72 h) or `npm deprecate` (outside that window).
- **004**, **005**, **013**, **022**, **026**: marked `superseded by 031` with a one-line `Update (2026-05-15)` pointer.

The supersession choice on **013**: its single-workflow design is the exact alternative ADR 031 reverses. The portable correctness measures in 013 (SHA pin + verification, `cancel-in-progress: false`, npm provenance, `.nvmrc`) carry forward into the per-package publish workflows.