### PR TITLE
feat(ri): validate DCC conformity claims at issuance

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -103,10 +103,19 @@ jest.mock('@uncefact/untp-ri-services', () => ({
 const mockUpdateCredentialPublished = jest.fn();
 const mockListCredentials = jest.fn();
 const mockGetDidByDid = jest.fn();
+const mockFindConformityScheme = jest.fn();
 jest.mock('@/lib/prisma/repositories', () => ({
   updateCredentialPublished: (...args: unknown[]) => mockUpdateCredentialPublished(...args),
   listCredentials: (...args: unknown[]) => mockListCredentials(...args),
   getDidByDid: (...args: unknown[]) => mockGetDidByDid(...args),
+  findConformitySchemeByCanonicalId: (...args: unknown[]) => mockFindConformityScheme(...args),
+}));
+
+// Conformity-vocabulary validator mock — the real cross-check is unit-tested in
+// `@uncefact/untp-utils`; here we only assert the route wires it up.
+const mockValidateConformityClaim = jest.fn();
+jest.mock('@uncefact/untp-utils/conformity-vocabulary', () => ({
+  validateConformityClaim: (...args: unknown[]) => mockValidateConformityClaim(...args),
 }));
 
 const mockAssertPublicUrl = jest.fn();
@@ -183,6 +192,7 @@ const STORAGE_RESPONSE = {
 const stubBridge = {
   buildSubject: jest.fn().mockReturnValue({}),
   extractRefs: jest.fn().mockReturnValue({ organisations: [], facilities: [], products: [] }),
+  extractConformityClaim: jest.fn().mockReturnValue(null),
 };
 
 const DATA_MODEL = {
@@ -223,6 +233,11 @@ function setupHappyPath() {
     storageResponse: STORAGE_RESPONSE,
     primaryEntity: {},
   });
+  // Conformity-claim defaults: no claim on the credential (non-DCC), so the
+  // validator is not invoked. DCC tests override these.
+  stubBridge.extractConformityClaim.mockReturnValue(null);
+  mockValidateConformityClaim.mockReturnValue([]);
+  mockFindConformityScheme.mockResolvedValue(null);
 }
 
 // ---------------------------------------------------------------------------
@@ -988,6 +1003,127 @@ describe('POST /api/v1/credentials', () => {
 
       expect(res.status).toBe(500);
       expect(json.error).toContain('Signing service unavailable');
+    });
+  });
+
+  // ── Conformity claim validation (advisory) ──────────────────────────────
+  describe('conformity claim validation', () => {
+    const CLAIM = {
+      scheme: 'https://coppermark.org',
+      profile: 'https://coppermark.org/rra/v3.0',
+      criteria: [{ criterion: 'https://coppermark.org/rra/v3.0/criterion/26' }],
+    };
+    const SCHEME = { canonicalId: 'https://coppermark.org', profiles: [] };
+
+    it('validates the extracted claim against the resolved scheme and attaches no warnings on a clean match', async () => {
+      stubBridge.extractConformityClaim.mockReturnValue(CLAIM);
+      mockFindConformityScheme.mockResolvedValue(SCHEME);
+      mockValidateConformityClaim.mockReturnValue([]);
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(mockFindConformityScheme).toHaveBeenCalledWith('https://coppermark.org', 'tenant-1');
+      expect(mockValidateConformityClaim).toHaveBeenCalledWith(CLAIM, SCHEME);
+      expect(json.warnings).toBeUndefined();
+    });
+
+    it('attaches the validator warnings (with structured detail) to the response', async () => {
+      stubBridge.extractConformityClaim.mockReturnValue(CLAIM);
+      mockFindConformityScheme.mockResolvedValue(SCHEME);
+      mockValidateConformityClaim.mockReturnValue([
+        {
+          code: 'conformity-criterion.not-in-profile',
+          message: 'Criterion is not published by the profile.',
+          received: 'https://coppermark.org/rra/v3.0/criterion/26',
+          pointer: '/criteria/0',
+        },
+      ]);
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.warnings).toEqual([
+        {
+          code: 'conformity-criterion.not-in-profile',
+          message: 'Criterion is not published by the profile.',
+          received: 'https://coppermark.org/rra/v3.0/criterion/26',
+          pointer: '/criteria/0',
+        },
+      ]);
+    });
+
+    it('passes a null scheme to the validator when the scheme URI is unknown', async () => {
+      stubBridge.extractConformityClaim.mockReturnValue(CLAIM);
+      mockFindConformityScheme.mockResolvedValue(null);
+      mockValidateConformityClaim.mockReturnValue([
+        { code: 'conformity-scheme.not-found', message: 'Scheme URI is not in the known set.' },
+      ]);
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(mockValidateConformityClaim).toHaveBeenCalledWith(CLAIM, null);
+      expect(json.warnings[0].code).toBe('conformity-scheme.not-found');
+    });
+
+    it('skips validation entirely when the credential carries no conformity claim', async () => {
+      stubBridge.extractConformityClaim.mockReturnValue(null);
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(mockFindConformityScheme).not.toHaveBeenCalled();
+      expect(mockValidateConformityClaim).not.toHaveBeenCalled();
+      expect(json.warnings).toBeUndefined();
+    });
+
+    it('never blocks issuance: emits an advisory warning when extraction throws', async () => {
+      stubBridge.extractConformityClaim.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.warnings).toEqual([expect.objectContaining({ code: 'conformity-claim.validation-error' })]);
+    });
+
+    it('never blocks issuance: degrades to an advisory warning when the scheme lookup rejects', async () => {
+      stubBridge.extractConformityClaim.mockReturnValue(CLAIM);
+      mockFindConformityScheme.mockRejectedValue(new Error('db down'));
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.warnings).toEqual([expect.objectContaining({ code: 'conformity-claim.validation-error' })]);
+    });
+
+    it('never blocks issuance: degrades to an advisory warning when the validator throws', async () => {
+      stubBridge.extractConformityClaim.mockReturnValue(CLAIM);
+      mockFindConformityScheme.mockResolvedValue(SCHEME);
+      mockValidateConformityClaim.mockImplementation(() => {
+        throw new Error('validator blew up');
+      });
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.warnings).toEqual([expect.objectContaining({ code: 'conformity-claim.validation-error' })]);
     });
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -18,12 +18,20 @@ import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
 import { resolveStorageService } from '@/lib/services/resolve-storage-service';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
-import { getDidByDid } from '@/lib/prisma/repositories';
+import { getDidByDid, findConformitySchemeByCanonicalId } from '@/lib/prisma/repositories';
 import { buildPublishLinks } from '@uncefact/untp-ri-services';
 import type { CredentialPayload, ExtractedRefs } from '@uncefact/untp-ri-services';
+import { validateConformityClaim } from '@uncefact/untp-utils/conformity-vocabulary';
 import { publishingOptionsSchema } from '@/lib/swagger/schemas';
 
-type CredentialWarning = { code: string; message: string };
+type CredentialWarning = {
+  code: string;
+  message: string;
+  received?: unknown;
+  expected?: unknown;
+  remediation?: string;
+  pointer?: string;
+};
 
 const logger = apiLogger.child({ route: '/api/v1/credentials' });
 
@@ -173,6 +181,28 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
         message: 'Failed to extract references from credential payload — publishing will be skipped',
       });
     }
+  }
+
+  // ── Step 3.6: Conformity claim validation (advisory) ────────────────────
+  // For credentials carrying a conformity claim (the DCC), cross-check the
+  // claim's scheme / profile / criteria URIs against the locally cached
+  // vocabulary. Advisory only per ADR-033 §3: a mismatch never blocks
+  // issuance; it surfaces as `conformity-*` warnings on the response. Reads
+  // only the local projection (no network).
+  try {
+    const subject = credentialPayload.credentialSubject as Record<string, unknown>;
+    const claim = bridge.extractConformityClaim(subject);
+    if (claim) {
+      const scheme = await findConformitySchemeByCanonicalId(claim.scheme, tenantId);
+      warnings.push(...validateConformityClaim(claim, scheme));
+    }
+  } catch (error) {
+    logger.error({ err: error, credentialType }, 'Conformity claim validation failed');
+    warnings.push({
+      code: 'conformity-claim.validation-error',
+      message:
+        'Conformity claim validation could not be performed; credential was issued without conformity vocabulary checks.',
+    });
   }
 
   // ── Step 4: Validate issuer DID ownership ────────────────────────────────

--- a/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.test.ts
@@ -124,6 +124,15 @@ describe('findConformitySchemeByCanonicalId', () => {
     expect(result).not.toHaveProperty('owner');
   });
 
+  it('filters out a profile-criterion row whose criterion relation is missing', async () => {
+    const row = schemeRow();
+    row.profiles[0].criteria.unshift({ criterion: null } as unknown as (typeof row.profiles)[0]['criteria'][0]);
+    mockFindMany.mockResolvedValue([row]);
+    const result = await findConformitySchemeByCanonicalId(CANONICAL, TENANT);
+    expect(result?.profiles[0].criteria).toHaveLength(1);
+    expect(result?.profiles[0].criteria[0].canonicalId).toBe('https://coppermark.org/rra/v3.0/criterion/26');
+  });
+
   it('returns null when no row exists in either lane', async () => {
     mockFindMany.mockResolvedValue([]);
     expect(await findConformitySchemeByCanonicalId(CANONICAL, TENANT)).toBeNull();

--- a/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.test.ts
@@ -1,0 +1,139 @@
+import { findConformitySchemeByCanonicalId } from './conformity-scheme.repository';
+import { SYSTEM_TENANT_ID } from '../constants';
+
+jest.mock('../prisma', () => ({
+  prisma: {
+    conformityScheme: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../prisma';
+
+const mockFindMany = (prisma.conformityScheme as unknown as { findMany: jest.Mock }).findMany;
+
+const TENANT = 'tenant-1';
+const CANONICAL = 'https://coppermark.org';
+
+/** Builds a persisted-scheme row as Prisma would return it (with the include graph). */
+function schemeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    canonicalId: CANONICAL,
+    tenantId: SYSTEM_TENANT_ID,
+    sourceUrl: 'https://coppermark.org/scheme.json',
+    specVersion: '0.7.0',
+    name: 'Coppermark',
+    description: 'A scheme',
+    documentation: null,
+    ownerCanonicalId: 'https://coppermark.org',
+    ownerName: 'Coppermark Org',
+    profiles: [
+      {
+        canonicalId: 'https://coppermark.org/rra/v3.0',
+        name: 'RRA v3.0',
+        version: '3.0',
+        status: 'active',
+        description: null,
+        documentation: null,
+        validFrom: '2025-01-01',
+        criteria: [
+          {
+            criterion: {
+              canonicalId: 'https://coppermark.org/rra/v3.0/criterion/26',
+              name: 'Criterion 26',
+              version: '3.0',
+              status: 'active',
+              description: null,
+              documentation: null,
+              topics: [{ canonicalId: 'https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions' }],
+              tags: [],
+            },
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('findConformitySchemeByCanonicalId', () => {
+  it('projects a persisted row into the utils ConformityScheme shape', async () => {
+    mockFindMany.mockResolvedValue([schemeRow()]);
+
+    const result = await findConformitySchemeByCanonicalId(CANONICAL, TENANT);
+
+    expect(result).toEqual({
+      canonicalId: CANONICAL,
+      sourceUrl: 'https://coppermark.org/scheme.json',
+      specVersion: '0.7.0',
+      name: 'Coppermark',
+      description: 'A scheme',
+      owner: { canonicalId: 'https://coppermark.org', name: 'Coppermark Org' },
+      profiles: [
+        {
+          canonicalId: 'https://coppermark.org/rra/v3.0',
+          name: 'RRA v3.0',
+          version: '3.0',
+          status: 'active',
+          validFrom: '2025-01-01',
+          criteria: [
+            {
+              canonicalId: 'https://coppermark.org/rra/v3.0/criterion/26',
+              name: 'Criterion 26',
+              version: '3.0',
+              status: 'active',
+              topics: [{ canonicalId: 'https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions' }],
+              tags: [],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('queries both the system-tenant and caller-tenant lanes', async () => {
+    mockFindMany.mockResolvedValue([]);
+    await findConformitySchemeByCanonicalId(CANONICAL, TENANT);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { canonicalId: CANONICAL, tenantId: { in: [SYSTEM_TENANT_ID, TENANT] } } }),
+    );
+  });
+
+  it('prefers the system-tenant row over a tenant-imported row for the same URI', async () => {
+    mockFindMany.mockResolvedValue([
+      schemeRow({ tenantId: TENANT, name: 'Tenant Import' }),
+      schemeRow({ tenantId: SYSTEM_TENANT_ID, name: 'System Canonical' }),
+    ]);
+
+    const result = await findConformitySchemeByCanonicalId(CANONICAL, TENANT);
+    expect(result?.name).toBe('System Canonical');
+  });
+
+  it('falls back to the tenant-imported row when no system row exists', async () => {
+    mockFindMany.mockResolvedValue([schemeRow({ tenantId: TENANT, name: 'Tenant Import' })]);
+    const result = await findConformitySchemeByCanonicalId(CANONICAL, TENANT);
+    expect(result?.name).toBe('Tenant Import');
+  });
+
+  it('omits owner when neither owner field is set', async () => {
+    mockFindMany.mockResolvedValue([schemeRow({ ownerCanonicalId: null, ownerName: null })]);
+    const result = await findConformitySchemeByCanonicalId(CANONICAL, TENANT);
+    expect(result).not.toHaveProperty('owner');
+  });
+
+  it('returns null when no row exists in either lane', async () => {
+    mockFindMany.mockResolvedValue([]);
+    expect(await findConformitySchemeByCanonicalId(CANONICAL, TENANT)).toBeNull();
+  });
+
+  it('tolerates a null topics column', async () => {
+    const row = schemeRow();
+    row.profiles[0].criteria[0].criterion.topics = null as unknown as [];
+    mockFindMany.mockResolvedValue([row]);
+    const result = await findConformitySchemeByCanonicalId(CANONICAL, TENANT);
+    expect(result?.profiles[0].criteria[0].topics).toEqual([]);
+  });
+});

--- a/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.ts
@@ -39,7 +39,7 @@ function toCriterion(row: CriterionRow): ConformityCriterion {
     ...(row.description != null && { description: row.description }),
     ...(row.documentation != null && { documentation: row.documentation }),
     topics: toTopics(row.topics),
-    tags: row.tags,
+    tags: Array.isArray(row.tags) ? row.tags : [],
   };
 }
 
@@ -52,7 +52,7 @@ function toProfile(row: ProfileRow): ConformityProfile {
     ...(row.description != null && { description: row.description }),
     ...(row.documentation != null && { documentation: row.documentation }),
     ...(row.validFrom != null && { validFrom: row.validFrom }),
-    criteria: row.criteria.map((pc) => toCriterion(pc.criterion)),
+    criteria: row.criteria.filter((pc) => pc.criterion != null).map((pc) => toCriterion(pc.criterion)),
   };
 }
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/conformity-scheme.repository.ts
@@ -1,0 +1,100 @@
+import type {
+  ConformityScheme,
+  ConformityProfile,
+  ConformityCriterion,
+  ConformityTopic,
+} from '@uncefact/untp-utils/conformity-vocabulary';
+import { prisma } from '../prisma';
+import { SYSTEM_TENANT_ID } from '../constants';
+
+/**
+ * Prisma include shape that pulls a scheme's full profile -> criterion graph
+ * in one query, so the projection is built without per-row fetches.
+ */
+const SCHEME_GRAPH_INCLUDE = {
+  profiles: { include: { criteria: { include: { criterion: true } } } },
+} as const;
+
+type SchemeRow = Awaited<ReturnType<typeof loadRows>>[number];
+type ProfileRow = SchemeRow['profiles'][number];
+type CriterionRow = ProfileRow['criteria'][number]['criterion'];
+
+function loadRows(canonicalId: string, tenantId: string) {
+  return prisma.conformityScheme.findMany({
+    where: { canonicalId, tenantId: { in: [SYSTEM_TENANT_ID, tenantId] } },
+    include: SCHEME_GRAPH_INCLUDE,
+  });
+}
+
+function toTopics(value: unknown): ConformityTopic[] {
+  return Array.isArray(value) ? (value as ConformityTopic[]) : [];
+}
+
+function toCriterion(row: CriterionRow): ConformityCriterion {
+  return {
+    canonicalId: row.canonicalId,
+    name: row.name,
+    version: row.version,
+    status: row.status,
+    ...(row.description != null && { description: row.description }),
+    ...(row.documentation != null && { documentation: row.documentation }),
+    topics: toTopics(row.topics),
+    tags: row.tags,
+  };
+}
+
+function toProfile(row: ProfileRow): ConformityProfile {
+  return {
+    canonicalId: row.canonicalId,
+    name: row.name,
+    version: row.version,
+    status: row.status,
+    ...(row.description != null && { description: row.description }),
+    ...(row.documentation != null && { documentation: row.documentation }),
+    ...(row.validFrom != null && { validFrom: row.validFrom }),
+    criteria: row.criteria.map((pc) => toCriterion(pc.criterion)),
+  };
+}
+
+function toScheme(row: SchemeRow): ConformityScheme {
+  return {
+    canonicalId: row.canonicalId,
+    sourceUrl: row.sourceUrl,
+    specVersion: row.specVersion,
+    name: row.name,
+    ...(row.description != null && { description: row.description }),
+    ...(row.documentation != null && { documentation: row.documentation }),
+    ...((row.ownerCanonicalId != null || row.ownerName != null) && {
+      owner: {
+        ...(row.ownerCanonicalId != null && { canonicalId: row.ownerCanonicalId }),
+        ...(row.ownerName != null && { name: row.ownerName }),
+      },
+    }),
+    profiles: row.profiles.map(toProfile),
+  };
+}
+
+/**
+ * Loads a conformity scheme by its canonical URI, projected into the
+ * `@uncefact/untp-utils` {@link ConformityScheme} shape that
+ * `validateConformityClaim` consumes. Profiles and their criteria (with topics)
+ * are included.
+ *
+ * Visibility follows ADR-033: a system-tenant row (UNTP-discovered or
+ * system-seeded) takes precedence over a tenant-imported row for the same
+ * canonical URI, so the system row is checked first and the caller's tenant row
+ * is used only as a fallback.
+ *
+ * @param canonicalId - The scheme's canonical URI (no version segment).
+ * @param tenantId - The calling tenant.
+ * @returns The projected scheme, or `null` when no row exists in either lane.
+ */
+export async function findConformitySchemeByCanonicalId(
+  canonicalId: string,
+  tenantId: string,
+): Promise<ConformityScheme | null> {
+  const rows = await loadRows(canonicalId, tenantId);
+  // A system-tenant row supersedes a tenant-imported row for the same URI.
+  const row = rows.find((r) => r.tenantId === SYSTEM_TENANT_ID) ?? rows[0] ?? null;
+  return row ? toScheme(row) : null;
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/index.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/index.ts
@@ -10,3 +10,4 @@ export * from './facility.repository';
 export * from './product.repository';
 export * from './data-model.repository';
 export * from './render-template.repository';
+export * from './conformity-scheme.repository';

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.test.ts
@@ -73,6 +73,15 @@ describe('extractDccConformityClaim (v0.7.0)', () => {
     ]);
   });
 
+  it('skips null assessment and null criterion entries from a malformed payload', () => {
+    const subject = {
+      referenceScheme: { id: 'https://s.example' },
+      referenceProfile: { id: 'https://s.example/p/1.0.0' },
+      conformityAssessment: [null, { assessmentCriteria: [null, { id: 'https://s.example/c/1.0.0' }] }],
+    } as unknown as Record<string, unknown>;
+    expect(extractDccConformityClaim(subject)?.criteria).toEqual([{ criterion: 'https://s.example/c/1.0.0' }]);
+  });
+
   it('returns null when the scheme reference is missing', () => {
     expect(extractDccConformityClaim({ referenceProfile: { id: 'https://s.example/p/1.0.0' } })).toBeNull();
   });

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.test.ts
@@ -1,0 +1,87 @@
+import { extractDccConformityClaim } from './conformity-claim';
+
+describe('extractDccConformityClaim (v0.7.0)', () => {
+  it('extracts scheme, profile, and criteria with topics', () => {
+    const subject = {
+      referenceScheme: { id: 'https://coppermark.org' },
+      referenceProfile: { id: 'https://coppermark.org/rra/v3.0' },
+      conformityAssessment: [
+        {
+          assessmentCriteria: [
+            {
+              id: 'https://coppermark.org/rra/v3.0/criterion/26',
+              conformityTopic: [{ id: 'https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions' }],
+            },
+          ],
+        },
+        {
+          assessmentCriteria: [{ id: 'https://coppermark.org/rra/v3.0/criterion/27' }],
+        },
+      ],
+    };
+
+    expect(extractDccConformityClaim(subject)).toEqual({
+      scheme: 'https://coppermark.org',
+      profile: 'https://coppermark.org/rra/v3.0',
+      criteria: [
+        {
+          criterion: 'https://coppermark.org/rra/v3.0/criterion/26',
+          conformityTopic: 'https://vocabulary.uncefact.org/conformity-topic/greenhouse-gas-emissions',
+        },
+        { criterion: 'https://coppermark.org/rra/v3.0/criterion/27' },
+      ],
+    });
+  });
+
+  it('returns an empty criteria array when no assessments are present', () => {
+    const subject = {
+      referenceScheme: { id: 'https://coppermark.org' },
+      referenceProfile: { id: 'https://coppermark.org/rra/v3.0' },
+    };
+    expect(extractDccConformityClaim(subject)).toEqual({
+      scheme: 'https://coppermark.org',
+      profile: 'https://coppermark.org/rra/v3.0',
+      criteria: [],
+    });
+  });
+
+  it('skips assessment criteria without an id', () => {
+    const subject = {
+      referenceScheme: { id: 'https://s.example' },
+      referenceProfile: { id: 'https://s.example/p/1.0.0' },
+      conformityAssessment: [{ assessmentCriteria: [{ name: 'no id here' }, { id: 'https://s.example/c/1.0.0' }] }],
+    };
+    expect(extractDccConformityClaim(subject)?.criteria).toEqual([{ criterion: 'https://s.example/c/1.0.0' }]);
+  });
+
+  it('omits conformityTopic when the topic array is empty or the entry has no id', () => {
+    const subject = {
+      referenceScheme: { id: 'https://s.example' },
+      referenceProfile: { id: 'https://s.example/p/1.0.0' },
+      conformityAssessment: [
+        {
+          assessmentCriteria: [
+            { id: 'https://s.example/c/1.0.0', conformityTopic: [] },
+            { id: 'https://s.example/c/2.0.0', conformityTopic: [{}] },
+          ],
+        },
+      ],
+    };
+    expect(extractDccConformityClaim(subject)?.criteria).toEqual([
+      { criterion: 'https://s.example/c/1.0.0' },
+      { criterion: 'https://s.example/c/2.0.0' },
+    ]);
+  });
+
+  it('returns null when the scheme reference is missing', () => {
+    expect(extractDccConformityClaim({ referenceProfile: { id: 'https://s.example/p/1.0.0' } })).toBeNull();
+  });
+
+  it('returns null when the profile reference is missing', () => {
+    expect(extractDccConformityClaim({ referenceScheme: { id: 'https://s.example' } })).toBeNull();
+  });
+
+  it('returns null for an empty subject', () => {
+    expect(extractDccConformityClaim({})).toBeNull();
+  });
+});

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.ts
@@ -37,8 +37,9 @@ export function extractDccConformityClaim(subject: CredentialSubject): Conformit
 
   const criteria: ConformityClaim['criteria'] = [];
   for (const assessment of dcc.conformityAssessment ?? []) {
+    if (!assessment) continue;
     for (const criterion of assessment.assessmentCriteria ?? []) {
-      if (!criterion.id) continue;
+      if (!criterion?.id) continue;
       const topic = criterion.conformityTopic?.[0]?.id;
       criteria.push({ criterion: criterion.id, ...(topic ? { conformityTopic: topic } : {}) });
     }

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/conformity-claim.ts
@@ -1,0 +1,48 @@
+import type { ConformityClaim } from '@uncefact/untp-utils/conformity-vocabulary';
+import type { CredentialSubject } from '../../../../types.js';
+
+// Subset of the v0.7.0 DCC credentialSubject shape relevant to the conformity
+// claim. The scheme and profile are referenced at the subject root; the
+// criteria (and their topics) live on each conformity assessment.
+type DccTopic = { id?: string };
+type DccCriterion = { id?: string; conformityTopic?: DccTopic[] };
+type DccAssessment = { assessmentCriteria?: DccCriterion[] };
+type DccConformitySubject = {
+  referenceScheme?: { id?: string };
+  referenceProfile?: { id?: string };
+  conformityAssessment?: DccAssessment[];
+};
+
+/**
+ * Extracts the conformity claim from a v0.7.0 Digital Conformity Credential
+ * subject into the minimal shape {@link ConformityClaim} the validator needs.
+ *
+ * The v0.7.0 DCC does not carry a single `conformityClaim` object; the claim is
+ * assembled from `referenceScheme`, `referenceProfile`, and the criteria listed
+ * across `conformityAssessment[].assessmentCriteria[]`. Each criterion's first
+ * `conformityTopic` (when present) scopes the claim for that criterion.
+ *
+ * @param subject - The DCC `credentialSubject`.
+ * @returns The extracted claim, or `null` when the subject references neither a
+ *   scheme nor a profile (nothing to validate against the catalogue).
+ */
+export function extractDccConformityClaim(subject: CredentialSubject): ConformityClaim | null {
+  const dcc = subject as DccConformitySubject;
+  const scheme = dcc.referenceScheme?.id;
+  const profile = dcc.referenceProfile?.id;
+
+  if (!scheme || !profile) {
+    return null;
+  }
+
+  const criteria: ConformityClaim['criteria'] = [];
+  for (const assessment of dcc.conformityAssessment ?? []) {
+    for (const criterion of assessment.assessmentCriteria ?? []) {
+      if (!criterion.id) continue;
+      const topic = criterion.conformityTopic?.[0]?.id;
+      criteria.push({ criterion: criterion.id, ...(topic ? { conformityTopic: topic } : {}) });
+    }
+  }
+
+  return { scheme, profile, criteria };
+}

--- a/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/index.ts
+++ b/packages/services/src/data-model-bridges/data-models/dcc/versions/v070/index.ts
@@ -1,8 +1,10 @@
 import type { VersionSpec } from '../../../../types.js';
 import { buildDccSubject } from './builder.js';
 import { extractDccRefs } from './extractor.js';
+import { extractDccConformityClaim } from './conformity-claim.js';
 
 export const dccV070Spec: VersionSpec = {
   builder: buildDccSubject,
   extractor: extractDccRefs,
+  conformityClaimExtractor: extractDccConformityClaim,
 };

--- a/packages/services/src/data-model-bridges/make-bridge.ts
+++ b/packages/services/src/data-model-bridges/make-bridge.ts
@@ -8,5 +8,8 @@ export function makeBridge(spec: VersionSpec): IDataModelBridge {
     extractRefs(subject) {
       return spec.extractor(subject);
     },
+    extractConformityClaim(subject) {
+      return spec.conformityClaimExtractor ? spec.conformityClaimExtractor(subject) : null;
+    },
   };
 }

--- a/packages/services/src/data-model-bridges/types.ts
+++ b/packages/services/src/data-model-bridges/types.ts
@@ -1,3 +1,5 @@
+import type { ConformityClaim } from '@uncefact/untp-utils/conformity-vocabulary';
+
 // Bridge-specific CredentialSubject (object-only, NOT the VC payload union)
 export type CredentialSubject = Record<string, unknown>;
 
@@ -105,14 +107,25 @@ export type ConformityRefs = NonNullable<ExtractedRefs['conformity']>;
 export interface IDataModelBridge<TSubject extends CredentialSubject = CredentialSubject> {
   buildSubject(entities: BridgeEntities): TSubject;
   extractRefs(subject: TSubject): ExtractedRefs;
+  /**
+   * Extracts the conformity claim from the subject for conformity vocabulary
+   * validation, or
+   * `null` when the credential type / version carries no conformity claim
+   * (only the Digital Conformity Credential does). Bridges without a claim
+   * extractor return `null`.
+   */
+  extractConformityClaim(subject: TSubject): ConformityClaim | null;
 }
 
 // ── Internal types (not exported from index.ts) ───────────────────────────────
 
 export type SubjectBuilder = (entities: BridgeEntities) => CredentialSubject;
 export type RefsExtractor = (subject: CredentialSubject) => ExtractedRefs;
+export type ConformityClaimExtractor = (subject: CredentialSubject) => ConformityClaim | null;
 
 export interface VersionSpec {
   builder: SubjectBuilder;
   extractor: RefsExtractor;
+  /** Optional; only credential types carrying a conformity claim (DCC) set this. */
+  conformityClaimExtractor?: ConformityClaimExtractor;
 }


### PR DESCRIPTION
This PR re-introduces conformity claim validation at Digital Conformity Credential issuance, so a holder receiving a DCC can trust that its `conformityClaim` scheme, profile, and criteria URIs were checked against real, owner-published vocabulary contents at issue time.

The check was removed in #670 when the prior tenant-import CVC model was sunset; it now reads the v0.7 ingestion-pipeline catalogue (the `ConformityScheme` / `ConformityProfile` / `ConformityCriterion` projection) instead of the retired per-tenant import document. On `POST /api/v1/credentials`, for a credential that carries a conformity claim (the DCC), the route extracts the claim, loads the referenced scheme from the local projection, and cross-checks the scheme, profile, and criteria URIs via the shared `validateConformityClaim` from `@uncefact/untp-utils`.

Per ADR-033 §3 the check is advisory: a mismatch never blocks issuance. It surfaces as `conformity-*` warnings on the response, and any error in the validation path degrades to a single `conformity-claim.validation-error` warning so a transient failure (for example a database read error) can never turn issuance into a 500. Validation reads only the local projection, with no network calls on the request path.

The v0.7 DCC bridge gains a `conformityClaimExtractor` (a new optional `VersionSpec` member, symmetric with the existing builder and refs extractor) that maps `referenceScheme`, `referenceProfile`, and `conformityAssessment[].assessmentCriteria[]` into the shared `ConformityClaim`. Bridges without one return `null`, so non-DCC issuance is unaffected. Scheme reads use a new `findConformitySchemeByCanonicalId` repository that projects the persisted graph into the utils `ConformityScheme` shape; a system-tenant row supersedes a tenant-imported row for the same canonical URI, matching the ADR-033 anti-overlay precedence.

Closes #545

## Test plan
- [x] A DCC whose claim matches the resolved scheme issues with no conformity warnings
- [x] An unknown scheme, profile, or criterion surfaces the corresponding `conformity-*` warning while still issuing
- [x] Issuance is never blocked when the extractor, the scheme lookup, or the validator throws (advisory degradation)
- [x] Non-DCC credentials skip conformity validation entirely
- [x] The scheme projection maps profiles, criteria, and topics correctly, prefers the system-tenant row, and tolerates a null topics column
- [x] The DCC claim extractor handles missing scheme/profile, empty criteria, criteria without ids, and empty or id-less topic arrays
