### PR TITLE
feat(ri): seed conformity schemes via the custom-seed manifest

### DIFF
--- a/documentation/docs/reference-implementation/operations/custom-seed.md
+++ b/documentation/docs/reference-implementation/operations/custom-seed.md
@@ -7,7 +7,7 @@ title: Custom Seed
 
 The Reference Implementation ships with a set of [default seed data](./startup.md#step-2-database-seed) — registrars, identifier schemes, data models, render templates, and service instances. These defaults cover common UNTP use cases out of the box.
 
-Deployers who need additional data — custom registrars, identifier schemes, data models, render templates, or CVC catalogues — can supply a YAML manifest via a Docker volume mount, without modifying the source code or rebuilding the image.
+Deployers who need additional data — custom registrars, identifier schemes, data models, render templates, or conformity schemes — can supply a YAML manifest via a Docker volume mount, without modifying the source code or rebuilding the image.
 
 ## How It Works
 
@@ -66,10 +66,10 @@ Each ID must be unique across the entire manifest. If an ID matches a record alr
 The manifest is a YAML file with four top-level arrays. All are optional — omit any section you do not need.
 
 ```yaml
-registrars: []        # Identifier registrars with nested schemes and qualifiers
-dataModels: []        # Data model extension configurations
-renderTemplates: []   # HTML render templates (files referenced by relative path)
-cvcCatalogues: []     # Remote CVC catalogue endpoints to import
+registrars: []         # Identifier registrars with nested schemes and qualifiers
+dataModels: []         # Data model extension configurations
+renderTemplates: []    # HTML render templates (files referenced by relative path)
+conformitySchemes: []  # Conformity schemes to ingest under the system tenant
 ```
 
 ### Registrars
@@ -206,30 +206,33 @@ The template file at the specified path is uploaded to the storage service durin
 Only one render template per data model may have `isDefault: true`. If multiple templates for the same data model are marked as default, validation will fail.
 :::
 
-### CVC Catalogues
+### Conformity Schemes
 
-CVC (Conformity Verification Certificate) catalogues define remote endpoints from which conformity credential catalogues are imported.
+Conformity schemes are ingested under the system tenant with `source = SYSTEM_SEED`. Each entry points at a single scheme document — either a remote URL the loader fetches at seed time, or a local JSON-LD file in the mount directory.
 
 ```yaml
-cvcCatalogues:
-  - id: "clxyz1234567890cvc01"
-    name: "Example CVC Catalogue"
-    version: "0.6.0"
-    endpointUrl: "https://example.com/api/cvc-catalogue"
+conformitySchemes:
+  - url: "https://vocab.example.com/scheme-a"
+    version: "0.7.0"
+  - file: "schemes/scheme-b.json"
+    version: "0.7.0"
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | CUID v1 | Yes | Unique identifier |
-| `name` | string | Yes | Display name |
-| `version` | string | Yes | CVC specification version (must be a supported version) |
-| `endpointUrl` | URL | Yes | Remote endpoint to fetch the catalogue from |
+| `url` | URL | Yes (or `file`) | HTTP(S) URL of the scheme document to fetch at seed time |
+| `file` | string | Yes (or `url`) | Path relative to the mount directory of a local JSON-LD scheme document |
+| `version` | string | Yes | CVC specification version this document conforms to, e.g. `"0.7.0"` |
 
-The endpoint is fetched during seed processing (with automatic retry on failure). The remote service must be reachable at seed time.
+Exactly one of `url` or `file` must be set per entry. The scheme's display name and structure (profiles, criteria) are derived from the document itself; no operator-supplied name is required.
+
+The seed loader is **insert-only-if-absent**: if a row already exists at `(sourceUrl, systemTenantId)` (from a prior seed run, UNTP discovery, or operator action), the entry is skipped. This preserves any post-seed updates rather than overwriting them.
+
+For file entries, the loader reads the top-level `id` (or `@id`) from the JSON-LD document to determine the row's `sourceUrl`. The file must be a valid JSON-LD scheme document.
 
 ## Complete Example
 
-Below is a full example manifest that provisions a custom registrar with an identifier scheme, a data model extension, a render template, and a CVC catalogue.
+Below is a full example manifest that provisions a custom registrar with an identifier scheme, a data model extension, a render template, and two conformity schemes (one fetched from a URL, one read from a local file).
 
 Mount directory structure:
 
@@ -273,11 +276,11 @@ renderTemplates:
     renderMethodType: "RenderTemplate2024"
     isDefault: true
 
-cvcCatalogues:
-  - id: "clxyz1234567890cvcau"
-    name: "AU Conformity Catalogue"
-    version: "0.6.0"
-    endpointUrl: "https://example.com/api/cvc-catalogue"
+conformitySchemes:
+  - url: "https://vocab.example.com/au-scheme"
+    version: "0.7.0"
+  - file: "schemes/au-fallback-scheme.json"
+    version: "0.7.0"
 ```
 
 ## Validation
@@ -305,18 +308,18 @@ After schema validation passes, the system checks cross-references and constrain
 - **Path traversal protection** — template file paths cannot reference files outside the mount directory (e.g. `../../etc/passwd` is rejected)
 - **Default template uniqueness** — only one render template per data model may be marked as `isDefault: true`
 - **Tenant ID collision protection** — IDs that already exist in a non-system tenant cannot be upserted
-- **CVC version support** — catalogue versions must be supported by the system
 
 If any validation error is detected, the seed process exits with code 1 and logs the specific errors. No data is written.
+
+Conformity scheme entries are validated structurally (URL XOR file, required `version`) at Phase 1. Other concerns (URL reachability, file existence, presence of the `ConformityScheme` data-model row for the entry's `version`) are evaluated at processing time and recorded as per-entry skips or failures; they do not abort the seed pass.
 
 ## Processing Order
 
 Once validation passes, the custom seed processes entities in the following order:
 
 1. **Upload render template files** to the storage service
-2. **Fetch CVC catalogues** from remote endpoints (with retry)
-3. **Upsert all entities** (registrars, schemes, qualifiers, data models, render templates) in a single atomic database transaction
-4. **Import CVC catalogues** (outside the main transaction)
+2. **Upsert all entities** (registrars, schemes, qualifiers, data models, render templates) in a single atomic database transaction
+3. **Ingest conformity schemes** (outside the main transaction). For each entry, the loader either fetches the URL or reads the file, then runs the scheme through the CVC pipeline (fetch → JSON parse → schema validate → JSON-LD expand → parse → persist). Per-entry failures are logged and counted; the loop continues to the next entry.
 
 ## Important Notes
 
@@ -325,5 +328,5 @@ Once validation passes, the custom seed processes entities in the following orde
 - **Atomic** — registrars, schemes, qualifiers, data models, and render templates are written in a single database transaction. If any write fails, the entire batch is rolled back.
 - **System tenant ownership** — all custom seed entities are owned by the system tenant.
 - **Storage service required for templates** — if your manifest includes render templates, the storage service must be configured and reachable at seed time.
-- **Network access required for CVC catalogues** — catalogue endpoints must be reachable at seed time.
+- **Network access required for URL-sourced conformity schemes** — any `conformitySchemes` entry with a `url` field must be reachable at seed time. File-sourced entries are read directly from the mount directory and do not need network access.
 - **Exit on error** — validation failures cause the seed process to exit with code 1, preventing the application from starting with invalid data.

--- a/packages/reference-implementation/Dockerfile
+++ b/packages/reference-implementation/Dockerfile
@@ -148,7 +148,12 @@ COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation
 # Modules required by prisma/seed.ts (relative imports from ../src/lib/...)
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/prisma/constants.ts ./src/lib/prisma/constants.ts
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/prisma/generated ./src/lib/prisma/generated
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/prisma/prisma.ts ./src/lib/prisma/prisma.ts
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/config ./src/lib/config
+# Modules required by prisma/custom-seed.ts (conformity-scheme ingestion path)
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/api/logger.ts ./src/lib/api/logger.ts
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/schema-loader.ts ./src/lib/credentials/schema-loader.ts
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/cvc ./src/lib/cvc
 # Render templates used by prisma/seed.ts
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/templates ./src/templates
 

--- a/packages/reference-implementation/prisma/__tests__/custom-seed-schema.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/custom-seed-schema.test.ts
@@ -623,6 +623,58 @@ describe('customSeedSchema — renderTemplates', () => {
   });
 });
 
+// ── Conformity schemes ────────────────────────────────────────────────────────
+
+describe('customSeedSchema — conformitySchemes', () => {
+  it('accepts a URL-only entry with a version', () => {
+    const result = customSeedSchema.safeParse({
+      conformitySchemes: [{ url: 'https://example.com/scheme', version: '0.7.0' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a file-only entry with a version', () => {
+    const result = customSeedSchema.safeParse({
+      conformitySchemes: [{ file: 'schemes/example.json', version: '0.7.0' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an entry with neither `url` nor `file`', () => {
+    const result = customSeedSchema.safeParse({
+      conformitySchemes: [{ version: '0.7.0' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an entry with both `url` and `file` set', () => {
+    const result = customSeedSchema.safeParse({
+      conformitySchemes: [{ url: 'https://example.com/scheme', file: 'a.json', version: '0.7.0' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an entry missing the `version` field', () => {
+    const result = customSeedSchema.safeParse({
+      conformitySchemes: [{ url: 'https://example.com/scheme' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an entry with a non-URL value in `url`', () => {
+    const result = customSeedSchema.safeParse({
+      conformitySchemes: [{ url: 'not-a-url', version: '0.7.0' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults conformitySchemes to [] when omitted', () => {
+    const result = customSeedSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.conformitySchemes).toEqual([]);
+  });
+});
+
 // ── Type exports ──────────────────────────────────────────────────────────────
 
 describe('customSeedSchema — exported types', () => {

--- a/packages/reference-implementation/prisma/__tests__/custom-seed-upsert.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/custom-seed-upsert.test.ts
@@ -27,6 +27,7 @@ function emptyManifest(): CustomSeedManifest {
     registrars: [],
     dataModels: [],
     renderTemplates: [],
+    conformitySchemes: [],
   };
 }
 

--- a/packages/reference-implementation/prisma/__tests__/custom-seed-validate.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/custom-seed-validate.test.ts
@@ -71,6 +71,7 @@ function emptyManifest(): CustomSeedManifest {
     registrars: [],
     dataModels: [],
     renderTemplates: [],
+    conformitySchemes: [],
   };
 }
 
@@ -116,6 +117,7 @@ describe('validateManifestReferences', () => {
         ],
         dataModels: [buildDataModel()],
         renderTemplates: [buildRenderTemplate()],
+        conformitySchemes: [],
       };
 
       const errors = validateManifestReferences(manifest, buildCtx());

--- a/packages/reference-implementation/prisma/__tests__/custom-seed.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/custom-seed.test.ts
@@ -15,6 +15,16 @@ jest.mock('yaml', () => ({
   parse: jest.fn(),
 }));
 
+// ── Mock the CVC ingest entry to avoid pulling utils + undici through jest ────
+
+jest.mock('../../src/lib/cvc/index.js', () => ({
+  ingestConformityScheme: jest.fn(),
+}));
+
+jest.mock('../../src/lib/credentials/schema-loader.js', () => ({
+  schemaLoader: { load: jest.fn() },
+}));
+
 // ── Mock process.exit ────────────────────────────────────────────────────────
 
 const mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {
@@ -71,11 +81,12 @@ function createMockPrisma() {
   });
 
   return {
-    dataModel: { findMany: findManyFn },
+    dataModel: { findMany: findManyFn, findFirst: jest.fn().mockResolvedValue(null) },
     registrar: { findMany: findManyFn, upsert: upsertFn },
     identifierScheme: { findMany: findManyFn, upsert: upsertFn },
     schemeQualifier: { findMany: findManyFn, upsert: upsertFn },
     renderTemplate: { findMany: findManyFn, upsert: upsertFn },
+    conformityScheme: { findUnique: jest.fn().mockResolvedValue(null) },
     $transaction: transactionFn,
   } as unknown as CustomSeedDependencies['prisma'];
 }
@@ -230,6 +241,97 @@ describe('runCustomSeed', () => {
 
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(deps.logger.error).toHaveBeenCalledWith(expect.stringContaining('storage service'));
+    });
+  });
+
+  describe('conformitySchemes seed processing', () => {
+    function setupManifest(conformitySchemes: unknown[]) {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.readFileSync as jest.Mock).mockImplementation((p: string) => {
+        if (p.endsWith('seed.yaml')) return '';
+        return Buffer.from('{"id":"https://example.com/scheme","name":"Example"}');
+      });
+      (parseYaml as jest.Mock).mockReturnValue({
+        registrars: [],
+        dataModels: [],
+        renderTemplates: [],
+        conformitySchemes,
+      });
+    }
+
+    it('ingests a URL-based conformity scheme entry when not already present', async () => {
+      setupManifest([{ url: 'https://example.com/scheme', version: '0.7.0' }]);
+      const deps = createDeps();
+      const ingestMock = require('../../src/lib/cvc/index.js').ingestConformityScheme as jest.Mock;
+      ingestMock.mockResolvedValue({ kind: 'success', schemeId: 'row-1' });
+      (deps.prisma.dataModel.findFirst as jest.Mock).mockResolvedValue({
+        schemaUrl: 'https://example.com/schema.json',
+      });
+
+      await runCustomSeed(deps);
+
+      expect(deps.prisma.conformityScheme.findUnique).toHaveBeenCalledWith({
+        where: { sourceUrl_tenantId: { sourceUrl: 'https://example.com/scheme', tenantId: SYSTEM_TENANT_ID } },
+      });
+      expect(ingestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceUrl: 'https://example.com/scheme',
+          source: 'SYSTEM_SEED',
+          tenantId: SYSTEM_TENANT_ID,
+          conformitySchemaUrl: 'https://example.com/schema.json',
+          conformityVocabularySpecVersion: '0.7.0',
+        }),
+      );
+    });
+
+    it('skips an entry whose (sourceUrl, tenantId) row already exists (insert-only-if-absent)', async () => {
+      setupManifest([{ url: 'https://example.com/scheme', version: '0.7.0' }]);
+      const deps = createDeps();
+      const ingestMock = require('../../src/lib/cvc/index.js').ingestConformityScheme as jest.Mock;
+      (deps.prisma.conformityScheme.findUnique as jest.Mock).mockResolvedValue({ id: 'existing-row' });
+
+      await runCustomSeed(deps);
+
+      expect(ingestMock).not.toHaveBeenCalled();
+      expect(deps.logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceUrl: 'https://example.com/scheme' }),
+        expect.stringContaining('insert-only-if-absent'),
+      );
+    });
+
+    it('skips an entry whose version has no ConformityScheme DataModel row', async () => {
+      setupManifest([{ url: 'https://example.com/scheme', version: '9.9.9' }]);
+      const deps = createDeps();
+      const ingestMock = require('../../src/lib/cvc/index.js').ingestConformityScheme as jest.Mock;
+      (deps.prisma.dataModel.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await runCustomSeed(deps);
+
+      expect(ingestMock).not.toHaveBeenCalled();
+      expect(deps.logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ version: '9.9.9' }),
+        expect.stringContaining('ConformityScheme DataModel'),
+      );
+    });
+
+    it('ingests a file-based entry by reading the JSON-LD and extracting `id` as sourceUrl', async () => {
+      setupManifest([{ file: 'schemes/example.json', version: '0.7.0' }]);
+      const deps = createDeps();
+      const ingestMock = require('../../src/lib/cvc/index.js').ingestConformityScheme as jest.Mock;
+      ingestMock.mockResolvedValue({ kind: 'success', schemeId: 'row-1' });
+      (deps.prisma.dataModel.findFirst as jest.Mock).mockResolvedValue({
+        schemaUrl: 'https://example.com/schema.json',
+      });
+
+      await runCustomSeed(deps);
+
+      expect(ingestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceUrl: 'https://example.com/scheme',
+          source: 'SYSTEM_SEED',
+          prefetched: expect.objectContaining({ body: expect.any(Uint8Array) }),
+        }),
+      );
     });
   });
 });

--- a/packages/reference-implementation/prisma/custom-seed-schema.ts
+++ b/packages/reference-implementation/prisma/custom-seed-schema.ts
@@ -128,6 +128,36 @@ export const customSeedRenderTemplateSchema = z.object({
 
 export type CustomSeedRenderTemplate = z.infer<typeof customSeedRenderTemplateSchema>;
 
+// ── Conformity scheme schema ──────────────────────────────────────────────────
+
+/**
+ * A conformity scheme to seed under the system tenant (`source = SYSTEM_SEED`).
+ *
+ * Each entry references exactly one source:
+ * - `url`: an HTTP(S) URL the seed loader fetches at seed-time.
+ * - `file`: a path relative to the custom-seed directory pointing at a local
+ *   JSON-LD document.
+ *
+ * The scheme's display name and structure are derived from the document
+ * itself; the operator does not supply a name. The `version` selects the CVC
+ * specification version (and therefore the JSON Schema URL resolved from the
+ * `ConformityScheme` data-model row).
+ */
+export const customSeedConformitySchemeSchema = z
+  .object({
+    /** HTTP(S) URL of the scheme document to fetch at seed-time. */
+    url: z.string().url().optional(),
+    /** Path relative to the custom-seed directory of a local JSON-LD scheme document. */
+    file: z.string().optional(),
+    /** CVC specification version this document conforms to, e.g. `"0.7.0"`. */
+    version: z.string(),
+  })
+  .refine((entry) => (entry.url === undefined) !== (entry.file === undefined), {
+    message: 'Exactly one of `url` or `file` must be provided',
+  });
+
+export type CustomSeedConformityScheme = z.infer<typeof customSeedConformitySchemeSchema>;
+
 // ── Root manifest schema ──────────────────────────────────────────────────────
 
 /**
@@ -151,6 +181,12 @@ export const customSeedSchema = z.object({
 
   /** Render templates to upsert (template files are read from disk via the `file` path). */
   renderTemplates: customSeedRenderTemplateSchema
+    .array()
+    .nullish()
+    .transform((v) => v ?? []),
+
+  /** Conformity schemes to ingest under the system tenant as `SYSTEM_SEED`. */
+  conformitySchemes: customSeedConformitySchemeSchema
     .array()
     .nullish()
     .transform((v) => v ?? []),

--- a/packages/reference-implementation/prisma/custom-seed.ts
+++ b/packages/reference-implementation/prisma/custom-seed.ts
@@ -4,7 +4,9 @@ import { parse as parseYaml } from 'yaml';
 import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
 import type { LoggerService as Logger } from '@uncefact/untp-ri-services';
 import type { PrismaClient, Prisma } from '../src/lib/prisma/generated/index.js';
-import { RenderMethodType } from '../src/lib/prisma/generated/index.js';
+import { ConformitySchemeSource, RenderMethodType } from '../src/lib/prisma/generated/index.js';
+import { schemaLoader } from '../src/lib/credentials/schema-loader.js';
+import { ingestConformityScheme } from '../src/lib/cvc/index.js';
 import { customSeedSchema, type CustomSeedManifest } from './custom-seed-schema.js';
 import { validateManifestReferences, type ValidationContext } from './custom-seed-validate.js';
 import { buildUpsertOperations } from './custom-seed-upsert.js';
@@ -42,7 +44,11 @@ export interface CustomSeedDependencies {
  * Count total entities in a parsed manifest.
  */
 function countEntities(manifest: CustomSeedManifest): number {
-  let count = manifest.registrars.length + manifest.dataModels.length + manifest.renderTemplates.length;
+  let count =
+    manifest.registrars.length +
+    manifest.dataModels.length +
+    manifest.renderTemplates.length +
+    manifest.conformitySchemes.length;
 
   for (const registrar of manifest.registrars) {
     count += registrar.identifierSchemes.length;
@@ -52,6 +58,123 @@ function countEntities(manifest: CustomSeedManifest): number {
   }
 
   return count;
+}
+
+// ── Conformity scheme seed processing ────────────────────────────────────────
+
+interface ConformitySchemeSeedSummary {
+  ingested: number;
+  skipped: number;
+  failed: number;
+}
+
+/**
+ * Processes the `conformitySchemes` entries from the manifest after the main
+ * upsert transaction has committed. Each entry is ingested under
+ * `tenantId = SYSTEM_TENANT_ID` with `source = SYSTEM_SEED`. Existing rows
+ * (matched by `(sourceUrl, tenantId)`) are left untouched — the policy is
+ * insert-only-if-absent so that subsequent UNTP discovery or operator updates
+ * are preserved. The schema URL is resolved from the `ConformityScheme`
+ * system data-model row keyed by `(credentialType, version)`.
+ */
+async function processConformitySchemes(
+  deps: CustomSeedDependencies,
+  manifest: CustomSeedManifest,
+): Promise<ConformitySchemeSeedSummary> {
+  const { logger, prisma, systemTenantId, customSeedDir } = deps;
+  const summary: ConformitySchemeSeedSummary = { ingested: 0, skipped: 0, failed: 0 };
+
+  for (const entry of manifest.conformitySchemes) {
+    try {
+      let sourceUrl: string;
+      let prefetchedBody: Uint8Array | undefined;
+
+      if (entry.url !== undefined) {
+        sourceUrl = entry.url;
+      } else if (entry.file !== undefined) {
+        const filePath = path.resolve(customSeedDir, entry.file);
+        if (!fs.existsSync(filePath)) {
+          logger.error({ file: entry.file, filePath }, 'Conformity scheme seed file not found; skipping');
+          summary.failed += 1;
+          continue;
+        }
+        const bytes = fs.readFileSync(filePath);
+        let doc: { id?: string; '@id'?: string };
+        try {
+          doc = JSON.parse(bytes.toString('utf-8')) as { id?: string; '@id'?: string };
+        } catch (parseErr) {
+          logger.error({ file: entry.file, err: parseErr }, 'Conformity scheme seed file is not valid JSON; skipping');
+          summary.failed += 1;
+          continue;
+        }
+        const canonicalId = doc.id ?? doc['@id'];
+        if (typeof canonicalId !== 'string' || canonicalId.length === 0) {
+          logger.error({ file: entry.file }, 'Conformity scheme seed file missing top-level `id`; skipping');
+          summary.failed += 1;
+          continue;
+        }
+        sourceUrl = canonicalId;
+        prefetchedBody = new Uint8Array(bytes);
+      } else {
+        logger.error({ entry }, 'Conformity scheme entry has neither `url` nor `file`; skipping');
+        summary.failed += 1;
+        continue;
+      }
+
+      const existing = await prisma.conformityScheme.findUnique({
+        where: { sourceUrl_tenantId: { sourceUrl, tenantId: systemTenantId } },
+      });
+      if (existing) {
+        logger.info({ sourceUrl }, 'Conformity scheme already present (insert-only-if-absent); skipping');
+        summary.skipped += 1;
+        continue;
+      }
+
+      const dataModel = await prisma.dataModel.findFirst({
+        where: { tenantId: systemTenantId, credentialType: 'ConformityScheme', version: entry.version },
+      });
+      if (!dataModel) {
+        logger.error(
+          { version: entry.version, sourceUrl },
+          'ConformityScheme DataModel row for this version is not seeded; skipping',
+        );
+        summary.failed += 1;
+        continue;
+      }
+
+      const result = await ingestConformityScheme({
+        sourceUrl,
+        source: ConformitySchemeSource.SYSTEM_SEED,
+        tenantId: systemTenantId,
+        conformitySchemaUrl: dataModel.schemaUrl,
+        schemaLoader,
+        conformityVocabularySpecVersion: entry.version,
+        ...(prefetchedBody !== undefined ? { prefetched: { body: prefetchedBody } } : {}),
+      });
+
+      if (result.kind === 'success') {
+        logger.info({ sourceUrl, schemeId: result.schemeId }, 'Seeded conformity scheme');
+        summary.ingested += 1;
+      } else if (result.kind === 'failure') {
+        logger.error(
+          { sourceUrl, status: result.error.status, message: result.error.message },
+          'Failed to seed conformity scheme',
+        );
+        summary.failed += 1;
+      } else {
+        logger.info({ sourceUrl }, 'Conformity scheme reported unchanged on seed; counted as ingested');
+        summary.ingested += 1;
+      }
+    } catch (err) {
+      logger.error(
+        { err: err instanceof Error ? err.message : err, entry },
+        'Unexpected error while seeding conformity scheme; skipping',
+      );
+      summary.failed += 1;
+    }
+  }
+
+  return summary;
 }
 
 // ── Main orchestrator ────────────────────────────────────────────────────────
@@ -389,13 +512,22 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
     { timeout: TRANSACTION_TIMEOUT, maxWait: TRANSACTION_MAX_WAIT },
   );
 
-  // ── 9. Log success summary ────────────────────────────────────────────
+  // ── 9. Ingest conformity schemes (post-transaction) ───────────────────
+  // Each ingest manages its own transaction internally; run after the main
+  // commit so failures here don't roll back the upserts above.
+  const conformitySummary =
+    manifest.conformitySchemes.length > 0
+      ? await processConformitySchemes(deps, manifest)
+      : { ingested: 0, skipped: 0, failed: 0 };
+
+  // ── 10. Log success summary ───────────────────────────────────────────
   const summary = {
     registrars: ops.registrars.length,
     identifierSchemes: ops.identifierSchemes.length,
     qualifiers: ops.qualifiers.length,
     dataModels: ops.dataModels.length,
     renderTemplates: ops.renderTemplates.length,
+    conformitySchemes: conformitySummary,
   };
 
   logger.info(summary, 'Custom seed completed successfully');

--- a/packages/reference-implementation/prisma/custom-seed.ts
+++ b/packages/reference-implementation/prisma/custom-seed.ts
@@ -93,6 +93,16 @@ async function processConformitySchemes(
         sourceUrl = entry.url;
       } else if (entry.file !== undefined) {
         const filePath = path.resolve(customSeedDir, entry.file);
+        const normalisedSeedDir = path.normalize(customSeedDir);
+        const normalisedFilePath = path.normalize(filePath);
+        if (!normalisedFilePath.startsWith(normalisedSeedDir + path.sep) && normalisedFilePath !== normalisedSeedDir) {
+          logger.error(
+            { file: entry.file, filePath },
+            'Conformity scheme seed file path resolves outside the seed directory (potential path traversal); skipping',
+          );
+          summary.failed += 1;
+          continue;
+        }
         if (!fs.existsSync(filePath)) {
           logger.error({ file: entry.file, filePath }, 'Conformity scheme seed file not found; skipping');
           summary.failed += 1;
@@ -107,7 +117,7 @@ async function processConformitySchemes(
           summary.failed += 1;
           continue;
         }
-        const canonicalId = doc.id ?? doc['@id'];
+        const canonicalId = doc?.id ?? doc?.['@id'];
         if (typeof canonicalId !== 'string' || canonicalId.length === 0) {
           logger.error({ file: entry.file }, 'Conformity scheme seed file missing top-level `id`; skipping');
           summary.failed += 1;

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -522,6 +522,40 @@ async function main() {
     logger.info({ dataModelId: dm.id, credentialType: dm.credentialType }, 'Data model created');
   }
 
+  // ── Seed the ConformityScheme data model row ────────────────────────────────
+  // The custom-seed `conformitySchemes` processor resolves the JSON Schema URL
+  // for ingestion by looking this row up via (credentialType, version). It
+  // does not share the `UNTP_BASE` URL pattern with the credential data models;
+  // the CVC artefacts live under the production `untp.unece.org` origin.
+  const CONFORMITY_SCHEME_DATA_MODEL_ID = 'c4fxk5o3sqrm6n0u7c7akm0sb';
+  const conformitySchemeExists = await prisma.dataModel.findUnique({
+    where: { id: CONFORMITY_SCHEME_DATA_MODEL_ID },
+  });
+  if (conformitySchemeExists) {
+    logger.info(
+      { dataModelId: CONFORMITY_SCHEME_DATA_MODEL_ID, credentialType: 'ConformityScheme' },
+      'Data model already exists, skipping',
+    );
+  } else {
+    await prisma.dataModel.create({
+      data: {
+        id: CONFORMITY_SCHEME_DATA_MODEL_ID,
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'Conformity Scheme v0.7.0',
+        credentialType: 'ConformityScheme',
+        version: '0.7.0',
+        isExtension: false,
+        schemaUrl: 'https://untp.unece.org/artefacts/schema/v0.7.0/cvc/ConformityScheme.json',
+        contextUrl: 'https://untp.unece.org/artefacts/contexts/v0.7.0/cvc/ConformityScheme.context.jsonld',
+        websiteUrl: 'https://untp.unece.org/docs/specification/ConformityVocabularyCatalog',
+      },
+    });
+    logger.info(
+      { dataModelId: CONFORMITY_SCHEME_DATA_MODEL_ID, credentialType: 'ConformityScheme' },
+      'Data model created',
+    );
+  }
+
   // ── Seed default render templates ───────────────────────────────────────────
   // Upload .hbs templates to the storage service and record the returned URIs.
   // Requires the storage service to be available (skipped otherwise).
@@ -727,7 +761,7 @@ async function main() {
 
 main()
   .catch((e) => {
-    logger.error({ error: e }, 'Seed failed');
+    logger.error({ err: e }, 'Seed failed');
     process.exit(1);
   })
   .finally(async () => {

--- a/packages/reference-implementation/src/lib/credentials/schema-loader.ts
+++ b/packages/reference-implementation/src/lib/credentials/schema-loader.ts
@@ -1,6 +1,6 @@
 import { makeInMemoryTtlCache } from '@uncefact/untp-utils/cache';
 import { makeSchemaLoader, type SchemaLoader } from '@uncefact/untp-utils/schema-loaders';
-import { apiLogger } from '@/lib/api/logger';
+import { apiLogger } from '../api/logger';
 
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
 const logger = apiLogger.child({ module: 'schema-loader' });

--- a/packages/reference-implementation/src/lib/cvc/ingest-conformity-scheme.ts
+++ b/packages/reference-implementation/src/lib/cvc/ingest-conformity-scheme.ts
@@ -9,8 +9,8 @@ import type {
   ConformityCriterion as ParsedCriterion,
   ConformityScheme as ParsedScheme,
 } from '@uncefact/untp-utils/conformity-vocabulary';
-import { ConformityFetchStatus, ConformitySchemeSource, Prisma } from '@/lib/prisma/generated';
-import { prisma } from '@/lib/prisma/prisma';
+import { ConformityFetchStatus, ConformitySchemeSource, Prisma } from '../prisma/generated';
+import { prisma } from '../prisma/prisma';
 
 export interface IngestConformitySchemeInput {
   sourceUrl: string;

--- a/packages/reference-implementation/src/lib/cvc/run-untp-discovery.ts
+++ b/packages/reference-implementation/src/lib/cvc/run-untp-discovery.ts
@@ -1,8 +1,8 @@
 import { parseConformityCatalogue } from '@uncefact/untp-utils/conformity-vocabulary';
 import type { SchemaLoader } from '@uncefact/untp-utils/schema-loaders';
-import { apiLogger } from '@/lib/api/logger';
-import { ConformityFetchStatus, ConformitySchemeSource } from '@/lib/prisma/generated';
-import { prisma } from '@/lib/prisma/prisma';
+import { apiLogger } from '../api/logger';
+import { ConformityFetchStatus, ConformitySchemeSource } from '../prisma/generated';
+import { prisma } from '../prisma/prisma';
 import { ingestConformityScheme } from './ingest-conformity-scheme';
 
 const logger = apiLogger.child({ module: 'cvc-discovery' });

--- a/packages/reference-implementation/src/lib/prisma/prisma.ts
+++ b/packages/reference-implementation/src/lib/prisma/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from './generated';
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -136,22 +136,6 @@ export async function getDataModelById(id: string, tenantId: string): Promise<Da
 }
 
 /**
- * Looks up a system-provisioned data model by `(credentialType, version)`.
- * Used by infrastructure paths that need the canonical schema or context URL
- * for a known credential type (e.g. the CVC seed loader resolving the
- * `ConformityScheme` JSON Schema URL).
- */
-export async function findSystemDataModelByTypeAndVersion(
-  credentialType: string,
-  version: string,
-): Promise<DataModelListItem | null> {
-  return prisma.dataModel.findFirst({
-    where: { tenantId: SYSTEM_TENANT_ID, credentialType, version },
-    include: DATA_MODEL_LIST_INCLUDE,
-  });
-}
-
-/**
  * Lists data models for a tenant, including system-provisioned configs.
  * Supports filtering by isExtension, credentialType, and version.
  * Returns lean items without extensions or renderTemplates.

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -136,6 +136,22 @@ export async function getDataModelById(id: string, tenantId: string): Promise<Da
 }
 
 /**
+ * Looks up a system-provisioned data model by `(credentialType, version)`.
+ * Used by infrastructure paths that need the canonical schema or context URL
+ * for a known credential type (e.g. the CVC seed loader resolving the
+ * `ConformityScheme` JSON Schema URL).
+ */
+export async function findSystemDataModelByTypeAndVersion(
+  credentialType: string,
+  version: string,
+): Promise<DataModelListItem | null> {
+  return prisma.dataModel.findFirst({
+    where: { tenantId: SYSTEM_TENANT_ID, credentialType, version },
+    include: DATA_MODEL_LIST_INCLUDE,
+  });
+}
+
+/**
  * Lists data models for a tenant, including system-provisioned configs.
  * Supports filtering by isExtension, credentialType, and version.
  * Returns lean items without extensions or renderTemplates.


### PR DESCRIPTION
This PR adds a `conformitySchemes` array to the custom-seed manifest so deployers can pre-populate the `ConformityScheme` system-tenant table at seed time. Each entry references one scheme document, sourced either from a remote URL the loader fetches or a local JSON-LD file in the mount directory, and carries a required `version` that the loader uses to resolve the JSON Schema URL from a system `DataModel` row before running the document through the existing CVC pipeline (`ingestConformityScheme`) with `source = SYSTEM_SEED`. Insert-only-if-absent: existing rows at `(sourceUrl, SYSTEM_TENANT_ID)` are left untouched so post-seed UNTP discovery and operator updates are preserved.

Closes #689.

## Notable changes outside the seed loader

- `src/lib/cvc/{ingest-conformity-scheme,run-untp-discovery}.ts` and `src/lib/credentials/schema-loader.ts` move from `@/`-aliased imports to relative imports so the seed-time `tsx` runtime can resolve them without `tsconfig.json` being reachable in the container image.
- `src/lib/prisma/prisma.ts` imports `PrismaClient` from `./generated` rather than the aliased `@prisma/client`; the alias only resolves under the Next.js bundler, not under ESM at seed time.
- `prisma/seed.ts` switches the top-level catch from `{ error: e }` to `{ err: e }` so pino serialises the Error properly in failure logs.
- `Dockerfile` COPYs the new seed-time dependencies into the runtime image (`src/lib/cvc/`, `src/lib/credentials/schema-loader.ts`, `src/lib/api/logger.ts`, `src/lib/prisma/prisma.ts`).
- `documentation/docs/reference-implementation/operations/custom-seed.md` replaces the stale `cvcCatalogues` section with the new `conformitySchemes` documentation and updates the manifest summary, complete example, processing order, and important-notes sections.

## Test plan
- [x] 11 new unit tests: 7 zod schema cases (URL-only, file-only, both-set rejection, missing version, non-URL `url`, default `[]`) and 4 orchestration cases (URL ingest, skip-if-exists, skip-if-no-DataModel, file ingest with top-level `id` extraction).
- [x] Existing custom-seed test fixtures updated with `conformitySchemes: []`; all 652 `src/lib` tests still pass.
- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm lint:check` clean (0 errors).
- [x] End-to-end smoke against a live Postgres in Docker: built the image with the new Dockerfile COPY lines, applied the new migration, ran the seed with a manifest containing one URL entry and one file entry. Confirmed the scheme + profile + criterion rows persisted under the system tenant with `source = SYSTEM_SEED`, and that a re-run with the same manifest skipped both entries via the insert-only-if-absent guard.