### PR TITLE
refactor(services): align cvc types on lastModifiedHeader

### DIFF
--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
@@ -90,24 +90,29 @@ describe('resolveAndParseConformityScheme', () => {
       expect(result.scheme).toEqual(fakeScheme());
       expect(result.raw).toEqual({ '@context': [], id: 'x', name: 'x', includedProfile: [] });
       expect(result.etag).toBe('"abc"');
-      expect(result.lastModified).toBe('Wed, 21 May 2026 12:00:00 GMT');
+      expect(result.lastModifiedHeader).toBe('Wed, 21 May 2026 12:00:00 GMT');
       expect(result.bodyDigest).toBeDefined();
     });
 
-    it('transcodes the cached resource into the resolver input shape', async () => {
+    it('passes the cached resource to resolveDocumentIfChanged', async () => {
+      const cached = { etag: '"prev"', lastModifiedHeader: 'Tue, 20 May 2026 11:00:00 GMT' };
       mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
       mockValidateJsonLd.mockResolvedValue(undefined);
       mockValidateAgainstSchemas.mockResolvedValue(undefined);
       mockParseConformityScheme.mockReturnValue(fakeScheme());
 
-      await resolveAndParseConformityScheme(
-        baseInput({ cached: { etag: '"prev"', lastModified: 'Tue, 20 May 2026 11:00:00 GMT' } }),
-      );
-      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, {
-        etag: '"prev"',
-        lastModifiedHeader: 'Tue, 20 May 2026 11:00:00 GMT',
-        bodyDigest: undefined,
-      });
+      await resolveAndParseConformityScheme(baseInput({ cached }));
+      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, cached);
+    });
+
+    it('passes an empty object to resolveDocumentIfChanged when no cached resource is supplied', async () => {
+      mockResolveDocumentIfChanged.mockResolvedValue(loadedResponse('{"id":"x"}'));
+      mockValidateJsonLd.mockResolvedValue(undefined);
+      mockValidateAgainstSchemas.mockResolvedValue(undefined);
+      mockParseConformityScheme.mockReturnValue(fakeScheme());
+
+      await resolveAndParseConformityScheme(baseInput());
+      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, {});
     });
   });
 
@@ -123,7 +128,7 @@ describe('resolveAndParseConformityScheme', () => {
           prefetched: {
             body: new TextEncoder().encode('{"id":"seed"}'),
             etag: '"seed-etag"',
-            lastModified: 'Mon, 19 May 2026 10:00:00 GMT',
+            lastModifiedHeader: 'Mon, 19 May 2026 10:00:00 GMT',
           },
         }),
       );

--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
@@ -23,7 +23,7 @@ import {
  * Three terminal outcomes:
  * `{ kind: 'unchanged' }`, the conditional-fetch skip chain hit; bump
  *   `lastFetchedAt` only, retain previous content.
- * `{ kind: 'success', scheme, raw, bodyDigest, etag?, lastModified? }`,
+ * `{ kind: 'success', scheme, raw, bodyDigest, etag?, lastModifiedHeader? }`,
  *   full upsert of the scheme + profiles + criteria + cache validators.
  * `{ kind: 'failure', error }`, a gate failed. Caller persists
  *   `lastFetchStatus = error.status` and retains previous content.
@@ -38,23 +38,19 @@ export async function resolveAndParseConformityScheme(
 ): Promise<ResolveAndParseConformitySchemeResult> {
   let body: Uint8Array;
   let etag: string | undefined;
-  let lastModified: string | undefined;
+  let lastModifiedHeader: string | undefined;
 
   if (input.prefetched) {
     body = input.prefetched.body;
     etag = input.prefetched.etag;
-    lastModified = input.prefetched.lastModified;
+    lastModifiedHeader = input.prefetched.lastModifiedHeader;
   } else {
     try {
-      const outcome = await resolveDocumentIfChanged(input.sourceUrl, {
-        etag: input.cached?.etag,
-        lastModifiedHeader: input.cached?.lastModified,
-        bodyDigest: input.cached?.bodyDigest,
-      });
+      const outcome = await resolveDocumentIfChanged(input.sourceUrl, input.cached ?? {});
       if (outcome.kind === 'unchanged') return { kind: 'unchanged' };
       body = outcome.result.body;
       etag = outcome.result.etag;
-      lastModified = outcome.result.lastModified;
+      lastModifiedHeader = outcome.result.lastModified;
     } catch (cause) {
       return failure(RESOLVE_FAILURE_STATUS.FetchFailed, input.sourceUrl, cause);
     }
@@ -102,7 +98,7 @@ export async function resolveAndParseConformityScheme(
     raw: parsedJson,
     bodyDigest,
     ...(etag !== undefined ? { etag } : {}),
-    ...(lastModified !== undefined ? { lastModified } : {}),
+    ...(lastModifiedHeader !== undefined ? { lastModifiedHeader } : {}),
   };
 }
 

--- a/packages/services/src/cvc/types.ts
+++ b/packages/services/src/cvc/types.ts
@@ -25,7 +25,7 @@ export type ConformitySchemeSource = 'UNTP' | 'SYSTEM_SEED' | 'TENANT_IMPORTED';
 export interface PrefetchedDocument {
   body: Uint8Array;
   etag?: string;
-  lastModified?: string;
+  lastModifiedHeader?: string;
 }
 
 /**
@@ -34,7 +34,7 @@ export interface PrefetchedDocument {
  */
 export interface CachedResource {
   etag?: string;
-  lastModified?: string;
+  lastModifiedHeader?: string;
   bodyDigest?: MultibaseDigest;
 }
 
@@ -69,7 +69,7 @@ export interface ResolveAndParseConformitySchemeSuccess {
   raw: unknown;
   bodyDigest: MultibaseDigest;
   etag?: string;
-  lastModified?: string;
+  lastModifiedHeader?: string;
 }
 
 /** The skip chain hit; persist `lastFetchedAt` only and retain previous content. */


### PR DESCRIPTION
This PR renames `lastModified` to `lastModifiedHeader` on the three CVC surface interfaces (`PrefetchedDocument`, `CachedResource`, `ResolveAndParseConformitySchemeSuccess`), which results in the services API matching the Prisma column, the upstream `resolveDocumentIfChanged` input shape, and the language used in ADR-033 §1. The suffix also disambiguates the raw HTTP header string from `lastFetchedAt` (a `DateTime` on the Prisma row).

The function used to transcode `input.cached?.lastModified` into the resolver's `lastModifiedHeader`; after the rename `CachedResource` matches the resolver input shape exactly, so the function passes `input.cached ?? {}` through directly. Reading from `outcome.result.lastModified` (utils' resolver output, unchanged) still transcodes locally; aligning the utils output is a follow-up.

Related to #543.

## Test plan
- [x] 19 unit tests pass.
- [x] Added a focused test asserting `{}` is passed to `resolveDocumentIfChanged` when no cached resource is supplied, to lock the `?? {}` fallback against regression.
- [x] `pnpm build:services` clean.
- [x] `pnpm lint:check` clean (0 errors).