### PR TITLE
fix(ri): scope identifier uniqueness to the tenant

### DIFF
--- a/packages/reference-implementation/prisma/__tests__/schema-tenancy.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/schema-tenancy.test.ts
@@ -1,0 +1,21 @@
+import { Prisma } from '../../src/lib/prisma/generated';
+
+/**
+ * Regression guard for the multi-tenancy uniqueness contract on Identifier.
+ *
+ * Identifier schemes seeded under the system tenant are shared rows, so a
+ * uniqueness key of [schemeId, value] alone makes identifier values unique
+ * across ALL tenants: the second tenant to register a value against a shared
+ * scheme fails on a constraint it cannot see (all identifier reads are
+ * tenant-filtered) and cannot recover from. Uniqueness must therefore include
+ * the tenant, matching the convention used by every other tenant-owned model.
+ */
+describe('Identifier tenancy contract', () => {
+  it('scopes identifier uniqueness to the tenant', () => {
+    const model = Prisma.dmmf.datamodel.models.find((m) => m.name === 'Identifier');
+
+    expect(model).toBeDefined();
+    expect(model?.uniqueFields).toContainEqual(['schemeId', 'value', 'tenantId']);
+    expect(model?.uniqueFields).not.toContainEqual(['schemeId', 'value']);
+  });
+});

--- a/packages/reference-implementation/prisma/migrations/20260610000000_tenant_scope_identifier_uniqueness/migration.sql
+++ b/packages/reference-implementation/prisma/migrations/20260610000000_tenant_scope_identifier_uniqueness/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "Identifier_schemeId_value_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Identifier_schemeId_value_tenantId_key" ON "Identifier"("schemeId", "value", "tenantId");

--- a/packages/reference-implementation/prisma/schema.prisma
+++ b/packages/reference-implementation/prisma/schema.prisma
@@ -280,7 +280,7 @@ model Identifier {
   facilitySecondaries     FacilitySecondaryIdentifier[]     @relation("FacilitySecondaryIdentifiers")
   productSecondaries      ProductSecondaryIdentifier[]      @relation("ProductSecondaryIdentifiers")
 
-  @@unique([schemeId, value])
+  @@unique([schemeId, value, tenantId])
   @@index([tenantId])
 }
 


### PR DESCRIPTION
This PR scopes the `Identifier` unique key to the tenant (`@@unique([schemeId, value, tenantId])`), which lets two tenants register the same identifier value against a shared system-seeded scheme instead of the second tenant failing on a database constraint it cannot see or recover from. This brings `Identifier` in line with the tenant-scoped uniqueness convention used by every other tenant-owned model in the schema.

The migration widens the existing constraint (the old key guarantees no duplicates under the new one), so it cannot fail on existing data and is rollback-safe: the previous app version never relies on the stricter index, it only trips over it.

Closes #709

## Test plan

- [x] Regression test pins the tenant-scoped key via the generated client and fails if the old global key returns
- [x] Full reference implementation test suite passes (112 suites, 1490 tests)
- [x] No code consumes the old compound-key accessor or relies on global uniqueness (all identifier lookups are by id plus tenant)
