### PR TITLE
fix(ci): upgrade npm to v11 in publish workflows for OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish-untp-ri-services.yml
+++ b/.github/workflows/publish-untp-ri-services.yml
@@ -17,9 +17,11 @@ name: 'Publish — @uncefact/untp-ri-services'
 # Authentication uses npm OIDC Trusted Publishing. The npmjs.com Trusted
 # Publisher for `@uncefact/untp-ri-services` must be configured to point at
 # this workflow filename. Publish is done via `npm publish` (not
-# `pnpm publish`): OIDC Trusted Publishing landed in the npm CLI (v11+)
-# which ships with Node 22; pnpm 9.x still uses the legacy `_authToken`
-# flow and produces anonymous requests that npm rejects with a 404.
+# `pnpm publish`) because pnpm 9.x still uses the legacy `_authToken` flow.
+#
+# OIDC Trusted Publishing requires npm CLI >= 11.5.0. Node 22 (pinned via
+# .nvmrc) bundles npm 10.x, so we explicitly upgrade npm before publishing.
+# Without the upgrade, the publish PUT is anonymous and npm responds 404.
 #
 # See ADR 031: docs/adrs/031-per-package-tag-triggered-npm-release.md
 
@@ -65,6 +67,9 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
+
+      - name: Upgrade npm to v11 (OIDC Trusted Publishing requires >= 11.5)
+        run: npm install --global npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '@uncefact/untp-ri-services...'

--- a/.github/workflows/publish-untp-utils.yml
+++ b/.github/workflows/publish-untp-utils.yml
@@ -7,11 +7,13 @@ name: 'Publish — @uncefact/untp-utils'
 #
 # Authentication uses npm OIDC Trusted Publishing. The npmjs.com Trusted
 # Publisher for `@uncefact/untp-utils` must be configured to point at this
-# workflow filename. Publish is done via `npm publish` (not `pnpm publish`):
-# OIDC Trusted Publishing landed in the npm CLI (v11+) which ships with
-# Node 22; pnpm 9.x still uses the legacy `_authToken` flow and produces
-# anonymous requests that npm rejects with a 404. The build step stays on
-# pnpm so the workspace install / filter still works.
+# workflow filename. Publish is done via `npm publish` (not `pnpm publish`)
+# because pnpm 9.x still uses the legacy `_authToken` flow. The build step
+# stays on pnpm so the workspace install / filter still works.
+#
+# OIDC Trusted Publishing requires npm CLI >= 11.5.0. Node 22 (pinned via
+# .nvmrc) bundles npm 10.x, so we explicitly upgrade npm before publishing.
+# Without the upgrade, the publish PUT is anonymous and npm responds 404.
 #
 # See ADR 031: docs/adrs/031-per-package-tag-triggered-npm-release.md
 
@@ -57,6 +59,9 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
+
+      - name: Upgrade npm to v11 (OIDC Trusted Publishing requires >= 11.5)
+        run: npm install --global npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter '@uncefact/untp-utils...'


### PR DESCRIPTION
This PR adds an explicit npm CLI upgrade step (`npm install --global npm@11`) before the publish step in both per-package publish workflows, so the OIDC Trusted Publishing handshake actually runs.

Node 22.22.2 ships with npm 10.9.7. npm's Trusted Publishing auth flow lives in npm CLI >= 11.5.0; in 10.x the publish step issues an anonymous PUT regardless of the workflow's id-token permission, which the registry rejects with a misleading 404. The provenance attestation in 10.x still succeeds because that is a separate OIDC flow direct to sigstore.

Tarball contents are unaffected. Verified locally: `npm@11 pack --dry-run` produces a tarball with the same shasum (`62c02cecf95196e87c679dc9f1c3d6c1f3c2a525`) and integrity hash as the CI run on npm 10.9.7. The npm version only changes the auth protocol used during the upload.

Verified the rejection is on npm's side, not the OIDC claims: sigstore log 1546347734 shows the token's repo, owner, ref, workflow path, and event_name all match the registered Trusted Publisher entries on both packages.

After merge: delete and re-push `untp-utils-v0.1.0` at the new HEAD of `next` to retrigger the (now-fixed) workflow.