### PR TITLE
fix(ci): publish npm packages via npm CLI instead of pnpm

### DIFF
--- a/.github/workflows/publish-untp-ri-services.yml
+++ b/.github/workflows/publish-untp-ri-services.yml
@@ -6,16 +6,20 @@ name: 'Publish — @uncefact/untp-ri-services'
 # The tag is the release event; this workflow publishes the artefact and
 # nothing else.
 #
-# Services depends on @uncefact/untp-utils via the workspace protocol. pnpm
-# publish rewrites the workspace specifier into the installed semver range
-# at publish time, so the published artefact pins to whatever utils version
-# was installed when this workflow ran. If the runtime utils version needs
-# to change, publish utils first (untp-utils-v<X.Y.Z> tag), then push the
-# services tag.
+# Services may depend on @uncefact/untp-utils via the workspace protocol.
+# `npm publish` does NOT rewrite `workspace:*` specifiers; if such a dep is
+# introduced in packages/services/package.json, the publish step must
+# replace it with a concrete semver range before running, otherwise the
+# published manifest will contain an invalid `workspace:*` specifier and
+# installers will fail. There is no such workspace dep at the time of
+# writing.
 #
 # Authentication uses npm OIDC Trusted Publishing. The npmjs.com Trusted
 # Publisher for `@uncefact/untp-ri-services` must be configured to point at
-# this workflow filename.
+# this workflow filename. Publish is done via `npm publish` (not
+# `pnpm publish`): OIDC Trusted Publishing landed in the npm CLI (v11+)
+# which ships with Node 22; pnpm 9.x still uses the legacy `_authToken`
+# flow and produces anonymous requests that npm rejects with a 404.
 #
 # See ADR 031: docs/adrs/031-per-package-tag-triggered-npm-release.md
 
@@ -88,4 +92,4 @@ jobs:
         working-directory: packages/services
         env:
           NPM_CONFIG_PROVENANCE: 'true'
-        run: pnpm publish --no-git-checks --access public --tag ${{ steps.dist.outputs.tag }}
+        run: npm publish --access public --tag ${{ steps.dist.outputs.tag }}

--- a/.github/workflows/publish-untp-utils.yml
+++ b/.github/workflows/publish-untp-utils.yml
@@ -7,7 +7,11 @@ name: 'Publish — @uncefact/untp-utils'
 #
 # Authentication uses npm OIDC Trusted Publishing. The npmjs.com Trusted
 # Publisher for `@uncefact/untp-utils` must be configured to point at this
-# workflow filename.
+# workflow filename. Publish is done via `npm publish` (not `pnpm publish`):
+# OIDC Trusted Publishing landed in the npm CLI (v11+) which ships with
+# Node 22; pnpm 9.x still uses the legacy `_authToken` flow and produces
+# anonymous requests that npm rejects with a 404. The build step stays on
+# pnpm so the workspace install / filter still works.
 #
 # See ADR 031: docs/adrs/031-per-package-tag-triggered-npm-release.md
 
@@ -76,4 +80,4 @@ jobs:
         working-directory: packages/untp-utils
         env:
           NPM_CONFIG_PROVENANCE: 'true'
-        run: pnpm publish --no-git-checks --access public --tag ${{ steps.dist.outputs.tag }}
+        run: npm publish --access public --tag ${{ steps.dist.outputs.tag }}


### PR DESCRIPTION
This PR switches the npm publish step in both per-package publish workflows from `pnpm publish` to `npm publish`, so OIDC Trusted Publishing actually authenticates and the registry stops returning 404.

The repo pins pnpm to 9.x, which does not implement npm's OIDC Trusted Publishing flow. Its publish step still uses the legacy `_authToken` mechanism, so without a stored token the request is anonymous and npm rejects with 404. OIDC Trusted Publishing landed in the npm CLI from v11 onward, which ships with Node 22 (the version already used in these workflows). The build step stays on pnpm so the workspace install / filter behaviour is unchanged.

Verified against the actual failure: the SLSA attestation in sigstore log 1546321816 shows the OIDC token's repo, owner, ref, workflow path, and event_name all match what is registered on npmjs.com for both packages. The mismatch is on the npm side; pnpm 9 never presents that token to the registry.

After merge: delete the `untp-utils-v0.1.0` tag and re-tag the new HEAD of `next`, which retriggers the (now-fixed) workflow.