### PR TITLE
fix(ci): trim wasted action minutes across release workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,11 +5,15 @@ on:
   # (which target an in-flight feature branch instead of `next`) need CI
   # too; the previous `branches: [next]` filter skipped them silently.
   pull_request: {}
-  # Running on push to `next` (post-merge) is intentional: it lets the
-  # `quality` job populate the `node_modules` cache from `refs/heads/next`,
-  # which subsequent PRs can then restore from. GitHub Actions caches
-  # written from a PR ref are scoped to that PR; only caches written from
-  # the base branch are shared across PRs targeting it.
+  # Running on push to `next` (post-merge) is intentional but narrow: it
+  # exists solely to let the `quality` job repopulate the `node_modules`
+  # cache from `refs/heads/next` so subsequent PRs can restore from it.
+  # GitHub Actions caches written from a PR ref are scoped to that PR;
+  # only caches written from the base branch are shared across PRs
+  # targeting it.
+  # All other jobs (qa matrix, e2e image builds, e2e runs) are PR-only
+  # via job-level `if:` guards below — re-running them post-merge adds
+  # no signal because the PR already validated the same code.
   push:
     branches:
       - next
@@ -79,6 +83,7 @@ jobs:
 
   qa:
     name: QA (${{ matrix.package }})
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: quality
     strategy:
@@ -142,6 +147,7 @@ jobs:
   # and the RI E2E matrix starts as soon as the RI image is ready.
   build-e2e-image-ri:
     name: Build E2E image (RI)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: [quality, qa]
     steps:
@@ -241,6 +247,7 @@ jobs:
 
   build-e2e-image-playground:
     name: Build E2E image (playground)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: [quality, qa]
     steps:
@@ -325,6 +332,7 @@ jobs:
 
   e2e-ri:
     name: E2E RI (${{ matrix.mode }})
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: [quality, qa, build-e2e-image-ri]
     strategy:
@@ -505,6 +513,7 @@ jobs:
 
   e2e-playground:
     name: E2E (untp-playground)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: [quality, qa, build-e2e-image-playground]
     steps:

--- a/.github/workflows/buld_publish_docs.yml
+++ b/.github/workflows/buld_publish_docs.yml
@@ -1,10 +1,17 @@
 name: Deploy to GitHub Pages
 
+# Only fires when files relevant to the Docusaurus build change. Pushes
+# that do not touch any of these paths leave the GitHub Pages site as-is
+# and do not consume action minutes.
 on:
   push:
     branches:
       - next
       - main
+    paths:
+      - 'documentation/**'
+      - '.github/workflows/buld_publish_docs.yml'
+      - '.nvmrc'
 
 # peaceiris/actions-gh-pages pushes the built site to the gh-pages branch,
 # which needs contents: write. Everything else stays at the default-deny

--- a/.github/workflows/docker-playground.yml
+++ b/.github/workflows/docker-playground.yml
@@ -77,5 +77,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope per workflow so the playground build does not share a
+          # cache key with the RI build. Unscoped `type=gha` caches collide
+          # across workflows, evicting each other's deps + builder layers.
+          cache-from: type=gha,scope=docker-playground
+          cache-to: type=gha,scope=docker-playground,mode=max

--- a/.github/workflows/docker-ri.yml
+++ b/.github/workflows/docker-ri.yml
@@ -88,5 +88,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope per workflow so the RI build does not share a cache key
+          # with the playground build. Unscoped `type=gha` caches collide
+          # across workflows, evicting each other's deps + builder layers.
+          cache-from: type=gha,scope=docker-ri
+          cache-to: type=gha,scope=docker-ri,mode=max


### PR DESCRIPTION
Four small, independent CI hygiene fixes surfaced from observing recent runs.

- **`buld_publish_docs.yml`** had no `paths:` filter on its `push` trigger, so it deployed to GitHub Pages on every merge to `next` regardless of whether `documentation/**` changed. Add a `paths:` filter (mirrors `docs_build.yml`).
- **`build_test.yml`** ran the full PR pipeline a second time on push to `next` (post-merge). The `push` trigger is retained because the `quality` job populates a shared `node_modules` cache on `refs/heads/next` that subsequent PRs restore from; the other jobs (`qa`, `build-e2e-image-ri`, `build-e2e-image-playground`, `e2e-ri`, `e2e-playground`) are gated to `pull_request` only.
- **`docker-ri.yml`** and **`docker-playground.yml`** use unscoped `type=gha` BuildKit cache. Both workflows therefore share one cache key and evict each other's deps + builder layers on every run. Add `scope=docker-ri` / `scope=docker-playground` so each workflow owns its own slot.

Two known but out-of-scope warnings observed in the same logs and worth surfacing for a follow-up: `tree-sitter` / `tree-sitter-json` / `tree-sitter-yaml` have no arm64 prebuilt and fall through to `node-gyp` compilation that fails (Python missing in Alpine) on every multi-arch build; and a Prisma postinstall warning fires in the deps stage because the schema lives in a later stage.