### PR TITLE
fix(services): default Accept to application/ld+json when fetching conformity schemes

### DIFF
--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.test.ts
@@ -102,7 +102,9 @@ describe('resolveAndParseConformityScheme', () => {
       mockParseConformityScheme.mockReturnValue(fakeScheme());
 
       await resolveAndParseConformityScheme(baseInput({ cached }));
-      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, cached);
+      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, cached, {
+        headers: { Accept: 'application/ld+json' },
+      });
     });
 
     it('passes an empty object to resolveDocumentIfChanged when no cached resource is supplied', async () => {
@@ -112,7 +114,13 @@ describe('resolveAndParseConformityScheme', () => {
       mockParseConformityScheme.mockReturnValue(fakeScheme());
 
       await resolveAndParseConformityScheme(baseInput());
-      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(SOURCE_URL, {});
+      expect(mockResolveDocumentIfChanged).toHaveBeenCalledWith(
+        SOURCE_URL,
+        {},
+        {
+          headers: { Accept: 'application/ld+json' },
+        },
+      );
     });
   });
 

--- a/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
+++ b/packages/services/src/cvc/resolve-and-parse-conformity-scheme.ts
@@ -46,7 +46,9 @@ export async function resolveAndParseConformityScheme(
     lastModifiedHeader = input.prefetched.lastModifiedHeader;
   } else {
     try {
-      const outcome = await resolveDocumentIfChanged(input.sourceUrl, input.cached ?? {});
+      const outcome = await resolveDocumentIfChanged(input.sourceUrl, input.cached ?? {}, {
+        headers: { Accept: 'application/ld+json' },
+      });
       if (outcome.kind === 'unchanged') return { kind: 'unchanged' };
       body = outcome.result.body;
       etag = outcome.result.etag;


### PR DESCRIPTION
This PR defaults the `Accept` header on the CVC fetch to `application/ld+json`, which results in the function correctly retrieving JSON-LD scheme documents from publishers that content-negotiate, instead of getting `text/html` and tripping `INVALID_JSON`.

Verified against the deployed register (`https://untp.unece.org/assets/files/register-aac7758c2e3fe71fa2309ca898d66d55.json`): all four registered schemes (RBA VAP, RMAP, GBA Battery Passport, Copper Mark) serve their `vocabularyURL` as JSON-LD only when `Accept: application/ld+json` is supplied.

Related to #543.

## Test plan
- [x] 19 unit tests pass; assertions on `resolveDocumentIfChanged` updated to require the header.