### PR TITLE
chore(release): @uncefact/untp-utils v0.1.0

### DIFF
--- a/packages/untp-utils/CHANGELOG.md
+++ b/packages/untp-utils/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to `@uncefact/untp-utils` are documented here. The format
+follows [Keep a Changelog](https://keepachangelog.com/) and the version
+numbers follow semantic versioning. The package ships via the
+`untp-utils-v<X.Y.Z>` tag-triggered publish workflow described in
+[ADR 031](../../docs/adrs/031-per-package-tag-triggered-npm-release.md).
+
+## [0.1.0] - 2026-05-15
+
+Initial public release.
+
+### Public surface
+
+Entry point (`@uncefact/untp-utils`) re-exports everything from
+`@uncefact/untp-utils/multibase-digest`. The package today contains a single
+module; the dedicated subpath export exists so future additions can be
+imported independently without expanding the top-level barrel.
+
+`@uncefact/untp-utils/multibase-digest`
+
+- `MultibaseDigest` class — immutable value object wrapping a multibase-
+  encoded multihash digest.
+  - `static async fromData(data: Uint8Array, opts: MultibaseDigestOptions): Promise<MultibaseDigest>` hashes the input bytes with the chosen algorithm and returns the digest.
+  - `static fromDigest(digest: Uint8Array, opts: MultibaseDigestOptions): MultibaseDigest` wraps an already-computed raw digest.
+  - `static fromString(encoded: string): MultibaseDigest` parses a multibase-encoded multihash string. Accepts both `base58btc` (`z…`) and `base64` (`m…`) prefixes; rejects malformed inputs and unsupported algorithms.
+  - `toString(base?: MultibaseEncoding): string` re-encodes without re-hashing. Defaults to the encoding the instance was constructed with.
+  - `async verify(data: Uint8Array): Promise<boolean>` re-hashes the supplied bytes with the digest's algorithm and compares.
+- `HashAlgorithm` type alias — `'sha2-256' | 'sha2-512'`.
+- `MultibaseEncoding` type alias — `'base58btc' | 'base64'`.
+- `MultibaseDigestOptions` type alias — `{ algorithm: HashAlgorithm; base: MultibaseEncoding }`.
+
+### Notes
+
+- Built on `multiformats@^13`. The library exists primarily to give other
+  UNTP packages (reference implementation, services, playground) a single
+  canonical implementation of multibase + multihash, so the same code
+  produces and verifies digests on both sides of any integrity check.
+- Built as ESM only. The package's `"type": "module"` declaration applies;
+  CJS-mode consumers should either import via dynamic `import()` or run a
+  bundler with ESM interop.
+
+[0.1.0]: https://github.com/uncefact/tests-untp/releases/tag/untp-utils-v0.1.0

--- a/packages/untp-utils/RELEASE_NOTES.md
+++ b/packages/untp-utils/RELEASE_NOTES.md
@@ -1,0 +1,60 @@
+# `@uncefact/untp-utils` release notes
+
+User-facing release notes for `@uncefact/untp-utils`. Each entry frames what
+the release lets you do, not how it does it. For a technical, per-change
+record see [CHANGELOG.md](./CHANGELOG.md).
+
+## 0.1.0 — 2026-05-15
+
+First public release.
+
+### Self-describing content digests, in one place
+
+UNTP credentials use multibase-encoded multihash digests
+(`digestMultibase`) to assert the integrity of content they link to —
+render templates, attestations, etc. Up to now,
+every UNTP project that needed to produce or verify one of those digests
+had its own short, hand-rolled implementation. This release factors that
+into a single library so the reference implementation, the playground,
+and any third-party integration verify against the same code path.
+
+### A small, focused API
+
+One class, three factory methods, and a `.verify()`. You can:
+
+- Hash bytes and get a digest (`MultibaseDigest.fromData`).
+- Wrap a digest you already have (`MultibaseDigest.fromDigest`).
+- Parse a digest that arrived as a string from somewhere else
+  (`MultibaseDigest.fromString`).
+- Re-encode between `base58btc` and `base64` without re-hashing
+  (`.toString('base64')`).
+- Verify content against an existing digest (`.verify(bytes)`) without
+  having to remember which hash algorithm was used — the multihash
+  prefix tells the library, so callers don't.
+
+The algorithms covered today are `sha2-256` and `sha2-512`; the
+encodings are `base58btc` (the `z…` form most common in UNTP credentials)
+and `base64` (the `m…` form). New algorithms or encodings are additive
+and don't change existing call sites.
+
+### Designed to be the one true implementation
+
+If you produce a digest with this library and someone else verifies it
+with this library, you don't need to coordinate the algorithm or
+encoding ahead of time — the multihash prefix on the digest carries
+that information. That's the property that lets us replace the
+hand-rolled implementations across the repo with one shared library
+and stop worrying about producer/verifier drift.
+
+### Where to install
+
+```bash
+npm install @uncefact/untp-utils
+```
+
+### Where to learn more
+
+- API documentation: see `CHANGELOG.md` for the full public surface of
+  this release.
+- Multibase specification: <https://github.com/multiformats/multibase>
+- Multihash specification: <https://github.com/multiformats/multihash>


### PR DESCRIPTION
This PR stages the first stable release of `@uncefact/untp-utils`. Adds `packages/untp-utils/CHANGELOG.md` (technical) and `packages/untp-utils/RELEASE_NOTES.md` (user-facing).

After merge, bootstrap the package name on npm with a `0.0.1` publish + deprecate, configure the Trusted Publisher on npmjs.com pointing at `publish-untp-utils.yml`, then push the `untp-utils-v0.1.0` git tag to cut the release via OIDC.