### PR TITLE
fix(test-suite): make Tier 2 schema mapper UNTP 0.7.0-aware

### DIFF
--- a/packages/untp-test-suite/src/untp-test/schema-mapper/default-mappings.json
+++ b/packages/untp-test-suite/src/untp-test/schema-mapper/default-mappings.json
@@ -27,6 +27,31 @@
       "schemaUrlPattern": "https://test.uncefact.org/vocabulary/untp/dte/untp-dte-schema-{version}.json"
     },
     {
+      "credentialType": "DigitalProductPassport",
+      "versionRegex": "https://vocabulary\\.uncefact\\.org/untp/([^/]+)/context/",
+      "schemaUrlPattern": "https://untp.unece.org/artefacts/schema/v{version}/dpp/DigitalProductPassport.json"
+    },
+    {
+      "credentialType": "DigitalConformityCredential",
+      "versionRegex": "https://vocabulary\\.uncefact\\.org/untp/([^/]+)/context/",
+      "schemaUrlPattern": "https://untp.unece.org/artefacts/schema/v{version}/dcc/ConformityCredential.json"
+    },
+    {
+      "credentialType": "DigitalFacilityRecord",
+      "versionRegex": "https://vocabulary\\.uncefact\\.org/untp/([^/]+)/context/",
+      "schemaUrlPattern": "https://untp.unece.org/artefacts/schema/v{version}/dfr/DigitalFacilityRecord.json"
+    },
+    {
+      "credentialType": "DigitalIdentityAnchor",
+      "versionRegex": "https://vocabulary\\.uncefact\\.org/untp/([^/]+)/context/",
+      "schemaUrlPattern": "https://untp.unece.org/artefacts/schema/v{version}/dia/DigitalIdentityAnchor.json"
+    },
+    {
+      "credentialType": "DigitalTraceabilityEvent",
+      "versionRegex": "https://vocabulary\\.uncefact\\.org/untp/([^/]+)/context/",
+      "schemaUrlPattern": "https://untp.unece.org/artefacts/schema/v{version}/dte/DigitalTraceabilityEvent.json"
+    },
+    {
       "credentialType": "VerifiableCredential",
       "schemaUrlPattern": "https://raw.githubusercontent.com/w3c/vc-data-model/refs/heads/main/schema/verifiable-credential/verifiable-credential-schema.json"
     }

--- a/packages/untp-test-suite/src/untp-test/schema-mapper/loader.ts
+++ b/packages/untp-test-suite/src/untp-test/schema-mapper/loader.ts
@@ -157,36 +157,30 @@ function getSchemaUrlFromMappings(credential: any, mappings: SchemaMappingConfig
     return null;
   }
 
-  // Find matching mapping by credential type
-  let matchedMapping: SchemaMappingConfig | undefined;
-
-  // Look for specific target type
-  if (credential.type.includes(targetType)) {
-    matchedMapping = mappings.find((mapping) => mapping.credentialType === targetType);
-  } else {
-    // Target type not found in credential - return null
+  // Target type must be present in the credential
+  if (!credential.type.includes(targetType)) {
     return null;
   }
 
-  if (!matchedMapping) {
-    return null;
-  }
-
-  // If no version regex, return the schema URL as-is
-  if (!matchedMapping.versionRegex) {
-    return matchedMapping.schemaUrlPattern;
-  }
-
-  // Extract version using the regex
+  // A credential type may have more than one mapping (e.g. one per UNTP context
+  // scheme: the 0.6.x per-type context and the 0.7.0 unified context). Try every
+  // mapping for this type and return the first that resolves a URL, rather than
+  // committing to the first entry and giving up if its versionRegex does not match.
   const credentialString = JSON.stringify(credential);
-  const versionMatch = credentialString.match(new RegExp(matchedMapping.versionRegex));
 
-  if (!versionMatch || !versionMatch[1]) {
-    return null;
+  for (const mapping of mappings.filter((m) => m.credentialType === targetType)) {
+    // If no version regex, the schema URL is fixed.
+    if (!mapping.versionRegex) {
+      return mapping.schemaUrlPattern;
+    }
+
+    const versionMatch = credentialString.match(new RegExp(mapping.versionRegex));
+    if (versionMatch && versionMatch[1]) {
+      return mapping.schemaUrlPattern.replace('{version}', versionMatch[1]);
+    }
   }
 
-  const version = versionMatch[1];
-  return matchedMapping.schemaUrlPattern.replace('{version}', version);
+  return null;
 }
 
 /**

--- a/packages/untp-test-suite/src/untp-test/schema-mapper/loader.ts
+++ b/packages/untp-test-suite/src/untp-test/schema-mapper/loader.ts
@@ -162,21 +162,32 @@ function getSchemaUrlFromMappings(credential: any, mappings: SchemaMappingConfig
     return null;
   }
 
+  // The version is carried by the credential's @context URLs, so match the
+  // versionRegex against those rather than a JSON.stringify of the whole
+  // credential (which could match a version-like string elsewhere in the data).
+  // @context may be a single string or an array that mixes URL strings with
+  // inline context objects; consider only the string entries.
+  const rawContext = credential['@context'];
+  const contextUrls = (Array.isArray(rawContext) ? rawContext : [rawContext]).filter(
+    (entry: unknown): entry is string => typeof entry === 'string',
+  );
+
   // A credential type may have more than one mapping (e.g. one per UNTP context
   // scheme: the 0.6.x per-type context and the 0.7.0 unified context). Try every
   // mapping for this type and return the first that resolves a URL, rather than
   // committing to the first entry and giving up if its versionRegex does not match.
-  const credentialString = JSON.stringify(credential);
-
   for (const mapping of mappings.filter((m) => m.credentialType === targetType)) {
     // If no version regex, the schema URL is fixed.
     if (!mapping.versionRegex) {
       return mapping.schemaUrlPattern;
     }
 
-    const versionMatch = credentialString.match(new RegExp(mapping.versionRegex));
-    if (versionMatch && versionMatch[1]) {
-      return mapping.schemaUrlPattern.replace('{version}', versionMatch[1]);
+    const versionRegex = new RegExp(mapping.versionRegex);
+    for (const contextUrl of contextUrls) {
+      const versionMatch = contextUrl.match(versionRegex);
+      if (versionMatch && versionMatch[1]) {
+        return mapping.schemaUrlPattern.replace('{version}', versionMatch[1]);
+      }
     }
   }
 

--- a/packages/untp-test-suite/src/untp-test/test-utils.ts
+++ b/packages/untp-test-suite/src/untp-test/test-utils.ts
@@ -290,18 +290,30 @@ export function extractUNTPVersion(credential: any): string | null {
     return null;
   }
 
-  // Create regex patterns for all UNTP credential types
+  // 0.6.x scheme: per-type context, e.g.
+  // https://test.uncefact.org/vocabulary/untp/dpp/0.6.0/ — version is the 2nd group.
   const abbreviations = Object.values(UNTP_CREDENTIAL_TYPE_ABBREVIATIONS);
-  const untpContextRegex = new RegExp(
+  const legacyContextRegex = new RegExp(
     `https://test\\.uncefact\\.org/vocabulary/untp/(${abbreviations.join('|')})/([^/]+)/`,
   );
 
+  // 0.7.0+ scheme: single unified context, e.g.
+  // https://vocabulary.uncefact.org/untp/0.7.0/context/ — version is the 1st group.
+  const unifiedContextRegex = new RegExp('https://vocabulary\\.uncefact\\.org/untp/([^/]+)/context/');
+
   for (const contextUrl of credential['@context']) {
-    if (typeof contextUrl === 'string') {
-      const match = contextUrl.match(untpContextRegex);
-      if (match && match[2]) {
-        return match[2]; // Return the captured version (second capture group)
-      }
+    if (typeof contextUrl !== 'string') {
+      continue;
+    }
+
+    const legacyMatch = contextUrl.match(legacyContextRegex);
+    if (legacyMatch && legacyMatch[2]) {
+      return legacyMatch[2];
+    }
+
+    const unifiedMatch = contextUrl.match(unifiedContextRegex);
+    if (unifiedMatch && unifiedMatch[1]) {
+      return unifiedMatch[1];
     }
   }
 

--- a/packages/untp-test-suite/test-fixtures/untp-0.7.0/digital-product-passport.json
+++ b/packages/untp-test-suite/test-fixtures/untp-0.7.0/digital-product-passport.json
@@ -1,0 +1,76 @@
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vocabulary.uncefact.org/untp/0.7.0/context/"],
+  "type": ["DigitalProductPassport", "VerifiableCredential"],
+  "id": "https://example.org/credentials/dpp/0001",
+  "issuer": {
+    "type": ["CredentialIssuer"],
+    "id": "did:web:example.org",
+    "name": "Example Issuer"
+  },
+  "validFrom": "2026-01-01T00:00:00Z",
+  "name": "Example Digital Product Passport",
+  "credentialSubject": {
+    "type": ["Product"],
+    "id": "https://example.org/product/0001",
+    "name": "Example Product",
+    "idScheme": {
+      "type": ["IdentifierScheme"],
+      "id": "https://example.org/identifiers/",
+      "name": "Example Identifier Scheme"
+    },
+    "idGranularity": "batch",
+    "producedAtFacility": {
+      "type": ["Facility"],
+      "id": "https://example.org/facility/0001",
+      "name": "Example Facility"
+    },
+    "countryOfProduction": {
+      "countryCode": "AU",
+      "countryName": "Australia"
+    },
+    "productCategory": [
+      {
+        "code": "0000",
+        "name": "Example Category",
+        "schemeId": "https://example.org/scheme/category",
+        "schemeName": "Example Category Scheme"
+      }
+    ],
+    "performanceClaim": [
+      {
+        "type": ["Claim"],
+        "id": "https://example.org/claim/0001",
+        "name": "Example Performance Claim",
+        "claimDate": "2026-01-01",
+        "referenceCriteria": [
+          {
+            "type": ["Criterion"],
+            "id": "https://example.org/scheme/example/criterion/0001",
+            "name": "Example Criterion"
+          }
+        ],
+        "conformityTopic": [
+          {
+            "type": ["ConformityTopic"],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/supply-chain-traceability",
+            "name": "Supply Chain Traceability"
+          }
+        ],
+        "claimedPerformance": [
+          {
+            "metric": {
+              "type": ["PerformanceMetric"],
+              "id": "https://example.org/metric/0001",
+              "name": "Example Metric"
+            },
+            "score": {
+              "code": "PASS",
+              "rank": 1,
+              "definition": "Example performance verified"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The Tier 2 schema mapper derived the schema URL only from the 0.6.x per-type context scheme (test.uncefact.org/vocabulary/untp/<abbr>/<version>/). UNTP 0.7.0 uses a single unified context (vocabulary.uncefact.org/untp/<version>/context/), which never matched, so getSchemaUrlForCredential returned null and every 0.7.0 credential failed at the guard assertion ("expected null to be a string") before schema validation.

- loader.ts: getSchemaUrlFromMappings now tries every mapping for the credential type and returns the first that resolves, instead of giving up on the first entry whose versionRegex does not match (this also unblocks adding a parallel 0.7.0 mapping for the same type).
- default-mappings.json: add 0.7.0 entries (unified context -> untp.unece.org artefacts schemas) alongside the existing 0.6.x entries. Note the DCC artefact is published as dcc/ConformityCredential.json (no Digital prefix), so it needs an explicit pattern; a uniform Digital<Type>.json template would 404.
- test-utils.ts: extractUNTPVersion also recognises the unified 0.7.0 context.

The 0.6.x path is untouched (version-aware, parallel mappings). Adds a minimal, generic 0.7.0 DPP fixture (no third-party context dependency) that passes Tier 1, Tier 2 schema and Tier 3 RDF.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
  - 📗 Update any related documentation and include any relevant screenshots.
  - 📚 Update Swagger/API documentation if you modified API endpoints or schemas.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

The Tier 2 schema mapper derived the UNTP schema URL only from the 0.6.x per-type context scheme (`https://test.uncefact.org/vocabulary/untp/<abbr>/<version>/`). UNTP 0.7.0 uses a single unified context (`https://vocabulary.uncefact.org/untp/<version>/context/`), which never matched, so `getSchemaUrlForCredential` returned `null` and every 0.7.0 credential failed at the guard assertion (`expected null to be a string`) before schema validation ever ran.

This PR makes the mapper version-aware, leaving the 0.6.x path untouched:

1. `schema-mapper/loader.ts` — `getSchemaUrlFromMappings` now iterates over every mapping for the credential type and returns the first that resolves a URL, instead of selecting the first entry and giving up when its `versionRegex` does not match. This also fixes the selection bug that blocked the obvious workaround of adding a second (0.7.0) mapping for the same `credentialType`.
2. `schema-mapper/default-mappings.json` — adds 0.7.0 entries (unified context → `untp.unece.org/artefacts` schemas) alongside the existing 0.6.x entries. Note: the v0.7.0 DCC artefact is published as `dcc/ConformityCredential.json` (no `Digital` prefix), unlike the other four types, so it needs an explicit pattern — a uniform `Digital<Type>.json` template would 404.
3. `test-utils.ts` — `extractUNTPVersion` now also recognises the unified 0.7.0 context.

All five published v0.7.0 artefact paths were verified to return HTTP 200: `dpp/DigitalProductPassport.json`, `dcc/ConformityCredential.json`, `dfr/DigitalFacilityRecord.json`, `dia/DigitalIdentityAnchor.json`, `dte/DigitalTraceabilityEvent.json`.

## Related Tickets & Documents

Fixes #711

## Mobile & Desktop Screenshots/Recordings

Not applicable — no visual changes (test-suite code only).

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Added as an integration test, consistent with this package's existing self-test mechanism (the suite runs its own conformance tiers over credential fixtures rather than a separate unit-test runner — `jest.config.mjs` in this package is an inactive stub with `testMatch: []`, and `jest` is not a devDependency here). A minimal, generic UNTP 0.7.0 DPP fixture (`test-fixtures/untp-0.7.0/`, no third-party `@context` dependency) is added: with this fix it now resolves the schema URL and passes Tier 2 (and Tier 1 + Tier 3 RDF). The bundled 0.6.x example credentials are unchanged (still 23 passing / 1 failing — the pre-existing trust-anchor example failure). A jest-based unit test for the loader fall-through can be added if preferred, but would require introducing `jest`/`ts-jest` to this package (touching the lockfile), so it is left out to keep the change focused — happy to add it on request.

Note for the reviewer: `pnpm build` for this package exits non-zero on a pre-existing, unrelated error (`TS7016: Could not find a declaration file for module 'jsonld'` in `n3-utils.ts`) that is present on `next` before this PR; `tsc` still emits `dist/` and the CLI runs. This PR does not touch `n3-utils.ts` and does not introduce the error.

## Added to documentation?

- [ ] 📖 [Reference Implementation docs site](https://uncefact.github.io/tests-untp/docs/reference-implementation/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## API Documentation Updated?

- [ ] 📚 Updated Swagger schemas in `schemas.ts`
- [ ] ✅ Verified Zod schemas match Prisma database schema
- [x] 🙅 No API changes in this PR

## [optional] Are there any post-deployment tasks we need to perform?

None.