### PR TITLE
feat(utils): add StructuredError base class for ADR-035 rollout

### DIFF
--- a/packages/untp-utils/src/index.ts
+++ b/packages/untp-utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './multibase-digest/index.js';
+export * from './structured-error.js';
 export * from './validation-outcome.js';
 export * from './detect-version-from-context.js';
 export * from './conformity-vocabulary/index.js';

--- a/packages/untp-utils/src/structured-error.test.ts
+++ b/packages/untp-utils/src/structured-error.test.ts
@@ -1,0 +1,122 @@
+import { StructuredError, type StructuredErrorInit } from './structured-error.js';
+
+describe('StructuredError', () => {
+  describe('constructor', () => {
+    it('assigns code and message', () => {
+      const e = new StructuredError({ code: 'demo.code', message: 'demo message' });
+      expect(e.code).toBe('demo.code');
+      expect(e.message).toBe('demo message');
+    });
+
+    it('assigns received / expected / remediation / pointer when supplied', () => {
+      const e = new StructuredError({
+        code: 'demo.code',
+        message: 'm',
+        received: { foo: 1 },
+        expected: 'bar',
+        remediation: 'do something',
+        pointer: '/foo/bar',
+      });
+      expect(e.received).toEqual({ foo: 1 });
+      expect(e.expected).toBe('bar');
+      expect(e.remediation).toBe('do something');
+      expect(e.pointer).toBe('/foo/bar');
+    });
+
+    it('leaves optional fields undefined when not supplied', () => {
+      const e = new StructuredError({ code: 'c', message: 'm' });
+      expect(e.received).toBeUndefined();
+      expect(e.expected).toBeUndefined();
+      expect(e.remediation).toBeUndefined();
+      expect(e.pointer).toBeUndefined();
+    });
+
+    it('omits absent optional fields from the instance (in-operator returns false)', () => {
+      const e = new StructuredError({ code: 'c', message: 'm' });
+      expect('received' in e).toBe(false);
+      expect('expected' in e).toBe(false);
+      expect('remediation' in e).toBe(false);
+      expect('pointer' in e).toBe(false);
+    });
+
+    it('includes supplied optional fields on the instance (in-operator returns true)', () => {
+      const e = new StructuredError({ code: 'c', message: 'm', received: 'x', pointer: '/y' });
+      expect('received' in e).toBe(true);
+      expect('pointer' in e).toBe(true);
+      expect('expected' in e).toBe(false);
+      expect('remediation' in e).toBe(false);
+    });
+  });
+
+  describe('Error.cause integration', () => {
+    it('wires cause through to the underlying Error', () => {
+      const underlying = new Error('boom');
+      const e = new StructuredError({ code: 'c', message: 'm', cause: underlying });
+      expect(e.cause).toBe(underlying);
+    });
+
+    it('omits cause from the underlying Error when not supplied', () => {
+      const e = new StructuredError({ code: 'c', message: 'm' });
+      expect(e.cause).toBeUndefined();
+    });
+
+    it('accepts non-Error causes (string, object, etc.)', () => {
+      const e = new StructuredError({ code: 'c', message: 'm', cause: 'string cause' });
+      expect(e.cause).toBe('string cause');
+    });
+  });
+
+  describe('name', () => {
+    it('resolves to the concrete subclass name in stack traces and logs', () => {
+      class PrivateAddressError extends StructuredError {}
+      const e = new PrivateAddressError({ code: 'url.private-address', message: 'm' });
+      expect(e.name).toBe('PrivateAddressError');
+    });
+
+    it('uses StructuredError when constructed directly (not via a subclass)', () => {
+      const e = new StructuredError({ code: 'c', message: 'm' });
+      expect(e.name).toBe('StructuredError');
+    });
+  });
+
+  describe('instanceof and Error inheritance', () => {
+    it('is an instance of Error', () => {
+      const e = new StructuredError({ code: 'c', message: 'm' });
+      expect(e).toBeInstanceOf(Error);
+    });
+
+    it('is an instance of StructuredError when constructed directly', () => {
+      const e = new StructuredError({ code: 'c', message: 'm' });
+      expect(e).toBeInstanceOf(StructuredError);
+    });
+
+    it('preserves the StructuredError instanceof check for concrete subclasses', () => {
+      class SubError extends StructuredError {}
+      const e = new SubError({ code: 'c', message: 'm' });
+      expect(e).toBeInstanceOf(SubError);
+      expect(e).toBeInstanceOf(StructuredError);
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('throwability', () => {
+    it('round-trips through try/catch as the concrete subclass', () => {
+      class DemoError extends StructuredError {
+        readonly extraField: string;
+        constructor(init: StructuredErrorInit & { extraField: string }) {
+          super(init);
+          this.extraField = init.extraField;
+        }
+      }
+      let caught: unknown;
+      try {
+        throw new DemoError({ code: 'demo.x', message: 'm', extraField: 'value' });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(DemoError);
+      expect((caught as DemoError).extraField).toBe('value');
+      expect((caught as DemoError).code).toBe('demo.x');
+    });
+  });
+});

--- a/packages/untp-utils/src/structured-error.ts
+++ b/packages/untp-utils/src/structured-error.ts
@@ -1,0 +1,73 @@
+/**
+ * System-wide base class for structured diagnostics, per ADR-035.
+ *
+ * Sub-entries and consumer packages extend this class with their own typed
+ * hierarchies. Lives in `@uncefact/untp-utils` because every workspace
+ * package already depends on it; the name is neutral, not utils-specific.
+ *
+ * @see ../../../docs/adrs/035-utils-throws-structured-errors.md
+ */
+export interface StructuredErrorInit {
+  /** Stable, namespaced identifier (e.g. `url.private-address`). */
+  code: string;
+  /** Human-facing summary. */
+  message: string;
+  /** Failing input or upstream value. */
+  received?: unknown;
+  /** What was expected. */
+  expected?: unknown;
+  /** Suggested next step. */
+  remediation?: string;
+  /** RFC 6901 JSON pointer into the input. */
+  pointer?: string;
+  /** Underlying error wrapped via `Error.cause`. */
+  cause?: unknown;
+}
+
+export class StructuredError extends Error {
+  readonly code: string;
+  // `declare` keeps these out of the class-field initializer; absent
+  // optionals stay absent on the instance (so `'received' in e` is honest).
+  declare readonly received?: unknown;
+  declare readonly expected?: unknown;
+  declare readonly remediation?: string;
+  declare readonly pointer?: string;
+
+  constructor(init: StructuredErrorInit) {
+    super(init.message, init.cause !== undefined ? { cause: init.cause } : undefined);
+    this.name = new.target.name;
+    this.code = init.code;
+    if (init.received !== undefined) this.received = init.received;
+    if (init.expected !== undefined) this.expected = init.expected;
+    if (init.remediation !== undefined) this.remediation = init.remediation;
+    if (init.pointer !== undefined) this.pointer = init.pointer;
+  }
+}
+
+/**
+ * Advisory diagnostic returned on the success path of functions that
+ * opt into warnings (ADR-035 §5).
+ */
+export interface StructuredWarning {
+  code: string;
+  message: string;
+  received?: unknown;
+  expected?: unknown;
+  remediation?: string;
+  pointer?: string;
+}
+
+/**
+ * One entry in a multi-failure case (e.g. one of N Ajv `allErrors`).
+ * Carried on the thrown subclass as `failures: readonly ValidationFailure[]`
+ * (ADR-035 §4). Same shape as {@link StructuredWarning}; the type
+ * distinguishes fatal sub-failure from advisory at the call site.
+ */
+export interface ValidationFailure {
+  code: string;
+  message: string;
+  received?: unknown;
+  expected?: unknown;
+  remediation?: string;
+  pointer?: string;
+}

--- a/packages/untp-utils/src/structured-error.ts
+++ b/packages/untp-utils/src/structured-error.ts
@@ -7,7 +7,7 @@
  *
  * @see ../../../docs/adrs/035-utils-throws-structured-errors.md
  */
-export interface StructuredErrorInit {
+export interface StructuredDiagnostic {
   /** Stable, namespaced identifier (e.g. `url.private-address`). */
   code: string;
   /** Human-facing summary. */
@@ -20,6 +20,9 @@ export interface StructuredErrorInit {
   remediation?: string;
   /** RFC 6901 JSON pointer into the input. */
   pointer?: string;
+}
+
+export interface StructuredErrorInit extends StructuredDiagnostic {
   /** Underlying error wrapped via `Error.cause`. */
   cause?: unknown;
 }
@@ -48,14 +51,7 @@ export class StructuredError extends Error {
  * Advisory diagnostic returned on the success path of functions that
  * opt into warnings (ADR-035 §5).
  */
-export interface StructuredWarning {
-  code: string;
-  message: string;
-  received?: unknown;
-  expected?: unknown;
-  remediation?: string;
-  pointer?: string;
-}
+export interface StructuredWarning extends StructuredDiagnostic {}
 
 /**
  * One entry in a multi-failure case (e.g. one of N Ajv `allErrors`).
@@ -63,11 +59,4 @@ export interface StructuredWarning {
  * (ADR-035 §4). Same shape as {@link StructuredWarning}; the type
  * distinguishes fatal sub-failure from advisory at the call site.
  */
-export interface ValidationFailure {
-  code: string;
-  message: string;
-  received?: unknown;
-  expected?: unknown;
-  remediation?: string;
-  pointer?: string;
-}
+export interface ValidationFailure extends StructuredDiagnostic {}


### PR DESCRIPTION
Foundation PR for the [ADR-035](https://github.com/uncefact/tests-untp/blob/next/docs/adrs/035-utils-throws-structured-errors.md) rollout. Adds the system-wide structured-diagnostic types so subsequent sub-entry refactors and consumer migrations have a stable base to build on.

- `StructuredError` class (named neutrally, lives in `@uncefact/untp-utils`'s main entry). Carries the ADR-035 payload (`code`, `message`, `received`, `expected`, `remediation`, `pointer`, plus native `Error.cause`). Subclasses lock their `code` and may add typed fields.
- `StructuredErrorInit` interface (constructor input).
- `StructuredWarning` interface (advisory diagnostics returned on the success path of functions that opt into warnings per ADR-035 §5).
- `ValidationFailure` interface (one entry in a multi-failure case carried as `failures: readonly ValidationFailure[]` on the thrown subclass per ADR-035 §4).