### PR TITLE
fix(test-suite): make Tier 3 product-claim discovery UNTP 0.7.0-aware

### DIFF
--- a/packages/untp-test-suite/src/untp-test/rdf-utils.ts
+++ b/packages/untp-test-suite/src/untp-test/rdf-utils.ts
@@ -85,7 +85,7 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
       PREFIX vc: <https://www.w3.org/2018/credentials#>
       PREFIX result: <http://example.org/result#>
 
-      SELECT ?credential ?product ?productName ?claim ?topic ?conformance ?criterion ?criterionName
+      SELECT ?credential ?product ?productName ?claim ?topic ?criterion ?criterionName
              (EXISTS { ?claim result:allCriteriaVerified true } AS ?claimVerified)
              (EXISTS { ?claim result:verifiedCriterion ?criterion } AS ?criterionVerified)
       WHERE {
@@ -94,7 +94,9 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
         ?product a untp:Product .
         ?product schemaorg:name ?productName .
 
-        # Find performance claims (the 0.7.0 equivalent of conformityClaim)
+        # Find performance claims (the 0.7.0 equivalent of conformityClaim).
+        # Note: 0.7.0 has no boolean conformance predicate on the claim
+        # (verified against the RDF expansion of real 0.7.0 DPPs), so it is not selected.
         ?product untp:performanceClaim ?claim .
         ?claim untp:conformityTopic ?topic .
 
@@ -237,7 +239,7 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
       PREFIX vc: <https://www.w3.org/2018/credentials#>
       PREFIX result: <http://example.org/result#>
 
-      SELECT ?credential ?product ?productName ?claim ?topic ?conformance
+      SELECT ?credential ?product ?productName ?claim ?topic
              (EXISTS { ?claim result:allCriteriaVerified true } AS ?claimVerified)
       WHERE {
         ?credential a untp:DigitalProductPassport .
@@ -245,7 +247,8 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
         ?product a untp:Product .
         ?product schemaorg:name ?productName .
 
-        # Find performance claims
+        # Find performance claims (0.7.0 has no boolean conformance predicate on
+        # the claim, so it is not selected).
         ?product untp:performanceClaim ?claim .
         ?claim untp:conformityTopic ?topic .
 

--- a/packages/untp-test-suite/src/untp-test/rdf-utils.ts
+++ b/packages/untp-test-suite/src/untp-test/rdf-utils.ts
@@ -38,8 +38,20 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
     // Create a query engine
     const mySparqlEngine = new querySparql.QueryEngine();
 
-    // Execute a SPARQL query directly on the n3store to get products, claims, and criteria
-    const result = await mySparqlEngine.queryBindings(
+    // Create maps for organizing the data
+    const productsMap = new Map<string, Product>();
+    const claimsMap = new Map<string, Claim>();
+
+    // UNTP has two context schemes that expand to different RDF shapes:
+    //  - 0.6.x: per-type vocabulary (test.uncefact.org/vocabulary/untp/{dpp,core}/0/),
+    //    with an intermediate `untp:product` node and `conformityClaim` /
+    //    `assessmentCriteria` predicates.
+    //  - 0.7.0+: a single unified vocabulary (vocabulary.uncefact.org/untp/), where the
+    //    `credentialSubject` IS the Product and claims use `performanceClaim` /
+    //    `referenceCriteria`.
+    // Query both shapes (version-aware) so a graph in either version yields products.
+    const criteriaQueries = [
+      // 0.6.x scheme
       `
       PREFIX dpp: <https://test.uncefact.org/vocabulary/untp/dpp/0/>
       PREFIX schemaorg: <https://schema.org/>
@@ -66,17 +78,35 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
         ?criterion schemaorg:name ?criterionName .
       }
     `,
-      {
-        sources: [n3store],
-      },
-    );
+      // 0.7.0+ unified scheme
+      `
+      PREFIX untp: <https://vocabulary.uncefact.org/untp/>
+      PREFIX schemaorg: <https://schema.org/>
+      PREFIX vc: <https://www.w3.org/2018/credentials#>
+      PREFIX result: <http://example.org/result#>
 
-    // Create maps for organizing the data
-    const productsMap = new Map<string, Product>();
-    const claimsMap = new Map<string, Claim>();
+      SELECT ?credential ?product ?productName ?claim ?topic ?conformance ?criterion ?criterionName
+             (EXISTS { ?claim result:allCriteriaVerified true } AS ?claimVerified)
+             (EXISTS { ?claim result:verifiedCriterion ?criterion } AS ?criterionVerified)
+      WHERE {
+        ?credential a untp:DigitalProductPassport .
+        ?credential vc:credentialSubject ?product .
+        ?product a untp:Product .
+        ?product schemaorg:name ?productName .
 
-    // Process each binding (row of results) using async iteration
-    for await (const binding of result) {
+        # Find performance claims (the 0.7.0 equivalent of conformityClaim)
+        ?product untp:performanceClaim ?claim .
+        ?claim untp:conformityTopic ?topic .
+
+        # Get reference criteria (the 0.7.0 equivalent of assessmentCriteria)
+        ?claim untp:referenceCriteria ?criterion .
+        ?criterion schemaorg:name ?criterionName .
+      }
+    `,
+    ];
+
+    // Process one criteria binding into the products/claims maps.
+    const processCriteriaBinding = (binding: any) => {
       const dppId = binding.get('credential')?.value || '';
       const productId = binding.get('product')?.value || '';
       const productName = binding.get('productName')?.value || '';
@@ -124,7 +154,14 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
           verifiedBy: criterionVerified ? 'verified' : undefined,
         };
         claim.criteria.push(criterion);
-        //console.log(`Product ${productName}: Found criterion ${criterionName} for claim ${claim.topic}`)
+      }
+    };
+
+    // Execute the version-aware criteria queries and process their bindings.
+    for (const criteriaQuery of criteriaQueries) {
+      const result = await mySparqlEngine.queryBindings(criteriaQuery, { sources: [n3store] });
+      for await (const binding of result) {
+        processCriteriaBinding(binding);
       }
     }
 
@@ -165,8 +202,10 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
       }
     }
 
-    // Get simple claims (claims without criteria)
-    const simpleClaimsResult = await mySparqlEngine.queryBindings(
+    // Get simple claims (claims without criteria), version-aware across both
+    // the 0.6.x per-type scheme and the 0.7.0+ unified scheme.
+    const simpleClaimsQueries = [
+      // 0.6.x scheme
       `
       PREFIX dpp: <https://test.uncefact.org/vocabulary/untp/dpp/0/>
       PREFIX schemaorg: <https://schema.org/>
@@ -191,13 +230,33 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
         FILTER NOT EXISTS { ?claim untp:assessmentCriteria ?criterion }
       }
     `,
-      {
-        sources: [n3store],
-      },
-    );
+      // 0.7.0+ unified scheme
+      `
+      PREFIX untp: <https://vocabulary.uncefact.org/untp/>
+      PREFIX schemaorg: <https://schema.org/>
+      PREFIX vc: <https://www.w3.org/2018/credentials#>
+      PREFIX result: <http://example.org/result#>
 
-    // Process simple claims
-    for await (const binding of simpleClaimsResult) {
+      SELECT ?credential ?product ?productName ?claim ?topic ?conformance
+             (EXISTS { ?claim result:allCriteriaVerified true } AS ?claimVerified)
+      WHERE {
+        ?credential a untp:DigitalProductPassport .
+        ?credential vc:credentialSubject ?product .
+        ?product a untp:Product .
+        ?product schemaorg:name ?productName .
+
+        # Find performance claims
+        ?product untp:performanceClaim ?claim .
+        ?claim untp:conformityTopic ?topic .
+
+        # Ensure this is a simple claim (no reference criteria)
+        FILTER NOT EXISTS { ?claim untp:referenceCriteria ?criterion }
+      }
+    `,
+    ];
+
+    // Process one simple-claim binding into the products/claims maps.
+    const processSimpleClaimBinding = (binding: any) => {
       const dppId = binding.get('credential')?.value || '';
       const productId = binding.get('product')?.value || '';
       const productName = binding.get('productName')?.value || '';
@@ -233,6 +292,14 @@ export async function listAllProducts(n3store: n3.Store): Promise<Product[]> {
         claimsMap.get(claimKey)!.verified = true;
       }
       console.warn(`Product ${productName}: Found claim ${topic} without any criteria!`);
+    };
+
+    // Execute the version-aware simple-claim queries and process their bindings.
+    for (const simpleClaimsQuery of simpleClaimsQueries) {
+      const simpleClaimsResult = await mySparqlEngine.queryBindings(simpleClaimsQuery, { sources: [n3store] });
+      for await (const binding of simpleClaimsResult) {
+        processSimpleClaimBinding(binding);
+      }
     }
 
     return Array.from(productsMap.values());

--- a/packages/untp-test-suite/test-fixtures/untp-0.7.0/digital-product-passport.json
+++ b/packages/untp-test-suite/test-fixtures/untp-0.7.0/digital-product-passport.json
@@ -1,0 +1,76 @@
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vocabulary.uncefact.org/untp/0.7.0/context/"],
+  "type": ["DigitalProductPassport", "VerifiableCredential"],
+  "id": "https://example.org/credentials/dpp/0001",
+  "issuer": {
+    "type": ["CredentialIssuer"],
+    "id": "did:web:example.org",
+    "name": "Example Issuer"
+  },
+  "validFrom": "2026-01-01T00:00:00Z",
+  "name": "Example Digital Product Passport",
+  "credentialSubject": {
+    "type": ["Product"],
+    "id": "https://example.org/product/0001",
+    "name": "Example Product",
+    "idScheme": {
+      "type": ["IdentifierScheme"],
+      "id": "https://example.org/identifiers/",
+      "name": "Example Identifier Scheme"
+    },
+    "idGranularity": "batch",
+    "producedAtFacility": {
+      "type": ["Facility"],
+      "id": "https://example.org/facility/0001",
+      "name": "Example Facility"
+    },
+    "countryOfProduction": {
+      "countryCode": "AU",
+      "countryName": "Australia"
+    },
+    "productCategory": [
+      {
+        "code": "0000",
+        "name": "Example Category",
+        "schemeId": "https://example.org/scheme/category",
+        "schemeName": "Example Category Scheme"
+      }
+    ],
+    "performanceClaim": [
+      {
+        "type": ["Claim"],
+        "id": "https://example.org/claim/0001",
+        "name": "Example Performance Claim",
+        "claimDate": "2026-01-01",
+        "referenceCriteria": [
+          {
+            "type": ["Criterion"],
+            "id": "https://example.org/scheme/example/criterion/0001",
+            "name": "Example Criterion"
+          }
+        ],
+        "conformityTopic": [
+          {
+            "type": ["ConformityTopic"],
+            "id": "https://vocabulary.uncefact.org/conformity-topic/supply-chain-traceability",
+            "name": "Supply Chain Traceability"
+          }
+        ],
+        "claimedPerformance": [
+          {
+            "metric": {
+              "type": ["PerformanceMetric"],
+              "id": "https://example.org/metric/0001",
+              "name": "Example Metric"
+            },
+            "score": {
+              "code": "PASS",
+              "rank": 1,
+              "definition": "Example performance verified"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
listAllProducts queried only the 0.6.x per-type vocabulary (test.uncefact.org/vocabulary/untp/{dpp,core}/0/) with an intermediate untp:product node and conformityClaim/assessmentCriteria predicates. A 0.7.0 DPP expands to the unified vocabulary (vocabulary.uncefact.org/untp/) where the credentialSubject IS the Product and claims use performanceClaim/referenceCriteria, so the query bound nothing, listAllProducts returned [] and Tier 3 failed with "Should find products to verify: expected [] not to be empty".

rdf-utils.ts now runs version-aware queries (0.6.x and 0.7.0) for both the criteria and the simple-claim paths, sharing one binding processor. The 0.6.x path is unchanged.

Scope: this covers the product / performance-claim discovery path only. The DCC/DIA trust-chain remap (the verifier query and the N3 inference rules) is deferred to a follow-up, pending published UNTP 0.7.0 conformity-credential samples; per the evidential discipline we do not validate inference against self-authored artefacts. Consequently a 0.7.0 DPP now reaches the trust-chain assertion ("all issuers should be attested"), the same residual the 0.6.x example exhibits, instead of failing at product discovery.

Adds the same minimal generic 0.7.0 DPP fixture (no third-party context).

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
  - 📗 Update any related documentation and include any relevant screenshots.
  - 📚 Update Swagger/API documentation if you modified API endpoints or schemas.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

`listAllProducts` (`rdf-utils.ts`) queried only the 0.6.x per-type vocabulary (`https://test.uncefact.org/vocabulary/untp/{dpp,core}/0/`) with an intermediate `untp:product` node and the `conformityClaim` / `assessmentCriteria` predicates. A UNTP 0.7.0 DPP expands to the unified vocabulary (`https://vocabulary.uncefact.org/untp/`), where the `credentialSubject` is the `untp:Product` and claims use `performanceClaim` / `referenceCriteria`. The 0.6.x patterns therefore bound nothing, `listAllProducts` returned `[]`, and Tier 3 failed with `Should find products to verify: expected [] not to be empty`.

This PR makes the product/claim discovery version-aware: `listAllProducts` now runs the 0.6.x and 0.7.0 queries  (for both the criteria and the simple-claim paths), sharing a single binding processor. The 0.6.x path is unchanged.

**Scope (and what is intentionally deferred):** this PR covers the product / performance-claim discovery path only — the part for which real UNTP 0.7.0 RDF evidence exists (the namespace/predicate mapping is taken directly from the RDF expansion of real 0.7.0 DPPs). The DCC/DIA trust-chain remap (the verifier SPARQL in `rdf-utils.ts` and the N3 inference rules) is deferred to a follow-up, pending published UNTP 0.7.0 conformity-credential samples: I did not want to write inference rules validated only against self-authored DCC/DIA artefacts. As a result, a 0.7.0 DPP now reaches the trust-chain assertion (`all issuers should be attested`) — the same residual the bundled 0.6.x example exhibits — instead of failing earlier at product discovery.

## Related Tickets & Documents

Fixes #712 (product/claim discovery path; DCC/DIA trust-chain remap tracked as a follow-up)

## Mobile & Desktop Screenshots/Recordings

Not applicable — no visual changes (test-suite code only).

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Added as an integration test, consistent with this package's existing self-test mechanism (the suite runs its own conformance tiers over credential fixtures rather than a separate unit-test runner — `jest.config.mjs` here is an inactive stub with `testMatch: []`, and `jest` is not a devDependency of this package). The same minimal, generic UNTP 0.7.0 DPP fixture (`test-fixtures/untp-0.7.0/`, no third-party `@context`) is included. Before this PR, Tier 3 on a 0.7.0 DPP fails at `expected [] not to be empty`; after it, the product and its claims/criteria are found and the run proceeds to the trust-chain assertion. The bundled 0.6.x example credentials are unchanged (still 23 passing / 1 failing).

Note for the reviewer: `pnpm build` for this package exits non-zero on a pre-existing, unrelated error (`TS7016: Could not find a declaration file for module 'jsonld'` in `n3-utils.ts`) that is present on `next` before this PR; `tsc` still emits `dist/` and the CLI runs. This PR does not touch `n3-utils.ts` and does not introduce the error.

## Added to documentation?

- [ ] 📖 [Reference Implementation docs site](https://uncefact.github.io/tests-untp/docs/reference-implementation/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## API Documentation Updated?

- [ ] 📚 Updated Swagger schemas in `schemas.ts`
- [ ] ✅ Verified Zod schemas match Prisma database schema
- [x] 🙅 No API changes in this PR

## [optional] Are there any post-deployment tasks we need to perform?

None.