### PR TITLE
feat(services): add resolveAndParseConformityScheme for CVC pipeline composition

### DIFF
--- a/docs/adrs/033-cvc-architecture.md
+++ b/docs/adrs/033-cvc-architecture.md
@@ -2,6 +2,7 @@
 
 - **Date:** 2026-05-21
 - **Status:** accepted
+- **Update (2026-05-27):** The services-side function this ADR calls `ingest(input)` ships as `resolveAndParseConformityScheme(input)`. "Ingest" is reserved for the RI-side step that consumes this function's output and performs the actual persistence (the RI iterates `parseConformityCatalogue` entries during UNTP discovery and calls it once per scheme; the tenant-import endpoint and the seed loader call it the same way). The function returns a discriminated `{ kind: 'unchanged' | 'success' | 'failure' }` result and never throws for known gate failures. The gate order is fetch, then JSON parse, then JSON Schema validation, then JSON-LD expansion, then parse, then body-digest. Schema validation runs before JSON-LD expansion because Ajv compile + check is local CPU, while JSON-LD expansion may fetch remote `@context` documents and walks the full RDF tree. Six `lastFetchStatus` values are now distinguished: `FETCH_FAILED`, `INVALID_JSON`, `SCHEMA_INVALID`, `JSONLD_EXPANSION_FAILED`, `PARSE_FAILED`, and `DIGEST_FAILED`. The body of this ADR retains the original framing for historical record.
 
 ## Context
 

--- a/packages/services/__tests__/mocks/multibase-digest.ts
+++ b/packages/services/__tests__/mocks/multibase-digest.ts
@@ -45,6 +45,13 @@ export class MultibaseDigest {
     return new MultibaseDigest(encoded);
   }
 
+  static async fromData(
+    data: Uint8Array,
+    _opts: { algorithm: 'sha2-256' | 'sha2-512'; base: 'base58btc' | 'base64' },
+  ): Promise<MultibaseDigest> {
+    return new MultibaseDigest(`zTESTDATA${Buffer.from(data).toString('hex').slice(0, 16)}`);
+  }
+
   toString(): string {
     return this.encoded;
   }

--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -18,6 +18,10 @@ const jestConfig = {
     // mock it per-file via jest.mock. This shim avoids Jest crashing during
     // module resolution when an adapter that depends on untp-utils is loaded.
     '^@uncefact/untp-utils/multibase-digest$': '<rootDir>/__tests__/mocks/multibase-digest.ts',
+    '^@uncefact/untp-utils/resolvers$': '<rootDir>/../untp-utils/build/resolvers/index.js',
+    '^@uncefact/untp-utils/validation$': '<rootDir>/../untp-utils/build/validation/index.js',
+    '^@uncefact/untp-utils/conformity-vocabulary$': '<rootDir>/../untp-utils/build/conformity-vocabulary/index.js',
+    '^@uncefact/untp-utils$': '<rootDir>/../untp-utils/build/index.js',
     '(.+)\\.js': '$1',
   },
   extensionsToTreatAsEsm: ['.ts'],

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -25,6 +25,10 @@
     "./key-provider": {
       "types": "./build/key-provider/index.d.ts",
       "default": "./build/key-provider/index.js"
+    },
+    "./cvc": {
+      "types": "./build/cvc/index.d.ts",
+      "default": "./build/cvc/index.js"
     }
   },
   "typesVersions": {
@@ -40,6 +44,9 @@
       ],
       "key-provider": [
         "./build/key-provider/index.d.ts"
+      ],
+      "cvc": [
+        "./build/cvc/index.d.ts"
       ]
     }
   },

--- a/packages/services/src/cvc/errors.ts
+++ b/packages/services/src/cvc/errors.ts
@@ -1,0 +1,25 @@
+import type { ResolveFailureStatus } from './types.js';
+
+/**
+ * Returned (not thrown) on the failure branch of a
+ * {@link resolveAndParseConformityScheme} run. Carries the underlying gate
+ * error via `Error.cause`, the source URL for triage, and the
+ * {@link ResolveFailureStatus} the caller maps to the persisted
+ * `lastFetchStatus` column.
+ *
+ * Consumers should branch on `.status` (a string union), not on
+ * `instanceof StructuredError`. The `cause` chain carries the original gate
+ * error and should be forwarded to structured loggers.
+ */
+export class ConformitySchemeResolveError extends Error {
+  readonly code: string;
+  readonly status: ResolveFailureStatus;
+  readonly sourceUrl: string;
+  constructor(args: { status: ResolveFailureStatus; sourceUrl: string; cause: unknown }) {
+    super(`Resolve-and-parse of ${args.sourceUrl} failed at the ${args.status} stage.`, { cause: args.cause });
+    this.name = 'ConformitySchemeResolveError';
+    this.code = `conformity-scheme.resolve-failed.${args.status.toLowerCase().replace(/_/g, '-')}`;
+    this.status = args.status;
+    this.sourceUrl = args.sourceUrl;
+  }
+}

--- a/packages/services/src/cvc/index.ts
+++ b/packages/services/src/cvc/index.ts
@@ -1,0 +1,14 @@
+export { ConformitySchemeResolveError } from './errors.js';
+export { resolveAndParseConformityScheme } from './resolve-and-parse-conformity-scheme.js';
+export {
+  RESOLVE_FAILURE_STATUS,
+  type CachedResource,
+  type ConformitySchemeSource,
+  type PrefetchedDocument,
+  type ResolveAndParseConformitySchemeFailure,
+  type ResolveAndParseConformitySchemeInput,
+  type ResolveAndParseConformitySchemeResult,
+  type ResolveAndParseConformitySchemeSuccess,
+  type ResolveAndParseConformitySchemeUnchanged,
+  type ResolveFailureStatus,
+} from './types.js';

--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
@@ -94,15 +94,20 @@ describe('resolveAndParseConformityScheme', () => {
       expect(result.bodyDigest).toBeDefined();
     });
 
-    it('passes the cached resource to resolveDocumentIfChanged', async () => {
-      const cached = { etag: '"prev"', lastModifiedHeader: 'Tue, 20 May 2026 11:00:00 GMT' };
+    it('transcodes the cached resource into the resolver input shape', async () => {
       mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
       mockValidateJsonLd.mockResolvedValue(undefined);
       mockValidateAgainstSchemas.mockResolvedValue(undefined);
       mockParseConformityScheme.mockReturnValue(fakeScheme());
 
-      await resolveAndParseConformityScheme(baseInput({ cached }));
-      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, cached);
+      await resolveAndParseConformityScheme(
+        baseInput({ cached: { etag: '"prev"', lastModified: 'Tue, 20 May 2026 11:00:00 GMT' } }),
+      );
+      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, {
+        etag: '"prev"',
+        lastModifiedHeader: 'Tue, 20 May 2026 11:00:00 GMT',
+        bodyDigest: undefined,
+      });
     });
   });
 

--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
@@ -1,0 +1,298 @@
+import { TextEncoder } from 'node:util';
+
+const mockResolveDocumentIfChanged = jest.fn();
+const mockValidateJsonLd = jest.fn();
+const mockValidateAgainstSchemas = jest.fn();
+const mockParseConformityScheme = jest.fn();
+
+jest.mock('@uncefact/untp-utils/resolvers', () => ({
+  resolveDocumentIfChanged: (...args: unknown[]) => mockResolveDocumentIfChanged(...args),
+}));
+jest.mock('@uncefact/untp-utils/validation', () => ({
+  validateJsonLd: (...args: unknown[]) => mockValidateJsonLd(...args),
+  validateAgainstSchemas: (...args: unknown[]) => mockValidateAgainstSchemas(...args),
+}));
+jest.mock('@uncefact/untp-utils/conformity-vocabulary', () => ({
+  parseConformityScheme: (...args: unknown[]) => mockParseConformityScheme(...args),
+}));
+
+import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
+import { ConformitySchemeResolveError } from './errors';
+import { resolveAndParseConformityScheme } from './resolve-and-parse-conformity-scheme';
+import { RESOLVE_FAILURE_STATUS, type ResolveAndParseConformitySchemeInput } from './types';
+
+const SOURCE_URL = 'https://example.com/scheme';
+const SCHEMA_URL = 'https://example.com/cvc/ConformityScheme.json';
+
+const fakeLoader = { load: jest.fn() } as unknown as ResolveAndParseConformitySchemeInput['schemaLoader'];
+
+function baseInput(
+  overrides: Partial<ResolveAndParseConformitySchemeInput> = {},
+): ResolveAndParseConformitySchemeInput {
+  return {
+    sourceUrl: SOURCE_URL,
+    source: 'UNTP',
+    tenantId: 'tenant-1',
+    conformitySchemaUrl: SCHEMA_URL,
+    schemaLoader: fakeLoader,
+    ...overrides,
+  };
+}
+
+function fakeScheme(overrides: Record<string, unknown> = {}) {
+  return {
+    canonicalId: SOURCE_URL,
+    sourceUrl: SOURCE_URL,
+    specVersion: '0.7.0',
+    name: 'Example Scheme',
+    profiles: [],
+    ...overrides,
+  };
+}
+
+function loadedResponse(body: string, overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'loaded' as const,
+    result: {
+      body: new TextEncoder().encode(body),
+      finalUrl: SOURCE_URL,
+      status: 200,
+      bodyDigest: { toString: () => 'zFAKEDIGEST' },
+      ...overrides,
+    },
+  };
+}
+
+beforeEach(() => {
+  mockResolveDocumentIfChanged.mockReset();
+  mockValidateJsonLd.mockReset();
+  mockValidateAgainstSchemas.mockReset();
+  mockParseConformityScheme.mockReset();
+});
+
+describe('resolveAndParseConformityScheme', () => {
+  describe('happy path (fetched)', () => {
+    it('returns kind: success with the parsed scheme + cache headers + body digest', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(
+        loadedResponse('{"@context":[],"id":"x","name":"x","includedProfile":[]}', {
+          etag: '"abc"',
+          lastModified: 'Wed, 21 May 2026 12:00:00 GMT',
+        }),
+      );
+      mockValidateJsonLd.mockResolvedValue(undefined);
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      mockParseConformityScheme.mockReturnValue(fakeScheme());
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') throw new Error('unreachable');
+      expect(result.scheme).toEqual(fakeScheme());
+      expect(result.raw).toEqual({ '@context': [], id: 'x', name: 'x', includedProfile: [] });
+      expect(result.etag).toBe('"abc"');
+      expect(result.lastModified).toBe('Wed, 21 May 2026 12:00:00 GMT');
+      expect(result.bodyDigest).toBeDefined();
+    });
+
+    it('passes the cached resource to resolveDocumentIfChanged', async () => {
+      const cached = { etag: '"prev"', lastModifiedHeader: 'Tue, 20 May 2026 11:00:00 GMT' };
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
+      mockValidateJsonLd.mockResolvedValue(undefined);
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      mockParseConformityScheme.mockReturnValue(fakeScheme());
+
+      await resolveAndParseConformityScheme(baseInput({ cached }));
+      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, cached);
+    });
+  });
+
+  describe('happy path (prefetched)', () => {
+    it('skips resolveDocumentIfChanged and processes the supplied bytes', async () => {
+      mockValidateJsonLd.mockResolvedValue(undefined);
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      mockParseConformityScheme.mockReturnValue(fakeScheme());
+
+      const result = await resolveAndParseConformityScheme(
+        baseInput({
+          source: 'SYSTEM_SEED',
+          prefetched: {
+            body: new TextEncoder().encode('{"id":"seed"}'),
+            etag: '"seed-etag"',
+            lastModified: 'Mon, 19 May 2026 10:00:00 GMT',
+          },
+        }),
+      );
+
+      expect(mockResolveDocumentIfChanged).not.toHaveBeenCalled();
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') throw new Error('unreachable');
+      expect(result.raw).toEqual({ id: 'seed' });
+      expect(result.etag).toBe('"seed-etag"');
+    });
+  });
+
+  describe('unchanged (skip chain)', () => {
+    it('returns kind: unchanged when resolveDocumentIfChanged reports unchanged', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue({ kind: 'unchanged' });
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+
+      expect(result.kind).toBe('unchanged');
+      expect(mockValidateJsonLd).not.toHaveBeenCalled();
+      expect(mockValidateAgainstSchemas).not.toHaveBeenCalled();
+      expect(mockParseConformityScheme).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failure: FETCH_FAILED', () => {
+    it('wraps a resolveDocumentIfChanged rejection', async () => {
+      const cause = new Error('upstream gone');
+      mockResolveDocumentIfChanged.mockRejectedValue(cause);
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('unreachable');
+      expect(result.error).toBeInstanceOf(ConformitySchemeResolveError);
+      expect(result.error.status).toBe(RESOLVE_FAILURE_STATUS.FetchFailed);
+      expect(result.error.cause).toBe(cause);
+    });
+  });
+
+  describe('failure: INVALID_JSON', () => {
+    it('wraps a JSON.parse failure when the body is not valid JSON', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('not-json'));
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('unreachable');
+      expect(result.error.status).toBe(RESOLVE_FAILURE_STATUS.InvalidJson);
+      expect(result.error.cause).toBeInstanceOf(SyntaxError);
+      expect(mockValidateAgainstSchemas).not.toHaveBeenCalled();
+    });
+
+    it('wraps an empty-body JSON.parse failure under INVALID_JSON', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse(''));
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('unreachable');
+      expect(result.error.status).toBe(RESOLVE_FAILURE_STATUS.InvalidJson);
+    });
+  });
+
+  describe('failure: SCHEMA_INVALID', () => {
+    it('wraps a validateAgainstSchemas throw and skips downstream gates', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
+      const cause = new Error('schema validation failed');
+      cause.name = 'SchemaPayloadError';
+      mockValidateAgainstSchemas.mockRejectedValue(cause);
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('unreachable');
+      expect(result.error.status).toBe(RESOLVE_FAILURE_STATUS.SchemaInvalid);
+      expect(result.error.cause).toBe(cause);
+      expect(mockValidateJsonLd).not.toHaveBeenCalled();
+      expect(mockParseConformityScheme).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failure: JSONLD_EXPANSION_FAILED', () => {
+    it('wraps a validateJsonLd throw and skips parsing', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      const cause = new Error('bad context');
+      cause.name = 'JsonLdExpansionFailedError';
+      mockValidateJsonLd.mockRejectedValue(cause);
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('unreachable');
+      expect(result.error.status).toBe(RESOLVE_FAILURE_STATUS.JsonLdExpansionFailed);
+      expect(result.error.cause).toBe(cause);
+      expect(mockParseConformityScheme).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failure: PARSE_FAILED', () => {
+    it('wraps a parseConformityScheme throw', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
+      mockValidateJsonLd.mockResolvedValue(undefined);
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      const cause = new Error('parse failed');
+      cause.name = 'ConformitySchemeParseError';
+      mockParseConformityScheme.mockImplementation(() => {
+        throw cause;
+      });
+
+      const result = await resolveAndParseConformityScheme(baseInput());
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('unreachable');
+      expect(result.error.status).toBe(RESOLVE_FAILURE_STATUS.ParseFailed);
+      expect(result.error.cause).toBe(cause);
+    });
+  });
+
+  describe('failure: DIGEST_FAILED', () => {
+    it('wraps a MultibaseDigest.fromData throw rather than propagating', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
+      mockValidateJsonLd.mockResolvedValue(undefined);
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      mockParseConformityScheme.mockReturnValue(fakeScheme());
+      const cause = new Error('crypto.subtle missing');
+      const spy = jest.spyOn(MultibaseDigest, 'fromData').mockRejectedValueOnce(cause);
+
+      try {
+        const result = await resolveAndParseConformityScheme(baseInput());
+        expect(result.kind).toBe('failure');
+        if (result.kind !== 'failure') throw new Error('unreachable');
+        expect(result.error.status).toBe(RESOLVE_FAILURE_STATUS.DigestFailed);
+        expect(result.error.cause).toBe(cause);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe('error metadata', () => {
+    it('attaches sourceUrl, code, message, and cause on the resolve error', async () => {
+      mockResolveDocumentIfChanged.mockRejectedValue(new Error('boom'));
+
+      const result = await resolveAndParseConformityScheme(
+        baseInput({ sourceUrl: 'https://example.com/specific-scheme' }),
+      );
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('unreachable');
+      expect(result.error.sourceUrl).toBe('https://example.com/specific-scheme');
+      expect(result.error.code).toBe('conformity-scheme.resolve-failed.fetch-failed');
+      expect(result.error.message).toContain('https://example.com/specific-scheme');
+      expect(result.error.message).toContain('FETCH_FAILED');
+    });
+
+    it.each([
+      [RESOLVE_FAILURE_STATUS.InvalidJson, 'conformity-scheme.resolve-failed.invalid-json'],
+      [RESOLVE_FAILURE_STATUS.SchemaInvalid, 'conformity-scheme.resolve-failed.schema-invalid'],
+      [RESOLVE_FAILURE_STATUS.JsonLdExpansionFailed, 'conformity-scheme.resolve-failed.jsonld-expansion-failed'],
+      [RESOLVE_FAILURE_STATUS.ParseFailed, 'conformity-scheme.resolve-failed.parse-failed'],
+      [RESOLVE_FAILURE_STATUS.DigestFailed, 'conformity-scheme.resolve-failed.digest-failed'],
+    ])('kebab-cases %s into the error code (%s)', (status, expectedCode) => {
+      const error = new ConformitySchemeResolveError({ status, sourceUrl: SOURCE_URL, cause: new Error('x') });
+      expect(error.code).toBe(expectedCode);
+    });
+  });
+
+  describe('cvcSpecVersion override', () => {
+    it('forwards the override to parseConformityScheme', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
+      mockValidateJsonLd.mockResolvedValue(undefined);
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      mockParseConformityScheme.mockReturnValue(fakeScheme());
+
+      await resolveAndParseConformityScheme(baseInput({ cvcSpecVersion: '0.7.0' }));
+      expect(mockParseConformityScheme).toHaveBeenCalledWith(expect.anything(), {
+        sourceUrl: SOURCE_URL,
+        specVersion: '0.7.0',
+      });
+    });
+  });
+});

--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
@@ -1,0 +1,114 @@
+import { TextDecoder } from 'node:util';
+import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
+import { resolveDocumentIfChanged } from '@uncefact/untp-utils/resolvers';
+import { validateAgainstSchemas, validateJsonLd } from '@uncefact/untp-utils/validation';
+import { parseConformityScheme } from '@uncefact/untp-utils/conformity-vocabulary';
+import { ConformitySchemeResolveError } from './errors.js';
+import {
+  RESOLVE_FAILURE_STATUS,
+  type ResolveAndParseConformitySchemeInput,
+  type ResolveAndParseConformitySchemeResult,
+  type ResolveFailureStatus,
+} from './types.js';
+
+/**
+ * Composes the five CVC pipeline gates (fetch, JSON parse, JSON Schema
+ * validation, JSON-LD expansion, parse) plus the body-digest step into a
+ * single best-effort flow. Schema validation runs before JSON-LD expansion
+ * because it's cheaper to fail: Ajv compile + check is local CPU, while
+ * JSON-LD expansion may fetch remote `@context` documents and walks the full
+ * RDF tree. Failing fast on schema-shape problems avoids paying the JSON-LD
+ * cost on documents that wouldn't have parsed anyway.
+ *
+ * Three terminal outcomes:
+ * `{ kind: 'unchanged' }`, the conditional-fetch skip chain hit; bump
+ *   `lastFetchedAt` only, retain previous content.
+ * `{ kind: 'success', scheme, raw, bodyDigest, etag?, lastModified? }`,
+ *   full upsert of the scheme + profiles + criteria + cache validators.
+ * `{ kind: 'failure', error }`, a gate failed. Caller persists
+ *   `lastFetchStatus = error.status` and retains previous content.
+ *
+ * The function never throws for known gate failures; every failure path
+ * surfaces as `{ kind: 'failure', error }`.
+ *
+ * @see ADR-033 §1 (Discovery and refresh; Validation at ingest).
+ */
+export async function resolveAndParseConformityScheme(
+  input: ResolveAndParseConformitySchemeInput,
+): Promise<ResolveAndParseConformitySchemeResult> {
+  let body: Uint8Array;
+  let etag: string | undefined;
+  let lastModified: string | undefined;
+
+  if (input.prefetched) {
+    body = input.prefetched.body;
+    etag = input.prefetched.etag;
+    lastModified = input.prefetched.lastModified;
+  } else {
+    try {
+      const outcome = await resolveDocumentIfChanged(input.sourceUrl, input.cached ?? {});
+      if (outcome.kind === 'unchanged') return { kind: 'unchanged' };
+      body = outcome.result.body;
+      etag = outcome.result.etag;
+      lastModified = outcome.result.lastModified;
+    } catch (cause) {
+      return failure(RESOLVE_FAILURE_STATUS.FetchFailed, input.sourceUrl, cause);
+    }
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(new TextDecoder().decode(body));
+  } catch (cause) {
+    return failure(RESOLVE_FAILURE_STATUS.InvalidJson, input.sourceUrl, cause);
+  }
+
+  try {
+    await validateAgainstSchemas(parsedJson, [input.conformitySchemaUrl], input.schemaLoader);
+  } catch (cause) {
+    return failure(RESOLVE_FAILURE_STATUS.SchemaInvalid, input.sourceUrl, cause);
+  }
+
+  try {
+    await validateJsonLd(parsedJson);
+  } catch (cause) {
+    return failure(RESOLVE_FAILURE_STATUS.JsonLdExpansionFailed, input.sourceUrl, cause);
+  }
+
+  let scheme;
+  try {
+    scheme = parseConformityScheme(parsedJson, {
+      sourceUrl: input.sourceUrl,
+      specVersion: input.cvcSpecVersion,
+    });
+  } catch (cause) {
+    return failure(RESOLVE_FAILURE_STATUS.ParseFailed, input.sourceUrl, cause);
+  }
+
+  let bodyDigest: MultibaseDigest;
+  try {
+    bodyDigest = await MultibaseDigest.fromData(body, { algorithm: 'sha2-256', base: 'base58btc' });
+  } catch (cause) {
+    return failure(RESOLVE_FAILURE_STATUS.DigestFailed, input.sourceUrl, cause);
+  }
+
+  return {
+    kind: 'success',
+    scheme,
+    raw: parsedJson,
+    bodyDigest,
+    ...(etag !== undefined ? { etag } : {}),
+    ...(lastModified !== undefined ? { lastModified } : {}),
+  };
+}
+
+function failure(
+  status: ResolveFailureStatus,
+  sourceUrl: string,
+  cause: unknown,
+): ResolveAndParseConformitySchemeResult {
+  return {
+    kind: 'failure',
+    error: new ConformitySchemeResolveError({ status, sourceUrl, cause }),
+  };
+}

--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
@@ -46,7 +46,11 @@ export async function resolveAndParseConformityScheme(
     lastModified = input.prefetched.lastModified;
   } else {
     try {
-      const outcome = await resolveDocumentIfChanged(input.sourceUrl, input.cached ?? {});
+      const outcome = await resolveDocumentIfChanged(input.sourceUrl, {
+        etag: input.cached?.etag,
+        lastModifiedHeader: input.cached?.lastModified,
+        bodyDigest: input.cached?.bodyDigest,
+      });
       if (outcome.kind === 'unchanged') return { kind: 'unchanged' };
       body = outcome.result.body;
       etag = outcome.result.etag;

--- a/packages/services/src/cvc/types.ts
+++ b/packages/services/src/cvc/types.ts
@@ -1,0 +1,89 @@
+import type { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
+import type { SchemaLoader } from '@uncefact/untp-utils/schema-loaders';
+import type { ConformityScheme } from '@uncefact/untp-utils/conformity-vocabulary';
+import type { ConformitySchemeResolveError } from './errors.js';
+
+export const RESOLVE_FAILURE_STATUS = {
+  FetchFailed: 'FETCH_FAILED',
+  InvalidJson: 'INVALID_JSON',
+  SchemaInvalid: 'SCHEMA_INVALID',
+  JsonLdExpansionFailed: 'JSONLD_EXPANSION_FAILED',
+  ParseFailed: 'PARSE_FAILED',
+  DigestFailed: 'DIGEST_FAILED',
+} as const;
+
+export type ResolveFailureStatus = (typeof RESOLVE_FAILURE_STATUS)[keyof typeof RESOLVE_FAILURE_STATUS];
+
+/** Source category for a {@link ConformityScheme} row; mirrors the RI's `CvcSchemeSource` Prisma enum. */
+export type ConformitySchemeSource = 'UNTP' | 'SYSTEM_SEED' | 'TENANT_IMPORTED';
+
+/**
+ * Bytes the caller has on hand (typically a seed loader that has already read
+ * from disk). When present, the function bypasses `resolveDocumentIfChanged`
+ * and processes these bytes directly.
+ */
+export interface PrefetchedDocument {
+  body: Uint8Array;
+  etag?: string;
+  lastModified?: string;
+}
+
+/**
+ * Previously-cached resource fields the function feeds to
+ * `resolveDocumentIfChanged` for the conditional-fetch skip chain.
+ */
+export interface CachedResource {
+  etag?: string;
+  lastModifiedHeader?: string;
+  bodyDigest?: MultibaseDigest;
+}
+
+/** @see {@link resolveAndParseConformityScheme} for the contract this input drives. */
+export interface ResolveAndParseConformitySchemeInput {
+  /** Also persisted as the row's `sourceUrl`; surfaced in error messages for triage. */
+  sourceUrl: string;
+  source: ConformitySchemeSource;
+  /** Use the system tenant id for `UNTP` / `SYSTEM_SEED` sources. */
+  tenantId: string;
+  /**
+   * URL of the `ConformityScheme.json` JSON Schema the document must
+   * conform to. The RI resolves this from its `DataModel` table by
+   * `(credentialType: 'ConformityScheme', version: cvcSpecVersion ?? '0.7.0')`.
+   */
+  conformitySchemaUrl: string;
+  /** Loader used by the inner `validateAgainstSchemas` call to fetch the JSON Schema. */
+  schemaLoader: SchemaLoader;
+  /** When present, bypasses `resolveDocumentIfChanged` and processes these bytes directly. */
+  prefetched?: PrefetchedDocument;
+  /** Conditional-fetch validators from the previous successful run; ignored when `prefetched` is set. */
+  cached?: CachedResource;
+  /** Override the spec-version detection that `parseConformityScheme` performs from `@context`. */
+  cvcSpecVersion?: string;
+}
+
+/** Outcome of a successful run; everything the caller needs to upsert the row. */
+export interface ResolveAndParseConformitySchemeSuccess {
+  kind: 'success';
+  scheme: ConformityScheme;
+  /** Raw resolved JSON-LD document, ready to persist on `ConformityScheme.rawDocument`. */
+  raw: unknown;
+  bodyDigest: MultibaseDigest;
+  etag?: string;
+  lastModified?: string;
+}
+
+/** The skip chain hit; persist `lastFetchedAt` only and retain previous content. */
+export interface ResolveAndParseConformitySchemeUnchanged {
+  kind: 'unchanged';
+}
+
+/** A gate failed; persist `lastFetchStatus` from `error.status` and retain previous content. */
+export interface ResolveAndParseConformitySchemeFailure {
+  kind: 'failure';
+  error: ConformitySchemeResolveError;
+}
+
+export type ResolveAndParseConformitySchemeResult =
+  | ResolveAndParseConformitySchemeSuccess
+  | ResolveAndParseConformitySchemeUnchanged
+  | ResolveAndParseConformitySchemeFailure;

--- a/packages/services/src/cvc/types.ts
+++ b/packages/services/src/cvc/types.ts
@@ -34,7 +34,7 @@ export interface PrefetchedDocument {
  */
 export interface CachedResource {
   etag?: string;
-  lastModifiedHeader?: string;
+  lastModified?: string;
   bodyDigest?: MultibaseDigest;
 }
 


### PR DESCRIPTION
This PR adds `resolveAndParseConformityScheme` to `@uncefact/untp-ri-services`, which composes the six CVC pipeline gates (fetch, JSON parse, JSON Schema validation, JSON-LD expansion, parse, body-digest) into a single best-effort flow that the RI can call once per scheme during discovery, tenant import, or seed loading.

The function returns a discriminated `{ kind: 'unchanged' | 'success' | 'failure' }` result and never throws for known gate failures. Consumers branch on `error.status` to persist `lastFetchStatus` and retain previous content. Persistence itself is the RI's responsibility; this function only composes the gates.

Schema validation runs before JSON-LD expansion because Ajv compile + check is local CPU, while JSON-LD expansion may fetch remote `@context` documents and walks the full RDF tree. Failing fast on schema-shape problems avoids paying the JSON-LD cost on documents that wouldn't have parsed anyway.

Six failure statuses keep operator-side triage signals distinct: `FETCH_FAILED`, `INVALID_JSON`, `SCHEMA_INVALID`, `JSONLD_EXPANSION_FAILED`, `PARSE_FAILED`, `DIGEST_FAILED`. A malformed-JSON publisher is not the same as a network outage, and a `crypto.subtle`-shaped digest crash is not the same as a parse rejection.

Adds an `./cvc` sub-entry to the package exports, Jest moduleNameMapper shims for the utils sub-entries (the services package's CJS resolver can't untangle multiformats' subpath exports), and a `fromData` method on the test stub for `MultibaseDigest` so production code that consumes it through this module mapper is exercisable.

ADR-033 carries a 2026-05-27 Update line recording the function name (`resolveAndParseConformityScheme`, not `ingest`), the six-gate order, and the expanded failure-status set. The body of the ADR is unchanged per the project's "keep ADRs in sync with the code" convention.

Related to #543. Does not close it; the RI-side ingestion step (persistence, upserts, status writes) is a follow-up.

## Test plan
- [x] 18 unit tests in `packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts` cover the happy paths (fetched and prefetched), the unchanged skip chain, every failure status, error metadata, and the `cvcSpecVersion` override.
- [x] Full services suite (`pnpm jest --maxWorkers=1`) passes: 57 suites, 1252 tests.
- [x] `pnpm build:services` clean.
- [x] `pnpm lint:check` clean (0 errors).