### PR TITLE
fix(docs): post-release documentation corrections

### DIFF
--- a/documentation/docs/_version-mapping.mdx
+++ b/documentation/docs/_version-mapping.mdx
@@ -13,7 +13,7 @@
 
             - **Version**: [1.2.1](https://github.com/uncefact/project-vckit/releases/tag/1.2.1)
             - **API Version**: 1.0.0
-            - **Documentation Version**: 1.2.1
+            - **Documentation Version**: 1.0.1
 
     ---
 

--- a/documentation/docs/migration-guides/v0.6.0.md
+++ b/documentation/docs/migration-guides/v0.6.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: v0.6.0
+title: UNTP v0.6.0
 ---
 
 import Disclaimer from '.././\_disclaimer.mdx';

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -139,16 +139,12 @@ const config: Config = {
               to: '/docs/reference-implementation/overview',
             },
             {
-              label: 'Technical Interoperability',
-              to: '/docs/reference-implementation/overview',
+              label: 'Test Suites',
+              to: '/docs/test-suites',
             },
             {
-              label: 'Semantic Interoperability',
-              to: '/docs/reference-implementation/overview',
-            },
-            {
-              label: 'Graph Validation',
-              to: '/docs/reference-implementation/overview',
+              label: 'UNTP Playground',
+              href: 'https://test.uncefact.org/untp-playground',
             },
           ],
         },

--- a/documentation/versioned_docs/version-0.2.0/migration-guides/v0.6.0.md
+++ b/documentation/versioned_docs/version-0.2.0/migration-guides/v0.6.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: v0.6.0
+title: UNTP v0.6.0
 ---
 
 import Disclaimer from '.././\_disclaimer.mdx';

--- a/documentation/versioned_docs/version-0.3.0/_version-mapping.mdx
+++ b/documentation/versioned_docs/version-0.3.0/_version-mapping.mdx
@@ -13,7 +13,7 @@
 
             - **Version**: [1.2.1](https://github.com/uncefact/project-vckit/releases/tag/1.2.1)
             - **API Version**: 1.0.0
-            - **Documentation Version**: 1.2.1
+            - **Documentation Version**: 1.0.1
 
     ---
 

--- a/documentation/versioned_docs/version-0.3.0/migration-guides/v0.6.0.md
+++ b/documentation/versioned_docs/version-0.3.0/migration-guides/v0.6.0.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: v0.6.0
+title: UNTP v0.6.0
 ---
 
 import Disclaimer from '.././\_disclaimer.mdx';

--- a/packages/reference-implementation/RELEASE_NOTES.md
+++ b/packages/reference-implementation/RELEASE_NOTES.md
@@ -10,8 +10,8 @@ with it is different. This release also brings the Reference Implementation up
 to UNTP v0.7.0.
 
 - Container image: [ghcr.io/uncefact/tests-untp/reference-implementation](https://github.com/uncefact/tests-untp/pkgs/container/tests-untp%2Freference-implementation) (`:0.3.0`, `:latest`)
-- Getting started: because of the architectural changes below, 0.3 is a fresh deployment rather than an in-place upgrade from 0.2. See the [Quick Start](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/quick-start).
-- Dependent services: the storage service and identity resolver move to v4 in this release. If you run existing instances, back up their data and follow the [v0.7.0 migration guide](https://uncefact.github.io/tests-untp/docs/0.3.0/migration-guides/v0.7.0) before upgrading them.
+- Getting started: because of the architectural changes below, 0.3 is a fresh deployment rather than an in-place upgrade from 0.2. See the [Quick Start](https://uncefact.github.io/tests-untp/docs/reference-implementation/quick-start).
+- Dependent services: the storage service and identity resolver move to v4 in this release. If you run existing instances, back up their data and follow the [v0.7.0 migration guide](https://uncefact.github.io/tests-untp/docs/migration-guides/v0.7.0) before upgrading them.
 
 ### From a configuration file to an application
 
@@ -23,7 +23,7 @@ gone: the application is backed by a database and an identity provider, and
 every operation is available as a REST endpoint with a browsable Swagger UI at
 `/api-docs`. What used to be a careful edit of a config file is now an
 application you run, call, and integrate with.
-See [System Architecture](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/system-architecture).
+See [System Architecture](https://uncefact.github.io/tests-untp/docs/reference-implementation/system-architecture).
 
 ### Multi-tenant from the ground up
 
@@ -33,7 +33,7 @@ authenticate through an identity provider. The instance runs in one of two
 modes: in open mode, people sign themselves up through the identity provider and
 a tenant is created for them automatically; in closed mode, whoever administers
 the identity provider provisions the users and maps each one to a tenant by
-group. See [Authentication and tenant modes](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/authentication/tenant-modes).
+group. See [Authentication and tenant modes](https://uncefact.github.io/tests-untp/docs/reference-implementation/authentication/tenant-modes).
 
 ### Your API secrets stay on the server
 
@@ -53,7 +53,7 @@ its own. That gives organisations an adoption ramp: start on the bundled
 services, move to your own instances of them as you mature, and eventually swap
 in a different implementation by contributing an adapter, with only the
 configuration changing at each step. See
-[Service Architecture](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/services/service-architecture).
+[Service Architecture](https://uncefact.github.io/tests-untp/docs/reference-implementation/services/service-architecture).
 
 ### Data models are versioned code, not static config
 
@@ -62,7 +62,7 @@ configuration file. In 0.3 they are versioned bridges in code: each UNTP version
 has its own builder and extractor, and the Reference Implementation selects the
 right one when you issue a credential. This is what lets a single deployment
 support both v0.6.x and v0.7.0 side by side. See
-[Data models](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/data-models/).
+[Data models](https://uncefact.github.io/tests-untp/docs/reference-implementation/data-models/).
 
 ### Issue, store, publish, and verify credentials
 
@@ -72,8 +72,8 @@ publish it to an identity resolver so trading partners can discover it from a
 product or facility identifier, and verify it. Verification fetches the
 credential, checks its integrity, verifies the issuer's signature, decrypts it if
 it is private, and renders it for a person to read. Recipients verify through a
-public, no-login [verify page](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/verify-page).
-See the [Credentials API](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/api/credentials).
+public, no-login [verify page](https://uncefact.github.io/tests-untp/docs/reference-implementation/verify-page).
+See the [Credentials API](https://uncefact.github.io/tests-untp/docs/reference-implementation/api/credentials).
 
 ### Master data you define once
 
@@ -84,7 +84,7 @@ registrars that govern their identifiers. You define an entity once and reuse it
 across credentials rather than re-entering it each time, and once a credential is
 issued the Reference Implementation links it back to the entities it describes,
 so you can find credentials by the entity they are about. See
-[Master data](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/master-data).
+[Master data](https://uncefact.github.io/tests-untp/docs/reference-implementation/master-data).
 
 ### Bring your own signing identity
 
@@ -93,7 +93,7 @@ DIDs their own adoption ramp. A tenant can issue compliant credentials from day
 one with the shared system DID, create a managed `did:web` where the verifiable
 credential service holds the keys, or run a self-managed DID whose document and
 key material live entirely on the tenant's own infrastructure. See
-[DIDs](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/api/dids).
+[DIDs](https://uncefact.github.io/tests-untp/docs/reference-implementation/api/dids).
 
 ### Built to be extended
 
@@ -114,8 +114,8 @@ data model's authors, that works out of the box. A tenant can use it as-is or
 treat it as a starting point: retrieve it, restyle it for their own branding, and
 upload the result as their own template, which then takes precedence once set as
 the default for that data model. See the
-[Data Models API](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/api/data-models)
-and [Render Templates API](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/api/render-templates).
+[Data Models API](https://uncefact.github.io/tests-untp/docs/reference-implementation/api/data-models)
+and [Render Templates API](https://uncefact.github.io/tests-untp/docs/reference-implementation/api/render-templates).
 
 ### UNTP v0.7.0 and upgraded dependent services
 
@@ -126,8 +126,8 @@ context. The storage service and identity resolver were upgraded to v4, and
 stored integrity digests moved to a multibase format, with existing data
 converted automatically on upgrade. Conformity vocabulary now follows the
 v0.7.0 per-scheme model with a read-only browse API; see
-[Conformity handling](https://uncefact.github.io/tests-untp/docs/0.3.0/reference-implementation/data-models/conformity-handling).
-The [v0.7.0 migration guide](https://uncefact.github.io/tests-untp/docs/0.3.0/migration-guides/v0.7.0)
+[Conformity handling](https://uncefact.github.io/tests-untp/docs/reference-implementation/data-models/conformity-handling).
+The [v0.7.0 migration guide](https://uncefact.github.io/tests-untp/docs/migration-guides/v0.7.0)
 covers all of this in detail.
 
 ### A foundation for integration and self-service


### PR DESCRIPTION
This PR makes several documentation corrections following the 0.3.0 release.

- **Release notes:** the doc-site links used `/docs/0.3.0/...`, which 404s while 0.3.0 is the latest version (Docusaurus serves the latest at the unversioned `/docs/...`, exposing the versioned path only once a newer version archives it). Switched the 14 links to `/docs/...` so they resolve.
- **Version mapping:** corrected the vckit documentation version to 1.0.1.
- **Migration guide:** labelled the v0.6.0 guide "UNTP v0.6.0" to match the v0.7.0 guide.
- **Footer:** the "Test Suites and Tools" section still listed the removed Technical Interoperability, Semantic Interoperability, and Graph Validation sections (all pointing at the reference implementation overview); replaced them with the Test Suites landing page and the UNTP Playground.
