### PR TITLE
refactor(utils): drop barrel re-exports for /multibase-digest and /conformity-vocabulary

### DIFF
--- a/packages/reference-implementation/jest.config.mjs
+++ b/packages/reference-implementation/jest.config.mjs
@@ -30,6 +30,7 @@ const jestConfig = {
     '^@uncefact/untp-utils/validation$': '<rootDir>/../untp-utils/build/validation/index.js',
     '^@uncefact/untp-utils/schema-loaders$': '<rootDir>/../untp-utils/build/schema-loaders/index.js',
     '^@uncefact/untp-utils/cache$': '<rootDir>/../untp-utils/build/cache/index.js',
+    '^@uncefact/untp-utils/conformity-vocabulary$': '<rootDir>/../untp-utils/build/conformity-vocabulary/index.js',
     '^@uncefact/untp-utils$': '<rootDir>/../untp-utils/build/index.js',
     '^@reference-implementation/components$': '<rootDir>/node_modules/@reference-implementation/components/build/index.js',
   },

--- a/packages/reference-implementation/jest.config.mjs
+++ b/packages/reference-implementation/jest.config.mjs
@@ -30,7 +30,7 @@ const jestConfig = {
     '^@uncefact/untp-utils/validation$': '<rootDir>/../untp-utils/build/validation/index.js',
     '^@uncefact/untp-utils/schema-loaders$': '<rootDir>/../untp-utils/build/schema-loaders/index.js',
     '^@uncefact/untp-utils/cache$': '<rootDir>/../untp-utils/build/cache/index.js',
-    '^@uncefact/untp-utils$': '<rootDir>/src/__mocks__/uncefact/multibase-digest.ts',
+    '^@uncefact/untp-utils$': '<rootDir>/../untp-utils/build/index.js',
     '^@reference-implementation/components$': '<rootDir>/node_modules/@reference-implementation/components/build/index.js',
   },
   transform: {

--- a/packages/untp-utils/src/index.ts
+++ b/packages/untp-utils/src/index.ts
@@ -1,5 +1,3 @@
-export * from './multibase-digest/index.js';
 export * from './structured-error.js';
 export * from './validation-outcome.js';
 export * from './detect-version-from-context.js';
-export * from './conformity-vocabulary/index.js';


### PR DESCRIPTION
Follows #681. Removes the legacy barrel re-exports for `/multibase-digest` and `/conformity-vocabulary` from `@uncefact/untp-utils`'s main entry. An empirical audit before this PR showed **zero consumers in the monorepo import these from the bare main entry** — every consumer uses an explicit sub-entry path (`/multibase-digest`, `/validation`, `/schema-loaders`, `/cache`, etc.).

`structured-error`, `validation-outcome`, and `detect-version-from-context` stay in the main entry as "main-entry-only" symbols with no sub-entry of their own. (`validation-outcome` goes away with the `/conformity-vocabulary` throws migration in a follow-up.)

The RI's jest `moduleNameMapper` for the bare main entry now points at the real build instead of the multibase-digest mock. Safe because (a) nothing imports the bare main entry, (b) after the cleanup the bare main entry no longer transitively loads multibase-digest's multiformats subpath imports.

Stacked on top of #681. GitHub will auto-retarget to `next` when #681 merges.

## Test plan

- [x] `untp-utils`: 228 / 228 tests pass, build clean.
- [x] Reference implementation typechecks (two pre-existing errors in `verify/route.ts` and `lib/api/validation.ts` are unchanged from `next`).
- [x] Lint 0 errors.