### PR TITLE
feat(utils): add /node sub-entry with validatePublicUrl SSRF guard

### DIFF
--- a/packages/untp-utils/jest.config.js
+++ b/packages/untp-utils/jest.config.js
@@ -13,7 +13,7 @@ const jestConfig = {
     },
   },
   moduleNameMapper: {
-    '(.+)\\.js': '$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   extensionsToTreatAsEsm: ['.ts'],
 };

--- a/packages/untp-utils/package.json
+++ b/packages/untp-utils/package.json
@@ -24,6 +24,10 @@
     "./schema-loaders": {
       "types": "./build/schema-loaders/index.d.ts",
       "default": "./build/schema-loaders/index.js"
+    },
+    "./node": {
+      "types": "./build/node/index.d.ts",
+      "default": "./build/node/index.js"
     }
   },
   "typesVersions": {
@@ -39,6 +43,9 @@
       ],
       "schema-loaders": [
         "./build/schema-loaders/index.d.ts"
+      ],
+      "node": [
+        "./build/node/index.d.ts"
       ]
     }
   },
@@ -69,6 +76,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "ipaddr.js": "^2.4.0",
     "jsonld": "^8.3.3",
     "multiformats": "^13.3.1"
   },

--- a/packages/untp-utils/src/node/codes.ts
+++ b/packages/untp-utils/src/node/codes.ts
@@ -1,0 +1,24 @@
+/**
+ * Validation error codes for `@uncefact/untp-utils/node`.
+ *
+ * Thing-oriented and namespaced per ADR-034: the namespace identifies what
+ * the code is *about* (a URL, a hostname, a resolved address), not the
+ * activity that detected it. Stable; consumers may branch on them with
+ * exhaustive switches.
+ */
+export const NodeUrlValidationCode = {
+  /** The string could not be parsed as a URL. */
+  InvalidUrl: 'url.invalid',
+  /** The URL scheme is not in the allowed list (default: `http:`, `https:`). */
+  UnsupportedScheme: 'url.unsupported-scheme',
+  /** The URL has no hostname, or the hostname is a known private/loopback name (e.g. `localhost`, `*.local`, `*.internal`). */
+  PrivateHostname: 'url.private-hostname',
+  /** DNS resolution failed for the URL's hostname (resolver rejected the query, e.g. `ENOTFOUND`, `EAI_AGAIN`). */
+  ResolutionFailed: 'url.resolution-failed',
+  /** DNS resolution succeeded but returned no addresses for the URL's hostname. */
+  ResolutionEmpty: 'url.resolution-empty',
+  /** The hostname resolved to a private / loopback / link-local / cloud-metadata IP address. */
+  PrivateAddress: 'url.private-address',
+} as const;
+
+export type NodeUrlValidationCode = (typeof NodeUrlValidationCode)[keyof typeof NodeUrlValidationCode];

--- a/packages/untp-utils/src/node/index.ts
+++ b/packages/untp-utils/src/node/index.ts
@@ -1,0 +1,8 @@
+export { NodeUrlValidationCode } from './codes.js';
+export { isPrivateHostname, isPrivateIpv4, isPrivateIpv6 } from './is-private-ip.js';
+export {
+  validatePublicUrl,
+  type ValidatePublicUrlOptions,
+  type ValidatePublicUrlValue,
+  type ValidatePublicUrlOutcome,
+} from './validate-public-url.js';

--- a/packages/untp-utils/src/node/is-private-ip.test.ts
+++ b/packages/untp-utils/src/node/is-private-ip.test.ts
@@ -103,4 +103,10 @@ describe('isPrivateHostname', () => {
     expect(isPrivateHostname('1.1.1.1')).toBe(false);
     expect(isPrivateHostname('2606:4700:4700::1111')).toBe(false);
   });
+
+  it('handles IPv6 literals wrapped in brackets (as URL.hostname returns)', () => {
+    expect(isPrivateHostname('[::1]')).toBe(true);
+    expect(isPrivateHostname('[fc00::1]')).toBe(true);
+    expect(isPrivateHostname('[2606:4700:4700::1111]')).toBe(false);
+  });
 });

--- a/packages/untp-utils/src/node/is-private-ip.test.ts
+++ b/packages/untp-utils/src/node/is-private-ip.test.ts
@@ -1,0 +1,106 @@
+import { isPrivateHostname, isPrivateIpv4, isPrivateIpv6 } from './is-private-ip.js';
+
+describe('isPrivateIpv4', () => {
+  it.each([['1.1.1.1'], ['8.8.8.8'], ['151.101.0.1']])(
+    'returns false for the unmistakeably public address %s',
+    (addr) => {
+      expect(isPrivateIpv4(addr)).toBe(false);
+    },
+  );
+
+  it.each([
+    ['0.0.0.0'], // unspecified
+    ['10.0.0.1'], // RFC 1918
+    ['10.255.255.255'],
+    ['100.64.0.1'], // CGNAT
+    ['127.0.0.1'], // loopback
+    ['127.255.255.255'],
+    ['169.254.0.1'], // link-local
+    ['169.254.169.254'], // cloud metadata (AWS/GCP/Azure)
+    ['172.16.0.1'], // RFC 1918
+    ['172.31.255.255'],
+    ['192.168.0.1'], // RFC 1918
+    ['192.168.255.255'],
+    ['224.0.0.1'], // multicast
+    ['255.255.255.255'], // broadcast
+    ['198.18.0.1'], // benchmarking
+    ['203.0.113.1'], // TEST-NET-3 (reserved)
+    ['100.100.100.200'], // Alibaba Cloud metadata (publicly routable, but explicitly blocked)
+  ])('returns true for the private/reserved/metadata address %s', (addr) => {
+    expect(isPrivateIpv4(addr)).toBe(true);
+  });
+
+  it('returns false for non-IPv4 input', () => {
+    expect(isPrivateIpv4('not an ip')).toBe(false);
+    expect(isPrivateIpv4('::1')).toBe(false);
+    expect(isPrivateIpv4('')).toBe(false);
+  });
+});
+
+describe('isPrivateIpv6', () => {
+  it.each([
+    ['2606:4700:4700::1111'], // Cloudflare public DNS
+    ['2001:4860:4860::8888'], // Google public DNS
+  ])('returns false for the unmistakeably public address %s', (addr) => {
+    expect(isPrivateIpv6(addr)).toBe(false);
+  });
+
+  it.each([
+    ['::'], // unspecified
+    ['::1'], // loopback
+    ['fe80::1'], // link-local
+    ['fc00::1'], // unique local
+    ['fd00::1'], // unique local
+    ['ff02::1'], // multicast
+    ['2001:db8::1'], // documentation / reserved
+    ['2002::1'], // 6to4
+  ])('returns true for the non-public address %s', (addr) => {
+    expect(isPrivateIpv6(addr)).toBe(true);
+  });
+
+  it('treats IPv4-mapped IPv6 addresses by their embedded IPv4 status', () => {
+    expect(isPrivateIpv6('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateIpv6('::ffff:169.254.169.254')).toBe(true);
+    expect(isPrivateIpv6('::ffff:1.1.1.1')).toBe(false);
+  });
+
+  it('returns false for non-IPv6 input', () => {
+    expect(isPrivateIpv6('not an ip')).toBe(false);
+    expect(isPrivateIpv6('10.0.0.1')).toBe(false);
+    expect(isPrivateIpv6('')).toBe(false);
+  });
+});
+
+describe('isPrivateHostname', () => {
+  it.each([
+    [''],
+    ['localhost'],
+    ['LOCALHOST'],
+    ['foo.localhost'],
+    ['bar.local'],
+    ['printer.local.'], // trailing dot is stripped
+    ['db.internal'],
+    ['svc.intranet'],
+    ['file-server.lan'],
+    ['router.home'],
+    ['app.corp'],
+    ['vault.private'],
+  ])('returns true for the private hostname %s', (host) => {
+    expect(isPrivateHostname(host)).toBe(true);
+  });
+
+  it.each([['example.com'], ['api.cloudflare.com'], ['google.com.']])(
+    'returns false for the public hostname %s',
+    (host) => {
+      expect(isPrivateHostname(host)).toBe(false);
+    },
+  );
+
+  it('defers to IP predicates when the hostname is an IP literal', () => {
+    expect(isPrivateHostname('127.0.0.1')).toBe(true);
+    expect(isPrivateHostname('169.254.169.254')).toBe(true);
+    expect(isPrivateHostname('::1')).toBe(true);
+    expect(isPrivateHostname('1.1.1.1')).toBe(false);
+    expect(isPrivateHostname('2606:4700:4700::1111')).toBe(false);
+  });
+});

--- a/packages/untp-utils/src/node/is-private-ip.ts
+++ b/packages/untp-utils/src/node/is-private-ip.ts
@@ -116,7 +116,14 @@ export function isPrivateIpv6(address: string): boolean {
  */
 export function isPrivateHostname(host: string): boolean {
   if (!host) return true;
-  const lower = host.toLowerCase().replace(/\.$/, '');
+  // Strip leading/trailing brackets (URL.hostname wraps IPv6 literals like
+  // `[::1]`) and any trailing dot before further checks; without this, a
+  // direct caller passing `URL.hostname` for an IPv6 URL would silently
+  // miss the private-range match.
+  const lower = host
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .replace(/\.$/, '');
   if (lower === 'localhost') return true;
   if (PRIVATE_HOSTNAME_SUFFIXES.some((suffix) => lower.endsWith(suffix))) return true;
   if (isIPv4(lower)) return isPrivateIpv4(lower);

--- a/packages/untp-utils/src/node/is-private-ip.ts
+++ b/packages/untp-utils/src/node/is-private-ip.ts
@@ -1,0 +1,125 @@
+import { isIPv4, isIPv6 } from 'node:net';
+import ipaddr from 'ipaddr.js';
+
+/**
+ * The single `ipaddr.js` range category that represents a publicly routable
+ * unicast address. Anything else (loopback, link-local, private, multicast,
+ * unique-local, reserved, 6to4, teredo, etc.) is rejected. An allowlist is
+ * safer than enumerating disallowed buckets: new range names introduced by
+ * future `ipaddr.js` versions default to "block" rather than "allow".
+ */
+const PUBLIC_RANGE = 'unicast';
+
+/**
+ * Cloud-metadata IPv4 addresses listed explicitly for belt-and-braces
+ * coverage. Both addresses are already classified as non-`unicast` by
+ * `ipaddr.js` (the AWS / GCP / Azure address via link-local
+ * `169.254.0.0/16`, the Alibaba address via CGNAT `100.64.0.0/10`), but the
+ * explicit listing means a future change to `ipaddr.js`'s range taxonomy
+ * cannot accidentally promote them to `unicast`.
+ *
+ * @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+ * @see https://help.aliyun.com/document_detail/49122.html
+ */
+const ADDITIONAL_BLOCKED_IPV4 = new Set(['169.254.169.254', '100.100.100.200']);
+
+/**
+ * Hostname suffixes that name resources reachable only on a local network and
+ * must not be allowed to leave the host. Matched case-insensitively against
+ * the full hostname (e.g. `foo.localhost`, `printer.local`, `db.internal`).
+ *
+ * `.localhost` is reserved by RFC 6761; `.local` is reserved by RFC 6762
+ * (Multicast DNS); `.internal` is on the IANA / ICANN reserved list for
+ * private use (per RFC 9499 and ICANN board resolution, 2024); the
+ * remainder (`.intranet`, `.lan`, `.home`, `.corp`, `.private`) are
+ * widely-used private-network conventions that are blocked from ICANN
+ * delegation. Treating them as private is a conservative default for an
+ * SSRF guard.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6761 Special-Use Domain Names
+ * @see https://datatracker.ietf.org/doc/html/rfc6762 Multicast DNS
+ * @see https://datatracker.ietf.org/doc/html/rfc9499 DNS Terminology
+ */
+const PRIVATE_HOSTNAME_SUFFIXES = [
+  '.localhost',
+  '.local',
+  '.internal',
+  '.intranet',
+  '.lan',
+  '.home',
+  '.corp',
+  '.private',
+];
+
+/**
+ * Returns `true` if `address` is an IPv4 address string that does not fall in
+ * the public unicast range, or that matches a known cloud-metadata IP. Use
+ * this to gate outbound connections to tenant-supplied addresses.
+ *
+ * Fails closed: if `ipaddr.js` cannot parse a value that passed
+ * `node:net`'s `isIPv4` (parser/grammar skew across versions), the function
+ * returns `true` rather than letting the address through.
+ *
+ * Returns `false` for non-IPv4 input (including unparseable strings).
+ * Callers handle parsing themselves and pass only IP literals. Never throws.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc1918 Address Allocation for Private Internets
+ * @see https://datatracker.ietf.org/doc/html/rfc6598 IANA-Reserved IPv4 Prefix for Shared Address Space (CGNAT)
+ * @see https://datatracker.ietf.org/doc/html/rfc3927 Dynamic Configuration of IPv4 Link-Local Addresses
+ * @see https://datatracker.ietf.org/doc/html/rfc5735 Special Use IPv4 Addresses
+ */
+export function isPrivateIpv4(address: string): boolean {
+  if (!isIPv4(address)) return false;
+  if (ADDITIONAL_BLOCKED_IPV4.has(address)) return true;
+  try {
+    return ipaddr.parse(address).range() !== PUBLIC_RANGE;
+  } catch {
+    return true; // Fail closed: cannot prove the address is public, so treat as private.
+  }
+}
+
+/**
+ * Returns `true` if `address` is an IPv6 address string that does not fall in
+ * the public unicast range. IPv4-mapped addresses (`::ffff:a.b.c.d`) are
+ * additionally re-checked against {@link isPrivateIpv4} so an IPv4 private
+ * address tunnelled as IPv6 cannot bypass the predicate.
+ *
+ * Fails closed on parser drift, mirroring {@link isPrivateIpv4}.
+ *
+ * Returns `false` for non-IPv6 input. Never throws.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc4291 IP Version 6 Addressing Architecture
+ * @see https://datatracker.ietf.org/doc/html/rfc4193 Unique Local IPv6 Unicast Addresses
+ */
+export function isPrivateIpv6(address: string): boolean {
+  if (!isIPv6(address)) return false;
+  try {
+    const parsed = ipaddr.parse(address);
+    if (parsed.kind() !== 'ipv6') return true; // Defensive: parser/version skew. Fail closed.
+    const v6 = parsed as ipaddr.IPv6;
+    if (v6.isIPv4MappedAddress()) {
+      return isPrivateIpv4(v6.toIPv4Address().toString());
+    }
+    return v6.range() !== PUBLIC_RANGE;
+  } catch {
+    return true; // Fail closed: cannot prove the address is public, so treat as private.
+  }
+}
+
+/**
+ * Returns `true` if `host` always names a local resource (`localhost`,
+ * anything under `.localhost`, `.local`, `.internal`, etc.) or an IP literal
+ * in a non-public range.
+ *
+ * The empty string is treated as private (a URL with no hostname must never
+ * be allowed out).
+ */
+export function isPrivateHostname(host: string): boolean {
+  if (!host) return true;
+  const lower = host.toLowerCase().replace(/\.$/, '');
+  if (lower === 'localhost') return true;
+  if (PRIVATE_HOSTNAME_SUFFIXES.some((suffix) => lower.endsWith(suffix))) return true;
+  if (isIPv4(lower)) return isPrivateIpv4(lower);
+  if (isIPv6(lower)) return isPrivateIpv6(lower);
+  return false;
+}

--- a/packages/untp-utils/src/node/validate-public-url.test.ts
+++ b/packages/untp-utils/src/node/validate-public-url.test.ts
@@ -1,0 +1,303 @@
+import { jest } from '@jest/globals';
+import { NodeUrlValidationCode } from './codes.js';
+
+const lookup = jest.fn();
+
+jest.unstable_mockModule('node:dns/promises', () => ({
+  default: { lookup },
+  lookup,
+}));
+
+const { validatePublicUrl } = await import('./validate-public-url.js');
+
+describe('validatePublicUrl', () => {
+  beforeEach(() => {
+    lookup.mockReset();
+  });
+
+  describe('URL parsing', () => {
+    it('emits an InvalidUrl error when the string is not a parseable URL', async () => {
+      const outcome = await validatePublicUrl('not a url');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.InvalidUrl,
+          received: 'not a url',
+        }),
+      );
+      expect(outcome.value).toBeUndefined();
+      expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scheme', () => {
+    it('rejects URLs whose scheme is not in the default allow list', async () => {
+      const outcome = await validatePublicUrl('ftp://example.com/path');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.UnsupportedScheme,
+          received: 'ftp:',
+        }),
+      );
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('accepts a caller-supplied allowedSchemes list', async () => {
+      lookup.mockResolvedValue([{ address: '1.1.1.1', family: 4 }] as never);
+
+      const outcome = await validatePublicUrl('wss://example.com/ws', {
+        allowedSchemes: ['wss:', 'ws:'],
+      });
+
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value).toEqual({ address: '1.1.1.1', family: 4 });
+    });
+
+    it('compares schemes case-insensitively', async () => {
+      lookup.mockResolvedValue([{ address: '1.1.1.1', family: 4 }] as never);
+
+      const outcome = await validatePublicUrl('HTTPS://example.com/');
+
+      expect(outcome.errors).toEqual([]);
+    });
+  });
+
+  describe('hostname', () => {
+    it('rejects localhost without DNS lookup', async () => {
+      const outcome = await validatePublicUrl('http://localhost/path');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateHostname,
+          received: 'localhost',
+        }),
+      );
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects .internal suffix without DNS lookup', async () => {
+      const outcome = await validatePublicUrl('http://db.internal/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateHostname,
+        }),
+      );
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects a literal private IPv4 in the URL without DNS lookup', async () => {
+      const outcome = await validatePublicUrl('http://10.0.0.1/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateHostname,
+        }),
+      );
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects a literal IPv6 loopback in the URL without DNS lookup', async () => {
+      const outcome = await validatePublicUrl('http://[::1]/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateHostname,
+        }),
+      );
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('returns the literal IP for a public IPv4 host without calling DNS', async () => {
+      const outcome = await validatePublicUrl('http://1.1.1.1/');
+
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value).toEqual({ address: '1.1.1.1', family: 4 });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('returns the literal IP for a public IPv6 host without calling DNS', async () => {
+      const outcome = await validatePublicUrl('http://[2606:4700:4700::1111]/');
+
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value).toEqual({ address: '2606:4700:4700::1111', family: 6 });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects a literal 0.0.0.0 host without DNS lookup', async () => {
+      const outcome = await validatePublicUrl('http://0.0.0.0/');
+
+      expect(outcome.errors[0]).toEqual(expect.objectContaining({ code: NodeUrlValidationCode.PrivateHostname }));
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects userinfo@host smuggling where the host is private', async () => {
+      // `URL` discards the `evil.com@` userinfo and leaves the hostname as
+      // `127.0.0.1`. This is the canonical SSRF bypass; pin the regression.
+      const outcome = await validatePublicUrl('http://evil.com@127.0.0.1/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateHostname,
+          received: '127.0.0.1',
+        }),
+      );
+      expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DNS resolution', () => {
+    it('emits a ResolutionFailed error when dns.lookup rejects', async () => {
+      lookup.mockRejectedValue(new Error('ENOTFOUND example.com') as never);
+
+      const outcome = await validatePublicUrl('https://example.com/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.ResolutionFailed,
+          received: 'ENOTFOUND example.com',
+        }),
+      );
+      expect(outcome.value).toBeUndefined();
+    });
+
+    it('emits a ResolutionEmpty error when the resolver returns no records', async () => {
+      lookup.mockResolvedValue([] as never);
+
+      const outcome = await validatePublicUrl('https://example.com/');
+
+      expect(outcome.errors[0]).toEqual(expect.objectContaining({ code: NodeUrlValidationCode.ResolutionEmpty }));
+    });
+
+    it('passes the family option through to dns.lookup with all: true', async () => {
+      lookup.mockResolvedValue([{ address: '1.1.1.1', family: 4 }] as never);
+
+      await validatePublicUrl('https://example.com/', { family: 4 });
+
+      expect(lookup).toHaveBeenCalledWith('example.com', { family: 4, all: true });
+    });
+
+    it('defaults the family option to 0 (any)', async () => {
+      lookup.mockResolvedValue([{ address: '1.1.1.1', family: 4 }] as never);
+
+      await validatePublicUrl('https://example.com/');
+
+      expect(lookup).toHaveBeenCalledWith('example.com', { family: 0, all: true });
+    });
+
+    it('emits a ResolutionFailed error when dns returns an unsupported family', async () => {
+      lookup.mockResolvedValue([{ address: 'whatever', family: 7 }] as never);
+
+      const outcome = await validatePublicUrl('https://example.com/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.ResolutionFailed,
+          received: { address: 'whatever', family: 7 },
+        }),
+      );
+    });
+  });
+
+  describe('rebind defence', () => {
+    it('rejects a hostname that resolves to AWS metadata', async () => {
+      lookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }] as never);
+
+      const outcome = await validatePublicUrl('https://metadata.attacker.example/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateAddress,
+          received: ['169.254.169.254'],
+        }),
+      );
+      expect(outcome.value).toBeUndefined();
+    });
+
+    it('rejects a hostname that resolves to an RFC 1918 address', async () => {
+      lookup.mockResolvedValue([{ address: '10.0.0.1', family: 4 }] as never);
+
+      const outcome = await validatePublicUrl('https://internal.attacker.example/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateAddress,
+          received: ['10.0.0.1'],
+        }),
+      );
+    });
+
+    it('rejects a hostname that resolves to an IPv6 loopback', async () => {
+      lookup.mockResolvedValue([{ address: '::1', family: 6 }] as never);
+
+      const outcome = await validatePublicUrl('https://example.com/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateAddress,
+          received: ['::1'],
+        }),
+      );
+    });
+
+    it('rejects a hostname that resolves to an IPv6 unique-local address', async () => {
+      lookup.mockResolvedValue([{ address: 'fc00::1', family: 6 }] as never);
+
+      const outcome = await validatePublicUrl('https://example.com/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateAddress,
+          received: ['fc00::1'],
+        }),
+      );
+    });
+
+    it('rejects a hostname that resolves to an IPv4-mapped private IPv6 address', async () => {
+      lookup.mockResolvedValue([{ address: '::ffff:10.0.0.1', family: 6 }] as never);
+
+      const outcome = await validatePublicUrl('https://example.com/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateAddress,
+          received: ['::ffff:10.0.0.1'],
+        }),
+      );
+    });
+
+    it('rejects when any A or AAAA record is private even if others are public', async () => {
+      lookup.mockResolvedValue([
+        { address: '1.1.1.1', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ] as never);
+
+      const outcome = await validatePublicUrl('https://mixed.attacker.example/');
+
+      expect(outcome.errors[0]).toEqual(
+        expect.objectContaining({
+          code: NodeUrlValidationCode.PrivateAddress,
+          received: ['169.254.169.254'],
+        }),
+      );
+      expect(outcome.value).toBeUndefined();
+    });
+
+    it('returns the first resolved IP so callers can use it as the connect target', async () => {
+      // Connecting via outcome.value.address rather than the hostname is what
+      // closes the DNS rebinding window: a subsequent lookup could return a
+      // private IP, but the caller has already pinned a safe one from this
+      // resolution pass.
+      lookup.mockResolvedValue([
+        { address: '1.1.1.1', family: 4 },
+        { address: '8.8.8.8', family: 4 },
+      ] as never);
+
+      const outcome = await validatePublicUrl('https://example.com/');
+
+      expect(outcome.errors).toEqual([]);
+      expect(outcome.value).toEqual({ address: '1.1.1.1', family: 4 });
+    });
+  });
+});

--- a/packages/untp-utils/src/node/validate-public-url.ts
+++ b/packages/untp-utils/src/node/validate-public-url.ts
@@ -1,0 +1,183 @@
+import { isIP } from 'node:net';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import type { ParseOutcome, ValidationError } from '../validation-outcome.js';
+import { isPrivateHostname, isPrivateIpv4, isPrivateIpv6 } from './is-private-ip.js';
+import { NodeUrlValidationCode } from './codes.js';
+
+/**
+ * Options for {@link validatePublicUrl}.
+ */
+export interface ValidatePublicUrlOptions {
+  /**
+   * URL schemes that are allowed. Compared case-insensitively against the
+   * scheme parsed by `URL`, which always includes the trailing colon
+   * (e.g. `http:`, `https:`). The template literal type enforces the
+   * trailing colon at compile time. Defaults to `['http:', 'https:']`.
+   */
+  allowedSchemes?: readonly `${string}:`[];
+  /**
+   * IP family hint passed to `dns.lookup`. `0` (default) returns whichever
+   * family the resolver prefers, `4` forces IPv4-only, `6` forces IPv6-only.
+   */
+  family?: 0 | 4 | 6;
+}
+
+/**
+ * The resolved address that callers must use when actually connecting, so
+ * the connection target matches the address that {@link validatePublicUrl}
+ * checked. Connecting via the hostname instead allows DNS rebinding: a
+ * subsequent resolution can return a different (and private) IP.
+ */
+export interface ValidatePublicUrlValue {
+  /** The hostname's resolved IP address (an IPv4 or IPv6 literal). */
+  address: string;
+  /** Address family of {@link address}. */
+  family: 4 | 6;
+}
+
+/**
+ * Outcome of validating a URL for outbound use, per ADR-034. `value` is
+ * present iff `errors.length === 0`.
+ */
+export type ValidatePublicUrlOutcome = ParseOutcome<ValidatePublicUrlValue>;
+
+const DEFAULT_ALLOWED_SCHEMES: readonly `${string}:`[] = ['http:', 'https:'];
+
+/**
+ * Validates that `url` is a parseable HTTP(S) URL whose hostname resolves to
+ * publicly routable IP addresses, and returns one of those resolved
+ * addresses so the caller can connect to that exact IP. Resolving and
+ * connecting in two separate steps would open a DNS rebinding window;
+ * consumers must use `outcome.value.address` as the connection target.
+ *
+ * DNS resolution is performed with `all: true`, so every A and AAAA record
+ * is inspected. The URL is rejected if *any* resolved address is in a
+ * private / loopback / link-local / cloud-metadata range. This prevents a
+ * mixed public/private DNS response from sneaking a private record past
+ * the check.
+ *
+ * Per ADR-034, this function does not throw for input-related failures.
+ * Parse failures, scheme mismatches, private hostnames, resolution
+ * failures, and private resolved addresses all surface as entries in
+ * `errors[]`.
+ *
+ * @see https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+ */
+export async function validatePublicUrl(
+  url: string,
+  options?: ValidatePublicUrlOptions,
+): Promise<ValidatePublicUrlOutcome> {
+  const errors: ValidationError[] = [];
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    errors.push({
+      code: NodeUrlValidationCode.InvalidUrl,
+      message: 'URL could not be parsed.',
+      received: url,
+      raw: error,
+    });
+    return { errors, warnings: [] };
+  }
+
+  const allowedSchemes = options?.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
+  const scheme = parsed.protocol.toLowerCase();
+  if (!allowedSchemes.some((s) => s.toLowerCase() === scheme)) {
+    errors.push({
+      code: NodeUrlValidationCode.UnsupportedScheme,
+      message: `URL scheme ${scheme} is not in the allowed list.`,
+      received: scheme,
+      expected: [...allowedSchemes],
+    });
+    return { errors, warnings: [] };
+  }
+
+  // URL.hostname wraps IPv6 literals in brackets (e.g. `[::1]`); strip them
+  // so the hostname can be passed to predicates and DNS resolution. Note
+  // that `URL` already discards any `userinfo@` prefix from the hostname,
+  // so smuggling attempts like `http://evil.com@127.0.0.1/` resolve to
+  // `127.0.0.1` and are caught by isPrivateHostname below.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  if (isPrivateHostname(hostname)) {
+    errors.push({
+      code: NodeUrlValidationCode.PrivateHostname,
+      message: `Hostname ${hostname || '(empty)'} names a private or local resource.`,
+      received: hostname,
+    });
+    return { errors, warnings: [] };
+  }
+
+  // If the hostname is already an IP literal, skip DNS resolution; the
+  // literal itself is the resolved address, and the private-range check
+  // above (via isPrivateHostname) has already validated it.
+  const literalFamily = isIP(hostname);
+  if (literalFamily === 4 || literalFamily === 6) {
+    return { value: { address: hostname, family: literalFamily }, errors: [], warnings: [] };
+  }
+
+  let records: { address: string; family: number }[];
+  try {
+    records = await dnsLookup(hostname, { family: options?.family ?? 0, all: true });
+  } catch (error) {
+    errors.push({
+      code: NodeUrlValidationCode.ResolutionFailed,
+      message: `DNS resolution failed for ${hostname}.`,
+      received: error instanceof Error ? error.message : String(error),
+      raw: error,
+    });
+    return { errors, warnings: [] };
+  }
+
+  if (records.length === 0) {
+    errors.push({
+      code: NodeUrlValidationCode.ResolutionEmpty,
+      message: `DNS resolver returned no addresses for ${hostname}.`,
+      received: hostname,
+    });
+    return { errors, warnings: [] };
+  }
+
+  const publicRecords: { address: string; family: 4 | 6 }[] = [];
+  const privateRecords: string[] = [];
+  for (const record of records) {
+    if (record.family !== 4 && record.family !== 6) {
+      errors.push({
+        code: NodeUrlValidationCode.ResolutionFailed,
+        message: `DNS resolver returned an unsupported address family ${record.family} for ${hostname}.`,
+        received: { address: record.address, family: record.family },
+        expected: 'family 4 or 6',
+      });
+      return { errors, warnings: [] };
+    }
+    const isPrivate = record.family === 4 ? isPrivateIpv4(record.address) : isPrivateIpv6(record.address);
+    if (isPrivate) {
+      privateRecords.push(record.address);
+    } else {
+      publicRecords.push({ address: record.address, family: record.family });
+    }
+  }
+
+  // Reject if *any* resolved record is private. A hostname with mixed
+  // public/private A or AAAA records must not be allowed through: the
+  // consumer's connect call could pick the private one.
+  if (privateRecords.length > 0) {
+    errors.push({
+      code: NodeUrlValidationCode.PrivateAddress,
+      message: `Hostname ${hostname} resolved to a private address.`,
+      received: privateRecords,
+    });
+    return { errors, warnings: [] };
+  }
+
+  // All records are public; pin the first one as the connect target. The
+  // first matches what a default single-address `dns.lookup` would have
+  // returned, so the choice is predictable for consumers.
+  const pinned = publicRecords[0];
+  return {
+    value: { address: pinned.address, family: pinned.family },
+    errors: [],
+    warnings: [],
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,6 +751,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.20.0)
+      ipaddr.js:
+        specifier: ^2.4.0
+        version: 2.4.0
       jsonld:
         specifier: ^8.3.3
         version: 8.3.3(web-streams-polyfill@3.3.3)


### PR DESCRIPTION
This PR adds a Node-only `@uncefact/untp-utils/node` sub-entry exposing `validatePublicUrl` (DNS-aware SSRF guard) and the underlying private-address predicates `isPrivateIpv4`, `isPrivateIpv6`, `isPrivateHostname`. The sub-entry is the foundation that `@uncefact/untp-utils/resolvers` (#672) and the RI ingestion service (#543) will build on, and is the canonical impl that the three existing in-repo SSRF guards will migrate to (#673).

Coverage of the canonical attack surface: RFC 1918 / loopback / link-local / CGNAT / multicast / broadcast / TEST-NET / benchmarking IPv4, IPv6 ULA / link-local / IPv4-mapped / 6to4 / Teredo / documentation, cloud metadata (`169.254.169.254`, `100.100.100.200`), private hostname suffixes (`.localhost`, `.local`, `.internal`, `.intranet`, `.lan`, `.home`, `.corp`, `.private`), and the canonical `userinfo@host` smuggling bypass.

`dns.lookup` is called with `all: true` so every A/AAAA record is inspected; the URL is rejected if any single record is private. The returned `outcome.value.address` is the resolved IP, intended to be used as the connect target so consumers can close the DNS rebinding window end-to-end. Connection-time pinning is the responsibility of `@uncefact/untp-utils/resolvers` (#672).

Per ADR-034 the function does not throw for input-related failures; results surface as `ValidationOutcome` entries with namespaced thing-oriented codes.

Closes #671

## Test plan

- [x] Unit tests cover IPv4 / IPv6 / hostname predicates against the canonical range set
- [x] DNS path tests cover happy path, lookup rejection, empty resolver response, mixed public+private records, IPv6 ULA via DNS, IPv4-mapped IPv6 via DNS, unsupported address family
- [x] URL path tests cover invalid URL, unsupported scheme, case-insensitive scheme comparison, custom `allowedSchemes`, literal IP shortcut (v4 + v6), private hostname rejection, `userinfo@host` smuggling regression, `http://0.0.0.0/` end-to-end
- [x] `pnpm --filter @uncefact/untp-utils build` clean
- [x] `pnpm --filter @uncefact/untp-utils test` 185/185 pass
- [x] `pnpm lint:check` 0 errors