### PR TITLE
fix(ri): map database conflicts to clean 409s and stop leaking ORM detail

### DIFF
--- a/docs/adrs/036-repository-boundary-database-error-translation.md
+++ b/docs/adrs/036-repository-boundary-database-error-translation.md
@@ -1,0 +1,40 @@
+# ADR-036: Database Error Translation at the Repository Boundary
+
+- **Date:** 2026-07-02
+- **Status:** accepted
+
+## Context
+
+Reference implementation API routes that perform constrained database writes (unique indexes, foreign keys, records deleted concurrently) let the ORM's errors propagate to the central error mapper's generic branch, which returned the raw error message to the client as a 500. This leaked internal detail (the ORM in use, table and column names, query shape) and returned an unhelpful status for what is semantically a conflict (#706). A full audit of the API surface found the same gap across most write routes, plus three modules that had each grown an identical private duck-type guard for the ORM's unique-constraint error code (#708 tracks the route-by-route adoption).
+
+Two questions needed settling: where ORM errors are translated into the application's domain errors, and what an unmapped database error looks like to a client.
+
+## Decision
+
+Database errors are translated at the repository boundary, and an unmapped database error surfaces as a generic 500 that reveals nothing about the database.
+
+1. **A shared helper owns detection and mapping.** `src/lib/prisma/db-errors.ts` provides duck-typed guards for Prisma's request error codes (unique constraint, foreign key, record not found) and `mapDatabaseError(error, context)`, which throws the matching domain error (`ConflictError`, `NotFoundError`, `ValidationError`) carrying an entity-specific message from the caller's context, and rethrows anything the context does not cover. Detection is duck-typed on the documented error `code` rather than `instanceof` against generated client classes, because errors crossing transaction callbacks do not reliably satisfy `instanceof` and the helper stays decoupled from the generated client. The module lives in the Prisma tree because its input is Prisma's error surface; it maps into the domain error vocabulary in `src/lib/api/errors.ts`.
+2. **Repositories are the persistence boundary.** A repository function performing a constrained write wraps the ORM call and calls `mapDatabaseError` with the wording the violation means for its entity (for example, a unique-constraint violation on identifier creation becomes a 409 "An identifier with this value already exists for the scheme"). ORM errors do not escape the repository layer. Routes stay thin: they let domain errors propagate and document the resulting statuses in Swagger.
+3. **The HTTP error mapper carries a sanitised backstop.** `handleRouteError` detects any database error that reaches it unmapped, logs the full detail server-side under a distinct message (`Unhandled database error`), and returns a generic 500 body that never echoes error text, so responses do not name the database or its internals. The distinct log line is the operational detector for repositories missing a mapping. The mapper's pre-existing final fallback still returns `Error.message` for non-database errors; sanitising that branch is a separate decision outside this ADR's scope.
+4. **Constraint violations are caught, not predicted.** Uniqueness is enforced by the database constraint and translated after the fact. Pre-checking (find-then-insert) races concurrent writers and gives false confidence; the constraint is the only authoritative check.
+
+## Consequences
+
+- Easier: every caller of a repository (routes, seed scripts, service-layer code) gets correct conflict semantics by construction, rather than per-route discipline. Adoption for #708 is one change per repository function instead of one per route.
+- Easier: unmapped gaps are discoverable in production by alerting on the `Unhandled database error` log line.
+- Easier: the three previously duplicated private unique-constraint guards are one shared implementation.
+- Harder: a repository cannot vary conflict wording per calling surface; the entity's message is the message. If a surface ever needs different wording, it must catch the domain error and rewrap it, which is deliberate friction.
+- Harder: repository unit tests carry the mapping assertions (ORM rejection becomes domain error), which adds a test obligation to every constrained write.
+
+## Alternatives Considered
+
+- **Translation at the route layer** (each handler wraps its repository calls and supplies request-specific wording). Rejected: it protects only the HTTP surface, leaving seeds and service-layer callers to leak raw ORM errors; it spreads try/catch boilerplate across handlers; and it depends on per-route discipline, which the API-surface audit showed does not hold here (fifteen routes had already missed it). Repositories in this codebase also already throw domain errors (`NotFoundError`, `ValidationError`), so route-level translation would cut against the established layering.
+- **A global filter mapping unique-constraint violations to a generic 409** ("resource already exists") with no per-call context. Rejected: it loses the entity-specific message, and it can mislabel, since a unique-constraint violation from a nested write inside a transaction is not necessarily a conflict on the resource the request created.
+- **Check-then-insert to pre-empt constraint violations.** Rejected: the check races concurrent writers, and wrapping both statements in a transaction does not close the race. At PostgreSQL's default READ COMMITTED isolation (which Prisma's `$transaction` inherits), two concurrent transactions each see no existing row and both proceed to insert; the second to commit still violates the constraint. Closing the race transactionally would require SERIALIZABLE isolation plus retry handling for serialisation failures, and row locking cannot help because the row being guarded does not exist yet. The pre-check therefore adds a query without removing the failure mode; the constraint violation still occurs and still needs handling.
+- **A distinct "database error" message on the sanitised 500.** Rejected: the caller cannot act differently on "database error" versus "unexpected error", so the specificity has no client value, while naming the database gives a probing client information for free. The distinction lives in the server-side log line instead.
+
+## References
+
+- #706 (this change), #708 (route-by-route adoption)
+- ADR-034, ADR-035 (error reporting and structured throws in `@uncefact/untp-utils`; same philosophy, different package)
+- Prisma error reference: https://www.prisma.io/docs/orm/reference/error-reference

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
@@ -110,6 +110,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: An identifier with this value already exists for the scheme
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
@@ -56,6 +56,12 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: An identifier with this value already exists for the scheme
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
@@ -10,6 +10,7 @@ jest.mock('next/server', () => ({
 import {
   NotFoundError,
   ForbiddenError,
+  ConflictError,
   UnprocessableError,
   ServiceRegistryError,
   ServiceInstanceNotFoundError,
@@ -56,6 +57,14 @@ describe('handleRouteError', () => {
     expect(res.status).toBe(404);
     const body = await (res as unknown as MockResponse).json();
     expect(body).toEqual({ error: 'missing' });
+  });
+
+  it('maps ConflictError to 409', async () => {
+    const res = handleRouteError(new ConflictError('already exists'));
+
+    expect(res.status).toBe(409);
+    const body = await (res as unknown as MockResponse).json();
+    expect(body).toEqual({ error: 'already exists' });
   });
 
   it('maps UnprocessableError to 422', async () => {
@@ -130,6 +139,31 @@ describe('handleRouteError', () => {
 
   it('maps a non-Error value to 500 with fallback message', async () => {
     const res = handleRouteError('string error');
+
+    expect(res.status).toBe(500);
+    const body = await (res as unknown as MockResponse).json();
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  // --- Database errors (sanitised backstop) ---
+
+  it('sanitises an unhandled Prisma known request error to a generic 500', async () => {
+    const dbError = new Error('Unique constraint failed on the fields: (`schemeId`,`value`,`tenantId`)');
+    dbError.name = 'PrismaClientKnownRequestError';
+    Object.assign(dbError, { code: 'P2002', clientVersion: '6.0.0' });
+
+    const res = handleRouteError(dbError);
+
+    expect(res.status).toBe(500);
+    const body = await (res as unknown as MockResponse).json();
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  it('sanitises a Prisma client validation error to a generic 500', async () => {
+    const dbError = new Error('Argument `id`: Invalid value provided. Expected StringFilter or String, provided Int.');
+    dbError.name = 'PrismaClientValidationError';
+
+    const res = handleRouteError(dbError);
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();

--- a/packages/reference-implementation/src/lib/api/handle-route-error.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.ts
@@ -8,6 +8,7 @@ import {
   ServiceRegistryError,
 } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
+import { isDatabaseError } from '@/lib/prisma/db-errors';
 import { ServiceError } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 
@@ -53,6 +54,14 @@ export function handleRouteError(e: unknown): Response {
   if (e instanceof ServiceError) {
     logger.error({ err: e, code: e.code, status: e.statusCode }, 'Service error');
     return NextResponse.json({ error: e.message, code: e.code }, { status: e.statusCode });
+  }
+  if (isDatabaseError(e)) {
+    // Database errors carry ORM internals (engine text, table and column names) in
+    // their message; log the detail, return only a generic body. Unlike the final
+    // fallback below, this branch never echoes error text. The distinct log message
+    // is the signal that a repository is missing a mapping.
+    logger.error({ err: e }, 'Unhandled database error');
+    return NextResponse.json({ error: 'An unexpected error has occurred.' }, { status: 500 });
   }
   logger.error({ err: e }, 'Unexpected error');
   return NextResponse.json({ error: errorMessage(e) }, { status: 500 });

--- a/packages/reference-implementation/src/lib/api/resolve-closed-mode-tenant.ts
+++ b/packages/reference-implementation/src/lib/api/resolve-closed-mode-tenant.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@/lib/prisma/generated';
 import { prisma } from '@/lib/prisma/prisma';
 import { createLogger } from '@uncefact/untp-ri-services/logging';
+import { isUniqueConstraintViolation } from '@/lib/prisma/db-errors';
 
 const logger = createLogger().child({ module: 'resolve-closed-mode-tenant' });
 
@@ -112,8 +113,4 @@ async function retryResolution(
     logger.error({ groupClaimValue, sub, error }, 'Retry resolution also failed');
     return null;
   }
-}
-
-function isUniqueConstraintViolation(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && (error as { code: string }).code === 'P2002';
 }

--- a/packages/reference-implementation/src/lib/api/service-account-user.ts
+++ b/packages/reference-implementation/src/lib/api/service-account-user.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@/lib/prisma/generated';
 import { prisma } from '@/lib/prisma/prisma';
 import { createLogger } from '@uncefact/untp-ri-services/logging';
+import { isUniqueConstraintViolation } from '@/lib/prisma/db-errors';
 
 const logger = createLogger().child({ module: 'service-account-user' });
 
@@ -85,8 +86,4 @@ export async function resolveServiceAccountUser(claims: ServiceAccountClaims): P
     logger.error({ sub: claims.sub, error }, 'Failed to provision service account user');
     return null;
   }
-}
-
-function isUniqueConstraintViolation(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && (error as { code: string }).code === 'P2002';
 }

--- a/packages/reference-implementation/src/lib/onboarding/handle-sign-in.ts
+++ b/packages/reference-implementation/src/lib/onboarding/handle-sign-in.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@uncefact/untp-ri-services/logging';
 import { getTenantConfig } from '@/lib/auth/tenant-config';
 import { extractGroupClaim } from '@/lib/auth/group-claim';
 import { decodeAccessToken } from '@/lib/auth/oidc-token';
+import { isUniqueConstraintViolation } from '@/lib/prisma/db-errors';
 
 const logger = createLogger().child({ module: 'handle-sign-in' });
 
@@ -176,8 +177,4 @@ async function handleOpenModeSignIn(
   }
 
   logger.info({ userId }, 'User onboarding completed successfully');
-}
-
-function isUniqueConstraintViolation(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && (error as { code: string }).code === 'P2002';
 }

--- a/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
@@ -61,6 +61,12 @@ describe('isDatabaseError', () => {
     expect(isDatabaseError(new Error('boom'))).toBe(false);
     expect(isDatabaseError(undefined)).toBe(false);
   });
+
+  it('returns false without throwing when name is not a string', () => {
+    const mangled = new Error('boom');
+    Object.defineProperty(mangled, 'name', { value: undefined });
+    expect(isDatabaseError(mangled)).toBe(false);
+  });
 });
 
 describe('mapDatabaseError', () => {

--- a/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
@@ -1,0 +1,100 @@
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+import {
+  isUniqueConstraintViolation,
+  isForeignKeyViolation,
+  isRecordNotFound,
+  isDatabaseError,
+  mapDatabaseError,
+} from './db-errors';
+
+/** Mimics the shape of a PrismaClientKnownRequestError without depending on the generated client. */
+function prismaKnownError(code: string): Error {
+  const error = new Error(
+    `\nInvalid \`prisma.identifier.create()\` invocation:\n\nUnique constraint failed on the fields: (\`schemeId\`,\`value\`,\`tenantId\`)`,
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code, clientVersion: '6.0.0' });
+  return error;
+}
+
+describe('isUniqueConstraintViolation', () => {
+  it('matches a P2002 error', () => {
+    expect(isUniqueConstraintViolation(prismaKnownError('P2002'))).toBe(true);
+  });
+
+  it('rejects other Prisma codes, plain errors, and non-objects', () => {
+    expect(isUniqueConstraintViolation(prismaKnownError('P2025'))).toBe(false);
+    expect(isUniqueConstraintViolation(new Error('P2002'))).toBe(false);
+    expect(isUniqueConstraintViolation(null)).toBe(false);
+    expect(isUniqueConstraintViolation('P2002')).toBe(false);
+  });
+});
+
+describe('isForeignKeyViolation', () => {
+  it('matches only P2003', () => {
+    expect(isForeignKeyViolation(prismaKnownError('P2003'))).toBe(true);
+    expect(isForeignKeyViolation(prismaKnownError('P2002'))).toBe(false);
+  });
+});
+
+describe('isRecordNotFound', () => {
+  it('matches only P2025', () => {
+    expect(isRecordNotFound(prismaKnownError('P2025'))).toBe(true);
+    expect(isRecordNotFound(prismaKnownError('P2003'))).toBe(false);
+  });
+});
+
+describe('isDatabaseError', () => {
+  it('matches errors carrying clientVersion', () => {
+    expect(isDatabaseError(prismaKnownError('P2002'))).toBe(true);
+  });
+
+  it('matches PrismaClient*-named errors without clientVersion', () => {
+    const error = new Error('Argument `id`: Invalid value provided.');
+    error.name = 'PrismaClientValidationError';
+    expect(isDatabaseError(error)).toBe(true);
+  });
+
+  it('rejects application errors and non-objects', () => {
+    expect(isDatabaseError(new ConflictError('conflict'))).toBe(false);
+    expect(isDatabaseError(new Error('boom'))).toBe(false);
+    expect(isDatabaseError(undefined)).toBe(false);
+  });
+});
+
+describe('mapDatabaseError', () => {
+  it('maps P2002 to ConflictError with the contextual message', () => {
+    const call = () => mapDatabaseError(prismaKnownError('P2002'), { conflict: 'Identifier already exists' });
+
+    expect(call).toThrow(ConflictError);
+    expect(call).toThrow('Identifier already exists');
+  });
+
+  it('maps P2025 to NotFoundError with the contextual message', () => {
+    expect(() => mapDatabaseError(prismaKnownError('P2025'), { notFound: 'Identifier not found' })).toThrow(
+      NotFoundError,
+    );
+  });
+
+  it('maps P2003 to ValidationError with the contextual message', () => {
+    expect(() =>
+      mapDatabaseError(prismaKnownError('P2003'), { invalidReference: 'Referenced scheme does not exist' }),
+    ).toThrow(ValidationError);
+  });
+
+  it('rethrows a database error whose code the context does not cover', () => {
+    const error = prismaKnownError('P2025');
+    expect(() => mapDatabaseError(error, { conflict: 'Identifier already exists' })).toThrow(error);
+  });
+
+  it('rethrows non-database errors unchanged', () => {
+    const error = new Error('network down');
+    expect(() => mapDatabaseError(error, { conflict: 'x', notFound: 'y', invalidReference: 'z' })).toThrow(error);
+  });
+
+  it('rethrows a non-database error even when it carries a matching code property', () => {
+    const impostor = Object.assign(new Error('not from the ORM'), { code: 'P2002' });
+    expect(() => mapDatabaseError(impostor, { conflict: 'x' })).toThrow(impostor);
+  });
+});

--- a/packages/reference-implementation/src/lib/prisma/db-errors.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.ts
@@ -45,7 +45,11 @@ export function isRecordNotFound(error: unknown): boolean {
 export function isDatabaseError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   if ('clientVersion' in error) return true;
-  return error instanceof Error && error.name.startsWith('PrismaClient');
+  return (
+    'name' in error &&
+    typeof (error as { name: unknown }).name === 'string' &&
+    (error as { name: string }).name.startsWith('PrismaClient')
+  );
 }
 
 /**

--- a/packages/reference-implementation/src/lib/prisma/db-errors.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.ts
@@ -1,0 +1,87 @@
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
+
+/**
+ * Database error detection and mapping.
+ *
+ * Prisma errors are detected by duck-typing rather than `instanceof` against the
+ * generated client's classes: errors that cross transaction callbacks or module
+ * boundaries do not reliably satisfy `instanceof`, and the duck-type keeps this
+ * module free of a dependency on the generated client. Error codes are Prisma's
+ * documented request-error codes:
+ * https://www.prisma.io/docs/orm/reference/error-reference
+ */
+
+function hasPrismaErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string' &&
+    (error as { code: string }).code === code
+  );
+}
+
+/** P2002: a unique-constraint violation (the record already exists). */
+export function isUniqueConstraintViolation(error: unknown): boolean {
+  return hasPrismaErrorCode(error, 'P2002');
+}
+
+/** P2003: a foreign-key violation (a referenced record does not exist, or dependants block the write). */
+export function isForeignKeyViolation(error: unknown): boolean {
+  return hasPrismaErrorCode(error, 'P2003');
+}
+
+/** P2025: the record required by the operation was not found (e.g. update/delete raced a delete). */
+export function isRecordNotFound(error: unknown): boolean {
+  return hasPrismaErrorCode(error, 'P2025');
+}
+
+/**
+ * True for any error thrown by the Prisma client (known request errors,
+ * client-side validation errors, initialisation errors, etc.). All Prisma
+ * client errors carry `clientVersion` and a `PrismaClient*` name.
+ */
+export function isDatabaseError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  if ('clientVersion' in error) return true;
+  return error instanceof Error && error.name.startsWith('PrismaClient');
+}
+
+/**
+ * Contextual messages for the database errors a call site expects, keyed by
+ * outcome: `conflict` (P2002 -> ConflictError, 409), `notFound` (P2025 ->
+ * NotFoundError, 404), `invalidReference` (P2003 -> ValidationError, 400).
+ * Provide a message only for the outcomes the operation can actually produce;
+ * anything else rethrows unchanged. At least one key is required: a call with
+ * no context is a plain rethrow and should not be written as a mapping.
+ */
+export type DatabaseErrorContext =
+  | { conflict: string; notFound?: string; invalidReference?: string }
+  | { conflict?: string; notFound: string; invalidReference?: string }
+  | { conflict?: string; notFound?: string; invalidReference: string };
+
+/**
+ * Maps a caught database error to the API's error contract, with a message
+ * that carries the caller's context (which resource conflicted, what was not
+ * found). Rethrows the original error unchanged when it is not a database
+ * error at all, or when the context does not cover its code. Rethrown
+ * database errors land in handleRouteError's sanitised database branch;
+ * a non-database error rethrown here follows the same path it would have
+ * taken without the mapping.
+ */
+export function mapDatabaseError(error: unknown, context: DatabaseErrorContext): never {
+  if (!isDatabaseError(error)) {
+    throw error;
+  }
+  if (context.conflict !== undefined && isUniqueConstraintViolation(error)) {
+    throw new ConflictError(context.conflict);
+  }
+  if (context.notFound !== undefined && isRecordNotFound(error)) {
+    throw new NotFoundError(context.notFound);
+  }
+  if (context.invalidReference !== undefined && isForeignKeyViolation(error)) {
+    throw new ValidationError(context.invalidReference);
+  }
+  throw error;
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
@@ -5,6 +5,7 @@ import {
   updateIdentifier,
   deleteIdentifier,
 } from './identifier.repository';
+import { ConflictError } from '@/lib/api/errors';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { SYSTEM_TENANT_ID } from '../constants';
 
@@ -41,6 +42,13 @@ const mockIdentifier = prisma.identifier as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
+
+function prismaUniqueConstraintError(): Error {
+  const error = new Error('Unique constraint failed on the fields: (`schemeId`,`value`,`tenantId`)');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('identifier.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -121,6 +129,34 @@ describe('identifier.repository', () => {
           value: 'invalid-value',
         }),
       ).rejects.toThrow(/does not match scheme validation pattern/);
+    });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifier.create.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = createIdentifier({
+        tenantId: TENANT_ID,
+        schemeId: SCHEME_ID,
+        value: '1234567890123',
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('An identifier with this value already exists for the scheme');
+    });
+
+    it('rethrows database errors that are not unique-constraint violations', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      const dbError = new Error('connection lost');
+      mockTx.identifier.create.mockRejectedValue(dbError);
+
+      await expect(
+        createIdentifier({
+          tenantId: TENANT_ID,
+          schemeId: SCHEME_ID,
+          value: '1234567890123',
+        }),
+      ).rejects.toThrow(dbError);
     });
   });
 
@@ -231,6 +267,31 @@ describe('identifier.repository', () => {
         },
       });
       expect(result.value).toBe('9876543210123');
+    });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifier.update.mockRejectedValue(prismaUniqueConstraintError());
+
+      await expect(updateIdentifier('ident-1', TENANT_ID, { value: '1234567890123' })).rejects.toThrow(
+        'An identifier with this value already exists for the scheme',
+      );
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      const raceError = new Error(
+        'An operation failed because it depends on one or more records that were required but not found.',
+      );
+      raceError.name = 'PrismaClientKnownRequestError';
+      Object.assign(raceError, { code: 'P2025', clientVersion: '6.0.0' });
+      mockTx.identifier.update.mockRejectedValue(raceError);
+
+      await expect(updateIdentifier('ident-1', TENANT_ID, { value: '1234567890123' })).rejects.toThrow(
+        'Identifier not found or access denied',
+      );
     });
 
     it('throws ValidationError if the new value does not match the pattern', async () => {

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
@@ -328,6 +328,16 @@ describe('identifier.repository', () => {
       expect(result).toEqual(IDENTIFIER_RECORD);
     });
 
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
+      const raceError = new Error('Record to delete does not exist.');
+      raceError.name = 'PrismaClientKnownRequestError';
+      Object.assign(raceError, { code: 'P2025', clientVersion: '6.0.0' });
+      mockTx.identifier.delete.mockRejectedValue(raceError);
+
+      await expect(deleteIdentifier('ident-1', TENANT_ID)).rejects.toThrow('Identifier not found or access denied');
+    });
+
     it('throws if identifier does not belong to the tenant', async () => {
       mockTx.identifier.findFirst.mockResolvedValue(null);
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
@@ -2,6 +2,7 @@ import { Identifier, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
+import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
@@ -86,16 +87,20 @@ export async function createIdentifier(input: CreateIdentifierInput): Promise<Id
   return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     await validateIdentifierValue(tx, input.schemeId, input.value, input.tenantId);
 
-    return tx.identifier.create({
-      data: {
-        tenantId: input.tenantId,
-        schemeId: input.schemeId,
-        value: input.value,
-      },
-      include: {
-        scheme: true,
-      },
-    });
+    try {
+      return await tx.identifier.create({
+        data: {
+          tenantId: input.tenantId,
+          schemeId: input.schemeId,
+          value: input.value,
+        },
+        include: {
+          scheme: true,
+        },
+      });
+    } catch (e) {
+      mapDatabaseError(e, { conflict: 'An identifier with this value already exists for the scheme' });
+    }
   });
 }
 
@@ -175,15 +180,22 @@ export async function updateIdentifier(
       await validateIdentifierValue(tx, existing.schemeId, input.value, tenantId);
     }
 
-    return tx.identifier.update({
-      where: { id },
-      data: {
-        ...(input.value !== undefined && { value: input.value }),
-      },
-      include: {
-        scheme: true,
-      },
-    });
+    try {
+      return await tx.identifier.update({
+        where: { id },
+        data: {
+          ...(input.value !== undefined && { value: input.value }),
+        },
+        include: {
+          scheme: true,
+        },
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        conflict: 'An identifier with this value already exists for the scheme',
+        notFound: 'Identifier not found or access denied',
+      });
+    }
   });
 }
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
@@ -213,8 +213,12 @@ export async function deleteIdentifier(id: string, tenantId: string): Promise<Id
       throw new NotFoundError('Identifier not found or access denied');
     }
 
-    return tx.identifier.delete({
-      where: { id },
-    });
+    try {
+      return await tx.identifier.delete({
+        where: { id },
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'Identifier not found or access denied' });
+    }
   });
 }


### PR DESCRIPTION
This PR translates database errors into the API's domain errors at the repository boundary, so creating or updating an identifier that collides with an existing one now returns a clean 409 Conflict instead of a 500 carrying raw ORM detail, and any database error that escapes unmapped is sanitised to a generic 500 with the full detail logged server-side.

A shared helper (`src/lib/prisma/db-errors.ts`) owns Prisma error detection and mapping. `createIdentifier` and `updateIdentifier` adopt it (unique-constraint conflicts map to 409, the concurrent-delete race on update maps to 404), the three previously duplicated private unique-constraint guards now import the shared one, and the identifiers Swagger annotations document the new 409. ADR-036 records the pattern and its rejected alternatives; #708 tracks adoption across the remaining write routes.

Closes #706

## Test plan
- [x] Unique-constraint violation on identifier create and update returns 409 with a clean, entity-specific message
- [x] Update racing a concurrent delete returns 404 instead of a 500
- [x] Unmapped database errors return a generic 500 body with no ORM text, with the detail logged server-side under a distinct message
- [x] Non-database errors and every existing error mapping behave unchanged
- [x] Full reference-implementation suite passes (1509 tests, 114 suites)
