### PR TITLE
feat(utils): add parseConformityCatalogue and extract shared parser helpers

### DIFF
--- a/packages/untp-utils/src/common/as-non-empty-string.test.ts
+++ b/packages/untp-utils/src/common/as-non-empty-string.test.ts
@@ -1,0 +1,27 @@
+import { asNonEmptyString } from './as-non-empty-string.js';
+
+describe('asNonEmptyString', () => {
+  it('returns the value for a non-empty string', () => {
+    expect(asNonEmptyString('foo')).toBe('foo');
+    expect(asNonEmptyString(' ')).toBe(' ');
+    expect(asNonEmptyString('0')).toBe('0');
+  });
+
+  it('returns undefined for the empty string', () => {
+    expect(asNonEmptyString('')).toBeUndefined();
+  });
+
+  it.each([
+    ['number', 0],
+    ['number (non-zero)', 42],
+    ['null', null],
+    ['undefined', undefined],
+    ['boolean true', true],
+    ['boolean false', false],
+    ['object', {}],
+    ['array', ['a']],
+    ['NaN', NaN],
+  ])('returns undefined for %s', (_label, value) => {
+    expect(asNonEmptyString(value)).toBeUndefined();
+  });
+});

--- a/packages/untp-utils/src/common/as-non-empty-string.ts
+++ b/packages/untp-utils/src/common/as-non-empty-string.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns `value` if it is a non-empty string, otherwise `undefined`.
+ * Useful inside parsers that emit a structured failure separately when a
+ * required field is missing or malformed, so the type check and the
+ * failure-emission policy stay decoupled.
+ */
+export function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/untp-utils/src/common/require-string.test.ts
+++ b/packages/untp-utils/src/common/require-string.test.ts
@@ -28,9 +28,9 @@ describe('makeRequireString', () => {
     ]);
   });
 
-  it('returns undefined and pushes a failure when the value is the empty string', () => {
+  it('returns undefined and pushes a failure when the value is the empty string (discriminated from typeof "string")', () => {
     expect(requireString('', 'scheme.name', '/name', failures)).toBeUndefined();
-    expect(failures[0]).toMatchObject({ code: CODE, pointer: '/name' });
+    expect(failures[0]).toMatchObject({ code: CODE, pointer: '/name', received: 'empty string' });
   });
 
   it.each([

--- a/packages/untp-utils/src/common/require-string.test.ts
+++ b/packages/untp-utils/src/common/require-string.test.ts
@@ -1,0 +1,62 @@
+import type { ValidationFailure } from '../structured-error.js';
+import { makeRequireString } from './require-string.js';
+
+const CODE = 'test.missing-required-field';
+
+describe('makeRequireString', () => {
+  let failures: ValidationFailure[];
+  const requireString = makeRequireString(CODE);
+
+  beforeEach(() => {
+    failures = [];
+  });
+
+  it('returns the value when it is a non-empty string', () => {
+    expect(requireString('foo', 'field', '/pointer', failures)).toBe('foo');
+    expect(failures).toEqual([]);
+  });
+
+  it('returns undefined and pushes a failure when the value is undefined', () => {
+    expect(requireString(undefined, 'scheme.id', '/id', failures)).toBeUndefined();
+    expect(failures).toEqual([
+      expect.objectContaining({
+        code: CODE,
+        pointer: '/id',
+        received: 'undefined',
+        expected: 'non-empty string',
+      }),
+    ]);
+  });
+
+  it('returns undefined and pushes a failure when the value is the empty string', () => {
+    expect(requireString('', 'scheme.name', '/name', failures)).toBeUndefined();
+    expect(failures[0]).toMatchObject({ code: CODE, pointer: '/name' });
+  });
+
+  it.each([
+    ['null', null, 'null'],
+    ['number', 42, 'number'],
+    ['boolean', true, 'boolean'],
+    ['object', {}, 'object'],
+    ['array', [], 'object'],
+  ])('returns undefined and pushes a failure when the value is %s', (_label, value, expectedReceived) => {
+    expect(requireString(value, 'field', '/p', failures)).toBeUndefined();
+    expect(failures[0]).toMatchObject({ code: CODE, received: expectedReceived });
+  });
+
+  it('uses the field name in the failure message', () => {
+    requireString(undefined, 'profile.criterion[2].id', '/profile/criterion/2/id', failures);
+    expect(failures[0].message).toContain('profile.criterion[2].id');
+  });
+
+  it('binds the code once per factory call (different codes do not bleed across instances)', () => {
+    const a = makeRequireString('foo.missing');
+    const b = makeRequireString('bar.missing');
+    const failuresA: ValidationFailure[] = [];
+    const failuresB: ValidationFailure[] = [];
+    a(undefined, 'x', '/x', failuresA);
+    b(undefined, 'y', '/y', failuresB);
+    expect(failuresA[0].code).toBe('foo.missing');
+    expect(failuresB[0].code).toBe('bar.missing');
+  });
+});

--- a/packages/untp-utils/src/common/require-string.ts
+++ b/packages/untp-utils/src/common/require-string.ts
@@ -23,7 +23,8 @@ export function makeRequireString(code: string) {
     failures.push({
       code,
       message: `${fieldName} is required and must be a non-empty string.`,
-      received: value === undefined ? 'undefined' : value === null ? 'null' : typeof value,
+      received:
+        value === undefined ? 'undefined' : value === null ? 'null' : value === '' ? 'empty string' : typeof value,
       expected: 'non-empty string',
       pointer,
     });

--- a/packages/untp-utils/src/common/require-string.ts
+++ b/packages/untp-utils/src/common/require-string.ts
@@ -1,0 +1,32 @@
+import type { ValidationFailure } from '../structured-error.js';
+import { asNonEmptyString } from './as-non-empty-string.js';
+
+/**
+ * Returns a `requireString(value, fieldName, pointer, failures)` helper
+ * pre-bound to a structured-failure `code`. When `value` is a non-empty
+ * string, returns it; otherwise pushes a {@link ValidationFailure} onto
+ * `failures` and returns `undefined`.
+ *
+ * Each parser binds the factory once per file with its sub-entry's
+ * missing-required-field code, keeping per-call sites unaware of the code
+ * namespace.
+ */
+export function makeRequireString(code: string) {
+  return function requireString(
+    value: unknown,
+    fieldName: string,
+    pointer: string,
+    failures: ValidationFailure[],
+  ): string | undefined {
+    const parsed = asNonEmptyString(value);
+    if (parsed !== undefined) return parsed;
+    failures.push({
+      code,
+      message: `${fieldName} is required and must be a non-empty string.`,
+      received: value === undefined ? 'undefined' : value === null ? 'null' : typeof value,
+      expected: 'non-empty string',
+      pointer,
+    });
+    return undefined;
+  };
+}

--- a/packages/untp-utils/src/conformity-vocabulary/errors.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/errors.ts
@@ -1,18 +1,19 @@
 import { StructuredError, type ValidationFailure } from '../structured-error.js';
 
 /**
- * Base for every diagnostic from `@uncefact/untp-utils/conformity-vocabulary`.
- * Catch to handle any conformity-vocabulary failure generically; catch a
- * concrete subclass for specific handling.
+ * Base for every diagnostic from `@uncefact/untp-utils/conformity-vocabulary`
+ * (scheme parsing, catalogue parsing, claim validation). Catch to handle any
+ * conformity-vocabulary failure generically; catch a concrete subclass for
+ * specific handling.
  */
-export class ConformitySchemeError extends StructuredError {}
+export class ConformityVocabularyError extends StructuredError {}
 
 /**
  * The document's CVC spec version could not be detected, or is not
  * supported by this build. Fail-fast: parsing aborts before per-field
  * checks run.
  */
-export class ConformityUnsupportedSpecVersionError extends ConformitySchemeError {
+export class ConformityUnsupportedSpecVersionError extends ConformityVocabularyError {
   constructor(received: string | undefined, supported: readonly string[]) {
     super({
       code: 'conformity-scheme.unsupported-spec-version',
@@ -28,13 +29,13 @@ export class ConformityUnsupportedSpecVersionError extends ConformitySchemeError
 }
 
 /**
- * The document failed structural parsing. Carries every per-field failure
- * (invalid shape, missing required field) in {@link failures}; each entry
- * has a stable `code` (`'conformity-scheme.invalid-shape'` or
+ * The scheme document failed structural parsing. Carries every per-field
+ * failure (invalid shape, missing required field) in {@link failures};
+ * each entry has a stable `code` (`'conformity-scheme.invalid-shape'` or
  * `'conformity-scheme.missing-required-field'`) plus the Ajv-style
  * `pointer`, `received`, and `expected`.
  */
-export class ConformitySchemeParseError extends ConformitySchemeError {
+export class ConformitySchemeParseError extends ConformityVocabularyError {
   readonly failures: readonly ValidationFailure[];
   constructor(failures: readonly ValidationFailure[]) {
     super({
@@ -42,5 +43,29 @@ export class ConformitySchemeParseError extends ConformitySchemeError {
       message: `Conformity scheme failed to parse with ${failures.length} failure(s).`,
     });
     this.failures = failures;
+  }
+}
+
+/**
+ * The UNTP Conformity Vocabulary Catalogue Register document failed
+ * structural parsing. Carries every per-entry / per-field failure in
+ * {@link failures} (codes `'conformity-catalogue.invalid-shape'` or
+ * `'conformity-catalogue.missing-required-field'`, with the Ajv-style
+ * `pointer`). {@link sourceUrl} is set when the parser was invoked with
+ * the URL the register was fetched from, for operator-side triage.
+ */
+export class ConformityCatalogueParseError extends ConformityVocabularyError {
+  readonly failures: readonly ValidationFailure[];
+  readonly sourceUrl?: string;
+  constructor(args: { failures: readonly ValidationFailure[]; sourceUrl?: string }) {
+    super({
+      code: 'conformity-catalogue.parse-failed',
+      message:
+        args.sourceUrl !== undefined
+          ? `Conformity catalogue at ${args.sourceUrl} failed to parse with ${args.failures.length} failure(s).`
+          : `Conformity catalogue failed to parse with ${args.failures.length} failure(s).`,
+    });
+    this.failures = args.failures;
+    if (args.sourceUrl !== undefined) this.sourceUrl = args.sourceUrl;
   }
 }

--- a/packages/untp-utils/src/conformity-vocabulary/index.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/index.ts
@@ -1,10 +1,16 @@
 export * from './types.js';
 export { ConformityWarningCode } from './codes.js';
-export { ConformitySchemeError, ConformityUnsupportedSpecVersionError, ConformitySchemeParseError } from './errors.js';
+export {
+  ConformityVocabularyError,
+  ConformityUnsupportedSpecVersionError,
+  ConformitySchemeParseError,
+  ConformityCatalogueParseError,
+} from './errors.js';
 export {
   parseConformityScheme,
   SUPPORTED_CVC_SPEC_VERSIONS,
   type ParseConformitySchemeOptions,
   type SupportedCvcSpecVersion,
 } from './parse-conformity-scheme.js';
+export { parseConformityCatalogue } from './parse-conformity-catalogue.js';
 export { validateConformityClaim } from './validate-conformity-claim.js';

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.test.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.test.ts
@@ -1,0 +1,319 @@
+import { ConformityVocabularyError, ConformityCatalogueParseError } from './errors.js';
+import { parseConformityCatalogue } from './parse-conformity-catalogue.js';
+
+const REGISTER_CONTEXT = ['https://example.com/context/register'];
+
+function entry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    '@type': ['ConformityVocabularyCatalogueEntry', 'ConformityScheme'],
+    id: 'https://example.com/registry/example',
+    name: 'Example Scheme',
+    vocabularyURL: 'https://vocab.example.com/scheme',
+    ...overrides,
+  };
+}
+
+function registerDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    '@context': REGISTER_CONTEXT,
+    '@type': ['ConformityVocabularyCatalogueRegister', 'Register'],
+    id: 'https://example.com/registry',
+    name: 'Test Register',
+    entries: [],
+    ...overrides,
+  };
+}
+
+describe('parseConformityCatalogue', () => {
+  describe('happy path', () => {
+    it('returns an empty entries array when the register has no entries', () => {
+      expect(parseConformityCatalogue(registerDoc())).toEqual({ entries: [] });
+    });
+
+    it('returns one entry per register entry with the three required fields', () => {
+      const doc = registerDoc({
+        entries: [
+          entry({
+            id: 'https://example.com/registry/scheme-a',
+            name: 'Scheme A',
+            vocabularyURL: 'https://vocab.example.com/scheme-a',
+          }),
+          entry({
+            id: 'https://example.com/registry/scheme-b',
+            name: 'Scheme B',
+            vocabularyURL: 'https://vocab.example.org/scheme-b',
+          }),
+        ],
+      });
+
+      expect(parseConformityCatalogue(doc).entries).toEqual([
+        {
+          canonicalId: 'https://example.com/registry/scheme-a',
+          vocabularyUrl: 'https://vocab.example.com/scheme-a',
+          name: 'Scheme A',
+        },
+        {
+          canonicalId: 'https://example.com/registry/scheme-b',
+          vocabularyUrl: 'https://vocab.example.org/scheme-b',
+          name: 'Scheme B',
+        },
+      ]);
+    });
+
+    it('ignores extra metadata fields on each entry', () => {
+      const doc = registerDoc({
+        entries: [
+          entry({
+            owner: { id: 'did:web:example.com', name: 'Example Org', website: 'https://example.com' },
+            shortName: 'EX',
+            statement: 'A statement.',
+            industrySector: { id: 'foo' },
+            geographicScope: { id: 'bar' },
+            endorsementLevel: 'Self',
+            licenseType: 'ProprietaryDocument',
+            profiles: [{ id: 'https://example.com/profile/1' }],
+          }),
+        ],
+      });
+
+      const { entries } = parseConformityCatalogue(doc);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toEqual({
+        canonicalId: 'https://example.com/registry/example',
+        vocabularyUrl: 'https://vocab.example.com/scheme',
+        name: 'Example Scheme',
+      });
+    });
+  });
+
+  describe('parse failures (accumulating)', () => {
+    it('throws ConformityCatalogueParseError with an invalid-shape failure when the document is not an object', () => {
+      const error = (() => {
+        try {
+          parseConformityCatalogue(null);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).failures).toEqual([
+        expect.objectContaining({
+          code: 'conformity-catalogue.invalid-shape',
+          received: 'null',
+        }),
+      ]);
+    });
+
+    it('throws when entries is missing', () => {
+      const doc = registerDoc({ entries: undefined });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).failures).toEqual([
+        expect.objectContaining({
+          code: 'conformity-catalogue.missing-required-field',
+          pointer: '/entries',
+        }),
+      ]);
+    });
+
+    it('throws when entries is not an array', () => {
+      const doc = registerDoc({ entries: 'not-an-array' });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).failures).toEqual([
+        expect.objectContaining({
+          code: 'conformity-catalogue.invalid-shape',
+          pointer: '/entries',
+        }),
+      ]);
+    });
+
+    it.each([
+      ['entry.id', { id: undefined }, '/entries/0/id'],
+      ['entry.name', { name: undefined }, '/entries/0/name'],
+      ['entry.vocabularyURL', { vocabularyURL: undefined }, '/entries/0/vocabularyURL'],
+    ])('throws with a missing-required-field failure when %s is missing', (_label, override, pointer) => {
+      const doc = registerDoc({ entries: [entry(override)] });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).failures).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'conformity-catalogue.missing-required-field', pointer }),
+        ]),
+      );
+    });
+
+    it('accumulates failures from every malformed entry in one pass', () => {
+      const doc = registerDoc({
+        entries: [entry(), entry({ id: undefined }), entry({ vocabularyURL: undefined }), entry({ name: undefined })],
+      });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      const failures = (error as ConformityCatalogueParseError).failures;
+      expect(failures).toHaveLength(3);
+      expect(failures.map((f) => f.pointer).sort()).toEqual([
+        '/entries/1/id',
+        '/entries/2/vocabularyURL',
+        '/entries/3/name',
+      ]);
+    });
+
+    it('accumulates all three field failures when a single entry is missing every required field (no intra-entry short-circuit)', () => {
+      const doc = registerDoc({
+        entries: [entry({ id: undefined, vocabularyURL: undefined, name: undefined })],
+      });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      const failures = (error as ConformityCatalogueParseError).failures;
+      expect(failures).toHaveLength(3);
+      expect(failures.map((f) => f.pointer).sort()).toEqual([
+        '/entries/0/id',
+        '/entries/0/name',
+        '/entries/0/vocabularyURL',
+      ]);
+      expect(failures.every((f) => f.code === 'conformity-catalogue.missing-required-field')).toBe(true);
+    });
+
+    it('throws when an entry is not an object', () => {
+      const doc = registerDoc({ entries: [entry(), 'not-an-object', null] });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      const failures = (error as ConformityCatalogueParseError).failures;
+      expect(failures.map((f) => f.pointer).sort()).toEqual(['/entries/1', '/entries/2']);
+    });
+
+    it('accumulates invalid-shape and missing-required-field failures across entries in one pass', () => {
+      const doc = registerDoc({
+        entries: [entry(), 'not-an-object', entry({ id: undefined })],
+      });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      const failures = (error as ConformityCatalogueParseError).failures;
+      const codes = failures.map((f) => f.code).sort();
+      expect(codes).toEqual(['conformity-catalogue.invalid-shape', 'conformity-catalogue.missing-required-field']);
+    });
+
+    it('throws when vocabularyURL is not a parseable URL', () => {
+      const doc = registerDoc({ entries: [entry({ vocabularyURL: 'not a url' })] });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).failures).toEqual([
+        expect.objectContaining({
+          code: 'conformity-catalogue.invalid-shape',
+          pointer: '/entries/0/vocabularyURL',
+          received: 'not a url',
+        }),
+      ]);
+    });
+  });
+
+  describe('status', () => {
+    it('extracts entry.status when present', () => {
+      const doc = registerDoc({ entries: [entry({ status: 'active' })] });
+      const { entries } = parseConformityCatalogue(doc);
+      expect(entries[0].status).toBe('active');
+    });
+
+    it('omits status when entry.status is absent', () => {
+      const { entries } = parseConformityCatalogue(registerDoc({ entries: [entry()] }));
+      expect(entries[0].status).toBeUndefined();
+    });
+
+    it('omits status when entry.status is the empty string', () => {
+      const { entries } = parseConformityCatalogue(registerDoc({ entries: [entry({ status: '' })] }));
+      expect(entries[0].status).toBeUndefined();
+    });
+  });
+
+  describe('options.sourceUrl', () => {
+    it('attaches sourceUrl to the thrown error when supplied', () => {
+      const error = (() => {
+        try {
+          parseConformityCatalogue(null, { sourceUrl: 'https://example.com/registry.json' });
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).sourceUrl).toBe('https://example.com/registry.json');
+      expect((error as Error).message).toContain('https://example.com/registry.json');
+    });
+
+    it('leaves sourceUrl undefined when not supplied', () => {
+      const error = (() => {
+        try {
+          parseConformityCatalogue(null);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).sourceUrl).toBeUndefined();
+    });
+  });
+
+  describe('hierarchy', () => {
+    it('extends ConformityVocabularyError (the sub-entry umbrella)', () => {
+      expect(() => parseConformityCatalogue(null)).toThrow(ConformityVocabularyError);
+    });
+  });
+});

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.test.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.test.ts
@@ -120,6 +120,27 @@ describe('parseConformityCatalogue', () => {
         expect.objectContaining({
           code: 'conformity-catalogue.missing-required-field',
           pointer: '/entries',
+          received: 'undefined',
+        }),
+      ]);
+    });
+
+    it('throws when entries is null (reports `null`, not `undefined`)', () => {
+      const doc = registerDoc({ entries: null });
+      const error = (() => {
+        try {
+          parseConformityCatalogue(doc);
+          return undefined;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(error).toBeInstanceOf(ConformityCatalogueParseError);
+      expect((error as ConformityCatalogueParseError).failures).toEqual([
+        expect.objectContaining({
+          code: 'conformity-catalogue.missing-required-field',
+          pointer: '/entries',
+          received: 'null',
         }),
       ]);
     });

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.ts
@@ -1,0 +1,135 @@
+import { asNonEmptyString } from '../common/as-non-empty-string.js';
+import { makeRequireString } from '../common/require-string.js';
+import type { ValidationFailure } from '../structured-error.js';
+import { ConformityCatalogueParseError } from './errors.js';
+import type { ConformityCatalogueEntry } from './types.js';
+
+const INVALID_SHAPE = 'conformity-catalogue.invalid-shape';
+const MISSING_REQUIRED_FIELD = 'conformity-catalogue.missing-required-field';
+
+const requireString = makeRequireString(MISSING_REQUIRED_FIELD);
+
+export interface ParseConformityCatalogueOptions {
+  /**
+   * URL the register was fetched from. Surfaces on
+   * {@link ConformityCatalogueParseError.sourceUrl} for operator triage when
+   * a parse fails.
+   */
+  sourceUrl?: string;
+}
+
+/**
+ * Parses the UNTP Conformity Vocabulary Catalogue Register document into a
+ * list of {@link ConformityCatalogueEntry}s. Each entry pairs the
+ * CVC-canonical scheme URI with the owner-published vocabulary URL,
+ * plus the human-readable name and optional lifecycle status.
+ *
+ * Lenient on per-entry fields beyond the ingestion-essential ones: optional
+ * metadata (owner, geographic scope, sector, etc.) is not surfaced here.
+ *
+ * @throws {ConformityCatalogueParseError} carrying every per-field failure
+ *   in `failures[]` if the document is structurally invalid.
+ *
+ * @see https://untp.unece.org/docs/specification/ConformityVocabularyCatalog
+ */
+export function parseConformityCatalogue(
+  doc: unknown,
+  options?: ParseConformityCatalogueOptions,
+): { entries: readonly ConformityCatalogueEntry[] } {
+  const failures: ValidationFailure[] = [];
+  const sourceUrl = options?.sourceUrl;
+
+  if (!doc || typeof doc !== 'object') {
+    failures.push({
+      code: INVALID_SHAPE,
+      message: 'Conformity catalogue document must be a non-null object.',
+      received: doc === null ? 'null' : typeof doc,
+      expected: 'object',
+      pointer: '',
+    });
+    throw new ConformityCatalogueParseError({ failures, sourceUrl });
+  }
+
+  const root = doc as Record<string, unknown>;
+  const rawEntries = root.entries;
+
+  if (rawEntries === undefined || rawEntries === null) {
+    failures.push({
+      code: MISSING_REQUIRED_FIELD,
+      message: 'Conformity catalogue document must include an `entries` array.',
+      received: 'undefined',
+      expected: 'array',
+      pointer: '/entries',
+    });
+    throw new ConformityCatalogueParseError({ failures, sourceUrl });
+  }
+
+  if (!Array.isArray(rawEntries)) {
+    failures.push({
+      code: INVALID_SHAPE,
+      message: 'Conformity catalogue `entries` must be an array.',
+      received: typeof rawEntries,
+      expected: 'array',
+      pointer: '/entries',
+    });
+    throw new ConformityCatalogueParseError({ failures, sourceUrl });
+  }
+
+  const entries: ConformityCatalogueEntry[] = [];
+  rawEntries.forEach((rawEntry, i) => {
+    const parsed = parseEntry(rawEntry, `/entries/${i}`, failures);
+    if (parsed) entries.push(parsed);
+  });
+
+  if (failures.length > 0) {
+    throw new ConformityCatalogueParseError({ failures, sourceUrl });
+  }
+
+  return { entries };
+}
+
+function parseEntry(
+  input: unknown,
+  pointer: string,
+  failures: ValidationFailure[],
+): ConformityCatalogueEntry | undefined {
+  if (!input || typeof input !== 'object') {
+    failures.push({
+      code: INVALID_SHAPE,
+      message: 'Catalogue entry must be a non-null object.',
+      received: input === null ? 'null' : typeof input,
+      expected: 'object',
+      pointer,
+    });
+    return undefined;
+  }
+
+  const entry = input as Record<string, unknown>;
+  const canonicalId = requireString(entry.id, 'entry.id', `${pointer}/id`, failures);
+  const vocabularyUrl = requireString(entry.vocabularyURL, 'entry.vocabularyURL', `${pointer}/vocabularyURL`, failures);
+  const name = requireString(entry.name, 'entry.name', `${pointer}/name`, failures);
+  const status = asNonEmptyString(entry.status);
+
+  if (vocabularyUrl !== undefined && !isParseableUrl(vocabularyUrl)) {
+    failures.push({
+      code: INVALID_SHAPE,
+      message: 'entry.vocabularyURL must be a parseable URL.',
+      received: vocabularyUrl,
+      expected: 'a string parseable by the URL constructor',
+      pointer: `${pointer}/vocabularyURL`,
+    });
+    return undefined;
+  }
+
+  if (!canonicalId || !vocabularyUrl || !name) return undefined;
+  return status !== undefined ? { canonicalId, vocabularyUrl, name, status } : { canonicalId, vocabularyUrl, name };
+}
+
+function isParseableUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-catalogue.ts
@@ -57,7 +57,7 @@ export function parseConformityCatalogue(
     failures.push({
       code: MISSING_REQUIRED_FIELD,
       message: 'Conformity catalogue document must include an `entries` array.',
-      received: 'undefined',
+      received: rawEntries === null ? 'null' : 'undefined',
       expected: 'array',
       pointer: '/entries',
     });

--- a/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.test.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parse-conformity-scheme.test.ts
@@ -1,4 +1,8 @@
-import { ConformitySchemeError, ConformitySchemeParseError, ConformityUnsupportedSpecVersionError } from './errors.js';
+import {
+  ConformityVocabularyError,
+  ConformitySchemeParseError,
+  ConformityUnsupportedSpecVersionError,
+} from './errors.js';
 import { parseConformityScheme } from './parse-conformity-scheme.js';
 
 const UNTP_V070_CONTEXT = 'https://vocabulary.uncefact.org/untp/0.7.0/context/';
@@ -297,14 +301,14 @@ describe('parseConformityScheme', () => {
   });
 
   describe('hierarchy', () => {
-    it('every concrete error extends ConformitySchemeError', () => {
+    it('every concrete error extends ConformityVocabularyError', () => {
       // unsupported version
       expect(() => parseConformityScheme(minimalSchemeDoc(), { sourceUrl: 'x', specVersion: '99.0.0' })).toThrow(
-        ConformitySchemeError,
+        ConformityVocabularyError,
       );
       // parse failure
       expect(() => parseConformityScheme(null, { sourceUrl: 'x', specVersion: '0.7.0' })).toThrow(
-        ConformitySchemeError,
+        ConformityVocabularyError,
       );
     });
   });

--- a/packages/untp-utils/src/conformity-vocabulary/parsers/v0-7-0.parser.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/parsers/v0-7-0.parser.ts
@@ -1,3 +1,5 @@
+import { asNonEmptyString } from '../../common/as-non-empty-string.js';
+import { makeRequireString } from '../../common/require-string.js';
 import type { ValidationFailure } from '../../structured-error.js';
 import type {
   ConformityCriterion,
@@ -11,6 +13,8 @@ const SPEC_VERSION = '0.7.0';
 
 const INVALID_SHAPE = 'conformity-scheme.invalid-shape';
 const MISSING_REQUIRED_FIELD = 'conformity-scheme.missing-required-field';
+
+const requireString = makeRequireString(MISSING_REQUIRED_FIELD);
 
 /**
  * Parses a v0.7.0 ConformityScheme JSON-LD document.
@@ -59,8 +63,8 @@ export function parseV070ConformityScheme(
     sourceUrl,
     specVersion: SPEC_VERSION,
     name,
-    description: optionalString(root.description),
-    documentation: optionalString(root.documentation),
+    description: asNonEmptyString(root.description),
+    documentation: asNonEmptyString(root.documentation),
     owner: parseOwner(root.owner),
     profiles,
   };
@@ -123,9 +127,9 @@ function parseProfile(
     name,
     version,
     status,
-    description: optionalString(p.description),
-    documentation: optionalString(p.documentation),
-    validFrom: optionalString(p.validFrom),
+    description: asNonEmptyString(p.description),
+    documentation: asNonEmptyString(p.documentation),
+    validFrom: asNonEmptyString(p.validFrom),
     criteria,
   };
 }
@@ -184,8 +188,8 @@ function parseCriterion(
     name,
     version,
     status,
-    description: optionalString(c.description),
-    documentation: optionalString(c.documentation),
+    description: asNonEmptyString(c.description),
+    documentation: asNonEmptyString(c.documentation),
     topics: parseTopics(c.conformityTopic),
     tags: parseTags(c.tag),
   };
@@ -220,14 +224,14 @@ function parseTopic(input: unknown): ConformityTopic | undefined {
     return undefined;
   }
   const t = input as Record<string, unknown>;
-  const id = optionalString(t.id);
+  const id = asNonEmptyString(t.id);
   if (!id) {
     return undefined;
   }
   return {
     canonicalId: id,
-    name: optionalString(t.name),
-    definition: optionalString(t.definition),
+    name: asNonEmptyString(t.name),
+    definition: asNonEmptyString(t.definition),
   };
 }
 
@@ -250,30 +254,7 @@ function parseOwner(input: unknown): ConformitySchemeOwner | undefined {
   }
   const o = input as Record<string, unknown>;
   return {
-    canonicalId: optionalString(o.id),
-    name: optionalString(o.name),
+    canonicalId: asNonEmptyString(o.id),
+    name: asNonEmptyString(o.name),
   };
-}
-
-function requireString(
-  value: unknown,
-  fieldName: string,
-  pointer: string,
-  failures: ValidationFailure[],
-): string | undefined {
-  if (typeof value !== 'string' || value.length === 0) {
-    failures.push({
-      code: MISSING_REQUIRED_FIELD,
-      message: `${fieldName} is required and must be a non-empty string.`,
-      received: value === undefined ? 'undefined' : value === null ? 'null' : typeof value,
-      expected: 'non-empty string',
-      pointer,
-    });
-    return undefined;
-  }
-  return value;
-}
-
-function optionalString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/packages/untp-utils/src/conformity-vocabulary/types.ts
+++ b/packages/untp-utils/src/conformity-vocabulary/types.ts
@@ -90,6 +90,22 @@ export interface ConformityScheme {
 }
 
 /**
+ * One entry in the UNTP Conformity Vocabulary Catalogue Register. Ingestion
+ * consumers route on {@link status} (skipping deprecated entries) and fetch
+ * the scheme document from {@link vocabularyUrl}.
+ */
+export interface ConformityCatalogueEntry {
+  /** CVC-canonical scheme URI; from the register entry's `id`. */
+  canonicalId: string;
+  /** Owner-published scheme document URL; from the register entry's `vocabularyURL`. Validated as a parseable URL at parse time. */
+  vocabularyUrl: string;
+  /** Human-readable scheme name. */
+  name: string;
+  /** Lifecycle status of the scheme in the register, when supplied (`'pilot'`, `'active'`, `'deprecated'`, etc.). */
+  status?: string;
+}
+
+/**
  * Warnings emitted by {@link validateConformityClaim}. Narrows
  * {@link StructuredWarning} so the `code` is one of the validator's known codes.
  */


### PR DESCRIPTION
Adds `parseConformityCatalogue` to `@uncefact/untp-utils/conformity-vocabulary`, parsing the UNTP Conformity Vocabulary Catalogue Register document into a list of `ConformityCatalogueEntry { canonicalId, vocabularyUrl, name, status? }`. This is the discovery-side primitive ingestion will compose with `resolveDocumentIfChanged`, `validateJsonLd`, `validateAgainstSchemas`, and `parseConformityScheme` to populate the local CVC projection.

Also extracts two duplicated parser helpers (`asNonEmptyString`, `makeRequireString`) into an internal `src/common/` directory consumed by both this parser and the existing `parseConformityScheme`'s v0.7.0 parser. `common/` is intentionally not exposed via `package.json` exports — internal-only.

## Errors

- `ConformitySchemeError` umbrella renamed to `ConformityVocabularyError` so the base honestly covers both scheme and catalogue parsing under one catch.
- New `ConformityCatalogueParseError` carries `readonly failures` plus an optional `sourceUrl` (set via `ParseConformityCatalogueOptions` so operator triage logs know which register URL produced the failure). Mirrors `ConformitySchemeParseError`'s shape.

## Parser specifics

- Each entry's `vocabularyURL` is validated as a parseable URL at parse time; a malformed URL surfaces as a structured `invalid-shape` failure rather than a downstream `TypeError` at fetch time.
- Optional `status` (`'pilot'` / `'active'` / `'deprecated'` etc.) is extracted so ingestion can skip deprecated entries without re-fetching the register.
- Register-only metadata (owner snapshot, sector, geographic scope, endorsement level, license type, established date, inline profiles list) is dropped — no current consumer, no Prisma column.

## Test plan

- [x] `untp-utils`: 356 / 356 tests pass.
- [x] Build clean.
- [x] Lint 0 errors.