### PR TITLE
chore(ci): sync ADR 031 and bump GitHub Actions versions

### DIFF
--- a/.github/workflows/buld_publish_docs.yml
+++ b/.github/workflows/buld_publish_docs.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -63,7 +63,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/.github/workflows/ci_cd-untp-playground.yml
+++ b/.github/workflows/ci_cd-untp-playground.yml
@@ -45,7 +45,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -55,7 +55,7 @@ jobs:
         working-directory: ./packages/untp-playground/infra
 
       - name: Deploy Stack
-        uses: pulumi/actions@v5
+        uses: pulumi/actions@v6
         with:
           command: up
           stack-name: ${{ env.STACK_NAME}}
@@ -113,7 +113,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -123,7 +123,7 @@ jobs:
         working-directory: ./packages/untp-playground/infra
 
       - name: Deploy Stack
-        uses: pulumi/actions@v5
+        uses: pulumi/actions@v6
         with:
           command: up
           stack-name: ${{ env.STACK_NAME}}

--- a/.github/workflows/disk-usage-audit.yml
+++ b/.github/workflows/disk-usage-audit.yml
@@ -65,7 +65,7 @@ jobs:
           docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" 2>/dev/null || true
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
         run: corepack enable
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
@@ -197,7 +197,7 @@ jobs:
           driver: docker-container
 
       - name: Build E2E Docker images (with layer cache)
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           files: docker-compose.e2e.yml
           load: true

--- a/docs/adrs/031-per-package-tag-triggered-npm-release.md
+++ b/docs/adrs/031-per-package-tag-triggered-npm-release.md
@@ -3,6 +3,9 @@
 - **Date:** 2026-05-15
 - **Status:** accepted
 - **Supersedes:** [004](./004-changesets-for-version-management.md), [005](./005-changeset-enforcement-via-three-layers.md), [013](./013-release-workflow-correctness-measures.md), [022](./022-rc-cycles-via-changesets-pre-mode.md), [026](./026-release-runbook-for-failure-recovery.md)
+- **Update (2026-05-15):** publishing `@uncefact/untp-utils@0.1.0` surfaced two implementation requirements that were not obvious from the body of this ADR; both are now enforced in the publish workflows under `.github/workflows/publish-untp-utils.yml` and `.github/workflows/publish-untp-ri-services.yml`.
+  - The publish step must run on **npm CLI >= 11.5** (the version that implements OIDC Trusted Publishing). Node 22 (pinned via `.nvmrc`) bundles npm 10.x, so the workflows shell out to `npx --yes npm@11 publish ...`. `pnpm publish` is unsuitable because pnpm 9.x still uses the legacy `_authToken` flow.
+  - Every npm-published `package.json` MUST declare a `repository.url` whose URL matches the GitHub repository the workflow runs in. npm cross-validates this against the sigstore provenance attestation and rejects mismatches with HTTP 422. Use the monorepo-aware form (`type` / `url` / `directory`).
 
 ## Context
 


### PR DESCRIPTION
This PR captures two pieces of follow-up from the `@uncefact/untp-utils@0.1.0` release: documents the implementation requirements that surfaced during publishing, and bumps the workflow actions that were behind their current stable majors.

## Commits

**`docs(adr): sync ADR 031 with npm publishing implementation reality`**

Adds an Update line to ADR 031 (per the "Keep ADRs in sync with the code" convention) noting two requirements not obvious from the body:
- publish step needs npm CLI >= 11.5 (shimmed via `npx --yes npm@11` since Node 22 bundles npm 10.x)
- npm-published `package.json` must declare a `repository.url` matching the GitHub repo, otherwise npm rejects with HTTP 422 (sigstore provenance cross-check)

The body of ADR 031 is unchanged; this is a forward-pointing update only.

**`chore(ci): bump GitHub Actions to current stable major versions`**

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v3 | v4 |
| actions/setup-node | v3 | v4 |
| peaceiris/actions-gh-pages | v3 | v4 |
| pulumi/actions | v5 | v6 |
| docker/bake-action | v5 | v6 |

All bumps are drop-in for the inputs we use; none of the workflows consume outputs from these actions, which is where the v5 to v6 breaks would normally surface.