### PR TITLE
feat(utils): add conformity-vocabulary sub-entry with scheme parser and claim validator

### DIFF
--- a/packages/untp-utils/package.json
+++ b/packages/untp-utils/package.json
@@ -12,12 +12,19 @@
     "./multibase-digest": {
       "types": "./build/multibase-digest/index.d.ts",
       "default": "./build/multibase-digest/index.js"
+    },
+    "./conformity-vocabulary": {
+      "types": "./build/conformity-vocabulary/index.d.ts",
+      "default": "./build/conformity-vocabulary/index.js"
     }
   },
   "typesVersions": {
     "*": {
       "multibase-digest": [
         "./build/multibase-digest/index.d.ts"
+      ],
+      "conformity-vocabulary": [
+        "./build/conformity-vocabulary/index.d.ts"
       ]
     }
   },
@@ -35,7 +42,8 @@
     "untp",
     "multibase",
     "multihash",
-    "digest"
+    "digest",
+    "conformity-vocabulary"
   ],
   "author": "",
   "license": "Apache-2.0",

--- a/packages/untp-utils/src/conformity-vocabulary/codes.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/codes.ts
@@ -1,0 +1,41 @@
+/**
+ * Conformity-vocabulary codes are thing-oriented and namespaced by the
+ * artefact the code is about (a scheme, a profile, a criterion), not the
+ * activity that detected it. Stable; consumers may branch on them with
+ * exhaustive switches.
+ *
+ * @see ADR-034 in `docs/adrs/`.
+ */
+
+/**
+ * Codes for warnings emitted by {@link validateConformityClaim}.
+ *
+ * Exported as an `as const` object so callers can reference codes by
+ * identifier (e.g. `ConformityWarningCode.SchemeNotFound`) rather than by
+ * raw string.
+ */
+export const ConformityWarningCode = {
+  SchemeNotFound: 'conformity-scheme.not-found',
+  ProfileNotFound: 'conformity-profile.not-found',
+  CriterionNotInProfile: 'conformity-criterion.not-in-profile',
+  CriterionMissing: 'conformity-criterion.missing',
+  CriterionTopicMismatch: 'conformity-criterion.topic-mismatch',
+} as const;
+
+export type ConformityWarningCode = (typeof ConformityWarningCode)[keyof typeof ConformityWarningCode];
+
+/**
+ * Codes for errors emitted by {@link parseConformityScheme} when the input
+ * document is malformed or unsupported. Errors are returned in
+ * `ParseOutcome.errors`, not thrown.
+ */
+export const ConformitySchemeErrorCode = {
+  /** Document is not a non-null object, or a required property has the wrong type. */
+  InvalidShape: 'conformity-scheme.invalid-shape',
+  /** A required field is missing or empty. */
+  MissingRequiredField: 'conformity-scheme.missing-required-field',
+  /** The detected (or supplied) CVC spec version is not supported by this build. */
+  UnsupportedSpecVersion: 'conformity-scheme.unsupported-spec-version',
+} as const;
+
+export type ConformitySchemeErrorCode = (typeof ConformitySchemeErrorCode)[keyof typeof ConformitySchemeErrorCode];

--- a/packages/untp-utils/src/conformity-vocabulary/index.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/index.ts
@@ -1,0 +1,9 @@
+export * from './types.js';
+export { ConformityWarningCode, ConformitySchemeErrorCode } from './codes.js';
+export {
+  parseConformityScheme,
+  SUPPORTED_CVC_SPEC_VERSIONS,
+  type ParseConformitySchemeOptions,
+  type SupportedCvcSpecVersion,
+} from './parse-conformity-scheme.js';
+export { validateConformityClaim } from './validate-conformity-claim.js';

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.test.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.test.ts
@@ -1,0 +1,298 @@
+import { ConformitySchemeErrorCode } from './codes.js';
+import { parseConformityScheme } from './parse-conformity-scheme.js';
+
+const UNTP_V070_CONTEXT = 'https://vocabulary.uncefact.org/untp/0.7.0/context/';
+
+function minimalSchemeDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    '@context': [UNTP_V070_CONTEXT],
+    type: ['ConformityScheme'],
+    id: 'https://example.com/scheme',
+    name: 'Example Scheme',
+    includedProfile: [],
+    ...overrides,
+  };
+}
+
+function profile(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'https://example.com/scheme/full/1.0.0',
+    name: 'Full',
+    version: '1.0.0',
+    status: 'active',
+    criterion: [],
+    ...overrides,
+  };
+}
+
+function criterion(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: ['Criterion'],
+    id: 'https://example.com/criterion/forced-labour/1.0.0',
+    name: 'Forced Labour',
+    version: '1.0.0',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('parseConformityScheme', () => {
+  describe('version handling', () => {
+    it('auto-detects 0.7.0 from the @context', () => {
+      const outcome = parseConformityScheme(minimalSchemeDoc(), {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.specVersion).toBe('0.7.0');
+    });
+
+    it('honours the specVersion override', () => {
+      const doc = minimalSchemeDoc({ '@context': ['https://unknown.example/ctx'] });
+      const outcome = parseConformityScheme(doc, {
+        sourceUrl: 'https://example.com/scheme',
+        specVersion: '0.7.0',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.specVersion).toBe('0.7.0');
+    });
+
+    it('returns an unsupported-spec-version error when version cannot be detected', () => {
+      const doc = minimalSchemeDoc({ '@context': ['https://unknown.example/ctx'] });
+      const outcome = parseConformityScheme(doc, { sourceUrl: 'https://example.com/scheme' });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toEqual([
+        expect.objectContaining({
+          code: ConformitySchemeErrorCode.UnsupportedSpecVersion,
+          received: 'undetected',
+          pointer: '/@context',
+        }),
+      ]);
+    });
+
+    it('returns an unsupported-spec-version error for a known-but-unsupported version', () => {
+      const outcome = parseConformityScheme(minimalSchemeDoc(), {
+        sourceUrl: 'https://example.com/scheme',
+        specVersion: '99.0.0',
+      });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toEqual([
+        expect.objectContaining({
+          code: ConformitySchemeErrorCode.UnsupportedSpecVersion,
+          received: '99.0.0',
+        }),
+      ]);
+    });
+  });
+
+  describe('happy path', () => {
+    it('parses a minimal scheme with no profiles', () => {
+      const outcome = parseConformityScheme(minimalSchemeDoc(), {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value).toMatchObject({
+        canonicalId: 'https://example.com/scheme',
+        sourceUrl: 'https://example.com/scheme',
+        specVersion: '0.7.0',
+        name: 'Example Scheme',
+        profiles: [],
+      });
+    });
+
+    it('parses a scheme with one profile and one criterion', () => {
+      const doc = minimalSchemeDoc({
+        includedProfile: [
+          profile({
+            criterion: [criterion()],
+          }),
+        ],
+      });
+      const outcome = parseConformityScheme(doc, {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.profiles).toHaveLength(1);
+      expect(outcome.value?.profiles[0].criteria[0].canonicalId).toBe(
+        'https://example.com/criterion/forced-labour/1.0.0',
+      );
+    });
+
+    it('parses inlined topic objects', () => {
+      const doc = minimalSchemeDoc({
+        includedProfile: [
+          profile({
+            criterion: [
+              criterion({
+                conformityTopic: [
+                  {
+                    type: ['ConformityTopic'],
+                    id: 'https://vocabulary.uncefact.org/conformity-topics/forced-labor-elimination',
+                    name: 'Forced Labor Elimination',
+                    definition: 'A definition.',
+                  },
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+      const outcome = parseConformityScheme(doc, {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.profiles[0].criteria[0].topics).toEqual([
+        {
+          canonicalId: 'https://vocabulary.uncefact.org/conformity-topics/forced-labor-elimination',
+          name: 'Forced Labor Elimination',
+          definition: 'A definition.',
+        },
+      ]);
+    });
+
+    it('parses a bare-string topic URI as a compact reference', () => {
+      const doc = minimalSchemeDoc({
+        includedProfile: [
+          profile({
+            criterion: [criterion({ conformityTopic: ['https://example.com/topics/foo'] })],
+          }),
+        ],
+      });
+      const outcome = parseConformityScheme(doc, {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.profiles[0].criteria[0].topics).toEqual([
+        { canonicalId: 'https://example.com/topics/foo' },
+      ]);
+    });
+
+    it('parses tags as a string array', () => {
+      const doc = minimalSchemeDoc({
+        includedProfile: [
+          profile({
+            criterion: [criterion({ tag: ['forced-labor', 'human-rights'] })],
+          }),
+        ],
+      });
+      const outcome = parseConformityScheme(doc, {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.profiles[0].criteria[0].tags).toEqual(['forced-labor', 'human-rights']);
+    });
+
+    it('captures the owner reference when present', () => {
+      const doc = minimalSchemeDoc({
+        owner: {
+          type: ['Party'],
+          id: 'https://example.com/owner',
+          name: 'Example Owner',
+        },
+      });
+      const outcome = parseConformityScheme(doc, {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.owner).toEqual({
+        canonicalId: 'https://example.com/owner',
+        name: 'Example Owner',
+      });
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns an invalid-shape error when the document is not an object', () => {
+      const outcome = parseConformityScheme(null, { sourceUrl: 'x', specVersion: '0.7.0' });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toEqual([
+        expect.objectContaining({
+          code: ConformitySchemeErrorCode.InvalidShape,
+          received: 'null',
+          expected: 'object',
+        }),
+      ]);
+    });
+
+    it.each([
+      ['scheme.id', { id: undefined }, '/id'],
+      ['scheme.name', { name: undefined }, '/name'],
+    ])('returns a missing-required-field error when %s is missing', (_, override, pointer) => {
+      const outcome = parseConformityScheme(minimalSchemeDoc(override), {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: ConformitySchemeErrorCode.MissingRequiredField,
+            pointer,
+          }),
+        ]),
+      );
+    });
+
+    it('accumulates multiple errors in a single parse pass', () => {
+      const outcome = parseConformityScheme(minimalSchemeDoc({ id: undefined, name: undefined }), {
+        sourceUrl: 'https://example.com/scheme',
+      });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toHaveLength(2);
+      const pointers = outcome.errors.map((e) => e.pointer);
+      expect(pointers).toEqual(expect.arrayContaining(['/id', '/name']));
+    });
+
+    it.each([
+      ['profile.id', { id: undefined }, '/includedProfile/0/id'],
+      ['profile.name', { name: undefined }, '/includedProfile/0/name'],
+      ['profile.version', { version: undefined }, '/includedProfile/0/version'],
+      ['profile.status', { status: undefined }, '/includedProfile/0/status'],
+    ])('returns a missing-required-field error when %s is missing', (_, override, pointer) => {
+      const doc = minimalSchemeDoc({ includedProfile: [profile(override)] });
+      const outcome = parseConformityScheme(doc, { sourceUrl: 'https://example.com/scheme' });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: ConformitySchemeErrorCode.MissingRequiredField,
+            pointer,
+          }),
+        ]),
+      );
+    });
+
+    it.each([
+      ['criterion.id', { id: undefined }, '/includedProfile/0/criterion/0/id'],
+      ['criterion.name', { name: undefined }, '/includedProfile/0/criterion/0/name'],
+      ['criterion.version', { version: undefined }, '/includedProfile/0/criterion/0/version'],
+      ['criterion.status', { status: undefined }, '/includedProfile/0/criterion/0/status'],
+    ])('returns a missing-required-field error when %s is missing', (_, override, pointer) => {
+      const doc = minimalSchemeDoc({
+        includedProfile: [profile({ criterion: [criterion(override)] })],
+      });
+      const outcome = parseConformityScheme(doc, { sourceUrl: 'https://example.com/scheme' });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: ConformitySchemeErrorCode.MissingRequiredField,
+            pointer,
+          }),
+        ]),
+      );
+    });
+
+    it('returns an invalid-shape error when includedProfile is not an array', () => {
+      const doc = minimalSchemeDoc({ includedProfile: 'not-an-array' });
+      const outcome = parseConformityScheme(doc, { sourceUrl: 'https://example.com/scheme' });
+      expect(outcome.value).toBeUndefined();
+      expect(outcome.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: ConformitySchemeErrorCode.InvalidShape,
+            pointer: '/includedProfile',
+          }),
+        ]),
+      );
+    });
+  });
+});

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.test.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.test.ts
@@ -181,6 +181,15 @@ describe('parseConformityScheme', () => {
       expect(outcome.value?.profiles[0].criteria[0].tags).toEqual(['forced-labor', 'human-rights']);
     });
 
+    it('parses a single string tag as a one-element array', () => {
+      const doc = minimalSchemeDoc({
+        includedProfile: [profile({ criterion: [criterion({ tag: 'forced-labor' })] })],
+      });
+      const outcome = parseConformityScheme(doc, { sourceUrl: 'https://example.com/scheme' });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.profiles[0].criteria[0].tags).toEqual(['forced-labor']);
+    });
+
     it('captures the owner reference when present', () => {
       const doc = minimalSchemeDoc({
         owner: {
@@ -197,6 +206,20 @@ describe('parseConformityScheme', () => {
         canonicalId: 'https://example.com/owner',
         name: 'Example Owner',
       });
+    });
+
+    it('parses owner as a bare URI string (compact form)', () => {
+      const doc = minimalSchemeDoc({ owner: 'https://example.com/owner' });
+      const outcome = parseConformityScheme(doc, { sourceUrl: 'https://example.com/scheme' });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.owner).toEqual({ canonicalId: 'https://example.com/owner' });
+    });
+
+    it('returns undefined owner when input is an array', () => {
+      const doc = minimalSchemeDoc({ owner: ['not', 'a', 'party'] });
+      const outcome = parseConformityScheme(doc, { sourceUrl: 'https://example.com/scheme' });
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value?.owner).toBeUndefined();
     });
   });
 

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.ts
@@ -1,0 +1,86 @@
+import { detectVersionFromContext } from '../detect-version-from-context.js';
+import type { ParseOutcome } from '../validation-outcome.js';
+import { ConformitySchemeErrorCode } from './codes.js';
+import { parseV070ConformityScheme } from './parsers/v0-7-0.parser.js';
+import type { ConformityScheme, ConformitySchemeError } from './types.js';
+
+/**
+ * Options for {@link parseConformityScheme}.
+ */
+export interface ParseConformitySchemeOptions {
+  /** The URL the document was fetched from; recorded on the returned scheme. */
+  sourceUrl: string;
+  /**
+   * Override the CVC spec version detection. When omitted, the version is
+   * derived from the document's `@context`. Useful for testing or when a
+   * draft document's `@context` is ambiguous.
+   */
+  specVersion?: string;
+}
+
+/** CVC spec versions this build can parse. */
+export const SUPPORTED_CVC_SPEC_VERSIONS = ['0.7.0'] as const;
+export type SupportedCvcSpecVersion = (typeof SUPPORTED_CVC_SPEC_VERSIONS)[number];
+
+type Parser = (doc: unknown, sourceUrl: string, errors: ConformitySchemeError[]) => ConformityScheme | undefined;
+
+const PARSERS: Record<SupportedCvcSpecVersion, Parser> = {
+  '0.7.0': parseV070ConformityScheme,
+};
+
+/**
+ * Parses an owner-published conformity scheme JSON-LD document into a
+ * structured tree.
+ *
+ * The spec version is detected from the document's `@context` (UNTP publishes
+ * versioned context URLs at `https://vocabulary.uncefact.org/untp/{version}/context/`).
+ * The detection can be overridden via `options.specVersion`.
+ *
+ * Per ADR-034, this function does not throw for input-related failures. All
+ * errors (malformed shape, missing required fields, unsupported spec
+ * version) are returned in the outcome's `errors` array. `value` is present
+ * iff `errors` is empty.
+ *
+ * @param doc - The parsed JSON-LD document.
+ * @param options - `sourceUrl` is required; `specVersion` is optional.
+ * @returns A `ParseOutcome` carrying the structured scheme on success or
+ *   an array of structured errors on failure.
+ *
+ * @see https://untp.unece.org/docs/specification/ConformityVocabularyCatalog
+ */
+export function parseConformityScheme(
+  doc: unknown,
+  options: ParseConformitySchemeOptions,
+): ParseOutcome<ConformityScheme> {
+  const errors: ConformitySchemeError[] = [];
+  const warnings: never[] = [];
+
+  const detected = options.specVersion ?? detectVersionFromContext(doc);
+  if (!detected) {
+    errors.push({
+      code: ConformitySchemeErrorCode.UnsupportedSpecVersion,
+      message: "Could not detect CVC spec version from the document's @context, and no override was supplied.",
+      received: 'undetected',
+      expected: [...SUPPORTED_CVC_SPEC_VERSIONS],
+      pointer: '/@context',
+    });
+    return { errors, warnings };
+  }
+
+  const parser = PARSERS[detected as SupportedCvcSpecVersion];
+  if (!parser) {
+    errors.push({
+      code: ConformitySchemeErrorCode.UnsupportedSpecVersion,
+      message: `CVC spec version '${detected}' is not supported by this build.`,
+      received: detected,
+      expected: [...SUPPORTED_CVC_SPEC_VERSIONS],
+    });
+    return { errors, warnings };
+  }
+
+  const value = parser(doc, options.sourceUrl, errors);
+  if (errors.length > 0 || !value) {
+    return { errors, warnings };
+  }
+  return { value, errors, warnings };
+}

--- a/packages/untp-utils/src/conformity-vocabulary/parsers/v0-7-0.parser.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parsers/v0-7-0.parser.ts
@@ -247,6 +247,9 @@ function parseTopic(input: unknown): ConformityTopic | undefined {
 }
 
 function parseTags(input: unknown): string[] {
+  if (typeof input === 'string' && input.length > 0) {
+    return [input];
+  }
   if (!Array.isArray(input)) {
     return [];
   }
@@ -254,7 +257,10 @@ function parseTags(input: unknown): string[] {
 }
 
 function parseOwner(input: unknown): ConformitySchemeOwner | undefined {
-  if (!input || typeof input !== 'object') {
+  if (typeof input === 'string' && input.length > 0) {
+    return { canonicalId: input };
+  }
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return undefined;
   }
   const o = input as Record<string, unknown>;

--- a/packages/untp-utils/src/conformity-vocabulary/parsers/v0-7-0.parser.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parsers/v0-7-0.parser.ts
@@ -1,0 +1,288 @@
+import { ConformitySchemeErrorCode } from '../codes.js';
+import type {
+  ConformityCriterion,
+  ConformityProfile,
+  ConformityScheme,
+  ConformitySchemeError,
+  ConformitySchemeOwner,
+  ConformityTopic,
+} from '../types.js';
+
+const SPEC_VERSION = '0.7.0';
+
+/**
+ * Parses a v0.7.0 ConformityScheme JSON-LD document.
+ *
+ * Per the v0.7 spec, the document is rooted at a Conformity Scheme that
+ * inlines its versioned Profiles, each of which inlines its versioned
+ * Criteria. The scheme URI is stable but not independently versioned;
+ * profile and criterion URIs include version segments.
+ *
+ * **Parser leniency.** This parser focuses on **structural extraction** of
+ * the fields the rest of the package needs. It is intentionally lenient
+ * relative to the canonical `ConformityScheme.json` JSON Schema: it does not
+ * re-enforce required fields the parser does not need to construct its
+ * output (for example, `endorsementLevel`, `requiredPerformance`, or the
+ * profile's back-reference `scheme`). Document-level conformance to the
+ * canonical schema is the responsibility of the upstream JSON Schema
+ * validation gate the ingestion pipeline runs before invoking the parser
+ * (see ADR-033 §1, "Validation at ingest"). The parser only emits errors
+ * for fields it cannot proceed without (the canonical IDs and the names,
+ * versions, and statuses of profiles and criteria).
+ *
+ * All errors are accumulated into the `errors` sink rather than thrown, so
+ * a single parse pass surfaces every problem it can detect.
+ *
+ * @param doc - The parsed JSON-LD document.
+ * @param sourceUrl - The URL the document was fetched from (recorded on the
+ *   returned scheme).
+ * @param errors - Sink the parser appends to on each detected problem.
+ * @returns The parsed scheme, or `undefined` if a fatal shape problem
+ *   prevented construction.
+ *
+ * @see https://untp.unece.org/docs/specification/ConformityVocabularyCatalog
+ * @see https://untp.unece.org/artefacts/schema/v0.7.0/cvc/ConformityScheme.json
+ */
+export function parseV070ConformityScheme(
+  doc: unknown,
+  sourceUrl: string,
+  errors: ConformitySchemeError[],
+): ConformityScheme | undefined {
+  if (!doc || typeof doc !== 'object') {
+    errors.push({
+      code: ConformitySchemeErrorCode.InvalidShape,
+      message: 'Conformity scheme document must be a non-null object.',
+      received: doc === null ? 'null' : typeof doc,
+      expected: 'object',
+      pointer: '',
+    });
+    return undefined;
+  }
+  const root = doc as Record<string, unknown>;
+
+  const canonicalId = requireString(root.id, 'scheme.id', '/id', errors);
+  const name = requireString(root.name, 'scheme.name', '/name', errors);
+
+  const profiles = parseProfiles(root.includedProfile, '/includedProfile', errors);
+
+  if (canonicalId === undefined || name === undefined) {
+    return undefined;
+  }
+
+  return {
+    canonicalId,
+    sourceUrl,
+    specVersion: SPEC_VERSION,
+    name,
+    description: optionalString(root.description),
+    documentation: optionalString(root.documentation),
+    owner: parseOwner(root.owner),
+    profiles,
+  };
+}
+
+function parseProfiles(input: unknown, pointer: string, errors: ConformitySchemeError[]): ConformityProfile[] {
+  if (input === undefined || input === null) {
+    return [];
+  }
+  if (!Array.isArray(input)) {
+    errors.push({
+      code: ConformitySchemeErrorCode.InvalidShape,
+      message: 'scheme.includedProfile must be an array.',
+      received: typeof input,
+      expected: 'array',
+      pointer,
+    });
+    return [];
+  }
+  const out: ConformityProfile[] = [];
+  input.forEach((entry, i) => {
+    const parsed = parseProfile(entry, i, `${pointer}/${i}`, errors);
+    if (parsed) {
+      out.push(parsed);
+    }
+  });
+  return out;
+}
+
+function parseProfile(
+  input: unknown,
+  index: number,
+  pointer: string,
+  errors: ConformitySchemeError[],
+): ConformityProfile | undefined {
+  if (!input || typeof input !== 'object') {
+    errors.push({
+      code: ConformitySchemeErrorCode.InvalidShape,
+      message: `Profile at index ${index} must be a non-null object.`,
+      received: input === null ? 'null' : typeof input,
+      expected: 'object',
+      pointer,
+    });
+    return undefined;
+  }
+  const p = input as Record<string, unknown>;
+  const canonicalId = requireString(p.id, `profile[${index}].id`, `${pointer}/id`, errors);
+  const name = requireString(p.name, `profile[${index}].name`, `${pointer}/name`, errors);
+  const version = requireString(p.version, `profile[${index}].version`, `${pointer}/version`, errors);
+  const status = requireString(p.status, `profile[${index}].status`, `${pointer}/status`, errors);
+
+  const criteria = parseCriteria(p.criterion, `${pointer}/criterion`, errors);
+
+  if (!canonicalId || !name || !version || !status) {
+    return undefined;
+  }
+
+  return {
+    canonicalId,
+    name,
+    version,
+    status,
+    description: optionalString(p.description),
+    documentation: optionalString(p.documentation),
+    validFrom: optionalString(p.validFrom),
+    criteria,
+  };
+}
+
+function parseCriteria(input: unknown, pointer: string, errors: ConformitySchemeError[]): ConformityCriterion[] {
+  if (input === undefined || input === null) {
+    return [];
+  }
+  if (!Array.isArray(input)) {
+    errors.push({
+      code: ConformitySchemeErrorCode.InvalidShape,
+      message: 'profile.criterion must be an array.',
+      received: typeof input,
+      expected: 'array',
+      pointer,
+    });
+    return [];
+  }
+  const out: ConformityCriterion[] = [];
+  input.forEach((entry, i) => {
+    const parsed = parseCriterion(entry, `${pointer}/${i}`, errors);
+    if (parsed) {
+      out.push(parsed);
+    }
+  });
+  return out;
+}
+
+function parseCriterion(
+  input: unknown,
+  pointer: string,
+  errors: ConformitySchemeError[],
+): ConformityCriterion | undefined {
+  if (!input || typeof input !== 'object') {
+    errors.push({
+      code: ConformitySchemeErrorCode.InvalidShape,
+      message: 'Criterion must be a non-null object.',
+      received: input === null ? 'null' : typeof input,
+      expected: 'object',
+      pointer,
+    });
+    return undefined;
+  }
+  const c = input as Record<string, unknown>;
+  const canonicalId = requireString(c.id, 'criterion.id', `${pointer}/id`, errors);
+  const name = requireString(c.name, 'criterion.name', `${pointer}/name`, errors);
+  const version = requireString(c.version, 'criterion.version', `${pointer}/version`, errors);
+  const status = requireString(c.status, 'criterion.status', `${pointer}/status`, errors);
+
+  if (!canonicalId || !name || !version || !status) {
+    return undefined;
+  }
+
+  return {
+    canonicalId,
+    name,
+    version,
+    status,
+    description: optionalString(c.description),
+    documentation: optionalString(c.documentation),
+    topics: parseTopics(c.conformityTopic),
+    tags: parseTags(c.tag),
+  };
+}
+
+function parseTopics(input: unknown): ConformityTopic[] {
+  if (input === undefined || input === null) {
+    return [];
+  }
+  if (!Array.isArray(input)) {
+    const single = parseTopic(input);
+    return single ? [single] : [];
+  }
+  const out: ConformityTopic[] = [];
+  for (const entry of input) {
+    const parsed = parseTopic(entry);
+    if (parsed) {
+      out.push(parsed);
+    }
+  }
+  return out;
+}
+
+function parseTopic(input: unknown): ConformityTopic | undefined {
+  if (typeof input === 'string') {
+    if (!input) {
+      return undefined;
+    }
+    return { canonicalId: input };
+  }
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+  const t = input as Record<string, unknown>;
+  const id = optionalString(t.id);
+  if (!id) {
+    return undefined;
+  }
+  return {
+    canonicalId: id,
+    name: optionalString(t.name),
+    definition: optionalString(t.definition),
+  };
+}
+
+function parseTags(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return input.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function parseOwner(input: unknown): ConformitySchemeOwner | undefined {
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+  const o = input as Record<string, unknown>;
+  return {
+    canonicalId: optionalString(o.id),
+    name: optionalString(o.name),
+  };
+}
+
+function requireString(
+  value: unknown,
+  fieldName: string,
+  pointer: string,
+  errors: ConformitySchemeError[],
+): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push({
+      code: ConformitySchemeErrorCode.MissingRequiredField,
+      message: `${fieldName} is required and must be a non-empty string.`,
+      received: value === undefined ? 'undefined' : value === null ? 'null' : typeof value,
+      expected: 'non-empty string',
+      pointer,
+    });
+    return undefined;
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/untp-utils/src/conformity-vocabulary/types.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/types.ts
@@ -1,0 +1,147 @@
+import type { ValidationError, ValidationWarning } from '../validation-outcome.js';
+import type { ConformitySchemeErrorCode, ConformityWarningCode } from './codes.js';
+
+/**
+ * Types for the UNTP Conformity Vocabulary primitives.
+ *
+ * Mirrors the v0.7 spec hierarchy: a Conformity Scheme inlines its versioned
+ * Profiles, each of which inlines its versioned Criteria. Scheme URIs are
+ * stable and not independently versioned; profile and criterion URIs include
+ * a version segment per spec.
+ *
+ * @see https://untp.unece.org/docs/specification/ConformityVocabularyCatalog
+ */
+
+/**
+ * Reference to the scheme owner. Optional; not all scheme documents carry it.
+ */
+export interface ConformitySchemeOwner {
+  /** Owner URI (typically a website or registered identifier). */
+  canonicalId?: string;
+  /** Human-readable owner name. */
+  name?: string;
+}
+
+/**
+ * A topic the criterion addresses (e.g. a SKOS concept from the UNTP
+ * conformity-topic vocabulary).
+ */
+export interface ConformityTopic {
+  /** Topic URI. */
+  canonicalId: string;
+  /** Human-readable name, when the topic is inlined as a structured object. */
+  name?: string;
+  /** Free-text definition, when present. */
+  definition?: string;
+}
+
+/**
+ * A single auditable criterion within a profile.
+ *
+ * The criterion URI is stable and versioned per spec (e.g.
+ * `myscheme.org/criterion/forced-labour/1.0.0`).
+ */
+export interface ConformityCriterion {
+  /** Canonical (versioned) criterion URI. */
+  canonicalId: string;
+  /** Human-readable criterion name. */
+  name: string;
+  /** Criterion version string (also encoded in `canonicalId`). */
+  version: string;
+  /** Lifecycle status, e.g. `active`. */
+  status: string;
+  description?: string;
+  documentation?: string;
+  /** Conformity topics this criterion addresses. */
+  topics: ConformityTopic[];
+  /** Free-form tags attached to the criterion. */
+  tags: string[];
+}
+
+/**
+ * A profile within a scheme. Profile URI is stable and versioned per spec.
+ */
+export interface ConformityProfile {
+  /** Canonical (versioned) profile URI. */
+  canonicalId: string;
+  name: string;
+  /** Profile version string (also encoded in `canonicalId`). */
+  version: string;
+  /** Lifecycle status, e.g. `active`. */
+  status: string;
+  description?: string;
+  documentation?: string;
+  /** Optional ISO-8601 date the profile becomes valid. */
+  validFrom?: string;
+  /** Criteria inlined within this profile. */
+  criteria: ConformityCriterion[];
+}
+
+/**
+ * A parsed conformity scheme as published by a scheme owner.
+ *
+ * The scheme URI is stable but not independently versioned. Profiles and
+ * criteria inside the scheme carry their own version segments.
+ */
+export interface ConformityScheme {
+  /** Canonical scheme URI (no version segment). */
+  canonicalId: string;
+  /** URL the scheme document was fetched from (callers pass this in). */
+  sourceUrl: string;
+  /** CVC specification version that was used to parse this document. */
+  specVersion: string;
+  /** Human-readable scheme name. */
+  name: string;
+  description?: string;
+  documentation?: string;
+  owner?: ConformitySchemeOwner;
+  profiles: ConformityProfile[];
+}
+
+// ---------------------------------------------------------------------------
+// Errors and warnings narrowed to this sub-entry's codes.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse errors emitted by {@link parseConformityScheme}. Narrows
+ * {@link ValidationError} so the `code` is one of the parser's known codes.
+ */
+export type ConformitySchemeError = ValidationError & { code: ConformitySchemeErrorCode };
+
+/**
+ * Warnings emitted by {@link validateConformityClaim}. Narrows
+ * {@link ValidationWarning} so the `code` is one of the validator's known codes.
+ */
+export type ConformityWarning = ValidationWarning & { code: ConformityWarningCode };
+
+// ---------------------------------------------------------------------------
+// Claim validation
+// ---------------------------------------------------------------------------
+
+/**
+ * A single criterion entry on a credential's conformity claim. The credential
+ * issuer asserts conformity to `criterion` and may declare a `conformityTopic`
+ * that scopes the claim to one of the topics the criterion publishes.
+ */
+export interface ConformityClaimCriterion {
+  /** Criterion URI the claim references. */
+  criterion: string;
+  /**
+   * Topic URI the claim is scoped to. Optional; when present, the validator
+   * checks it against the criterion's published topic set.
+   */
+  conformityTopic?: string;
+}
+
+/**
+ * A conformity claim extracted from a Digital Conformity Credential, in the
+ * minimal shape the validator needs.
+ */
+export interface ConformityClaim {
+  /** Scheme URI the claim references. */
+  scheme: string;
+  /** Profile URI the claim references. */
+  profile: string;
+  /** Criteria the claim addresses. */
+  criteria: ConformityClaimCriterion[];
+}

--- a/packages/untp-utils/src/conformity-vocabulary/validate-conformity-claim.test.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/validate-conformity-claim.test.ts
@@ -1,0 +1,245 @@
+import { ConformityWarningCode } from './codes.js';
+import type { ConformityClaim, ConformityScheme } from './types.js';
+import { validateConformityClaim } from './validate-conformity-claim.js';
+
+const SCHEME_URI = 'https://example.com/scheme';
+const PROFILE_URI = 'https://example.com/scheme/full/1.0.0';
+const CRITERION_A = 'https://example.com/criterion/a/1.0.0';
+const CRITERION_B = 'https://example.com/criterion/b/1.0.0';
+const TOPIC_A1 = 'https://vocabulary.uncefact.org/conformity-topics/a-1';
+const TOPIC_A2 = 'https://vocabulary.uncefact.org/conformity-topics/a-2';
+
+function scheme(): ConformityScheme {
+  return {
+    canonicalId: SCHEME_URI,
+    sourceUrl: SCHEME_URI,
+    specVersion: '0.7.0',
+    name: 'Test Scheme',
+    profiles: [
+      {
+        canonicalId: PROFILE_URI,
+        name: 'Full',
+        version: '1.0.0',
+        status: 'active',
+        criteria: [
+          {
+            canonicalId: CRITERION_A,
+            name: 'A',
+            version: '1.0.0',
+            status: 'active',
+            topics: [{ canonicalId: TOPIC_A1 }, { canonicalId: TOPIC_A2 }],
+            tags: [],
+          },
+          {
+            canonicalId: CRITERION_B,
+            name: 'B',
+            version: '1.0.0',
+            status: 'active',
+            topics: [],
+            tags: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('validateConformityClaim', () => {
+  it('returns no errors and no warnings when the claim matches the scheme exactly', () => {
+    const claim: ConformityClaim = {
+      scheme: SCHEME_URI,
+      profile: PROFILE_URI,
+      criteria: [{ criterion: CRITERION_A, conformityTopic: TOPIC_A1 }, { criterion: CRITERION_B }],
+    };
+    const outcome = validateConformityClaim(claim, scheme());
+    expect(outcome.errors).toEqual([]);
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  describe('scheme-not-found', () => {
+    it('fires when the scheme is null', () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [],
+      };
+      const outcome = validateConformityClaim(claim, null);
+      expect(outcome.warnings).toEqual([
+        expect.objectContaining({
+          code: ConformityWarningCode.SchemeNotFound,
+          received: SCHEME_URI,
+          pointer: '/scheme',
+        }),
+      ]);
+    });
+
+    it("fires when the scheme's canonicalId doesn't match the claim", () => {
+      const wrongScheme: ConformityScheme = { ...scheme(), canonicalId: 'https://other.example/scheme' };
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [{ criterion: CRITERION_A }],
+      };
+      const outcome = validateConformityClaim(claim, wrongScheme);
+      expect(outcome.warnings.map((w) => w.code)).toEqual([ConformityWarningCode.SchemeNotFound]);
+    });
+
+    it('short-circuits: no profile or criterion checks run', () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: 'https://example.com/scheme/does-not-exist/9.9.9',
+        criteria: [{ criterion: 'https://example.com/criterion/does-not-exist/9.9.9' }],
+      };
+      const outcome = validateConformityClaim(claim, null);
+      expect(outcome.warnings).toHaveLength(1);
+      expect(outcome.warnings[0].code).toBe(ConformityWarningCode.SchemeNotFound);
+    });
+  });
+
+  describe('profile-not-found', () => {
+    it("fires when the claim's profile URI is not among the scheme's profiles", () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: 'https://example.com/scheme/other/2.0.0',
+        criteria: [{ criterion: CRITERION_A }],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      expect(outcome.warnings).toEqual([
+        expect.objectContaining({
+          code: ConformityWarningCode.ProfileNotFound,
+          received: 'https://example.com/scheme/other/2.0.0',
+          expected: [PROFILE_URI],
+          pointer: '/profile',
+        }),
+      ]);
+    });
+
+    it('short-circuits: criterion checks do not run', () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: 'https://example.com/scheme/other/2.0.0',
+        criteria: [
+          { criterion: 'https://example.com/criterion/unknown/1.0.0' },
+          { criterion: CRITERION_A, conformityTopic: 'https://example.com/topics/unknown' },
+        ],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      expect(outcome.warnings).toHaveLength(1);
+    });
+  });
+
+  describe('criterion-not-in-profile', () => {
+    it("fires when a claim's criterion URI is not in the profile's published criteria", () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [
+          { criterion: CRITERION_A },
+          { criterion: CRITERION_B },
+          { criterion: 'https://example.com/criterion/unknown/1.0.0' },
+        ],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      expect(outcome.warnings).toEqual([
+        expect.objectContaining({
+          code: ConformityWarningCode.CriterionNotInProfile,
+          received: 'https://example.com/criterion/unknown/1.0.0',
+          expected: [CRITERION_A, CRITERION_B],
+          pointer: '/criteria/2/criterion',
+        }),
+      ]);
+    });
+
+    it('does not double-report missing criteria as topic-mismatch', () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [
+          { criterion: CRITERION_A },
+          { criterion: CRITERION_B },
+          {
+            criterion: 'https://example.com/criterion/unknown/1.0.0',
+            conformityTopic: 'https://example.com/topics/unknown',
+          },
+        ],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      const codes = outcome.warnings.map((w) => w.code);
+      expect(codes).toContain(ConformityWarningCode.CriterionNotInProfile);
+      expect(codes).not.toContain(ConformityWarningCode.CriterionTopicMismatch);
+    });
+  });
+
+  describe('criterion-missing', () => {
+    it('fires when the profile publishes a criterion the claim does not address', () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [{ criterion: CRITERION_A, conformityTopic: TOPIC_A1 }],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      expect(outcome.warnings).toEqual([
+        expect.objectContaining({
+          code: ConformityWarningCode.CriterionMissing,
+          expected: CRITERION_B,
+          pointer: '/criteria',
+        }),
+      ]);
+    });
+
+    it('fires for every missing criterion (no short-circuit)', () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      const missingExpected = outcome.warnings
+        .filter((w) => w.code === ConformityWarningCode.CriterionMissing)
+        .map((w) => w.expected);
+      expect(missingExpected).toEqual([CRITERION_A, CRITERION_B]);
+    });
+  });
+
+  describe('criterion-topic-mismatch', () => {
+    it("fires when the claim's topic for a criterion isn't in the criterion's published topics", () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [
+          { criterion: CRITERION_A, conformityTopic: 'https://example.com/topics/wrong' },
+          { criterion: CRITERION_B },
+        ],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      expect(outcome.warnings).toEqual([
+        expect.objectContaining({
+          code: ConformityWarningCode.CriterionTopicMismatch,
+          received: 'https://example.com/topics/wrong',
+          expected: [TOPIC_A1, TOPIC_A2],
+          pointer: '/criteria/0/conformityTopic',
+        }),
+      ]);
+    });
+
+    it('does not fire when the claim does not declare a topic', () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [{ criterion: CRITERION_A }, { criterion: CRITERION_B }],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      expect(outcome.warnings).toEqual([]);
+    });
+
+    it("does not fire when the claim's topic matches one of the criterion's topics", () => {
+      const claim: ConformityClaim = {
+        scheme: SCHEME_URI,
+        profile: PROFILE_URI,
+        criteria: [{ criterion: CRITERION_A, conformityTopic: TOPIC_A2 }, { criterion: CRITERION_B }],
+      };
+      const outcome = validateConformityClaim(claim, scheme());
+      expect(outcome.warnings).toEqual([]);
+    });
+  });
+});

--- a/packages/untp-utils/src/conformity-vocabulary/validate-conformity-claim.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/validate-conformity-claim.ts
@@ -1,0 +1,113 @@
+import type { ValidationOutcome } from '../validation-outcome.js';
+import { ConformityWarningCode } from './codes.js';
+import type { ConformityClaim, ConformityScheme, ConformityWarning } from './types.js';
+
+/**
+ * Validates a credential's conformity claim against a parsed scheme. The
+ * function is pure: it never fetches, never reads the database, never throws
+ * for input-related failures, and never mutates its inputs. The caller is
+ * responsible for sourcing the scheme that `claim.scheme` refers to.
+ *
+ * Per ADR-034, the outcome carries both `errors[]` (always empty in this
+ * function because the inputs are typed) and `warnings[]` (the meaningful
+ * output). The walk goes scheme → profile → criteria → criterion topics and
+ * short-circuits at the first miss:
+ *
+ * - If `scheme` is null (or its `canonicalId` doesn't match `claim.scheme`),
+ *   only `conformity-scheme.not-found` is emitted.
+ * - If the claim's profile is not in the scheme, only
+ *   `conformity-profile.not-found` is emitted.
+ * - Otherwise the criteria-level and topic-level checks run.
+ *
+ * Pointers on emitted warnings are relative to `claim`. Consumers re-map
+ * them by prepending a wrapper path if the claim was extracted from a
+ * larger document (e.g. an RI flow would prepend
+ * `/credentialSubject/conformityClaim` for display in the credential).
+ *
+ * @param claim - Conformity claim extracted from a DCC.
+ * @param scheme - The parsed scheme the caller looked up by `claim.scheme`,
+ *   or `null` when no scheme could be found.
+ * @returns A {@link ValidationOutcome} carrying advisory warnings.
+ *
+ * @see ADR-033 §3 for warning code definitions.
+ * @see ADR-034 for the error and warning reporting convention.
+ */
+export function validateConformityClaim(claim: ConformityClaim, scheme: ConformityScheme | null): ValidationOutcome {
+  const warnings: ConformityWarning[] = [];
+  const errors: never[] = [];
+
+  if (!scheme || scheme.canonicalId !== claim.scheme) {
+    warnings.push({
+      code: ConformityWarningCode.SchemeNotFound,
+      message: 'Scheme URI is not in the known set.',
+      received: claim.scheme,
+      pointer: '/scheme',
+    });
+    return { errors, warnings };
+  }
+
+  const profile = scheme.profiles.find((p) => p.canonicalId === claim.profile);
+  if (!profile) {
+    warnings.push({
+      code: ConformityWarningCode.ProfileNotFound,
+      message: "Profile URI is not among the scheme's published profiles.",
+      received: claim.profile,
+      expected: scheme.profiles.map((p) => p.canonicalId),
+      pointer: '/profile',
+    });
+    return { errors, warnings };
+  }
+
+  const profileCriteriaById = new Map(profile.criteria.map((c) => [c.canonicalId, c]));
+  const claimCriteriaIds = new Set(claim.criteria.map((c) => c.criterion));
+  const publishedCriterionIds = profile.criteria.map((c) => c.canonicalId);
+
+  // criterion-not-in-profile
+  claim.criteria.forEach((claimCriterion, i) => {
+    if (!profileCriteriaById.has(claimCriterion.criterion)) {
+      warnings.push({
+        code: ConformityWarningCode.CriterionNotInProfile,
+        message: "Criterion URI is not in the profile's published criterion list.",
+        received: claimCriterion.criterion,
+        expected: publishedCriterionIds,
+        pointer: `/criteria/${i}/criterion`,
+      });
+    }
+  });
+
+  // criterion-missing
+  for (const profileCriterion of profile.criteria) {
+    if (!claimCriteriaIds.has(profileCriterion.canonicalId)) {
+      warnings.push({
+        code: ConformityWarningCode.CriterionMissing,
+        message: 'Profile publishes a criterion that the claim does not address.',
+        expected: profileCriterion.canonicalId,
+        pointer: '/criteria',
+      });
+    }
+  }
+
+  // criterion-topic-mismatch
+  claim.criteria.forEach((claimCriterion, i) => {
+    if (!claimCriterion.conformityTopic) {
+      return;
+    }
+    const schemeCriterion = profileCriteriaById.get(claimCriterion.criterion);
+    if (!schemeCriterion) {
+      // already surfaced by criterion-not-in-profile
+      return;
+    }
+    const publishedTopicIds = schemeCriterion.topics.map((t) => t.canonicalId);
+    if (!publishedTopicIds.includes(claimCriterion.conformityTopic)) {
+      warnings.push({
+        code: ConformityWarningCode.CriterionTopicMismatch,
+        message: "Claim's declared topic is not among the criterion's published topics.",
+        received: claimCriterion.conformityTopic,
+        expected: publishedTopicIds,
+        pointer: `/criteria/${i}/conformityTopic`,
+      });
+    }
+  });
+
+  return { errors, warnings };
+}

--- a/packages/untp-utils/src/detect-version-from-context.test.ts
+++ b/packages/untp-utils/src/detect-version-from-context.test.ts
@@ -1,0 +1,79 @@
+import { detectVersionFromContext } from './detect-version-from-context.js';
+
+describe('detectVersionFromContext', () => {
+  describe('UNTP context detection (default domain set)', () => {
+    it('returns the version from a single string @context', () => {
+      const doc = { '@context': 'https://vocabulary.uncefact.org/untp/0.7.0/context/' };
+      expect(detectVersionFromContext(doc)).toBe('0.7.0');
+    });
+
+    it('returns the version when @context is an array including the UNTP context', () => {
+      const doc = {
+        '@context': ['https://www.w3.org/ns/credentials/v2', 'https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+      };
+      expect(detectVersionFromContext(doc)).toBe('0.7.0');
+    });
+
+    it('recognises pre-release versions', () => {
+      const doc = { '@context': 'https://vocabulary.uncefact.org/untp/0.7.0-rc.1/context/' };
+      expect(detectVersionFromContext(doc)).toBe('0.7.0-rc.1');
+    });
+
+    it('recognises the test.uncefact.org domain', () => {
+      const doc = { '@context': 'https://test.uncefact.org/untp/0.7.0/context/' };
+      expect(detectVersionFromContext(doc)).toBe('0.7.0');
+    });
+
+    it('returns undefined for non-UNTP context domains', () => {
+      const doc = { '@context': ['https://schema.org/', 'https://example.com/0.7.0/'] };
+      expect(detectVersionFromContext(doc)).toBeUndefined();
+    });
+
+    it('skips non-string entries within an array @context', () => {
+      const doc = {
+        '@context': [{ '@vocab': 'https://example.com/' }, 'https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+      };
+      expect(detectVersionFromContext(doc)).toBe('0.7.0');
+    });
+  });
+
+  describe('domain-scoped detection', () => {
+    it('finds the version under a caller-supplied domain (extension context)', () => {
+      const doc = {
+        '@context': [
+          'https://www.w3.org/ns/credentials/v2',
+          'https://vocabulary.uncefact.org/untp/0.7.0/context/',
+          'https://aatp.example.com/untp/0.5.0/context/',
+        ],
+      };
+      expect(detectVersionFromContext(doc, { domain: 'aatp.example.com' })).toBe('0.5.0');
+    });
+
+    it('returns undefined when no context matches the supplied domain', () => {
+      const doc = {
+        '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+      };
+      expect(detectVersionFromContext(doc, { domain: 'nope.example.com' })).toBeUndefined();
+    });
+  });
+
+  describe('input handling', () => {
+    it('returns undefined when @context is missing', () => {
+      expect(detectVersionFromContext({})).toBeUndefined();
+    });
+
+    it('returns undefined for non-object input', () => {
+      expect(detectVersionFromContext(null)).toBeUndefined();
+      expect(detectVersionFromContext(undefined)).toBeUndefined();
+      expect(detectVersionFromContext('a string')).toBeUndefined();
+      expect(detectVersionFromContext(42)).toBeUndefined();
+    });
+  });
+
+  describe('regex robustness', () => {
+    it('ignores version-like substrings outside a path segment', () => {
+      const doc = { '@context': 'https://vocabulary.uncefact.org/untp/context?v=1.2.3' };
+      expect(detectVersionFromContext(doc)).toBeUndefined();
+    });
+  });
+});

--- a/packages/untp-utils/src/detect-version-from-context.ts
+++ b/packages/untp-utils/src/detect-version-from-context.ts
@@ -1,0 +1,100 @@
+/**
+ * Domains UNTP publishes versioned contexts under. UNTP v0.7 and above
+ * publish to `vocabulary.uncefact.org`; earlier versions (pre-0.7) were
+ * published to `test.uncefact.org`. Both are kept in the matcher so
+ * documents from either era resolve to a version string.
+ */
+export const UNTP_CONTEXT_DOMAINS = ['vocabulary.uncefact.org', 'test.uncefact.org'] as const;
+
+/**
+ * A version segment in a UNTP-published context path. Matches a path segment
+ * shaped `/{major}.{minor}.{patch}[-prerelease]/`. The pre-release suffix
+ * captures common forms (`-rc1`, `-alpha.2`, `-2024-05-21`, etc.).
+ */
+const UNTP_VERSION_PATH_SEGMENT = /\/(\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?)\//;
+
+/**
+ * Options for {@link detectVersionFromContext}.
+ */
+export interface DetectVersionFromContextOptions {
+  /**
+   * When set, only context URLs whose hostname contains this substring are
+   * considered. Useful for extensions, where each extension publishes its own
+   * versioned context under a domain distinct from the UNTP core context.
+   *
+   * When omitted, any UNTP context domain ({@link UNTP_CONTEXT_DOMAINS}) is
+   * considered.
+   */
+  domain?: string;
+}
+
+/**
+ * Derives the spec version from a UNTP document's `@context` by looking for a
+ * path segment shaped `/{major}.{minor}.{patch}[-prerelease]/` inside a known
+ * UNTP context URL.
+ *
+ * Works for any UNTP artefact that publishes a versioned context: credentials
+ * (DPP, DCC, DFR, DIA, DTE), conformity schemes, identifier scheme registers,
+ * etc. The function is data-only: it never fetches, never resolves contexts.
+ *
+ * @param doc - Any object that may carry an `@context` field. The field may
+ *   be a string or an array; non-string entries in arrays are ignored.
+ *   Non-object inputs return `undefined`.
+ * @param options - {@link DetectVersionFromContextOptions}.
+ * @returns The detected version string (for example `0.7.0` or `0.7.0-rc1`),
+ *   or `undefined` when no matching UNTP context URL is found.
+ *
+ * @example
+ * detectVersionFromContext({ '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'] });
+ * // → '0.7.0'
+ *
+ * @example
+ * detectVersionFromContext(extensionCredential, { domain: 'aatp.example.com' });
+ * // → '0.5.0' (or whatever the extension publishes)
+ */
+export function detectVersionFromContext(
+  doc: unknown,
+  options: DetectVersionFromContextOptions = {},
+): string | undefined {
+  if (!doc || typeof doc !== 'object') {
+    return undefined;
+  }
+
+  const contextField = (doc as { '@context'?: unknown })['@context'];
+  const candidates = collectContextStrings(contextField);
+  const matchesDomain = buildDomainMatcher(options.domain);
+
+  for (const url of candidates) {
+    if (!matchesDomain(url)) {
+      continue;
+    }
+    const match = url.match(UNTP_VERSION_PATH_SEGMENT);
+    if (match) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+function collectContextStrings(context: unknown): string[] {
+  if (typeof context === 'string') {
+    return [context];
+  }
+  if (Array.isArray(context)) {
+    const out: string[] = [];
+    for (const entry of context) {
+      if (typeof entry === 'string') {
+        out.push(entry);
+      }
+    }
+    return out;
+  }
+  return [];
+}
+
+function buildDomainMatcher(domain: string | undefined): (url: string) => boolean {
+  if (domain) {
+    return (url) => url.includes(domain);
+  }
+  return (url) => UNTP_CONTEXT_DOMAINS.some((d) => url.includes(d));
+}

--- a/packages/untp-utils/src/index.ts
+++ b/packages/untp-utils/src/index.ts
@@ -1,1 +1,4 @@
 export * from './multibase-digest/index.js';
+export * from './validation-outcome.js';
+export * from './detect-version-from-context.js';
+export * from './conformity-vocabulary/index.js';

--- a/packages/untp-utils/src/validation-outcome.ts
+++ b/packages/untp-utils/src/validation-outcome.ts
@@ -1,0 +1,62 @@
+/**
+ * Library-agnostic error and warning shape for `@uncefact/untp-utils`.
+ *
+ * Every sub-entry that emits validation results uses these types. The
+ * convention is governed by ADR-034:
+ *
+ * - `code` is a namespaced, thing-oriented identifier (e.g.
+ *   `conformity-scheme.not-found`). Stable.
+ * - `message` is a neutral, library-agnostic factual summary. No app concepts.
+ * - `received` and `expected` are populated when the function can describe
+ *   the mismatch in structured terms.
+ * - `pointer` is populated by the library when its inputs let it construct
+ *   one unambiguously (Ajv `instancePath`, JSON-LD positions, internal
+ *   iteration indices); otherwise the consumer adds it. A library-supplied
+ *   pointer is relative to the input the consumer passed in; consumers
+ *   re-map by prepending a wrapper path if needed.
+ * - `remediation` is almost always consumer-supplied (the library cannot
+ *   know the user's audience or app concepts). Libraries may supply it only
+ *   when it is plainly derivable from `expected` and uses agnostic language.
+ * - `raw` is for wrapping third-party errors (Ajv, jsonld) for tooling.
+ *
+ * Functions in `@uncefact/untp-utils` do not throw for input-related
+ * failures; they return errors in an outcome. The caller decides whether
+ * to throw, log, collect across calls, or render inline.
+ *
+ * @see ADR-034 in `docs/adrs/`.
+ */
+
+export interface ValidationError {
+  code: string;
+  message: string;
+  received?: unknown;
+  expected?: unknown;
+  pointer?: string;
+  remediation?: string;
+  raw?: unknown;
+}
+
+export interface ValidationWarning {
+  code: string;
+  message: string;
+  received?: unknown;
+  expected?: unknown;
+  pointer?: string;
+  remediation?: string;
+}
+
+/**
+ * The shape returned by validators and parsers. Empty `errors` means the
+ * operation succeeded on its own terms; `warnings` are advisory either way.
+ */
+export interface ValidationOutcome {
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+/**
+ * The shape returned by parsers. `value` is present iff `errors.length === 0`.
+ */
+export interface ParseOutcome<T> extends ValidationOutcome {
+  value?: T;
+}


### PR DESCRIPTION
Adds the conformity-vocabulary primitives to `@uncefact/untp-utils` per ADR-033, applying the error and warning reporting convention from ADR-034.

## `@uncefact/untp-utils/conformity-vocabulary` sub-entry

- `parseConformityScheme(doc, options)` — parses v0.7 conformity scheme JSON-LD documents into a typed tree. Auto-detects the CVC spec version from `@context`; `options.specVersion` is an override.
- `validateConformityClaim(claim, scheme)` — pure validator emitting `conformity-{scheme,profile,criterion}.*` warnings. Walks scheme → profile → criteria → topic; short-circuits at the first miss; accumulates `criterion-missing` and `criterion-not-in-profile` across the claim.
- `ConformityWarningCode` / `ConformitySchemeErrorCode` as `as const` objects so consumers reference codes by identifier.

## Main entry additions

- `ValidationError`, `ValidationWarning`, `ValidationOutcome`, `ParseOutcome<T>` (the canonical ADR-034 types).
- `detectVersionFromContext(doc, options?)` and `UNTP_CONTEXT_DOMAINS` — derive the UNTP version from any artefact's `@context`. Cross-cutting; lives in main per the categorisation principle.

Errors and warnings are returned in arrays, never thrown (ADR-034 §5). Util-supplied pointers are JSON Pointer (RFC 6901) relative to the input. Messages are neutral and library-agnostic; consumers enrich with `pointer` re-mapping and `remediation` text.

`parseConformityCatalogue` (the registry-of-pointers parser) is deferred until UNTP ships the catalogue document shape.

Closes #659.

## Test plan
- [x] 44 unit tests covering version detection, parser happy paths and every required-field error path, every warning code, the short-circuit walk, and multi-error accumulation.
- [x] `pnpm build` and `pnpm test --maxWorkers=1` green (84/84 across the utils package).
- [x] `pnpm lint:check` green at workspace level.
- [x] Smoke-tested locally against a real v0.7 conformity scheme document (33 criteria across 1 profile, parsed cleanly).