### PR TITLE
chore(license): align package licenses with their distribution model

### DIFF
--- a/docs/adrs/032-per-package-licensing-policy.md
+++ b/docs/adrs/032-per-package-licensing-policy.md
@@ -1,0 +1,140 @@
+# ADR: Per-package licensing policy
+
+- **Date:** 2026-05-15
+- **Status:** accepted
+
+## Context
+
+The repository is a monorepo that publishes some packages to npm (libraries
+intended for third-party consumption) and ships others as user-facing
+applications or internal-only workspace dependencies. Until now, no policy
+documented which licence a new package should declare, and the existing
+packages declared inconsistent values: the two library packages
+(`@uncefact/untp-utils`, `@uncefact/untp-ri-services`) had `"license": "ISC"`
+left over from package scaffolding, while the three user-facing packages
+(`untp-reference-implementation`, `untp-playground`,
+`@reference-implementation/components`) had no `license` field at all and
+implicitly inherited the repository's root GPL-3.0 LICENSE.
+
+Two forces drive the decision:
+
+1. **Distribution model matters for licence choice.** Libraries published
+   to npm are designed to be embedded in third-party products. A copyleft
+   licence (GPL) on a library forces downstream products that link against
+   it to also adopt the GPL, which is a significant adoption barrier and
+   not the intent of these utility packages. User-facing applications and
+   workspace-internal packages have no such reach concern: the GPL on a
+   self-contained app is a deliberate signal that derivative works must
+   stay free.
+2. **Patent grant matters for libraries.** Apache-2.0 includes an explicit
+   patent grant clause that protects downstream consumers from patent
+   claims by contributors. GPL-3.0 has a weaker, derivative patent clause.
+   For libraries we want consumers to integrate without legal friction,
+   the explicit grant is valuable.
+
+Without a documented policy, every new package risks repeating the same
+ambiguity: copy-paste an old `package.json`, get whatever licence it had,
+and ship a mismatched value to npm. Once a tagged release goes out under
+the wrong licence, correcting it requires a new release and an audit of
+who consumed the wrong version.
+
+## Decision
+
+Adopt the following per-package licensing policy:
+
+- **Packages published to npm (libraries)** declare
+  `"license": "Apache-2.0"` and ship a verbatim `LICENSE` file containing
+  the Apache 2.0 text inside the package directory. The file ships in the
+  npm tarball (npm bundles `LICENSE` files automatically) so consumers see
+  the patent grant alongside the code.
+- **User-facing applications and workspace-internal packages** declare
+  `"license": "GPL-3.0-only"` and rely on the repository's root LICENSE
+  for the full text. They do not need a per-package `LICENSE` file because
+  they are not distributed as standalone artefacts via npm; they ship as
+  Docker images or built bundles that inherit the source repository's
+  licence by reference.
+
+The SPDX identifier for the GPL packages is `GPL-3.0-only` (not
+`GPL-3.0-or-later`) because the repository's root LICENSE is the verbatim
+GPL-3.0 text and the project has not added an "or any later version"
+notice anywhere. `-or-later` is only correct when the project explicitly
+opts in to future GPL versions, which this project has not done.
+
+Concrete package mapping at the time of this ADR:
+
+| Package                                | Distribution   | Licence            |
+|----------------------------------------|----------------|--------------------|
+| `@uncefact/untp-utils`                 | npm (library)  | Apache-2.0         |
+| `@uncefact/untp-ri-services`           | npm (library)  | Apache-2.0         |
+| `untp-reference-implementation`        | Docker image   | GPL-3.0-only       |
+| `untp-playground`                      | Docker image   | GPL-3.0-only       |
+| `@reference-implementation/components` | workspace-only | GPL-3.0-only       |
+
+When adding a new package, the maintainer picks the licence by asking
+"will this be published to npm for third-party consumption?". If yes,
+Apache-2.0 + per-package LICENSE file. If no, GPL-3.0-only and rely on
+the root LICENSE.
+
+## Consequences
+
+What becomes easier:
+
+- New library packages get the right licence by default; the policy is one
+  rule keyed off "is this on npm?".
+- npm consumers of the library packages get the patent grant in-tree, not
+  via a remote root LICENSE they may never see.
+- The user-facing apps remain clearly copyleft, which is consistent with
+  the project's posture of keeping the reference implementation open.
+
+What becomes harder:
+
+- The repository now ships two licences. Anyone redistributing the
+  monorepo as a whole (e.g. a fork) must understand that the per-package
+  `LICENSE` files take precedence within their package directories. This
+  is the standard monorepo pattern but it is more nuanced than a
+  single-licence repo.
+- If the project ever wants to migrate to `GPL-3.0-or-later` (to inherit
+  future FSF GPL versions), that is now a deliberate two-step: add the
+  "or any later version" notice to the root LICENSE / per-package
+  manifests, then update the SPDX identifier. This ADR locks in `-only`
+  to keep the SPDX identifier honest about current wording, not because
+  `-or-later` would be wrong forever.
+
+## Alternatives Considered
+
+**Single licence across the whole repository (all Apache-2.0, or all
+GPL-3.0).** Simpler to explain and easier for downstream redistributors.
+Rejected because the two distribution models have genuinely different
+needs: Apache-2.0 on the user-facing apps gives away copyleft protection
+we want; GPL-3.0 on the libraries forces a copyleft cascade that defeats
+the purpose of publishing utility libraries for third-party use. Picking
+one licence to fit both models means one of them is wrong.
+
+**MIT or ISC for the libraries.** Both are permissive and shorter to
+read. Rejected because neither includes an explicit patent grant. For
+libraries that may include cryptographic, identifier, or content-digest
+primitives (where patent risk is non-trivial), Apache-2.0's explicit
+grant is materially better than a permissive licence that is silent on
+patents.
+
+**`GPL-3.0-or-later` for the user-facing packages.** Rejected because the
+project's root LICENSE is verbatim GPL-3.0 text and there is no "or any
+later version" notice anywhere in the repository (no README clause, no
+per-file headers). The SPDX identifier must match what the project's
+licence notices actually say; using `-or-later` without an opt-in notice
+would mislead consumers about the project's intent.
+
+**No `license` field on the user-facing apps (status quo).** Works in
+practice because the root LICENSE covers them implicitly, but tooling
+(SBOM generators, dependency scanners, npm publish warnings) reads the
+`license` field and reports "no licence declared" when it is missing.
+Explicit is better than implicit.
+
+## References
+
+- Root [`LICENSE`](../../LICENSE) — GPL-3.0 text covering the repository.
+- [`packages/untp-utils/LICENSE`](../../packages/untp-utils/LICENSE) and
+  [`packages/services/LICENSE`](../../packages/services/LICENSE) — the
+  per-package Apache-2.0 LICENSE files this ADR introduces.
+- SPDX licence list: <https://spdx.org/licenses/>
+- Apache 2.0 patent grant clause (section 3): <https://www.apache.org/licenses/LICENSE-2.0>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@reference-implementation/components",
   "version": "0.2.0",
+  "private": true,
   "license": "GPL-3.0-only",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -96,8 +97,5 @@
     "typescript": "^5.9.3",
     "web-vitals": "^2.1.4",
     "webpack": "^5.11.0"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@reference-implementation/components",
   "version": "0.2.0",
+  "license": "GPL-3.0-only",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "type": "module",

--- a/packages/reference-implementation/package.json
+++ b/packages/reference-implementation/package.json
@@ -2,6 +2,7 @@
   "name": "untp-reference-implementation",
   "version": "0.2.0",
   "private": true,
+  "license": "GPL-3.0-only",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.75.0",

--- a/packages/services/LICENSE
+++ b/packages/services/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -59,7 +59,7 @@
   ],
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "@vckit/core-types": "1.0.0-beta.7",
     "ajv": "^8.17.1",

--- a/packages/untp-playground/package.json
+++ b/packages/untp-playground/package.json
@@ -2,6 +2,7 @@
   "name": "untp-playground",
   "version": "0.3.0",
   "private": true,
+  "license": "GPL-3.0-only",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/packages/untp-utils/LICENSE
+++ b/packages/untp-utils/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/untp-utils/package.json
+++ b/packages/untp-utils/package.json
@@ -38,7 +38,7 @@
     "digest"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "multiformats": "^13.3.1"
   },


### PR DESCRIPTION
This PR sets each package's `license` field to match how the package is distributed, so npm consumers of the library packages see the Apache-2.0 patent grant in the tarball and the user-facing apps line up with the repository's root GPL-3.0 LICENSE.

- `@uncefact/untp-utils` and `@uncefact/untp-ri-services` now declare `Apache-2.0` and ship an `Apache-2.0` LICENSE file inside the package directory. npm bundles per-package LICENSE files automatically.
- `untp-reference-implementation`, `untp-playground`, and `@reference-implementation/components` now declare `GPL-3.0-only`. They are not published to npm and continue to rely on the root LICENSE for the full text. The SPDX identifier is `-only` (not `-or-later`) because the root LICENSE is verbatim GPL-3.0 text with no "or any later version" notice.

The accompanying ADR (`docs/adrs/032-per-package-licensing-policy.md`) documents the policy so future packages adopt the correct licence by default.

## Test plan
- [x] SPDX identifiers verified against https://spdx.org/licenses/ (`Apache-2.0`, `GPL-3.0-only`).
- [x] Per-package LICENSE files contain the canonical 202-line Apache 2.0 text.
- [x] ADR mapping table matches the actual diff.