### PR TITLE
fix(ri): map database errors to domain errors across eight write repositories

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
@@ -121,6 +121,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: A data model with this name already exists for the credential type and version
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.ts
@@ -185,6 +185,12 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: A data model with this name already exists for the credential type and version
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -8,7 +8,7 @@ jest.mock('next/server', () => ({
 }));
 
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
+  const { ConflictError, NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
   const { ValidationError } = jest.requireActual('@/lib/api/validation');
 
   function jsonResponse(body: unknown, init?: { status?: number }) {
@@ -26,6 +26,9 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
           }
           if (e instanceof NotFoundError) {
             return jsonResponse({ error: (e as Error).message }, { status: 404 });
+          }
+          if (e instanceof ConflictError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 409 });
           }
           if (e instanceof ServiceRegistryError) {
             return jsonResponse({ error: (e as Error).message }, { status: 500 });
@@ -268,12 +271,9 @@ describe('POST /api/v1/dids/import', () => {
     expect(mockCreateDid).toHaveBeenCalledTimes(1);
   });
 
-  it('returns 500 when createDid throws a unique constraint error (duplicate DID)', async () => {
-    mockCreateDid.mockRejectedValueOnce(
-      Object.assign(new Error('Unique constraint failed on the fields: (`did`)'), {
-        code: 'P2002',
-      }),
-    );
+  it('returns 409 when createDid rejects with the duplicate-DID conflict', async () => {
+    const { ConflictError } = jest.requireActual('@/lib/api/errors');
+    mockCreateDid.mockRejectedValueOnce(new ConflictError('A DID record with this DID already exists'));
 
     const req = createFakeRequest({
       did: 'did:web:example.com',
@@ -285,8 +285,8 @@ describe('POST /api/v1/dids/import', () => {
     const res = await POST(req, createContext());
     const body = await res.json();
 
-    expect(res.status).toBe(500);
-    expect(body.error).toBeDefined();
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('A DID record with this DID already exists');
   });
 
   it('returns 500 when createDid rejects with a generic error', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -64,6 +64,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: A DID record with this DID already exists
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -79,7 +79,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
- *         description: A DID with this alias already exists on the service instance
+ *         description: A DID with this alias already exists on the service instance, or a DID record with this DID already exists
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -139,6 +139,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: The identifier is already the primary identifier of another facility
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -140,7 +140,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
- *         description: The identifier is already the primary identifier of another facility
+ *         description: The identifier is already the primary identifier of another facility, or a secondary identifier was concurrently linked by another request
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -73,6 +73,12 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: An identifier in this request is already the primary identifier of another facility
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -132,7 +132,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
- *         description: The identifier is already the primary identifier of another organisation
+ *         description: The identifier is already the primary identifier of another organisation, or a secondary identifier was concurrently linked by another request
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -131,6 +131,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: The identifier is already the primary identifier of another organisation
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -70,6 +70,12 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: An identifier in this request is already the primary identifier of another organisation
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -143,6 +143,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: The identifier is already the primary identifier of another product
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -144,7 +144,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
- *         description: The identifier is already the primary identifier of another product
+ *         description: The identifier is already the primary identifier of another product, or a secondary identifier was concurrently linked by another request
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/products/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.ts
@@ -89,6 +89,12 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: An identifier in this request is already the primary identifier of another product
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
@@ -198,6 +198,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: The registrar has schemes with identifiers and cannot be deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -140,7 +140,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
- *         description: An identifier scheme with this primary key already exists for the registrar
+ *         description: An identifier scheme with this primary key already exists for the registrar, or a qualifier with this key already exists for the scheme
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -139,6 +139,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: An identifier scheme with this primary key already exists for the registrar
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:
@@ -254,6 +260,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
  *         description: Scheme not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: The identifier scheme has identifiers and cannot be deleted
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.ts
@@ -88,6 +88,12 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: An identifier scheme with this primary key already exists for the registrar
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
@@ -7,6 +7,16 @@ jest.mock('next/server', () => ({
   },
 }));
 
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: { child: () => mockLogger },
+}));
+
 import {
   NotFoundError,
   ForbiddenError,
@@ -28,6 +38,8 @@ interface MockResponse {
 
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
+  mockLogger.warn.mockClear();
+  mockLogger.error.mockClear();
 });
 
 afterEach(() => {
@@ -130,11 +142,13 @@ describe('handleRouteError', () => {
   // --- Generic / unknown errors ---
 
   it('maps a generic Error to 500', async () => {
-    const res = handleRouteError(new Error('kaboom'));
+    const error = new Error('kaboom');
+    const res = handleRouteError(error);
 
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
     expect(body).toEqual({ error: 'kaboom' });
+    expect(mockLogger.error).toHaveBeenCalledWith({ err: error }, 'Unexpected error');
   });
 
   it('maps a non-Error value to 500 with fallback message', async () => {
@@ -157,6 +171,7 @@ describe('handleRouteError', () => {
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
     expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+    expect(mockLogger.error).toHaveBeenCalledWith({ err: dbError }, 'Unhandled database error');
   });
 
   it('sanitises a Prisma client validation error to a generic 500', async () => {
@@ -168,5 +183,6 @@ describe('handleRouteError', () => {
     expect(res.status).toBe(500);
     const body = await (res as unknown as MockResponse).json();
     expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+    expect(mockLogger.error).toHaveBeenCalledWith({ err: dbError }, 'Unhandled database error');
   });
 });

--- a/packages/reference-implementation/src/lib/api/resolve-closed-mode-tenant.test.ts
+++ b/packages/reference-implementation/src/lib/api/resolve-closed-mode-tenant.test.ts
@@ -17,6 +17,7 @@ const mockPrisma: any = {
 jest.mock('@/lib/prisma/prisma', () => ({ prisma: mockPrisma }));
 
 import { resolveClosedModeTenant } from './resolve-closed-mode-tenant';
+import { prismaError } from '@/lib/prisma/db-errors.fixtures';
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -109,5 +110,15 @@ describe('resolveClosedModeTenant', () => {
 
     const result = await resolveClosedModeTenant('/acme', 'sub-1');
     expect(result).toBeNull();
+  });
+
+  // Non-P2002 database error — must not be treated as the retry-worthy conflict
+  it('does not retry a database error that is not a unique-constraint violation', async () => {
+    mockPrisma.$transaction.mockRejectedValue(prismaError('P2025'));
+
+    const result = await resolveClosedModeTenant('/acme', 'sub-1');
+
+    expect(result).toBeNull();
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/reference-implementation/src/lib/api/resolve-closed-mode-tenant.test.ts
+++ b/packages/reference-implementation/src/lib/api/resolve-closed-mode-tenant.test.ts
@@ -93,7 +93,7 @@ describe('resolveClosedModeTenant', () => {
   // P2002 retry
   it('retries full resolution on P2002 unique constraint violation', async () => {
     // First attempt: transaction throws P2002
-    mockPrisma.$transaction.mockRejectedValueOnce({ code: 'P2002' });
+    mockPrisma.$transaction.mockRejectedValueOnce({ code: 'P2002', clientVersion: '6.0.0' });
     // Second attempt (retry): succeeds
     mockPrisma.$transaction.mockImplementationOnce((cb: (tx: unknown) => Promise<unknown>) => cb(mockPrisma));
     mockPrisma.tenant.findUnique.mockResolvedValue({ id: 'tenant-1' });

--- a/packages/reference-implementation/src/lib/api/service-account-user.test.ts
+++ b/packages/reference-implementation/src/lib/api/service-account-user.test.ts
@@ -158,7 +158,7 @@ describe('resolveServiceAccountUser', () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ id: 'user-race', tenantId: 'tenant-race' });
 
-    const p2002Error = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    const p2002Error = Object.assign(new Error('Unique constraint failed'), { code: 'P2002', clientVersion: '6.0.0' });
     mockPrisma.$transaction.mockRejectedValueOnce(p2002Error);
 
     const result = await resolveServiceAccountUser(CLAIMS);
@@ -172,7 +172,7 @@ describe('resolveServiceAccountUser', () => {
   it('returns null when retry lookup after P2002 still finds no user', async () => {
     mockPrisma.user.findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
 
-    const p2002Error = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    const p2002Error = Object.assign(new Error('Unique constraint failed'), { code: 'P2002', clientVersion: '6.0.0' });
     mockPrisma.$transaction.mockRejectedValueOnce(p2002Error);
 
     const result = await resolveServiceAccountUser(CLAIMS);

--- a/packages/reference-implementation/src/lib/prisma/db-errors.fixtures.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.fixtures.ts
@@ -1,0 +1,18 @@
+/**
+ * Test fixtures mirroring the error shapes the Prisma client throws, for
+ * suites that mock the client instead of running one. Kept beside
+ * db-errors.ts, whose duck-typed guards these shapes must satisfy;
+ * db-errors.test.ts anchors the shape against the real
+ * Prisma.PrismaClientKnownRequestError class so the fixtures and the guards
+ * cannot drift together.
+ */
+export function prismaError(code: 'P2002' | 'P2003' | 'P2025', message = 'Prisma request error'): Error {
+  const error = new Error(message);
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code, clientVersion: '6.19.2' });
+  return error;
+}
+
+export const prismaUniqueConstraintError = (message?: string): Error => prismaError('P2002', message);
+export const prismaForeignKeyViolationError = (message?: string): Error => prismaError('P2003', message);
+export const prismaRecordNotFoundError = (message?: string): Error => prismaError('P2025', message);

--- a/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
@@ -29,6 +29,11 @@ describe('isUniqueConstraintViolation', () => {
     expect(isUniqueConstraintViolation(null)).toBe(false);
     expect(isUniqueConstraintViolation('P2002')).toBe(false);
   });
+
+  it('rejects a non-Prisma error carrying a matching code property', () => {
+    const impostor = Object.assign(new Error('not from the ORM'), { code: 'P2002' });
+    expect(isUniqueConstraintViolation(impostor)).toBe(false);
+  });
 });
 
 describe('isForeignKeyViolation', () => {
@@ -36,12 +41,22 @@ describe('isForeignKeyViolation', () => {
     expect(isForeignKeyViolation(prismaKnownError('P2003'))).toBe(true);
     expect(isForeignKeyViolation(prismaKnownError('P2002'))).toBe(false);
   });
+
+  it('rejects a non-Prisma error carrying a matching code property', () => {
+    const impostor = Object.assign(new Error('not from the ORM'), { code: 'P2003' });
+    expect(isForeignKeyViolation(impostor)).toBe(false);
+  });
 });
 
 describe('isRecordNotFound', () => {
   it('matches only P2025', () => {
     expect(isRecordNotFound(prismaKnownError('P2025'))).toBe(true);
     expect(isRecordNotFound(prismaKnownError('P2003'))).toBe(false);
+  });
+
+  it('rejects a non-Prisma error carrying a matching code property', () => {
+    const impostor = Object.assign(new Error('not from the ORM'), { code: 'P2025' });
+    expect(isRecordNotFound(impostor)).toBe(false);
   });
 });
 

--- a/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.test.ts
@@ -1,3 +1,4 @@
+import { Prisma } from './generated';
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import {
@@ -7,24 +8,29 @@ import {
   isDatabaseError,
   mapDatabaseError,
 } from './db-errors';
+import {
+  prismaUniqueConstraintError,
+  prismaForeignKeyViolationError,
+  prismaRecordNotFoundError,
+} from './db-errors.fixtures';
 
-/** Mimics the shape of a PrismaClientKnownRequestError without depending on the generated client. */
-function prismaKnownError(code: string): Error {
-  const error = new Error(
-    `\nInvalid \`prisma.identifier.create()\` invocation:\n\nUnique constraint failed on the fields: (\`schemeId\`,\`value\`,\`tenantId\`)`,
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code, clientVersion: '6.0.0' });
-  return error;
+/** Runs a throwing function and returns the thrown value, for identity assertions. */
+function captureThrown(fn: () => void): unknown {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error('Expected function to throw');
 }
 
 describe('isUniqueConstraintViolation', () => {
   it('matches a P2002 error', () => {
-    expect(isUniqueConstraintViolation(prismaKnownError('P2002'))).toBe(true);
+    expect(isUniqueConstraintViolation(prismaUniqueConstraintError())).toBe(true);
   });
 
   it('rejects other Prisma codes, plain errors, and non-objects', () => {
-    expect(isUniqueConstraintViolation(prismaKnownError('P2025'))).toBe(false);
+    expect(isUniqueConstraintViolation(prismaRecordNotFoundError())).toBe(false);
     expect(isUniqueConstraintViolation(new Error('P2002'))).toBe(false);
     expect(isUniqueConstraintViolation(null)).toBe(false);
     expect(isUniqueConstraintViolation('P2002')).toBe(false);
@@ -34,12 +40,19 @@ describe('isUniqueConstraintViolation', () => {
     const impostor = Object.assign(new Error('not from the ORM'), { code: 'P2002' });
     expect(isUniqueConstraintViolation(impostor)).toBe(false);
   });
+
+  it('matches the code guards for a clientVersion-only error carrying a matching code', () => {
+    // Anchors the code guards to the clientVersion boundary-crossing signal
+    // (see isDatabaseError below), not just the PrismaClient*-named branch.
+    const impostor = Object.assign(new Error('lost identity'), { clientVersion: '6.19.2', code: 'P2002' });
+    expect(isUniqueConstraintViolation(impostor)).toBe(true);
+  });
 });
 
 describe('isForeignKeyViolation', () => {
   it('matches only P2003', () => {
-    expect(isForeignKeyViolation(prismaKnownError('P2003'))).toBe(true);
-    expect(isForeignKeyViolation(prismaKnownError('P2002'))).toBe(false);
+    expect(isForeignKeyViolation(prismaForeignKeyViolationError())).toBe(true);
+    expect(isForeignKeyViolation(prismaUniqueConstraintError())).toBe(false);
   });
 
   it('rejects a non-Prisma error carrying a matching code property', () => {
@@ -50,8 +63,8 @@ describe('isForeignKeyViolation', () => {
 
 describe('isRecordNotFound', () => {
   it('matches only P2025', () => {
-    expect(isRecordNotFound(prismaKnownError('P2025'))).toBe(true);
-    expect(isRecordNotFound(prismaKnownError('P2003'))).toBe(false);
+    expect(isRecordNotFound(prismaRecordNotFoundError())).toBe(true);
+    expect(isRecordNotFound(prismaForeignKeyViolationError())).toBe(false);
   });
 
   it('rejects a non-Prisma error carrying a matching code property', () => {
@@ -62,13 +75,21 @@ describe('isRecordNotFound', () => {
 
 describe('isDatabaseError', () => {
   it('matches errors carrying clientVersion', () => {
-    expect(isDatabaseError(prismaKnownError('P2002'))).toBe(true);
+    expect(isDatabaseError(prismaUniqueConstraintError())).toBe(true);
   });
 
   it('matches PrismaClient*-named errors without clientVersion', () => {
     const error = new Error('Argument `id`: Invalid value provided.');
     error.name = 'PrismaClientValidationError';
     expect(isDatabaseError(error)).toBe(true);
+  });
+
+  it('matches an object carrying clientVersion whose name does not start with PrismaClient', () => {
+    // clientVersion is the boundary-crossing signal: `name` can be lost when
+    // an error crosses a transaction callback or module boundary, but the
+    // ORM still attaches clientVersion.
+    const impostor = Object.assign(new Error('lost identity'), { clientVersion: '6.19.2' });
+    expect(isDatabaseError(impostor)).toBe(true);
   });
 
   it('rejects application errors and non-objects', () => {
@@ -82,40 +103,56 @@ describe('isDatabaseError', () => {
     Object.defineProperty(mangled, 'name', { value: undefined });
     expect(isDatabaseError(mangled)).toBe(false);
   });
+
+  it('recognises a real PrismaClientKnownRequestError instance', () => {
+    // Anchors the duck-type guards (and the fixtures module they share) against
+    // the real generated Prisma class, so the two cannot drift together.
+    const realError = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+      code: 'P2002',
+      clientVersion: '6.19.2',
+    });
+    expect(isDatabaseError(realError)).toBe(true);
+    expect(isUniqueConstraintViolation(realError)).toBe(true);
+  });
 });
 
 describe('mapDatabaseError', () => {
   it('maps P2002 to ConflictError with the contextual message', () => {
-    const call = () => mapDatabaseError(prismaKnownError('P2002'), { conflict: 'Identifier already exists' });
+    const call = () => mapDatabaseError(prismaUniqueConstraintError(), { conflict: 'Identifier already exists' });
 
     expect(call).toThrow(ConflictError);
     expect(call).toThrow('Identifier already exists');
   });
 
   it('maps P2025 to NotFoundError with the contextual message', () => {
-    expect(() => mapDatabaseError(prismaKnownError('P2025'), { notFound: 'Identifier not found' })).toThrow(
+    expect(() => mapDatabaseError(prismaRecordNotFoundError(), { notFound: 'Identifier not found' })).toThrow(
       NotFoundError,
     );
   });
 
   it('maps P2003 to ValidationError with the contextual message', () => {
     expect(() =>
-      mapDatabaseError(prismaKnownError('P2003'), { invalidReference: 'Referenced scheme does not exist' }),
+      mapDatabaseError(prismaForeignKeyViolationError(), { invalidReference: 'Referenced scheme does not exist' }),
     ).toThrow(ValidationError);
   });
 
   it('rethrows a database error whose code the context does not cover', () => {
-    const error = prismaKnownError('P2025');
-    expect(() => mapDatabaseError(error, { conflict: 'Identifier already exists' })).toThrow(error);
+    const error = prismaRecordNotFoundError();
+    const caught = captureThrown(() => mapDatabaseError(error, { conflict: 'Identifier already exists' }));
+    expect(caught).toBe(error);
   });
 
   it('rethrows non-database errors unchanged', () => {
     const error = new Error('network down');
-    expect(() => mapDatabaseError(error, { conflict: 'x', notFound: 'y', invalidReference: 'z' })).toThrow(error);
+    const caught = captureThrown(() =>
+      mapDatabaseError(error, { conflict: 'x', notFound: 'y', invalidReference: 'z' }),
+    );
+    expect(caught).toBe(error);
   });
 
   it('rethrows a non-database error even when it carries a matching code property', () => {
     const impostor = Object.assign(new Error('not from the ORM'), { code: 'P2002' });
-    expect(() => mapDatabaseError(impostor, { conflict: 'x' })).toThrow(impostor);
+    const caught = captureThrown(() => mapDatabaseError(impostor, { conflict: 'x' }));
+    expect(caught).toBe(impostor);
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/db-errors.ts
+++ b/packages/reference-implementation/src/lib/prisma/db-errors.ts
@@ -13,13 +13,11 @@ import { ValidationError } from '@/lib/api/validation';
  */
 
 function hasPrismaErrorCode(error: unknown, code: string): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof (error as { code: unknown }).code === 'string' &&
-    (error as { code: string }).code === code
-  );
+  // Gated on isDatabaseError so a non-Prisma error that happens to carry a
+  // matching `code` string is never misclassified as a constraint violation.
+  if (!isDatabaseError(error)) return false;
+  const candidate = error as { code?: unknown };
+  return typeof candidate.code === 'string' && candidate.code === code;
 }
 
 /** P2002: a unique-constraint violation (the record already exists). */
@@ -59,6 +57,11 @@ export function isDatabaseError(error: unknown): boolean {
  * Provide a message only for the outcomes the operation can actually produce;
  * anything else rethrows unchanged. At least one key is required: a call with
  * no context is a plain rethrow and should not be written as a mapping.
+ *
+ * A P2003 raised by a delete usually means an onDelete: Restrict relation
+ * blocked it, which a surface may treat as a conflict rather than a bad
+ * reference; call sites needing that semantic use the exported guards
+ * directly instead of `invalidReference`.
  */
 export type DatabaseErrorContext =
   | { conflict: string; notFound?: string; invalidReference?: string }

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
@@ -40,6 +40,11 @@ jest.mock('../prisma', () => ({
 // Import the mocked prisma after jest.mock
 import { prisma } from '../prisma';
 import { SYSTEM_TENANT_ID } from '../constants';
+import {
+  prismaForeignKeyViolationError,
+  prismaRecordNotFoundError,
+  prismaUniqueConstraintError,
+} from '../db-errors.fixtures';
 
 const mockDataModel = prisma.dataModel as unknown as {
   create: jest.Mock;
@@ -57,22 +62,6 @@ const DETAIL_INCLUDE_SHAPE = {
 const LIST_INCLUDE_SHAPE = {
   parentConfig: true,
 };
-
-function prismaUniqueConstraintError(): Error {
-  const error = new Error('Unique constraint failed on the fields: (`tenantId`,`name`,`credentialType`,`version`)');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaRecordNotFoundError(): Error {
-  const error = new Error(
-    'An operation failed because it depends on one or more records that were required but not found.',
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('data-model.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -452,6 +441,22 @@ describe('data-model.repository', () => {
       await expect(result).rejects.toThrow(NotFoundError);
       await expect(result).rejects.toThrow('Data model not found or access denied');
     });
+
+    it('rethrows a non-database error unchanged', async () => {
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      const dbError = new Error('connection lost');
+      mockTx.dataModel.update.mockRejectedValue(dbError);
+
+      await expect(updateDataModel('config-ext-1', TENANT_ID, { name: 'Updated Name' })).rejects.toBe(dbError);
+    });
+
+    it('rethrows a database error whose code the context does not cover', async () => {
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      const dbError = prismaForeignKeyViolationError();
+      mockTx.dataModel.update.mockRejectedValue(dbError);
+
+      await expect(updateDataModel('config-ext-1', TENANT_ID, { name: 'Updated Name' })).rejects.toBe(dbError);
+    });
   });
 
   describe('deleteDataModel', () => {
@@ -485,6 +490,22 @@ describe('data-model.repository', () => {
 
       await expect(result).rejects.toThrow(NotFoundError);
       await expect(result).rejects.toThrow('Data model not found or access denied');
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      const dbError = new Error('connection lost');
+      mockTx.dataModel.delete.mockRejectedValue(dbError);
+
+      await expect(deleteDataModel('config-ext-1', TENANT_ID)).rejects.toBe(dbError);
+    });
+
+    it('rethrows a database error whose code the context does not cover', async () => {
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      const dbError = prismaForeignKeyViolationError();
+      mockTx.dataModel.delete.mockRejectedValue(dbError);
+
+      await expect(deleteDataModel('config-ext-1', TENANT_ID)).rejects.toBe(dbError);
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.test.ts
@@ -5,6 +5,7 @@ import {
   updateDataModel,
   deleteDataModel,
 } from './data-model.repository';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 // Transaction mock — functions called via $transaction callback
@@ -56,6 +57,22 @@ const DETAIL_INCLUDE_SHAPE = {
 const LIST_INCLUDE_SHAPE = {
   parentConfig: true,
 };
+
+function prismaUniqueConstraintError(): Error {
+  const error = new Error('Unique constraint failed on the fields: (`tenantId`,`name`,`credentialType`,`version`)');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('data-model.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -208,6 +225,40 @@ describe('data-model.repository', () => {
         }),
         include: DETAIL_INCLUDE_SHAPE,
       });
+    });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockTx.dataModel.create.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = createDataModel(TENANT_ID, {
+        name: 'Digital Product Passport v0.6.0',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        isExtension: false,
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'A data model with this name already exists for the credential type and version',
+      );
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const dbError = new Error('connection lost');
+      mockTx.dataModel.create.mockRejectedValue(dbError);
+
+      await expect(
+        createDataModel(TENANT_ID, {
+          name: 'Digital Product Passport v0.6.0',
+          credentialType: 'DigitalProductPassport',
+          version: '0.6.0',
+          schemaUrl: 'https://example.com/schema.json',
+          contextUrl: 'https://example.com/context.jsonld',
+          isExtension: false,
+        }),
+      ).rejects.toThrow(dbError);
     });
   });
 
@@ -379,6 +430,28 @@ describe('data-model.repository', () => {
         include: DETAIL_INCLUDE_SHAPE,
       });
     });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.update.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = updateDataModel('config-ext-1', TENANT_ID, { name: 'Updated Name' });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'A data model with this name already exists for the credential type and version',
+      );
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateDataModel('config-ext-1', TENANT_ID, { name: 'Updated Name' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Data model not found or access denied');
+    });
   });
 
   describe('deleteDataModel', () => {
@@ -402,6 +475,16 @@ describe('data-model.repository', () => {
       await expect(deleteDataModel('config-1', 'other-tenant')).rejects.toThrow(
         'Data model not found or access denied',
       );
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.dataModel.findFirst.mockResolvedValue(EXTENSION_RECORD);
+      mockTx.dataModel.delete.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = deleteDataModel('config-ext-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Data model not found or access denied');
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/data-model.repository.ts
@@ -2,6 +2,7 @@ import { Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
+import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
@@ -104,20 +105,26 @@ export async function createDataModel(tenantId: string, input: CreateDataModelIn
       }
     }
 
-    return tx.dataModel.create({
-      data: {
-        tenantId,
-        name: input.name,
-        credentialType: input.credentialType,
-        version: input.version,
-        schemaUrl: input.schemaUrl,
-        contextUrl: input.contextUrl,
-        isExtension,
-        ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
-        ...(input.parentConfigId !== undefined && { parentConfigId: input.parentConfigId }),
-      },
-      include: DATA_MODEL_DETAIL_INCLUDE,
-    });
+    try {
+      return await tx.dataModel.create({
+        data: {
+          tenantId,
+          name: input.name,
+          credentialType: input.credentialType,
+          version: input.version,
+          schemaUrl: input.schemaUrl,
+          contextUrl: input.contextUrl,
+          isExtension,
+          ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
+          ...(input.parentConfigId !== undefined && { parentConfigId: input.parentConfigId }),
+        },
+        include: DATA_MODEL_DETAIL_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        conflict: 'A data model with this name already exists for the credential type and version',
+      });
+    }
   });
 }
 
@@ -195,16 +202,23 @@ export async function updateDataModel(
       throw new NotFoundError('Data model not found or access denied');
     }
 
-    return tx.dataModel.update({
-      where: { id },
-      data: {
-        ...(input.name !== undefined && { name: input.name }),
-        ...(input.schemaUrl !== undefined && { schemaUrl: input.schemaUrl }),
-        ...(input.contextUrl !== undefined && { contextUrl: input.contextUrl }),
-        ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
-      },
-      include: DATA_MODEL_DETAIL_INCLUDE,
-    });
+    try {
+      return await tx.dataModel.update({
+        where: { id },
+        data: {
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.schemaUrl !== undefined && { schemaUrl: input.schemaUrl }),
+          ...(input.contextUrl !== undefined && { contextUrl: input.contextUrl }),
+          ...(input.websiteUrl !== undefined && { websiteUrl: input.websiteUrl }),
+        },
+        include: DATA_MODEL_DETAIL_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        conflict: 'A data model with this name already exists for the credential type and version',
+        notFound: 'Data model not found or access denied',
+      });
+    }
   });
 }
 
@@ -223,6 +237,10 @@ export async function deleteDataModel(id: string, tenantId: string): Promise<voi
       throw new NotFoundError('Data model not found or access denied');
     }
 
-    await tx.dataModel.delete({ where: { id } });
+    try {
+      await tx.dataModel.delete({ where: { id } });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'Data model not found or access denied' });
+    }
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -41,6 +41,11 @@ jest.mock('../prisma', () => ({
 
 // Import the mocked prisma after jest.mock
 import { prisma } from '../prisma';
+import {
+  prismaUniqueConstraintError,
+  prismaForeignKeyViolationError,
+  prismaRecordNotFoundError,
+} from '../db-errors.fixtures';
 
 const mockDid = prisma.did as unknown as {
   create: jest.Mock;
@@ -48,29 +53,6 @@ const mockDid = prisma.did as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
-
-function prismaUniqueConstraintError(): Error {
-  const error = new Error('Unique constraint failed on the fields: (`did`)');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaForeignKeyError(): Error {
-  const error = new Error('Foreign key constraint failed on the field: `serviceInstanceId`');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaRecordNotFoundError(): Error {
-  const error = new Error(
-    'An operation failed because it depends on one or more records that were required but not found.',
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('did.repository', () => {
   const ORG_ID = 'org-1';
@@ -251,7 +233,7 @@ describe('did.repository', () => {
     });
 
     it('maps a foreign-key violation to ValidationError on the plain path', async () => {
-      mockDid.create.mockRejectedValue(prismaForeignKeyError());
+      mockDid.create.mockRejectedValue(prismaForeignKeyViolationError());
 
       const result = createDid({
         tenantId: ORG_ID,
@@ -267,7 +249,7 @@ describe('did.repository', () => {
 
     it('maps a foreign-key violation to ValidationError on the isDefault transaction path', async () => {
       mockTx.did.updateMany.mockResolvedValue({ count: 1 });
-      mockTx.did.create.mockRejectedValue(prismaForeignKeyError());
+      mockTx.did.create.mockRejectedValue(prismaForeignKeyViolationError());
 
       const result = createDid({
         tenantId: ORG_ID,
@@ -569,6 +551,22 @@ describe('did.repository', () => {
       await expect(result).rejects.toThrow(NotFoundError);
       await expect(result).rejects.toThrow('DID not found or access denied');
     });
+
+    it('rethrows a non-database error unchanged', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      const dbError = new Error('connection lost');
+      mockTx.did.update.mockRejectedValue(dbError);
+
+      await expect(updateDid('did-record-1', ORG_ID, { name: 'New Name' })).rejects.toBe(dbError);
+    });
+
+    it('rethrows a database error whose code the context does not cover', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      const dbError = prismaForeignKeyViolationError();
+      mockTx.did.update.mockRejectedValue(dbError);
+
+      await expect(updateDid('did-record-1', ORG_ID, { name: 'New Name' })).rejects.toBe(dbError);
+    });
   });
 
   describe('updateDidStatus', () => {
@@ -601,6 +599,22 @@ describe('did.repository', () => {
 
       await expect(result).rejects.toThrow(NotFoundError);
       await expect(result).rejects.toThrow('DID not found or access denied');
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      const dbError = new Error('connection lost');
+      mockTx.did.update.mockRejectedValue(dbError);
+
+      await expect(updateDidStatus('did-record-1', ORG_ID, 'VERIFIED' as DidStatus)).rejects.toBe(dbError);
+    });
+
+    it('rethrows a database error whose code the context does not cover', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      const dbError = prismaForeignKeyViolationError();
+      mockTx.did.update.mockRejectedValue(dbError);
+
+      await expect(updateDidStatus('did-record-1', ORG_ID, 'VERIFIED' as DidStatus)).rejects.toBe(dbError);
     });
   });
 
@@ -641,6 +655,22 @@ describe('did.repository', () => {
 
       await expect(result).rejects.toThrow(NotFoundError);
       await expect(result).rejects.toThrow('DID not found or access denied');
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      const dbError = new Error('connection lost');
+      mockTx.did.delete.mockRejectedValue(dbError);
+
+      await expect(deleteDid('did-record-1', ORG_ID)).rejects.toBe(dbError);
+    });
+
+    it('rethrows a database error whose code the context does not cover', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      const dbError = prismaForeignKeyViolationError();
+      mockTx.did.delete.mockRejectedValue(dbError);
+
+      await expect(deleteDid('did-record-1', ORG_ID)).rejects.toBe(dbError);
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -11,6 +11,8 @@ import {
 } from './did.repository';
 import { DidStatus } from '../generated';
 import { SYSTEM_TENANT_ID } from '../constants';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 // Transaction mock — functions called via $transaction callback
@@ -46,6 +48,29 @@ const mockDid = prisma.did as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
+
+function prismaUniqueConstraintError(): Error {
+  const error = new Error('Unique constraint failed on the fields: (`did`)');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaForeignKeyError(): Error {
+  const error = new Error('Foreign key constraint failed on the field: `serviceInstanceId`');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('did.repository', () => {
   const ORG_ID = 'org-1';
@@ -193,6 +218,82 @@ describe('did.repository', () => {
           serviceInstanceId: undefined,
         }),
       });
+    });
+
+    it('maps a unique-constraint violation to ConflictError on the plain path', async () => {
+      mockDid.create.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = createDid({
+        tenantId: ORG_ID,
+        did: 'did:web:example.com:org:123',
+        type: 'MANAGED',
+        keyId: 'key-1',
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('A DID record with this DID already exists');
+    });
+
+    it('maps a unique-constraint violation to ConflictError on the isDefault transaction path', async () => {
+      mockTx.did.updateMany.mockResolvedValue({ count: 1 });
+      mockTx.did.create.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = createDid({
+        tenantId: ORG_ID,
+        did: 'did:web:example.com:org:123',
+        type: 'MANAGED',
+        keyId: 'key-1',
+        isDefault: true,
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('A DID record with this DID already exists');
+    });
+
+    it('maps a foreign-key violation to ValidationError on the plain path', async () => {
+      mockDid.create.mockRejectedValue(prismaForeignKeyError());
+
+      const result = createDid({
+        tenantId: ORG_ID,
+        did: 'did:web:example.com:org:123',
+        type: 'MANAGED',
+        keyId: 'key-1',
+        serviceInstanceId: 'nonexistent',
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Service instance not found');
+    });
+
+    it('maps a foreign-key violation to ValidationError on the isDefault transaction path', async () => {
+      mockTx.did.updateMany.mockResolvedValue({ count: 1 });
+      mockTx.did.create.mockRejectedValue(prismaForeignKeyError());
+
+      const result = createDid({
+        tenantId: ORG_ID,
+        did: 'did:web:example.com:org:123',
+        type: 'MANAGED',
+        keyId: 'key-1',
+        isDefault: true,
+        serviceInstanceId: 'nonexistent',
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Service instance not found');
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const dbError = new Error('connection lost');
+      mockDid.create.mockRejectedValue(dbError);
+
+      await expect(
+        createDid({
+          tenantId: ORG_ID,
+          did: 'did:web:example.com:org:123',
+          type: 'MANAGED',
+          keyId: 'key-1',
+        }),
+      ).rejects.toThrow(dbError);
     });
   });
 
@@ -458,6 +559,16 @@ describe('did.repository', () => {
         'DID not found or access denied',
       );
     });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      mockTx.did.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateDid('did-record-1', ORG_ID, { name: 'New Name' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('DID not found or access denied');
+    });
   });
 
   describe('updateDidStatus', () => {
@@ -480,6 +591,16 @@ describe('did.repository', () => {
       await expect(updateDidStatus('did-record-1', 'other-org', 'VERIFIED' as DidStatus)).rejects.toThrow(
         'DID not found or access denied',
       );
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      mockTx.did.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateDidStatus('did-record-1', ORG_ID, 'VERIFIED' as DidStatus);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('DID not found or access denied');
     });
   });
 
@@ -510,6 +631,16 @@ describe('did.repository', () => {
 
       await expect(deleteDid('did-record-1', 'other-org')).rejects.toThrow('DID not found or access denied');
       expect(mockTx.did.delete).not.toHaveBeenCalled();
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.did.findFirst.mockResolvedValue(DID_RECORD);
+      mockTx.did.delete.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = deleteDid('did-record-1', ORG_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('DID not found or access denied');
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -1,6 +1,7 @@
 import { Did, DidStatus, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { NotFoundError } from '@/lib/api/errors';
+import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
@@ -59,21 +60,28 @@ export async function createDid(input: CreateDidInput): Promise<Did> {
     serviceInstanceId: input.serviceInstanceId,
   };
 
-  if (input.isDefault) {
-    return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
-      await tx.did.updateMany({
-        where: {
-          tenantId: input.tenantId,
-          isDefault: true,
-          type: { not: 'DEFAULT' },
-        },
-        data: { isDefault: false },
+  try {
+    if (input.isDefault) {
+      return await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        await tx.did.updateMany({
+          where: {
+            tenantId: input.tenantId,
+            isDefault: true,
+            type: { not: 'DEFAULT' },
+          },
+          data: { isDefault: false },
+        });
+        return tx.did.create({ data });
       });
-      return tx.did.create({ data });
+    }
+
+    return await prisma.did.create({ data });
+  } catch (e) {
+    mapDatabaseError(e, {
+      conflict: 'A DID record with this DID already exists',
+      invalidReference: 'Service instance not found',
     });
   }
-
-  return prisma.did.create({ data });
 }
 
 /**
@@ -202,14 +210,18 @@ export async function updateDid(id: string, tenantId: string, input: UpdateDidIn
       });
     }
 
-    return tx.did.update({
-      where: { id },
-      data: {
-        ...(input.name !== undefined && { name: input.name }),
-        ...(input.description !== undefined && { description: input.description }),
-        ...(input.isDefault !== undefined && { isDefault: input.isDefault }),
-      },
-    });
+    try {
+      return await tx.did.update({
+        where: { id },
+        data: {
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.description !== undefined && { description: input.description }),
+          ...(input.isDefault !== undefined && { isDefault: input.isDefault }),
+        },
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'DID not found or access denied' });
+    }
   });
 }
 
@@ -227,10 +239,14 @@ export async function updateDidStatus(id: string, tenantId: string, status: DidS
       throw new NotFoundError('DID not found or access denied');
     }
 
-    return tx.did.update({
-      where: { id },
-      data: { status },
-    });
+    try {
+      return await tx.did.update({
+        where: { id },
+        data: { status },
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'DID not found or access denied' });
+    }
   });
 }
 
@@ -248,9 +264,13 @@ export async function deleteDid(id: string, tenantId: string): Promise<void> {
       throw new NotFoundError('DID not found or access denied');
     }
 
-    await tx.did.delete({
-      where: { id },
-    });
+    try {
+      await tx.did.delete({
+        where: { id },
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'DID not found or access denied' });
+    }
   });
 }
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
@@ -5,6 +5,8 @@ import {
   updateFacility,
   deleteFacility,
 } from './facility.repository';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 // Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
@@ -49,6 +51,29 @@ const mockFacility = prisma.facility as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
+
+function prismaUniqueConstraintError(): Error {
+  const error = new Error('Unique constraint failed on the fields: (`primaryIdentifierId`)');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaForeignKeyViolationError(): Error {
+  const error = new Error('Foreign key constraint failed on the field: `identifierId`');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('facility.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -189,6 +214,33 @@ describe('facility.repository', () => {
           },
         ]),
       ).rejects.toThrow('Primary identifier must not also appear in secondary identifiers');
+    });
+
+    it('rejects duplicate secondary identifiers', async () => {
+      const result = createFacilities(TENANT_ID, [
+        { name: 'Warehouse', secondaryIdentifierIds: [SECONDARY_ID_A, SECONDARY_ID_A] },
+      ]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
+    });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockTx.facility.create.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = createFacilities(TENANT_ID, [{ name: 'Warehouse' }]);
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'An identifier in this request is already the primary identifier of another facility',
+      );
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const dbError = new Error('connection lost');
+      mockTx.facility.create.mockRejectedValue(dbError);
+
+      await expect(createFacilities(TENANT_ID, [{ name: 'Warehouse' }])).rejects.toThrow(dbError);
     });
   });
 
@@ -378,6 +430,23 @@ describe('facility.repository', () => {
       });
     });
 
+    it('maps a foreign-key violation on secondary-identifier replacement to ValidationError', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce({ id: SECONDARY_ID_A, tenantId: TENANT_ID })
+        .mockResolvedValueOnce({ id: SECONDARY_ID_B, tenantId: TENANT_ID });
+      mockTx.facilitySecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.facilitySecondaryIdentifier.createMany.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = updateFacility('facility-1', TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_A, SECONDARY_ID_B],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
+      expect(mockTx.facility.update).not.toHaveBeenCalled();
+    });
+
     it('clears secondary identifiers with empty array', async () => {
       mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
       mockTx.facilitySecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
@@ -397,6 +466,37 @@ describe('facility.repository', () => {
       await expect(updateFacility('facility-1', OTHER_TENANT, { name: 'Nope' })).rejects.toThrow(
         'Facility not found or access denied',
       );
+    });
+
+    it('rejects duplicate secondary identifiers', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+
+      const result = updateFacility('facility-1', TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_A, SECONDARY_ID_A],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
+    });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.update.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = updateFacility('facility-1', TENANT_ID, { name: 'Renamed Warehouse' });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('The identifier is already the primary identifier of another facility');
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateFacility('facility-1', TENANT_ID, { name: 'Renamed Warehouse' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Facility not found or access denied');
     });
   });
 
@@ -420,6 +520,16 @@ describe('facility.repository', () => {
       mockTx.facility.findFirst.mockResolvedValue(null);
 
       await expect(deleteFacility('facility-1', OTHER_TENANT)).rejects.toThrow('Facility not found or access denied');
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.delete.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = deleteFacility('facility-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Facility not found or access denied');
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
@@ -8,8 +8,13 @@ import {
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import {
+  prismaForeignKeyViolationError,
+  prismaRecordNotFoundError,
+  prismaUniqueConstraintError,
+} from '@/lib/prisma/db-errors.fixtures';
 
-// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+// Mock Prisma client. Use jest.fn() inside the factory to avoid hoisting issues.
 const mockTx = {
   identifier: {
     findFirst: jest.fn(),
@@ -20,6 +25,7 @@ const mockTx = {
   facility: {
     create: jest.fn(),
     findFirst: jest.fn(),
+    findUniqueOrThrow: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
   },
@@ -51,29 +57,6 @@ const mockFacility = prisma.facility as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
-
-function prismaUniqueConstraintError(): Error {
-  const error = new Error('Unique constraint failed on the fields: (`primaryIdentifierId`)');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaRecordNotFoundError(): Error {
-  const error = new Error(
-    'An operation failed because it depends on one or more records that were required but not found.',
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaForeignKeyViolationError(): Error {
-  const error = new Error('Foreign key constraint failed on the field: `identifierId`');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('facility.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -160,6 +143,41 @@ describe('facility.repository', () => {
       );
     });
 
+    it('creates a facility with primary and secondary identifiers', async () => {
+      mockTx.organisationEntity.findFirst.mockResolvedValue({ id: ORG_ID, tenantId: TENANT_ID });
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce({ id: PRIMARY_ID, tenantId: TENANT_ID }) // primary
+        .mockResolvedValueOnce({ id: SECONDARY_ID_A, tenantId: TENANT_ID }); // secondary
+
+      const createdFacility = { ...FACILITY_RECORD, secondaryIdentifiers: [] };
+      mockTx.facility.create.mockResolvedValue(createdFacility);
+      mockTx.facilitySecondaryIdentifier.createMany.mockResolvedValue({ count: 1 });
+      mockTx.facility.findUniqueOrThrow.mockResolvedValue(FACILITY_RECORD);
+
+      const result = await createFacilities(TENANT_ID, [
+        {
+          name: 'Main Warehouse',
+          operatingOrganisationId: ORG_ID,
+          primaryIdentifierId: PRIMARY_ID,
+          secondaryIdentifierIds: [SECONDARY_ID_A],
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(FACILITY_RECORD);
+      expect(mockTx.facilitySecondaryIdentifier.createMany).toHaveBeenCalledWith({
+        data: [{ facilityId: 'facility-1', identifierId: SECONDARY_ID_A }],
+      });
+      expect(mockTx.facility.findUniqueOrThrow).toHaveBeenCalledWith({
+        where: { id: 'facility-1' },
+        include: {
+          primaryIdentifier: { include: { scheme: { include: { registrar: true } } } },
+          secondaryIdentifiers: { include: { identifier: { include: { scheme: { include: { registrar: true } } } } } },
+          operatingOrganisation: true,
+        },
+      });
+    });
+
     it('creates multiple facilities', async () => {
       mockTx.facility.create.mockResolvedValue(FACILITY_RECORD);
 
@@ -237,10 +255,30 @@ describe('facility.repository', () => {
     });
 
     it('rethrows a non-database error unchanged', async () => {
-      const dbError = new Error('connection lost');
-      mockTx.facility.create.mockRejectedValue(dbError);
+      const nonDatabaseError = new Error('connection lost');
+      mockTx.facility.create.mockRejectedValue(nonDatabaseError);
 
-      await expect(createFacilities(TENANT_ID, [{ name: 'Warehouse' }])).rejects.toThrow(dbError);
+      await expect(createFacilities(TENANT_ID, [{ name: 'Warehouse' }])).rejects.toThrow(nonDatabaseError);
+    });
+
+    it('maps a foreign-key violation on facility creation to ValidationError', async () => {
+      mockTx.facility.create.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = createFacilities(TENANT_ID, [{ name: 'Warehouse' }]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced organisation or identifier no longer exists');
+    });
+
+    it('maps a foreign-key violation on secondary-identifier join creation to ValidationError', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_A, tenantId: TENANT_ID });
+      mockTx.facility.create.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facilitySecondaryIdentifier.createMany.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = createFacilities(TENANT_ID, [{ name: 'Warehouse', secondaryIdentifierIds: [SECONDARY_ID_A] }]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
     });
   });
 
@@ -443,7 +481,26 @@ describe('facility.repository', () => {
       });
 
       await expect(result).rejects.toThrow(ValidationError);
-      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
+      await expect(result).rejects.toThrow('The facility or one or more secondary identifiers no longer exist');
+      expect(mockTx.facility.update).not.toHaveBeenCalled();
+    });
+
+    it('maps a unique-constraint violation on secondary-identifier replacement to ConflictError', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.identifier.findFirst
+        .mockResolvedValueOnce({ id: SECONDARY_ID_A, tenantId: TENANT_ID })
+        .mockResolvedValueOnce({ id: SECONDARY_ID_B, tenantId: TENANT_ID });
+      mockTx.facilitySecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.facilitySecondaryIdentifier.createMany.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = updateFacility('facility-1', TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_A, SECONDARY_ID_B],
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'One or more secondary identifiers were concurrently linked to this facility; retry the request',
+      );
       expect(mockTx.facility.update).not.toHaveBeenCalled();
     });
 
@@ -496,7 +553,7 @@ describe('facility.repository', () => {
       const result = updateFacility('facility-1', TENANT_ID, { name: 'Renamed Warehouse' });
 
       await expect(result).rejects.toThrow(NotFoundError);
-      await expect(result).rejects.toThrow('Facility not found or access denied');
+      await expect(result).rejects.toThrow('Facility or a referenced resource not found');
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
@@ -149,31 +149,47 @@ export async function createFacilities(
       }
 
       // Create the facility entity
+      let facility: FacilityWithRelations;
       try {
-        results.push(
-          await tx.facility.create({
-            data: {
-              tenantId,
-              name,
-              description,
-              location: location ? (location as Prisma.InputJsonValue) : undefined,
-              operatingOrganisationId,
-              primaryIdentifierId,
-              ...(secondaryIdentifierIds?.length && {
-                secondaryIdentifiers: {
-                  createMany: {
-                    data: secondaryIdentifierIds.map((identifierId: string) => ({ identifierId })),
-                  },
-                },
-              }),
-            },
-            include: FACILITY_DETAIL_INCLUDE,
-          }),
-        );
+        facility = await tx.facility.create({
+          data: {
+            tenantId,
+            name,
+            description,
+            location: location ? (location as Prisma.InputJsonValue) : undefined,
+            operatingOrganisationId,
+            primaryIdentifierId,
+          },
+          include: FACILITY_DETAIL_INCLUDE,
+        });
       } catch (e) {
         mapDatabaseError(e, {
           conflict: 'An identifier in this request is already the primary identifier of another facility',
+          invalidReference: 'The referenced organisation or identifier no longer exists',
         });
+      }
+
+      // Create join rows for secondary identifiers
+      if (secondaryIdentifierIds?.length) {
+        try {
+          await tx.facilitySecondaryIdentifier.createMany({
+            data: secondaryIdentifierIds.map((identifierId: string) => ({
+              facilityId: facility.id,
+              identifierId,
+            })),
+          });
+        } catch (e) {
+          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+        }
+
+        // Re-fetch to include the newly created secondary identifier relations
+        const refetched = await tx.facility.findUniqueOrThrow({
+          where: { id: facility.id },
+          include: FACILITY_DETAIL_INCLUDE,
+        });
+        results.push(refetched);
+      } else {
+        results.push(facility);
       }
     }
 
@@ -299,7 +315,10 @@ export async function updateFacility(
             })),
           });
         } catch (e) {
-          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+          mapDatabaseError(e, {
+            conflict: 'One or more secondary identifiers were concurrently linked to this facility; retry the request',
+            invalidReference: 'The facility or one or more secondary identifiers no longer exist',
+          });
         }
       }
     }
@@ -333,7 +352,7 @@ export async function updateFacility(
     } catch (e) {
       mapDatabaseError(e, {
         conflict: 'The identifier is already the primary identifier of another facility',
-        notFound: 'Facility not found or access denied',
+        notFound: 'Facility or a referenced resource not found',
       });
     }
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
@@ -1,6 +1,7 @@
 import { Facility, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { NotFoundError } from '@/lib/api/errors';
+import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { UntpLocation } from '@/lib/types';
@@ -93,6 +94,22 @@ async function validateIdentifierOwnership(
 }
 
 /**
+ * Validates that the primary identifier is not also listed as a secondary
+ * identifier, and that secondary identifiers contain no duplicates.
+ */
+function validateNoPrimarySecondaryOverlap(
+  primaryIdentifierId: string | undefined | null,
+  secondaryIdentifierIds: string[],
+): void {
+  if (primaryIdentifierId && secondaryIdentifierIds.includes(primaryIdentifierId)) {
+    throw new ValidationError('Primary identifier must not also appear in secondary identifiers');
+  }
+  if (new Set(secondaryIdentifierIds).size !== secondaryIdentifierIds.length) {
+    throw new ValidationError('Secondary identifiers must not contain duplicates');
+  }
+}
+
+/**
  * Creates one or more facilities within a transaction.
  * Validates identifier ownership, organisation FK, and primary/secondary overlap.
  * Returns the created facilities with all includes.
@@ -125,35 +142,39 @@ export async function createFacilities(
 
       // Validate secondary identifier ownership and check for overlap with primary
       if (secondaryIdentifierIds?.length) {
-        if (primaryIdentifierId && secondaryIdentifierIds.includes(primaryIdentifierId)) {
-          throw new ValidationError('Primary identifier must not also appear in secondary identifiers');
-        }
+        validateNoPrimarySecondaryOverlap(primaryIdentifierId, secondaryIdentifierIds);
         for (const secId of secondaryIdentifierIds) {
           await validateIdentifierOwnership(tx, secId, tenantId, 'Secondary identifier');
         }
       }
 
       // Create the facility entity
-      const facility = await tx.facility.create({
-        data: {
-          tenantId,
-          name,
-          description,
-          location: location ? (location as Prisma.InputJsonValue) : undefined,
-          operatingOrganisationId,
-          primaryIdentifierId,
-          ...(secondaryIdentifierIds?.length && {
-            secondaryIdentifiers: {
-              createMany: {
-                data: secondaryIdentifierIds.map((identifierId: string) => ({ identifierId })),
-              },
+      try {
+        results.push(
+          await tx.facility.create({
+            data: {
+              tenantId,
+              name,
+              description,
+              location: location ? (location as Prisma.InputJsonValue) : undefined,
+              operatingOrganisationId,
+              primaryIdentifierId,
+              ...(secondaryIdentifierIds?.length && {
+                secondaryIdentifiers: {
+                  createMany: {
+                    data: secondaryIdentifierIds.map((identifierId: string) => ({ identifierId })),
+                  },
+                },
+              }),
             },
+            include: FACILITY_DETAIL_INCLUDE,
           }),
-        },
-        include: FACILITY_DETAIL_INCLUDE,
-      });
-
-      results.push(facility);
+        );
+      } catch (e) {
+        mapDatabaseError(e, {
+          conflict: 'An identifier in this request is already the primary identifier of another facility',
+        });
+      }
     }
 
     return results;
@@ -260,9 +281,7 @@ export async function updateFacility(
     // Validate secondary identifiers and check for overlap with primary
     if (secondaryIdentifierIds !== undefined) {
       const effectivePrimaryId = primaryIdentifierId === undefined ? existing.primaryIdentifierId : primaryIdentifierId;
-      if (effectivePrimaryId && secondaryIdentifierIds.includes(effectivePrimaryId)) {
-        throw new ValidationError('Primary identifier must not also appear in secondary identifiers');
-      }
+      validateNoPrimarySecondaryOverlap(effectivePrimaryId, secondaryIdentifierIds);
       for (const secId of secondaryIdentifierIds) {
         await validateIdentifierOwnership(tx, secId, tenantId, 'Secondary identifier');
       }
@@ -272,12 +291,16 @@ export async function updateFacility(
         where: { facilityId: id },
       });
       if (secondaryIdentifierIds.length > 0) {
-        await tx.facilitySecondaryIdentifier.createMany({
-          data: secondaryIdentifierIds.map((identifierId: string) => ({
-            facilityId: id,
-            identifierId,
-          })),
-        });
+        try {
+          await tx.facilitySecondaryIdentifier.createMany({
+            data: secondaryIdentifierIds.map((identifierId: string) => ({
+              facilityId: id,
+              identifierId,
+            })),
+          });
+        } catch (e) {
+          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+        }
       }
     }
 
@@ -301,11 +324,18 @@ export async function updateFacility(
       data.primaryIdentifier = { connect: { id: primaryIdentifierId } };
     }
 
-    return tx.facility.update({
-      where: { id },
-      data,
-      include: FACILITY_DETAIL_INCLUDE,
-    });
+    try {
+      return await tx.facility.update({
+        where: { id },
+        data,
+        include: FACILITY_DETAIL_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        conflict: 'The identifier is already the primary identifier of another facility',
+        notFound: 'Facility not found or access denied',
+      });
+    }
   });
 }
 
@@ -339,8 +369,12 @@ export async function deleteFacility(id: string, tenantId: string): Promise<Faci
       throw new NotFoundError('Facility not found or access denied');
     }
 
-    return tx.facility.delete({
-      where: { id },
-    });
+    try {
+      return await tx.facility.delete({
+        where: { id },
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'Facility not found or access denied' });
+    }
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
@@ -5,6 +5,8 @@ import {
   updateIdentifierScheme,
   deleteIdentifierScheme,
 } from './identifier-scheme.repository';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { SYSTEM_TENANT_ID } from '../constants';
 
@@ -17,6 +19,7 @@ const mockTx = {
   },
   schemeQualifier: {
     deleteMany: jest.fn(),
+    createMany: jest.fn(),
   },
 };
 
@@ -42,6 +45,29 @@ const mockIdentifierScheme = prisma.identifierScheme as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
+
+function prismaUniqueConstraintError(): Error {
+  const error = new Error('Unique constraint failed on the fields: (`registrarId`,`primaryKey`)');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaForeignKeyViolationError(): Error {
+  const error = new Error('Foreign key constraint failed on the field: `registrarId`');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('identifier-scheme.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -141,6 +167,75 @@ describe('identifier-scheme.repository', () => {
           registrar: true,
         },
       });
+    });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockIdentifierScheme.create.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = createIdentifierScheme({
+        tenantId: TENANT_ID,
+        registrarId: REGISTRAR_ID,
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{13,14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'An identifier scheme with this primary key already exists for the registrar',
+      );
+    });
+
+    it('maps a foreign-key violation to ValidationError', async () => {
+      mockIdentifierScheme.create.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = createIdentifierScheme({
+        tenantId: TENANT_ID,
+        registrarId: 'nonexistent-registrar',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{13,14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced registrar or IDR service instance does not exist');
+    });
+
+    it('rejects duplicate qualifier keys without hitting the database', async () => {
+      const result = createIdentifierScheme({
+        tenantId: TENANT_ID,
+        registrarId: REGISTRAR_ID,
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{13,14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [
+          { key: 'batch', description: 'Batch number', validationPattern: '^[A-Za-z0-9]{1,20}$' },
+          { key: 'batch', description: 'Duplicate batch', validationPattern: '^[A-Za-z0-9]{1,20}$' },
+        ],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Qualifier keys must be unique');
+      expect(mockIdentifierScheme.create).not.toHaveBeenCalled();
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const connectionError = new Error('connection lost');
+      mockIdentifierScheme.create.mockRejectedValue(connectionError);
+
+      await expect(
+        createIdentifierScheme({
+          tenantId: TENANT_ID,
+          registrarId: REGISTRAR_ID,
+          name: 'GTIN',
+          primaryKey: 'gtin',
+          validationPattern: '^\\d{13,14}$',
+          linkTemplate: '/{primaryKey}/{value}',
+        }),
+      ).rejects.toThrow(connectionError);
     });
   });
 
@@ -266,6 +361,7 @@ describe('identifier-scheme.repository', () => {
     it('replaces qualifiers when provided', async () => {
       mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
       mockTx.schemeQualifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.schemeQualifier.createMany.mockResolvedValue({ count: 1 });
       mockTx.identifierScheme.update.mockResolvedValue({
         ...SCHEME_RECORD,
         qualifiers: [
@@ -288,18 +384,44 @@ describe('identifier-scheme.repository', () => {
       expect(mockTx.schemeQualifier.deleteMany).toHaveBeenCalledWith({
         where: { schemeId: 'scheme-1' },
       });
+      expect(mockTx.schemeQualifier.createMany).toHaveBeenCalledWith({
+        data: [{ schemeId: 'scheme-1', key: 'serial', description: 'Serial number', validationPattern: '^[A-Z0-9]+$' }],
+      });
       expect(mockTx.identifierScheme.update).toHaveBeenCalledWith({
         where: { id: 'scheme-1' },
-        data: {
-          qualifiers: {
-            create: [{ key: 'serial', description: 'Serial number', validationPattern: '^[A-Z0-9]+$' }],
-          },
-        },
+        data: {},
         include: {
           qualifiers: true,
           registrar: true,
         },
       });
+    });
+
+    it('does not call schemeQualifier.createMany when qualifiers is an empty array', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.schemeQualifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.identifierScheme.update.mockResolvedValue({ ...SCHEME_RECORD, qualifiers: [] });
+
+      await updateIdentifierScheme('scheme-1', TENANT_ID, { qualifiers: [] });
+
+      expect(mockTx.schemeQualifier.deleteMany).toHaveBeenCalledWith({
+        where: { schemeId: 'scheme-1' },
+      });
+      expect(mockTx.schemeQualifier.createMany).not.toHaveBeenCalled();
+    });
+
+    it('maps a unique-constraint violation on qualifier creation to ConflictError with a clean message', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.schemeQualifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.schemeQualifier.createMany.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = updateIdentifierScheme('scheme-1', TENANT_ID, {
+        qualifiers: [{ key: 'serial', description: 'Serial number', validationPattern: '^[A-Z0-9]+$' }],
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('A qualifier with this key already exists for the scheme');
+      expect(mockTx.identifierScheme.update).not.toHaveBeenCalled();
     });
 
     it('allows setting idrServiceInstanceId to null', async () => {
@@ -325,6 +447,55 @@ describe('identifier-scheme.repository', () => {
         'Identifier scheme not found or access denied',
       );
     });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.update.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = updateIdentifierScheme('scheme-1', TENANT_ID, { primaryKey: 'gtin-14' });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'An identifier scheme with this primary key already exists for the registrar',
+      );
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateIdentifierScheme('scheme-1', TENANT_ID, { name: 'GTIN-14' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Identifier scheme not found or access denied');
+    });
+
+    it('maps a foreign-key violation to ValidationError', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.update.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = updateIdentifierScheme('scheme-1', TENANT_ID, { idrServiceInstanceId: 'nonexistent-si' });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced IDR service instance does not exist');
+    });
+
+    it('rejects duplicate qualifier keys without hitting the database', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+
+      const result = updateIdentifierScheme('scheme-1', TENANT_ID, {
+        qualifiers: [
+          { key: 'serial', description: 'Serial number', validationPattern: '^[A-Z0-9]+$' },
+          { key: 'serial', description: 'Duplicate serial', validationPattern: '^[A-Z0-9]+$' },
+        ],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Qualifier keys must be unique');
+      expect(mockTx.schemeQualifier.deleteMany).not.toHaveBeenCalled();
+      expect(mockTx.schemeQualifier.createMany).not.toHaveBeenCalled();
+      expect(mockTx.identifierScheme.update).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteIdentifierScheme', () => {
@@ -349,6 +520,26 @@ describe('identifier-scheme.repository', () => {
       await expect(deleteIdentifierScheme('scheme-1', 'other-tenant')).rejects.toThrow(
         'Identifier scheme not found or access denied',
       );
+    });
+
+    it('maps a foreign-key violation to ConflictError when identifiers still reference the scheme', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.delete.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = deleteIdentifierScheme('scheme-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('The identifier scheme has identifiers and cannot be deleted');
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.identifierScheme.delete.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = deleteIdentifierScheme('scheme-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Identifier scheme not found or access denied');
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
@@ -38,6 +38,11 @@ jest.mock('../prisma', () => ({
 
 // Import the mocked prisma after jest.mock
 import { prisma } from '../prisma';
+import {
+  prismaUniqueConstraintError,
+  prismaForeignKeyViolationError,
+  prismaRecordNotFoundError,
+} from '../db-errors.fixtures';
 
 const mockIdentifierScheme = prisma.identifierScheme as unknown as {
   create: jest.Mock;
@@ -45,29 +50,6 @@ const mockIdentifierScheme = prisma.identifierScheme as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
-
-function prismaUniqueConstraintError(): Error {
-  const error = new Error('Unique constraint failed on the fields: (`registrarId`,`primaryKey`)');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaRecordNotFoundError(): Error {
-  const error = new Error(
-    'An operation failed because it depends on one or more records that were required but not found.',
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaForeignKeyViolationError(): Error {
-  const error = new Error('Foreign key constraint failed on the field: `registrarId`');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('identifier-scheme.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -540,6 +522,22 @@ describe('identifier-scheme.repository', () => {
 
       await expect(result).rejects.toThrow(NotFoundError);
       await expect(result).rejects.toThrow('Identifier scheme not found or access denied');
+    });
+
+    it('rejects a unique-constraint violation with the original error (uncovered code)', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      const dbError = prismaUniqueConstraintError();
+      mockTx.identifierScheme.delete.mockRejectedValue(dbError);
+
+      await expect(deleteIdentifierScheme('scheme-1', TENANT_ID)).rejects.toBe(dbError);
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      const dbError = new Error('connection lost');
+      mockTx.identifierScheme.delete.mockRejectedValue(dbError);
+
+      await expect(deleteIdentifierScheme('scheme-1', TENANT_ID)).rejects.toBe(dbError);
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.ts
@@ -1,7 +1,9 @@
 import { IdentifierScheme, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { SYSTEM_TENANT_ID } from '../constants';
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { isForeignKeyViolation, mapDatabaseError } from '@/lib/prisma/db-errors';
+import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 /**
@@ -52,34 +54,56 @@ export type ListIdentifierSchemesOptions = {
 };
 
 /**
+ * Rejects duplicate qualifier keys within a single request. Duplicates in the
+ * request array are deterministic input, so they are validated up front rather
+ * than surfaced through the (schemeId, key) unique constraint.
+ */
+function validateQualifierKeys(qualifiers: QualifierInput[] | undefined): void {
+  if (!qualifiers) return;
+  const keys = qualifiers.map((q: QualifierInput) => q.key);
+  if (new Set(keys).size !== keys.length) {
+    throw new ValidationError('Qualifier keys must be unique');
+  }
+}
+
+/**
  * Creates a new identifier scheme with optional nested qualifiers.
  */
 export async function createIdentifierScheme(input: CreateIdentifierSchemeInput): Promise<IdentifierScheme> {
-  return prisma.identifierScheme.create({
-    data: {
-      tenantId: input.tenantId,
-      registrarId: input.registrarId,
-      name: input.name,
-      primaryKey: input.primaryKey,
-      validationPattern: input.validationPattern,
-      linkTemplate: input.linkTemplate,
-      idrServiceInstanceId: input.idrServiceInstanceId,
-      ...(input.qualifiers && {
-        qualifiers: {
-          create: input.qualifiers.map((q: QualifierInput) => ({
-            key: q.key,
-            description: q.description,
-            validationPattern: q.validationPattern,
-            ...(q.order !== undefined && { order: q.order }),
-          })),
-        },
-      }),
-    },
-    include: {
-      qualifiers: true,
-      registrar: true,
-    },
-  });
+  validateQualifierKeys(input.qualifiers);
+
+  try {
+    return await prisma.identifierScheme.create({
+      data: {
+        tenantId: input.tenantId,
+        registrarId: input.registrarId,
+        name: input.name,
+        primaryKey: input.primaryKey,
+        validationPattern: input.validationPattern,
+        linkTemplate: input.linkTemplate,
+        idrServiceInstanceId: input.idrServiceInstanceId,
+        ...(input.qualifiers && {
+          qualifiers: {
+            create: input.qualifiers.map((q: QualifierInput) => ({
+              key: q.key,
+              description: q.description,
+              validationPattern: q.validationPattern,
+              ...(q.order !== undefined && { order: q.order }),
+            })),
+          },
+        }),
+      },
+      include: {
+        qualifiers: true,
+        registrar: true,
+      },
+    });
+  } catch (e) {
+    mapDatabaseError(e, {
+      conflict: 'An identifier scheme with this primary key already exists for the registrar',
+      invalidReference: 'The referenced registrar or IDR service instance does not exist',
+    });
+  }
 }
 
 /**
@@ -153,39 +177,57 @@ export async function updateIdentifierScheme(
       throw new NotFoundError('Identifier scheme not found or access denied');
     }
 
-    // If qualifiers are provided, delete existing and recreate
+    validateQualifierKeys(input.qualifiers);
+
+    // If qualifiers are provided, delete existing and recreate. The recreate
+    // is guarded separately from the scheme update so a unique-constraint
+    // violation on (schemeId, key), such as a concurrent update racing this
+    // one, reports the qualifier conflict rather than a primary-key conflict.
     if (input.qualifiers !== undefined) {
       await tx.schemeQualifier.deleteMany({
         where: { schemeId: id },
       });
-    }
-
-    return tx.identifierScheme.update({
-      where: { id },
-      data: {
-        ...(input.name !== undefined && { name: input.name }),
-        ...(input.primaryKey !== undefined && { primaryKey: input.primaryKey }),
-        ...(input.validationPattern !== undefined && { validationPattern: input.validationPattern }),
-        ...(input.linkTemplate !== undefined && { linkTemplate: input.linkTemplate }),
-        ...(input.idrServiceInstanceId !== undefined && {
-          idrServiceInstanceId: input.idrServiceInstanceId,
-        }),
-        ...(input.qualifiers !== undefined && {
-          qualifiers: {
-            create: input.qualifiers.map((q: QualifierInput) => ({
+      if (input.qualifiers.length > 0) {
+        try {
+          await tx.schemeQualifier.createMany({
+            data: input.qualifiers.map((q: QualifierInput) => ({
+              schemeId: id,
               key: q.key,
               description: q.description,
               validationPattern: q.validationPattern,
               ...(q.order !== undefined && { order: q.order }),
             })),
-          },
-        }),
-      },
-      include: {
-        qualifiers: true,
-        registrar: true,
-      },
-    });
+          });
+        } catch (e) {
+          mapDatabaseError(e, { conflict: 'A qualifier with this key already exists for the scheme' });
+        }
+      }
+    }
+
+    try {
+      return await tx.identifierScheme.update({
+        where: { id },
+        data: {
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.primaryKey !== undefined && { primaryKey: input.primaryKey }),
+          ...(input.validationPattern !== undefined && { validationPattern: input.validationPattern }),
+          ...(input.linkTemplate !== undefined && { linkTemplate: input.linkTemplate }),
+          ...(input.idrServiceInstanceId !== undefined && {
+            idrServiceInstanceId: input.idrServiceInstanceId,
+          }),
+        },
+        include: {
+          qualifiers: true,
+          registrar: true,
+        },
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        conflict: 'An identifier scheme with this primary key already exists for the registrar',
+        notFound: 'Identifier scheme not found or access denied',
+        invalidReference: 'The referenced IDR service instance does not exist',
+      });
+    }
   });
 }
 
@@ -203,8 +245,18 @@ export async function deleteIdentifierScheme(id: string, tenantId: string): Prom
       throw new NotFoundError('Identifier scheme not found or access denied');
     }
 
-    return tx.identifierScheme.delete({
-      where: { id },
-    });
+    try {
+      return await tx.identifierScheme.delete({
+        where: { id },
+      });
+    } catch (e) {
+      // Identifier.scheme is declared with onDelete: Restrict, so the
+      // foreign-key violation here means dependants block the delete (a
+      // conflict), not that a referenced record is missing (a bad request).
+      if (isForeignKeyViolation(e)) {
+        throw new ConflictError('The identifier scheme has identifiers and cannot be deleted');
+      }
+      mapDatabaseError(e, { notFound: 'Identifier scheme not found or access denied' });
+    }
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
@@ -5,9 +5,10 @@ import {
   updateIdentifier,
   deleteIdentifier,
 } from './identifier.repository';
-import { ConflictError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { SYSTEM_TENANT_ID } from '../constants';
+import { prismaUniqueConstraintError, prismaRecordNotFoundError } from '../db-errors.fixtures';
 
 // Transaction mock — functions called via $transaction callback
 const mockTx = {
@@ -42,13 +43,6 @@ const mockIdentifier = prisma.identifier as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
-
-function prismaUniqueConstraintError(): Error {
-  const error = new Error('Unique constraint failed on the fields: (`schemeId`,`value`,`tenantId`)');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('identifier.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -274,24 +268,21 @@ describe('identifier.repository', () => {
       mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
       mockTx.identifier.update.mockRejectedValue(prismaUniqueConstraintError());
 
-      await expect(updateIdentifier('ident-1', TENANT_ID, { value: '1234567890123' })).rejects.toThrow(
-        'An identifier with this value already exists for the scheme',
-      );
+      const result = updateIdentifier('ident-1', TENANT_ID, { value: '1234567890123' });
+
+      await expect(result).rejects.toBeInstanceOf(ConflictError);
+      await expect(result).rejects.toThrow('An identifier with this value already exists for the scheme');
     });
 
     it('maps a record-not-found race to NotFoundError', async () => {
       mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
       mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
-      const raceError = new Error(
-        'An operation failed because it depends on one or more records that were required but not found.',
-      );
-      raceError.name = 'PrismaClientKnownRequestError';
-      Object.assign(raceError, { code: 'P2025', clientVersion: '6.0.0' });
-      mockTx.identifier.update.mockRejectedValue(raceError);
+      mockTx.identifier.update.mockRejectedValue(prismaRecordNotFoundError());
 
-      await expect(updateIdentifier('ident-1', TENANT_ID, { value: '1234567890123' })).rejects.toThrow(
-        'Identifier not found or access denied',
-      );
+      const result = updateIdentifier('ident-1', TENANT_ID, { value: '1234567890123' });
+
+      await expect(result).rejects.toBeInstanceOf(NotFoundError);
+      await expect(result).rejects.toThrow('Identifier not found or access denied');
     });
 
     it('throws ValidationError if the new value does not match the pattern', async () => {
@@ -330,12 +321,12 @@ describe('identifier.repository', () => {
 
     it('maps a record-not-found race to NotFoundError', async () => {
       mockTx.identifier.findFirst.mockResolvedValue(IDENTIFIER_RECORD);
-      const raceError = new Error('Record to delete does not exist.');
-      raceError.name = 'PrismaClientKnownRequestError';
-      Object.assign(raceError, { code: 'P2025', clientVersion: '6.0.0' });
-      mockTx.identifier.delete.mockRejectedValue(raceError);
+      mockTx.identifier.delete.mockRejectedValue(prismaRecordNotFoundError());
 
-      await expect(deleteIdentifier('ident-1', TENANT_ID)).rejects.toThrow('Identifier not found or access denied');
+      const result = deleteIdentifier('ident-1', TENANT_ID);
+
+      await expect(result).rejects.toBeInstanceOf(NotFoundError);
+      await expect(result).rejects.toThrow('Identifier not found or access denied');
     });
 
     it('throws if identifier does not belong to the tenant', async () => {

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
@@ -8,8 +8,13 @@ import {
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import {
+  prismaForeignKeyViolationError,
+  prismaRecordNotFoundError,
+  prismaUniqueConstraintError,
+} from '@/lib/prisma/db-errors.fixtures';
 
-// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+// Mock Prisma client. Use jest.fn() inside the factory to avoid hoisting issues.
 jest.mock('../prisma', () => ({
   prisma: {
     organisationEntity: {
@@ -42,29 +47,6 @@ const mockOrganisationEntity = prisma.organisationEntity as unknown as {
 };
 
 const mockTransaction = prisma.$transaction as unknown as jest.Mock;
-
-function prismaUniqueConstraintError(): Error {
-  const error = new Error('Unique constraint failed on the fields: (`primaryIdentifierId`)');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaRecordNotFoundError(): Error {
-  const error = new Error(
-    'An operation failed because it depends on one or more records that were required but not found.',
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaForeignKeyViolationError(): Error {
-  const error = new Error('Foreign key constraint failed on the field: `identifierId`');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('organisation.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -291,7 +273,7 @@ describe('organisation.repository', () => {
 
       // First org succeeds
       mockTx.organisationEntity.create.mockResolvedValueOnce(ORG_RECORD);
-      // Second org fails validation — primary identifier not found
+      // Second org fails validation because the primary identifier is not found
       mockTx.identifier.findFirst.mockResolvedValue(null);
 
       mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
@@ -349,11 +331,11 @@ describe('organisation.repository', () => {
     });
 
     it('rethrows a non-database error unchanged', async () => {
-      const dbError = new Error('connection lost');
+      const nonDatabaseError = new Error('connection lost');
       const mockTx = {
         identifier: { findFirst: jest.fn() },
         organisationEntity: {
-          create: jest.fn().mockRejectedValue(dbError),
+          create: jest.fn().mockRejectedValue(nonDatabaseError),
           findUniqueOrThrow: jest.fn(),
         },
         organisationSecondaryIdentifier: { createMany: jest.fn() },
@@ -361,7 +343,25 @@ describe('organisation.repository', () => {
 
       mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
 
-      await expect(createOrganisations(TENANT_ID, [{ name: 'Acme Corp' }])).rejects.toThrow(dbError);
+      await expect(createOrganisations(TENANT_ID, [{ name: 'Acme Corp' }])).rejects.toThrow(nonDatabaseError);
+    });
+
+    it('maps a foreign-key violation on primary identifier creation to ValidationError', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn().mockRejectedValue(prismaForeignKeyViolationError()),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = createOrganisations(TENANT_ID, [{ name: 'Acme Corp' }]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced primary identifier no longer exists');
     });
 
     it('maps a foreign-key violation on secondary-identifier creation to ValidationError', async () => {
@@ -628,7 +628,35 @@ describe('organisation.repository', () => {
       });
 
       await expect(result).rejects.toThrow(ValidationError);
-      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
+      await expect(result).rejects.toThrow('The organisation or one or more secondary identifiers no longer exist');
+      expect(mockTx.organisationEntity.update).not.toHaveBeenCalled();
+    });
+
+    it('maps a unique-constraint violation on secondary-identifier replacement to ConflictError', async () => {
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn(),
+        },
+        identifier: {
+          findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2),
+        },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+          createMany: jest.fn().mockRejectedValue(prismaUniqueConstraintError()),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = updateOrganisation('org-1', TENANT_ID, {
+        secondaryIdentifierIds: ['ident-2'],
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'One or more secondary identifiers were concurrently linked to this organisation; retry the request',
+      );
       expect(mockTx.organisationEntity.update).not.toHaveBeenCalled();
     });
 
@@ -722,7 +750,7 @@ describe('organisation.repository', () => {
       const result = updateOrganisation('org-1', TENANT_ID, { name: 'Acme Industries' });
 
       await expect(result).rejects.toThrow(NotFoundError);
-      await expect(result).rejects.toThrow('Organisation not found or access denied');
+      await expect(result).rejects.toThrow('Organisation or a referenced resource not found');
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
@@ -5,6 +5,8 @@ import {
   updateOrganisation,
   deleteOrganisation,
 } from './organisation.repository';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 // Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
@@ -40,6 +42,29 @@ const mockOrganisationEntity = prisma.organisationEntity as unknown as {
 };
 
 const mockTransaction = prisma.$transaction as unknown as jest.Mock;
+
+function prismaUniqueConstraintError(): Error {
+  const error = new Error('Unique constraint failed on the fields: (`primaryIdentifierId`)');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaForeignKeyViolationError(): Error {
+  const error = new Error('Foreign key constraint failed on the field: `identifierId`');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('organisation.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -282,6 +307,84 @@ describe('organisation.repository', () => {
       // First org was created inside the transaction but will be rolled back.
       expect(mockTx.organisationEntity.create).toHaveBeenCalledTimes(1);
     });
+
+    it('rejects duplicate secondary identifiers', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2) },
+        organisationEntity: {
+          create: jest.fn(),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = createOrganisations(TENANT_ID, [
+        { name: 'Acme Corp', secondaryIdentifierIds: [IDENTIFIER_RECORD_2.id, IDENTIFIER_RECORD_2.id] },
+      ]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
+    });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn().mockRejectedValue(prismaUniqueConstraintError()),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = createOrganisations(TENANT_ID, [{ name: 'Acme Corp' }]);
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'An identifier in this request is already the primary identifier of another organisation',
+      );
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const dbError = new Error('connection lost');
+      const mockTx = {
+        identifier: { findFirst: jest.fn() },
+        organisationEntity: {
+          create: jest.fn().mockRejectedValue(dbError),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: { createMany: jest.fn() },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      await expect(createOrganisations(TENANT_ID, [{ name: 'Acme Corp' }])).rejects.toThrow(dbError);
+    });
+
+    it('maps a foreign-key violation on secondary-identifier creation to ValidationError', async () => {
+      const mockTx = {
+        identifier: { findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2) },
+        organisationEntity: {
+          create: jest.fn().mockResolvedValue(ORG_RECORD),
+          findUniqueOrThrow: jest.fn(),
+        },
+        organisationSecondaryIdentifier: {
+          createMany: jest.fn().mockRejectedValue(prismaForeignKeyViolationError()),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = createOrganisations(TENANT_ID, [
+        { name: 'Acme Corp', secondaryIdentifierIds: [IDENTIFIER_RECORD_2.id] },
+      ]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
+    });
   });
 
   describe('getOrganisationById', () => {
@@ -446,6 +549,27 @@ describe('organisation.repository', () => {
       expect(result.name).toBe('Acme Industries');
     });
 
+    it('rejects duplicate secondary identifiers', async () => {
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn(),
+        },
+        identifier: { findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2) },
+        organisationSecondaryIdentifier: { deleteMany: jest.fn(), createMany: jest.fn() },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = updateOrganisation('org-1', TENANT_ID, {
+        secondaryIdentifierIds: [IDENTIFIER_RECORD_2.id, IDENTIFIER_RECORD_2.id],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
+      expect(mockTx.organisationEntity.update).not.toHaveBeenCalled();
+    });
+
     it('replaces secondary identifiers via deleteMany + createMany in transaction', async () => {
       const updatedOrg = {
         ...ORG_RECORD,
@@ -480,6 +604,32 @@ describe('organisation.repository', () => {
       });
       expect(mockTx.organisationEntity.update).toHaveBeenCalled();
       expect(result.secondaryIdentifiers).toHaveLength(1);
+    });
+
+    it('maps a foreign-key violation on secondary-identifier replacement to ValidationError', async () => {
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn(),
+        },
+        identifier: {
+          findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2),
+        },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+          createMany: jest.fn().mockRejectedValue(prismaForeignKeyViolationError()),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = updateOrganisation('org-1', TENANT_ID, {
+        secondaryIdentifierIds: ['ident-2'],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
+      expect(mockTx.organisationEntity.update).not.toHaveBeenCalled();
     });
 
     it('clears all secondary identifiers with empty array', async () => {
@@ -532,6 +682,48 @@ describe('organisation.repository', () => {
         'Organisation not found or access denied',
       );
     });
+
+    it('maps a unique-constraint violation to ConflictError with a clean message', async () => {
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn().mockRejectedValue(prismaUniqueConstraintError()),
+        },
+        identifier: { findFirst: jest.fn() },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = updateOrganisation('org-1', TENANT_ID, { name: 'Acme Industries' });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('The identifier is already the primary identifier of another organisation');
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn().mockRejectedValue(prismaRecordNotFoundError()),
+        },
+        identifier: { findFirst: jest.fn() },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = updateOrganisation('org-1', TENANT_ID, { name: 'Acme Industries' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Organisation not found or access denied');
+    });
   });
 
   describe('deleteOrganisation', () => {
@@ -573,6 +765,22 @@ describe('organisation.repository', () => {
       await expect(deleteOrganisation('org-1', OTHER_TENANT_ID)).rejects.toThrow(
         'Organisation not found or access denied',
       );
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          delete: jest.fn().mockRejectedValue(prismaRecordNotFoundError()),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = deleteOrganisation('org-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Organisation not found or access denied');
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
@@ -139,6 +139,7 @@ export async function createOrganisations(
       } catch (e) {
         mapDatabaseError(e, {
           conflict: 'An identifier in this request is already the primary identifier of another organisation',
+          invalidReference: 'The referenced primary identifier no longer exists',
         });
       }
 
@@ -279,7 +280,11 @@ export async function updateOrganisation(
             })),
           });
         } catch (e) {
-          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+          mapDatabaseError(e, {
+            conflict:
+              'One or more secondary identifiers were concurrently linked to this organisation; retry the request',
+            invalidReference: 'The organisation or one or more secondary identifiers no longer exist',
+          });
         }
       }
     }
@@ -307,7 +312,7 @@ export async function updateOrganisation(
     } catch (e) {
       mapDatabaseError(e, {
         conflict: 'The identifier is already the primary identifier of another organisation',
-        notFound: 'Organisation not found or access denied',
+        notFound: 'Organisation or a referenced resource not found',
       });
     }
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { NotFoundError } from '@/lib/api/errors';
+import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { UntpLocation } from '@/lib/types';
@@ -80,7 +81,8 @@ async function validateIdentifierOwnership(
 }
 
 /**
- * Validates that the primary identifier is not also listed as a secondary identifier.
+ * Validates that the primary identifier is not also listed as a secondary
+ * identifier, and that secondary identifiers contain no duplicates.
  */
 function validateNoPrimarySecondaryOverlap(
   primaryIdentifierId: string | undefined | null,
@@ -88,6 +90,9 @@ function validateNoPrimarySecondaryOverlap(
 ): void {
   if (primaryIdentifierId && secondaryIdentifierIds?.includes(primaryIdentifierId)) {
     throw new ValidationError('Primary identifier cannot also be a secondary identifier');
+  }
+  if (secondaryIdentifierIds && new Set(secondaryIdentifierIds).size !== secondaryIdentifierIds.length) {
+    throw new ValidationError('Secondary identifiers must not contain duplicates');
   }
 }
 
@@ -119,25 +124,36 @@ export async function createOrganisations(
       validateNoPrimarySecondaryOverlap(input.primaryIdentifierId, input.secondaryIdentifierIds);
 
       // Create the organisation entity
-      const organisation = await tx.organisationEntity.create({
-        data: {
-          tenantId,
-          name: input.name,
-          ...(input.description !== undefined && { description: input.description }),
-          ...(input.location !== undefined && { location: input.location as Prisma.InputJsonValue }),
-          ...(input.primaryIdentifierId !== undefined && { primaryIdentifierId: input.primaryIdentifierId }),
-        },
-        include: ORGANISATION_DETAIL_INCLUDE,
-      });
+      let organisation: OrganisationEntityWithRelations;
+      try {
+        organisation = await tx.organisationEntity.create({
+          data: {
+            tenantId,
+            name: input.name,
+            ...(input.description !== undefined && { description: input.description }),
+            ...(input.location !== undefined && { location: input.location as Prisma.InputJsonValue }),
+            ...(input.primaryIdentifierId !== undefined && { primaryIdentifierId: input.primaryIdentifierId }),
+          },
+          include: ORGANISATION_DETAIL_INCLUDE,
+        });
+      } catch (e) {
+        mapDatabaseError(e, {
+          conflict: 'An identifier in this request is already the primary identifier of another organisation',
+        });
+      }
 
       // Create join rows for secondary identifiers
       if (input.secondaryIdentifierIds?.length) {
-        await tx.organisationSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
-            organisationId: organisation.id,
-            identifierId,
-          })),
-        });
+        try {
+          await tx.organisationSecondaryIdentifier.createMany({
+            data: input.secondaryIdentifierIds.map((identifierId: string) => ({
+              organisationId: organisation.id,
+              identifierId,
+            })),
+          });
+        } catch (e) {
+          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+        }
 
         // Re-fetch to include the newly created secondary identifier relations
         const refetched = await tx.organisationEntity.findUniqueOrThrow({
@@ -255,12 +271,16 @@ export async function updateOrganisation(
         where: { organisationId: id },
       });
       if (input.secondaryIdentifierIds.length > 0) {
-        await tx.organisationSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
-            organisationId: id,
-            identifierId,
-          })),
-        });
+        try {
+          await tx.organisationSecondaryIdentifier.createMany({
+            data: input.secondaryIdentifierIds.map((identifierId: string) => ({
+              organisationId: id,
+              identifierId,
+            })),
+          });
+        } catch (e) {
+          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+        }
       }
     }
 
@@ -278,11 +298,18 @@ export async function updateOrganisation(
       data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
     }
 
-    return tx.organisationEntity.update({
-      where: { id },
-      data,
-      include: ORGANISATION_DETAIL_INCLUDE,
-    });
+    try {
+      return await tx.organisationEntity.update({
+        where: { id },
+        data,
+        include: ORGANISATION_DETAIL_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        conflict: 'The identifier is already the primary identifier of another organisation',
+        notFound: 'Organisation not found or access denied',
+      });
+    }
   });
 }
 
@@ -317,9 +344,13 @@ export async function deleteOrganisation(id: string, tenantId: string): Promise<
       throw new NotFoundError('Organisation not found or access denied');
     }
 
-    return tx.organisationEntity.delete({
-      where: { id },
-      include: ORGANISATION_DETAIL_INCLUDE,
-    });
+    try {
+      return await tx.organisationEntity.delete({
+        where: { id },
+        include: ORGANISATION_DETAIL_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'Organisation not found or access denied' });
+    }
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
@@ -2,8 +2,13 @@ import { createProducts, getProductById, listProducts, updateProduct, deleteProd
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import {
+  prismaForeignKeyViolationError,
+  prismaRecordNotFoundError,
+  prismaUniqueConstraintError,
+} from '@/lib/prisma/db-errors.fixtures';
 
-// Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
+// Mock Prisma client. Use jest.fn() inside the factory to avoid hoisting issues.
 const mockTx = {
   product: {
     findFirst: jest.fn(),
@@ -63,29 +68,6 @@ const mockProduct = prisma.product as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
-
-function prismaUniqueConstraintError(): Error {
-  const error = new Error('Unique constraint failed on the fields: (`primaryIdentifierId`)');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaRecordNotFoundError(): Error {
-  const error = new Error(
-    'An operation failed because it depends on one or more records that were required but not found.',
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaForeignKeyViolationError(): Error {
-  const error = new Error('Foreign key constraint failed on the field: `parentId`');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('product.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -319,6 +301,15 @@ describe('product.repository', () => {
       await expect(result).rejects.toThrow(ValidationError);
       await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
       expect(mockTx.product.create).not.toHaveBeenCalled();
+    });
+
+    it('maps a foreign-key violation on product creation to ValidationError', async () => {
+      mockTx.product.create.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = createProducts(TENANT_ID, [{ name: 'Test Product', level: 'MODEL' }]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('One or more referenced resources no longer exist');
     });
 
     it('maps a foreign-key violation on secondary-identifier creation to ValidationError', async () => {
@@ -611,7 +602,25 @@ describe('product.repository', () => {
       });
 
       await expect(result).rejects.toThrow(ValidationError);
-      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
+      await expect(result).rejects.toThrow('The product or one or more secondary identifiers no longer exist');
+      expect(mockTx.product.update).not.toHaveBeenCalled();
+    });
+
+    it('maps a unique-constraint violation on secondary-identifier replacement to ConflictError', async () => {
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
+      mockTx.productSecondaryIdentifier.deleteMany.mockResolvedValue({ count: 0 });
+      mockTx.productSecondaryIdentifier.createMany.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = updateProduct(PRODUCT_ID, TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_1],
+      });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'One or more secondary identifiers were concurrently linked to this product; retry the request',
+      );
+      expect(mockTx.product.update).not.toHaveBeenCalled();
     });
 
     it('clears secondary identifiers with empty array', async () => {
@@ -695,7 +704,7 @@ describe('product.repository', () => {
       const result = updateProduct(PRODUCT_ID, TENANT_ID, { name: 'Updated Name' });
 
       await expect(result).rejects.toThrow(NotFoundError);
-      await expect(result).rejects.toThrow('Product not found or access denied');
+      await expect(result).rejects.toThrow('Product or a referenced resource not found');
     });
   });
 
@@ -782,7 +791,7 @@ describe('product.repository', () => {
       const result = deleteProduct(PARENT_ID, TENANT_ID);
 
       await expect(result).rejects.toThrow(ValidationError);
-      await expect(result).rejects.toThrow('Cannot delete: BATCH product(s) depend on this MODEL');
+      await expect(result).rejects.toThrow('Cannot delete: dependent products exist');
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.test.ts
@@ -1,4 +1,6 @@
 import { createProducts, getProductById, listProducts, updateProduct, deleteProduct } from './product.repository';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 // Mock Prisma client — use jest.fn() inside the factory to avoid hoisting issues
@@ -61,6 +63,29 @@ const mockProduct = prisma.product as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
+
+function prismaUniqueConstraintError(): Error {
+  const error = new Error('Unique constraint failed on the fields: (`primaryIdentifierId`)');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2002', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaForeignKeyViolationError(): Error {
+  const error = new Error('Foreign key constraint failed on the field: `parentId`');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('product.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -272,6 +297,51 @@ describe('product.repository', () => {
         ]),
       ).rejects.toThrow('Primary identifier cannot also be a secondary identifier');
     });
+
+    it('maps a unique-constraint violation on create to ConflictError with a clean message', async () => {
+      mockTx.product.create.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = createProducts(TENANT_ID, [{ name: 'Test Product', level: 'MODEL' }]);
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow(
+        'An identifier in this request is already the primary identifier of another product',
+      );
+    });
+
+    it('rejects duplicate secondary identifiers without hitting the database', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
+
+      const result = createProducts(TENANT_ID, [
+        { name: 'Product', level: 'MODEL', secondaryIdentifierIds: [SECONDARY_ID_1, SECONDARY_ID_1] },
+      ]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
+      expect(mockTx.product.create).not.toHaveBeenCalled();
+    });
+
+    it('maps a foreign-key violation on secondary-identifier creation to ValidationError', async () => {
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
+      mockTx.product.create.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.productSecondaryIdentifier.createMany.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = createProducts(TENANT_ID, [
+        { name: 'Product', level: 'MODEL', secondaryIdentifierIds: [SECONDARY_ID_1] },
+      ]);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const connectionError = new Error('connection lost');
+      mockTx.product.create.mockRejectedValue(connectionError);
+
+      await expect(createProducts(TENANT_ID, [{ name: 'Test Product', level: 'MODEL' }])).rejects.toThrow(
+        connectionError,
+      );
+    });
   });
 
   describe('getProductById', () => {
@@ -476,6 +546,19 @@ describe('product.repository', () => {
       expect(result.name).toBe('Updated Name');
     });
 
+    it('rejects duplicate secondary identifiers without hitting the database', async () => {
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
+
+      const result = updateProduct(PRODUCT_ID, TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_1, SECONDARY_ID_1],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
+      expect(mockTx.product.update).not.toHaveBeenCalled();
+    });
+
     it('validates producedByOrganisationId FK on update', async () => {
       mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
       mockTx.organisationEntity.findFirst.mockResolvedValue(null);
@@ -515,6 +598,20 @@ describe('product.repository', () => {
         data: [{ productId: PRODUCT_ID, identifierId: SECONDARY_ID_1 }],
       });
       expect(result.secondaryIdentifiers).toHaveLength(1);
+    });
+
+    it('maps a foreign-key violation on secondary-identifier replacement to ValidationError', async () => {
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_1, tenantId: TENANT_ID });
+      mockTx.productSecondaryIdentifier.deleteMany.mockResolvedValue({ count: 0 });
+      mockTx.productSecondaryIdentifier.createMany.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = updateProduct(PRODUCT_ID, TENANT_ID, {
+        secondaryIdentifierIds: [SECONDARY_ID_1],
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('One or more secondary identifiers no longer exist');
     });
 
     it('clears secondary identifiers with empty array', async () => {
@@ -580,6 +677,26 @@ describe('product.repository', () => {
         'Product not found or access denied',
       );
     });
+
+    it('maps a unique-constraint violation on update to ConflictError with a clean message', async () => {
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.product.update.mockRejectedValue(prismaUniqueConstraintError());
+
+      const result = updateProduct(PRODUCT_ID, TENANT_ID, { name: 'Updated Name' });
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('The identifier is already the primary identifier of another product');
+    });
+
+    it('maps a record-not-found race on update to NotFoundError', async () => {
+      mockTx.product.findFirst.mockResolvedValue(PRODUCT_WITH_RELATIONS);
+      mockTx.product.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateProduct(PRODUCT_ID, TENANT_ID, { name: 'Updated Name' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Product not found or access denied');
+    });
   });
 
   describe('deleteProduct', () => {
@@ -644,6 +761,28 @@ describe('product.repository', () => {
       mockTx.product.findFirst.mockResolvedValue(null);
 
       await expect(deleteProduct(PRODUCT_ID, 'other-tenant')).rejects.toThrow('Product not found or access denied');
+    });
+
+    it('maps a record-not-found race on delete to NotFoundError', async () => {
+      mockTx.product.findFirst.mockResolvedValue(MODEL_PRODUCT);
+      mockTx.product.findMany.mockResolvedValue([]);
+      mockTx.product.delete.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = deleteProduct(PARENT_ID, TENANT_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Product not found or access denied');
+    });
+
+    it('maps a foreign-key violation on delete to ValidationError', async () => {
+      mockTx.product.findFirst.mockResolvedValue(MODEL_PRODUCT);
+      mockTx.product.findMany.mockResolvedValue([]);
+      mockTx.product.delete.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = deleteProduct(PARENT_ID, TENANT_ID);
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Cannot delete: BATCH product(s) depend on this MODEL');
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -223,6 +223,7 @@ export async function createProducts(tenantId: string, inputs: CreateProductInpu
       } catch (e) {
         mapDatabaseError(e, {
           conflict: 'An identifier in this request is already the primary identifier of another product',
+          invalidReference: 'One or more referenced resources no longer exist',
         });
       }
 
@@ -409,7 +410,10 @@ export async function updateProduct(
             })),
           });
         } catch (e) {
-          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+          mapDatabaseError(e, {
+            conflict: 'One or more secondary identifiers were concurrently linked to this product; retry the request',
+            invalidReference: 'The product or one or more secondary identifiers no longer exist',
+          });
         }
       }
     }
@@ -457,7 +461,7 @@ export async function updateProduct(
     } catch (e) {
       mapDatabaseError(e, {
         conflict: 'The identifier is already the primary identifier of another product',
-        notFound: 'Product not found or access denied',
+        notFound: 'Product or a referenced resource not found',
       });
     }
   });
@@ -504,10 +508,12 @@ export async function deleteProduct(id: string, tenantId: string): Promise<Produ
       return await tx.product.delete({ where: { id } });
     } catch (e) {
       // The restrict violation maps to a 400 (not a 409) to match the
-      // established contract of the BATCH-children pre-check above.
+      // established contract of the BATCH-children pre-check above. Unlike the
+      // pre-check, the constraint fires for a child of any level, so the
+      // message stays level-neutral.
       mapDatabaseError(e, {
         notFound: 'Product not found or access denied',
-        invalidReference: 'Cannot delete: BATCH product(s) depend on this MODEL',
+        invalidReference: 'Cannot delete: dependent products exist',
       });
     }
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -1,6 +1,7 @@
 import { Product, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { NotFoundError } from '@/lib/api/errors';
+import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
@@ -131,7 +132,8 @@ async function validateIdentifierOwnership(
 }
 
 /**
- * Validates that the primary identifier is not also listed as a secondary identifier.
+ * Validates that the primary identifier is not also listed as a secondary
+ * identifier, and that secondary identifiers contain no duplicates.
  */
 function validateNoPrimarySecondaryOverlap(
   primaryIdentifierId: string | undefined | null,
@@ -139,6 +141,9 @@ function validateNoPrimarySecondaryOverlap(
 ): void {
   if (primaryIdentifierId && secondaryIdentifierIds?.includes(primaryIdentifierId)) {
     throw new ValidationError('Primary identifier cannot also be a secondary identifier');
+  }
+  if (secondaryIdentifierIds && new Set(secondaryIdentifierIds).size !== secondaryIdentifierIds.length) {
+    throw new ValidationError('Secondary identifiers must not contain duplicates');
   }
 }
 
@@ -196,32 +201,43 @@ export async function createProducts(tenantId: string, inputs: CreateProductInpu
       validateNoPrimarySecondaryOverlap(input.primaryIdentifierId, input.secondaryIdentifierIds);
 
       // Create the product entity
-      const product = await tx.product.create({
-        data: {
-          tenantId,
-          name: input.name,
-          level: input.level,
-          ...(input.description !== undefined && { description: input.description }),
-          ...(input.parentId !== undefined && { parentId: input.parentId }),
-          ...(input.producedByOrganisationId !== undefined && {
-            producedByOrganisationId: input.producedByOrganisationId,
-          }),
-          ...(input.manufacturingFacilityId !== undefined && {
-            manufacturingFacilityId: input.manufacturingFacilityId,
-          }),
-          ...(input.primaryIdentifierId !== undefined && { primaryIdentifierId: input.primaryIdentifierId }),
-        },
-        include: PRODUCT_DETAIL_INCLUDE,
-      });
+      let product: ProductWithRelations;
+      try {
+        product = await tx.product.create({
+          data: {
+            tenantId,
+            name: input.name,
+            level: input.level,
+            ...(input.description !== undefined && { description: input.description }),
+            ...(input.parentId !== undefined && { parentId: input.parentId }),
+            ...(input.producedByOrganisationId !== undefined && {
+              producedByOrganisationId: input.producedByOrganisationId,
+            }),
+            ...(input.manufacturingFacilityId !== undefined && {
+              manufacturingFacilityId: input.manufacturingFacilityId,
+            }),
+            ...(input.primaryIdentifierId !== undefined && { primaryIdentifierId: input.primaryIdentifierId }),
+          },
+          include: PRODUCT_DETAIL_INCLUDE,
+        });
+      } catch (e) {
+        mapDatabaseError(e, {
+          conflict: 'An identifier in this request is already the primary identifier of another product',
+        });
+      }
 
       // Create join rows for secondary identifiers
       if (input.secondaryIdentifierIds?.length) {
-        await tx.productSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
-            productId: product.id,
-            identifierId,
-          })),
-        });
+        try {
+          await tx.productSecondaryIdentifier.createMany({
+            data: input.secondaryIdentifierIds.map((identifierId: string) => ({
+              productId: product.id,
+              identifierId,
+            })),
+          });
+        } catch (e) {
+          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+        }
 
         // Re-fetch to include the newly created secondary identifier relations
         const refetched = await tx.product.findUniqueOrThrow({
@@ -385,12 +401,16 @@ export async function updateProduct(
         where: { productId: id },
       });
       if (input.secondaryIdentifierIds.length > 0) {
-        await tx.productSecondaryIdentifier.createMany({
-          data: input.secondaryIdentifierIds.map((identifierId: string) => ({
-            productId: id,
-            identifierId,
-          })),
-        });
+        try {
+          await tx.productSecondaryIdentifier.createMany({
+            data: input.secondaryIdentifierIds.map((identifierId: string) => ({
+              productId: id,
+              identifierId,
+            })),
+          });
+        } catch (e) {
+          mapDatabaseError(e, { invalidReference: 'One or more secondary identifiers no longer exist' });
+        }
       }
     }
 
@@ -428,11 +448,18 @@ export async function updateProduct(
       data.primaryIdentifier = { connect: { id: input.primaryIdentifierId } };
     }
 
-    return tx.product.update({
-      where: { id },
-      data,
-      include: PRODUCT_DETAIL_INCLUDE,
-    });
+    try {
+      return await tx.product.update({
+        where: { id },
+        data,
+        include: PRODUCT_DETAIL_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        conflict: 'The identifier is already the primary identifier of another product',
+        notFound: 'Product not found or access denied',
+      });
+    }
   });
 }
 
@@ -473,6 +500,15 @@ export async function deleteProduct(id: string, tenantId: string): Promise<Produ
     if (items.length > 0) {
       await tx.product.updateMany({ where: { parentId: id, level: 'ITEM' }, data: { parentId: null } });
     }
-    return tx.product.delete({ where: { id } });
+    try {
+      return await tx.product.delete({ where: { id } });
+    } catch (e) {
+      // The restrict violation maps to a 400 (not a 409) to match the
+      // established contract of the BATCH-children pre-check above.
+      mapDatabaseError(e, {
+        notFound: 'Product not found or access denied',
+        invalidReference: 'Cannot delete: BATCH product(s) depend on this MODEL',
+      });
+    }
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.test.ts
@@ -5,6 +5,8 @@ import {
   updateRegistrar,
   deleteRegistrar,
 } from './registrar.repository';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { SYSTEM_TENANT_ID } from '../constants';
 
@@ -39,6 +41,22 @@ const mockRegistrar = prisma.registrar as unknown as {
   findMany: jest.Mock;
   count: jest.Mock;
 };
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaForeignKeyViolationError(): Error {
+  const error = new Error('Foreign key constraint failed on the field: `idrServiceInstanceId`');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('registrar.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -95,6 +113,29 @@ describe('registrar.repository', () => {
           idrServiceInstanceId: 'si-1',
         }),
       });
+    });
+
+    it('maps a foreign-key violation to ValidationError', async () => {
+      mockRegistrar.create.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = createRegistrar({
+        tenantId: TENANT_ID,
+        name: 'GS1',
+        namespace: 'gs1',
+        idrServiceInstanceId: 'nonexistent-si',
+      });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced IDR service instance does not exist');
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const connectionError = new Error('connection lost');
+      mockRegistrar.create.mockRejectedValue(connectionError);
+
+      await expect(createRegistrar({ tenantId: TENANT_ID, name: 'GS1', namespace: 'gs1' })).rejects.toThrow(
+        connectionError,
+      );
     });
   });
 
@@ -225,6 +266,26 @@ describe('registrar.repository', () => {
         'Registrar not found or access denied',
       );
     });
+
+    it('maps a foreign-key violation to ValidationError', async () => {
+      mockTx.registrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
+      mockTx.registrar.update.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = updateRegistrar('reg-1', TENANT_ID, { idrServiceInstanceId: 'nonexistent-si' });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced IDR service instance does not exist');
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.registrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
+      mockTx.registrar.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateRegistrar('reg-1', TENANT_ID, { name: 'GS1 Updated' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Registrar not found or access denied');
+    });
   });
 
   describe('deleteRegistrar', () => {
@@ -247,6 +308,26 @@ describe('registrar.repository', () => {
       mockTx.registrar.findFirst.mockResolvedValue(null);
 
       await expect(deleteRegistrar('reg-1', 'other-tenant')).rejects.toThrow('Registrar not found or access denied');
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.registrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
+      mockTx.registrar.delete.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = deleteRegistrar('reg-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Registrar not found or access denied');
+    });
+
+    it('maps a foreign-key violation to ConflictError when schemes still have identifiers', async () => {
+      mockTx.registrar.findFirst.mockResolvedValue(REGISTRAR_RECORD);
+      mockTx.registrar.delete.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = deleteRegistrar('reg-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(ConflictError);
+      await expect(result).rejects.toThrow('The registrar has schemes with identifiers and cannot be deleted');
     });
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/registrar.repository.ts
@@ -1,7 +1,8 @@
 import { Registrar, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { SYSTEM_TENANT_ID } from '../constants';
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { isForeignKeyViolation, mapDatabaseError } from '@/lib/prisma/db-errors';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 /**
@@ -37,15 +38,19 @@ export type ListRegistrarsOptions = {
  * Creates a new registrar scoped to an organisation (tenant).
  */
 export async function createRegistrar(input: CreateRegistrarInput): Promise<Registrar> {
-  return prisma.registrar.create({
-    data: {
-      tenantId: input.tenantId,
-      name: input.name,
-      namespace: input.namespace,
-      url: input.url,
-      idrServiceInstanceId: input.idrServiceInstanceId,
-    },
-  });
+  try {
+    return await prisma.registrar.create({
+      data: {
+        tenantId: input.tenantId,
+        name: input.name,
+        namespace: input.namespace,
+        url: input.url,
+        idrServiceInstanceId: input.idrServiceInstanceId,
+      },
+    });
+  } catch (e) {
+    mapDatabaseError(e, { invalidReference: 'The referenced IDR service instance does not exist' });
+  }
 }
 
 /**
@@ -109,15 +114,22 @@ export async function updateRegistrar(id: string, tenantId: string, input: Updat
       throw new NotFoundError('Registrar not found or access denied');
     }
 
-    return tx.registrar.update({
-      where: { id },
-      data: {
-        ...(input.name !== undefined && { name: input.name }),
-        ...(input.namespace !== undefined && { namespace: input.namespace }),
-        ...(input.url !== undefined && { url: input.url }),
-        ...(input.idrServiceInstanceId !== undefined && { idrServiceInstanceId: input.idrServiceInstanceId }),
-      },
-    });
+    try {
+      return await tx.registrar.update({
+        where: { id },
+        data: {
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.namespace !== undefined && { namespace: input.namespace }),
+          ...(input.url !== undefined && { url: input.url }),
+          ...(input.idrServiceInstanceId !== undefined && { idrServiceInstanceId: input.idrServiceInstanceId }),
+        },
+      });
+    } catch (e) {
+      mapDatabaseError(e, {
+        notFound: 'Registrar not found or access denied',
+        invalidReference: 'The referenced IDR service instance does not exist',
+      });
+    }
   });
 }
 
@@ -135,8 +147,19 @@ export async function deleteRegistrar(id: string, tenantId: string): Promise<Reg
       throw new NotFoundError('Registrar not found or access denied');
     }
 
-    return tx.registrar.delete({
-      where: { id },
-    });
+    try {
+      return await tx.registrar.delete({
+        where: { id },
+      });
+    } catch (e) {
+      // Deleting a registrar cascades into its schemes, and Identifier.scheme
+      // is declared with onDelete: Restrict, so a foreign-key violation here
+      // means identifiers block the cascade (a conflict), not that a
+      // referenced record is missing.
+      if (isForeignKeyViolation(e)) {
+        throw new ConflictError('The registrar has schemes with identifiers and cannot be deleted');
+      }
+      mapDatabaseError(e, { notFound: 'Registrar not found or access denied' });
+    }
   });
 }

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
@@ -6,6 +6,7 @@ import {
   deleteRenderTemplate,
   getDefaultRenderTemplate,
 } from './render-template.repository';
+import { NotFoundError } from '@/lib/api/errors';
 import { SYSTEM_TENANT_ID } from '../constants';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
@@ -51,6 +52,22 @@ const mockRenderTemplate = prisma.renderTemplate as unknown as {
 };
 
 const INCLUDE_SHAPE = {};
+
+function prismaRecordNotFoundError(): Error {
+  const error = new Error(
+    'An operation failed because it depends on one or more records that were required but not found.',
+  );
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
+  return error;
+}
+
+function prismaForeignKeyViolationError(): Error {
+  const error = new Error('Foreign key constraint failed on the field: `dataModelId`');
+  error.name = 'PrismaClientKnownRequestError';
+  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
+  return error;
+}
 
 describe('render-template.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -160,6 +177,36 @@ describe('render-template.repository', () => {
         }),
         include: INCLUDE_SHAPE,
       });
+    });
+
+    it('maps a foreign-key violation to NotFoundError when the data model was deleted before insert', async () => {
+      mockTx.renderTemplate.create.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = createRenderTemplate(TENANT_ID, {
+        name: 'DPP Default Template',
+        dataModelId: CONFIG_ID,
+        renderMethodType: 'RenderTemplate2024',
+        storageUrl: 'https://storage.example.com/templates/dpp-default.html',
+        digestMultibase: 'zTESTabc123',
+      });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Data model not found');
+    });
+
+    it('rethrows a non-database error unchanged', async () => {
+      const connectionError = new Error('connection lost');
+      mockTx.renderTemplate.create.mockRejectedValue(connectionError);
+
+      await expect(
+        createRenderTemplate(TENANT_ID, {
+          name: 'DPP Default Template',
+          dataModelId: CONFIG_ID,
+          renderMethodType: 'RenderTemplate2024',
+          storageUrl: 'https://storage.example.com/templates/dpp-default.html',
+          digestMultibase: 'zTESTabc123',
+        }),
+      ).rejects.toThrow(connectionError);
     });
   });
 
@@ -455,6 +502,16 @@ describe('render-template.repository', () => {
         include: INCLUDE_SHAPE,
       });
     });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
+      mockTx.renderTemplate.update.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = updateRenderTemplate('template-1', TENANT_ID, { name: 'Updated Template' });
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Render template not found or access denied');
+    });
   });
 
   describe('deleteRenderTemplate', () => {
@@ -480,6 +537,16 @@ describe('render-template.repository', () => {
       await expect(deleteRenderTemplate('template-1', 'other-tenant')).rejects.toThrow(
         'Render template not found or access denied',
       );
+    });
+
+    it('maps a record-not-found race to NotFoundError', async () => {
+      mockTx.renderTemplate.findFirst.mockResolvedValue(TEMPLATE_RECORD);
+      mockTx.renderTemplate.delete.mockRejectedValue(prismaRecordNotFoundError());
+
+      const result = deleteRenderTemplate('template-1', TENANT_ID);
+
+      await expect(result).rejects.toThrow(NotFoundError);
+      await expect(result).rejects.toThrow('Render template not found or access denied');
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.test.ts
@@ -40,6 +40,7 @@ jest.mock('../prisma', () => ({
 
 // Import the mocked prisma after jest.mock
 import { prisma } from '../prisma';
+import { prismaForeignKeyViolationError, prismaRecordNotFoundError } from '../db-errors.fixtures';
 
 const mockRenderTemplate = prisma.renderTemplate as unknown as {
   create: jest.Mock;
@@ -52,22 +53,6 @@ const mockRenderTemplate = prisma.renderTemplate as unknown as {
 };
 
 const INCLUDE_SHAPE = {};
-
-function prismaRecordNotFoundError(): Error {
-  const error = new Error(
-    'An operation failed because it depends on one or more records that were required but not found.',
-  );
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2025', clientVersion: '6.0.0' });
-  return error;
-}
-
-function prismaForeignKeyViolationError(): Error {
-  const error = new Error('Foreign key constraint failed on the field: `dataModelId`');
-  error.name = 'PrismaClientKnownRequestError';
-  Object.assign(error, { code: 'P2003', clientVersion: '6.0.0' });
-  return error;
-}
 
 describe('render-template.repository', () => {
   const TENANT_ID = 'tenant-1';
@@ -206,7 +191,7 @@ describe('render-template.repository', () => {
           storageUrl: 'https://storage.example.com/templates/dpp-default.html',
           digestMultibase: 'zTESTabc123',
         }),
-      ).rejects.toThrow(connectionError);
+      ).rejects.toBe(connectionError);
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/render-template.repository.ts
@@ -2,6 +2,7 @@ import { Prisma, RenderMethodType } from '../generated';
 import { prisma } from '../prisma';
 import { SYSTEM_TENANT_ID } from '../constants';
 import { NotFoundError } from '@/lib/api/errors';
+import { isForeignKeyViolation, mapDatabaseError } from '@/lib/prisma/db-errors';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 
 /**
@@ -107,25 +108,35 @@ export async function createRenderTemplate(
       });
     }
 
-    return tx.renderTemplate.create({
-      data: {
-        tenantId,
-        name: input.name,
-        dataModelId: input.dataModelId,
-        renderMethodType: input.renderMethodType,
-        storageUrl: input.storageUrl,
-        digestMultibase: input.digestMultibase,
-        isDefault: input.isDefault ?? false,
-        storageServiceInstanceId: input.storageServiceInstanceId,
-        storageExternalId: input.storageExternalId,
-        storageBucket: input.storageBucket,
-        storageContentType: input.storageContentType,
-        inline: input.inline,
-        mediaType: input.mediaType,
-        mediaQuery: input.mediaQuery,
-      },
-      include: RENDER_TEMPLATE_INCLUDE,
-    });
+    try {
+      return await tx.renderTemplate.create({
+        data: {
+          tenantId,
+          name: input.name,
+          dataModelId: input.dataModelId,
+          renderMethodType: input.renderMethodType,
+          storageUrl: input.storageUrl,
+          digestMultibase: input.digestMultibase,
+          isDefault: input.isDefault ?? false,
+          storageServiceInstanceId: input.storageServiceInstanceId,
+          storageExternalId: input.storageExternalId,
+          storageBucket: input.storageBucket,
+          storageContentType: input.storageContentType,
+          inline: input.inline,
+          mediaType: input.mediaType,
+          mediaQuery: input.mediaQuery,
+        },
+        include: RENDER_TEMPLATE_INCLUDE,
+      });
+    } catch (e) {
+      // The caller pre-checks the data model, so a foreign-key violation here
+      // means it was deleted between that check and this insert. Surface the
+      // same 404 the pre-check would have produced, not a bad-request error.
+      if (isForeignKeyViolation(e)) {
+        throw new NotFoundError('Data model not found');
+      }
+      throw e;
+    }
   });
 }
 
@@ -223,25 +234,29 @@ export async function updateRenderTemplate(
       });
     }
 
-    return tx.renderTemplate.update({
-      where: { id },
-      data: {
-        ...(input.name !== undefined && { name: input.name }),
-        ...(input.storageUrl !== undefined && { storageUrl: input.storageUrl }),
-        ...(input.digestMultibase !== undefined && { digestMultibase: input.digestMultibase }),
-        ...(input.isDefault !== undefined && { isDefault: input.isDefault }),
-        ...(input.storageServiceInstanceId !== undefined && {
-          storageServiceInstanceId: input.storageServiceInstanceId,
-        }),
-        ...(input.storageExternalId !== undefined && { storageExternalId: input.storageExternalId }),
-        ...(input.storageBucket !== undefined && { storageBucket: input.storageBucket }),
-        ...(input.storageContentType !== undefined && { storageContentType: input.storageContentType }),
-        ...(input.inline !== undefined && { inline: input.inline }),
-        ...(input.mediaType !== undefined && { mediaType: input.mediaType }),
-        ...(input.mediaQuery !== undefined && { mediaQuery: input.mediaQuery }),
-      },
-      include: RENDER_TEMPLATE_INCLUDE,
-    });
+    try {
+      return await tx.renderTemplate.update({
+        where: { id },
+        data: {
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.storageUrl !== undefined && { storageUrl: input.storageUrl }),
+          ...(input.digestMultibase !== undefined && { digestMultibase: input.digestMultibase }),
+          ...(input.isDefault !== undefined && { isDefault: input.isDefault }),
+          ...(input.storageServiceInstanceId !== undefined && {
+            storageServiceInstanceId: input.storageServiceInstanceId,
+          }),
+          ...(input.storageExternalId !== undefined && { storageExternalId: input.storageExternalId }),
+          ...(input.storageBucket !== undefined && { storageBucket: input.storageBucket }),
+          ...(input.storageContentType !== undefined && { storageContentType: input.storageContentType }),
+          ...(input.inline !== undefined && { inline: input.inline }),
+          ...(input.mediaType !== undefined && { mediaType: input.mediaType }),
+          ...(input.mediaQuery !== undefined && { mediaQuery: input.mediaQuery }),
+        },
+        include: RENDER_TEMPLATE_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'Render template not found or access denied' });
+    }
   });
 }
 
@@ -258,10 +273,14 @@ export async function deleteRenderTemplate(id: string, tenantId: string): Promis
       throw new NotFoundError('Render template not found or access denied');
     }
 
-    return tx.renderTemplate.delete({
-      where: { id },
-      include: RENDER_TEMPLATE_INCLUDE,
-    });
+    try {
+      return await tx.renderTemplate.delete({
+        where: { id },
+        include: RENDER_TEMPLATE_INCLUDE,
+      });
+    } catch (e) {
+      mapDatabaseError(e, { notFound: 'Render template not found or access denied' });
+    }
   });
 }
 


### PR DESCRIPTION
This PR adopts the repository-boundary database error translation (ADR-036) across eight write repositories, so constraint violations on data models, DIDs, facilities, organisations, products, identifier schemes, registrars, and render templates now return clean 409/404/400 responses with entity-specific messages instead of unmapped 500s. Adoption for the credential, service instance, and link registration repositories is tracked in #782.

Beyond the straight adoption, the edges are handled deliberately: qualifier recreation on scheme update is guarded separately so a concurrent qualifier-key collision reports the right conflict; registrar deletion blocked by identifiers (via the scheme cascade) returns a 409; secondary-identifier replacement maps both the concurrent-link conflict (409) and vanished-reference races (400); creates on organisations, facilities, and products map reference races to entity-specific 400s; update races report the entity or a referenced resource rather than misattributing the missing record; product deletion blocked by dependants reports a level-neutral message; duplicate identifiers or qualifier keys within one request are rejected as validation errors; and the Prisma error-code guards are gated on database-error detection so foreign errors sharing a code string are never misclassified. The new responses are documented in the Swagger annotations.

The repository suites share one Prisma-error fixture module anchored against the generated client's error class, rethrow paths assert error identity, and the central mapper's tests pin the distinct log message that marks an unmapped database error. The status returned when a reference vanishes between a pre-check and the write is decided in #781 for the sites whose routes document 404.

Closes #708

## Test plan
- [x] Unique-constraint violations on constrained creates and updates return 409 with entity-specific messages
- [x] Concurrent secondary-identifier replacement returns 409 instead of an unmapped 500 on organisations, facilities, and products
- [x] Reference races on organisation, facility, and product creates return 400 with clean messages
- [x] Update and delete races return 404 naming the entity or a referenced resource
- [x] Deletes blocked by dependent records return 409 (schemes, registrars) or the established level-neutral 400 (products)
- [x] Non-database errors propagate unchanged; unmapped database errors return the sanitised 500 with the distinct server-side log signal
- [x] Full reference-implementation suite passes (1649 tests, 118 suites)
