### PR TITLE
fix(ri): validate write-route request bodies with zod schemas

### DIFF
--- a/docs/adrs/037-zod-request-body-validation-at-the-route-boundary.md
+++ b/docs/adrs/037-zod-request-body-validation-at-the-route-boundary.md
@@ -1,0 +1,43 @@
+# ADR-037: Request-Body Validation with Zod Schemas at the Route Boundary
+
+- **Date:** 2026-07-02
+- **Status:** accepted
+
+## Context
+
+Most reference implementation write routes accept request bodies with little runtime shape validation: handlers check one or two fields with `isNonEmptyString` and pass the rest through unchecked type casts. Malformed input then fails deep in the stack (a `TypeError` on property access, Prisma's client-side argument validation, or an upstream service call) instead of returning a documented 400. The sanitised backstop from ADR-036 stops those responses leaking internals, but the status and message remain wrong: clients receive a generic 500 for what is a malformed request. An API-surface audit catalogued the gaps route by route (#736), including handlers that dereference a JSON `null` body, array fields never checked to be arrays, and a Zod schema that exists for documentation but is never applied to the incoming body.
+
+One route already validates properly: the identifier links publish route defines a Zod schema, parses the body with `safeParse`, and maps the first issue to a 400 naming the offending field. Zod is already a dependency of the package, and `src/lib/swagger/schemas.ts` already uses Zod to generate the OpenAPI component schemas. The open question was whether to extend that mechanism across the write surface or to grow the manual per-field helpers in `src/lib/api/validation.ts`.
+
+## Decision
+
+Every write route validates its request body with a Zod schema before calling repositories or upstream services, and the schemas live in a shared per-resource module.
+
+1. **Zod is the validation mechanism at the route boundary.** Each write route parses the raw body (`req.json()` guarded so malformed JSON and a literal `null` body become a 400) and runs it through a Zod schema with `safeParse`. On failure the route throws `ValidationError` with the first issue rendered as `field.path: message`, which the central error mapper returns as a 400. This extends the pattern the links publish route established rather than introducing a new one.
+2. **Schemas live in a shared per-resource module** (`src/lib/api/request-schemas/`, one file per resource). POST and PATCH handlers for a resource sit in different route files (`route.ts` and `[id]/route.ts`) but share field shapes; co-locating schemas in route files would duplicate those shapes. Keeping a resource's create and update schemas in one file also makes deriving one from the other possible where the shapes coincide (the link schemas do this via `.partial()`); most resources hand-declare both because their update shapes add nullable-clear semantics the create shapes lack.
+3. **Consumers import the resource file directly** (`@/lib/api/request-schemas/<resource>`), never through a barrel index. A barrel makes every importer transitively load every schema file and its dependencies (`@uncefact/untp-ri-services`, `@uncefact/untp-utils`), which breaks route tests that mock those packages with partial module factories: a test starts failing when an unrelated resource's schema needs an export the mock does not provide.
+4. **Unknown keys are stripped, not rejected.** Zod's default object behaviour (strip unknown keys) is kept, matching the links route. Clients that have been sending extra fields keep working; the handler only ever sees validated, known fields.
+5. **Validation covers shape and type, not existence.** Referential checks (does this identifier exist, does it belong to this tenant) stay in repositories and services, where ADR-036 already maps constraint violations. The schema's job ends at "this is a well-formed request".
+
+## Consequences
+
+- Easier: malformed input fails fast with a 400 naming the offending field, instead of a `TypeError` or a sanitised 500. The failure mode is documented and testable per schema rather than per code path.
+- Easier: handlers drop their unchecked `as` casts; `parsed.data` is the typed input, so the compiler enforces that only validated fields are used.
+- Easier: a resource's create and update schemas sit in the same file, so a field added to one verb is visible next to the other; where the shapes coincide the update schema can derive from the create schema directly.
+- Harder: request shapes are now declared twice, once in the request-schemas module and once in the hand-written Swagger `requestBody` annotations. The two can drift; folding the documentation generation onto the request schemas is a possible later step but out of scope here.
+- Harder: every new write route carries a schema obligation, and schema tests join the test surface.
+
+## Alternatives Considered
+
+- **Manual per-field checks via `src/lib/api/validation.ts` helpers.** Rejected: the audit showed this approach is exactly what left the gaps, because per-field discipline does not hold across dozens of fields and routes. Helpers validate one field at a time, so nothing enforces that every field was checked, `null` bodies and non-array arrays were repeatedly missed, and the handler still needs unchecked casts to name the body's type.
+- **Co-locating schemas in each route file** (the original links route layout). Rejected: a resource's create and update bodies share most field shapes but live in different route files, so co-location duplicates the shapes and lets them drift. The links publish route's previously co-located schema moved into the module for the same reason once the link update route needed the same field shapes.
+- **Extending `src/lib/swagger/schemas.ts` with the request schemas.** Rejected: that file's job is generating OpenAPI component schemas, and its shapes describe responses. Mixing request-validation schemas into it couples two concerns with different change cadences in one growing file; the request-schemas module can still be imported there later if documentation generation is unified.
+- **Rejecting unknown keys (`.strict()`).** Rejected: it turns previously accepted requests into 400s for clients that send extra fields, a behaviour break with no safety gain, since stripped fields never reach the handler.
+- **Validating inside repositories instead of routes.** Rejected: repositories receive typed inputs from many callers (routes, seeds, services) and are the wrong place to re-check shape on every call; the boundary where untyped external input enters the system is the route, so that is where shape validation belongs. This mirrors ADR-036's division: routes own request semantics, repositories own persistence semantics.
+
+## References
+
+- #736 (this change), #379 (credentials-route validation, absorbed by #736)
+- ADR-036 (database error translation; the sanitised backstop that currently catches these failures)
+- Existing pattern: `src/app/api/v1/identifiers/[id]/links/route.ts`
+- Zod: https://zod.dev

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -275,7 +275,7 @@ describe('POST /api/v1/credentials', () => {
       const json = await res.json();
 
       expect(res.status).toBe(400);
-      expect(json.error).toContain('credentialPayload is required');
+      expect(json.error).toContain('credentialPayload');
     });
 
     it('returns 400 when credentialPayload is not an object', async () => {
@@ -284,7 +284,7 @@ describe('POST /api/v1/credentials', () => {
       const json = await res.json();
 
       expect(res.status).toBe(400);
-      expect(json.error).toContain('credentialPayload is required');
+      expect(json.error).toContain('credentialPayload');
     });
 
     it('returns 400 when credentialType is missing', async () => {
@@ -293,7 +293,34 @@ describe('POST /api/v1/credentials', () => {
       const json = await res.json();
 
       expect(res.status).toBe(400);
-      expect(json.error).toContain('credentialType is required');
+      expect(json.error).toContain('credentialType');
+    });
+
+    it('returns 400 for a JSON null body', async () => {
+      const req = createFakeRequest(null);
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('body');
+    });
+
+    it('returns 400 when storageOptions.encrypt is not a boolean', async () => {
+      const req = createFakeRequest(validBody({ storageOptions: { encrypt: 'yes' as unknown as boolean } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('storageOptions.encrypt');
+    });
+
+    it('returns 400 when storageOptions.serviceInstanceId is not a string', async () => {
+      const req = createFakeRequest(validBody({ storageOptions: { serviceInstanceId: 42 as unknown as string } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toContain('storageOptions.serviceInstanceId');
     });
 
     it('accepts any non-empty credentialType string', async () => {
@@ -309,7 +336,7 @@ describe('POST /api/v1/credentials', () => {
       const json = await res.json();
 
       expect(res.status).toBe(400);
-      expect(json.error).toContain('version is required');
+      expect(json.error).toContain('version');
     });
   });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
 import {
   ValidationError,
-  isNonEmptyString,
+  parseRequestBody,
   parsePositiveInt,
   parseNonNegativeInt,
   parseBooleanString,
   assertPublicUrl,
 } from '@/lib/api/validation';
+import { issueCredentialRequestSchema } from '@/lib/api/request-schemas/credential';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { errorMessage } from '@/lib/api/errors';
 import { apiLogger } from '@/lib/api/logger';
@@ -24,7 +25,6 @@ import { getDidByDid, findConformitySchemeByCanonicalId } from '@/lib/prisma/rep
 import { buildPublishLinks } from '@uncefact/untp-ri-services';
 import type { CredentialPayload, ExtractedRefs } from '@uncefact/untp-ri-services';
 import { validateConformityClaim } from '@uncefact/untp-utils/conformity-vocabulary';
-import { publishingOptionsSchema } from '@/lib/swagger/schemas';
 
 type CredentialWarning = {
   code: string;
@@ -93,59 +93,15 @@ const logger = apiLogger.child({ route: '/api/v1/credentials' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  let body: {
-    credentialPayload?: CredentialPayload;
-    credentialType?: string;
-    version?: string;
-    storageOptions?: {
-      serviceInstanceId?: string;
-      encrypt?: boolean;
-    };
-    publishingOptions?: {
-      publish?: boolean;
-      linkType?: string;
-      linkTitle?: string;
-      qualifierPath?: string;
-      machineVerificationUrl?: string;
-      humanVerificationUrl?: string;
-      hreflang?: string[];
-      additionalRels?: string[];
-      public?: boolean;
-    };
-  };
+  // ── Step 1: Parse and validate request ──────────────────────────────────
 
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch (e) {
-    logger.warn({ err: e }, 'Failed to parse request body as JSON');
-    throw new ValidationError('Invalid JSON body');
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, issueCredentialRequestSchema);
 
-  // ── Step 1: Validate request ────────────────────────────────────────────
-
-  logger.info('Validating input parameters');
-  if (!body.credentialPayload || typeof body.credentialPayload !== 'object') {
-    throw new ValidationError('credentialPayload is required and must be an object');
-  }
-
-  if (!isNonEmptyString(body.credentialType)) {
-    throw new ValidationError('credentialType is required');
-  }
-
-  if (!isNonEmptyString(body.version)) {
-    throw new ValidationError('version is required');
-  }
-
-  const { credentialPayload, credentialType, version } = body;
+  const credentialPayload = body.credentialPayload as CredentialPayload;
+  const { credentialType, version } = body;
   const storageOptions = body.storageOptions ?? {};
-
-  const publishingOptionsParse = publishingOptionsSchema.safeParse(body.publishingOptions ?? {});
-  if (!publishingOptionsParse.success) {
-    const issue = publishingOptionsParse.error.issues[0];
-    throw new ValidationError(`publishingOptions.${issue.path.join('.') || ''}: ${issue.message}`);
-  }
-  const publishingOptions = publishingOptionsParse.data;
+  const publishingOptions = body.publishingOptions ?? {};
 
   // ── SSRF validation for URL fields ────────────────────────────────────
   if (process.env.VERIFY_ALLOW_PRIVATE_URLS !== 'true') {

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -353,6 +353,16 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.code).toBe('INVALID_RESPONSE');
   });
 
+  it('returns 422 when the fetched credential is a JSON array', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse([{ type: 'EnvelopedVerifiableCredential' }]));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Credential content is not a JSON object');
+    expect(json.code).toBe('INVALID_RESPONSE');
+  });
+
   it('returns 422 when the decrypted credential is JSON null', async () => {
     mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
     mockIsEncryptedEnvelope.mockReturnValue(true);

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -171,14 +171,21 @@ describe('POST /api/v1/credentials/verify', () => {
     const res = await POST(createFakeRequest({}));
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toBe('uri is required');
+    expect(json.error).toContain('uri');
   });
 
   it('returns 400 when uri is not a string', async () => {
     const res = await POST(createFakeRequest({ uri: 123 }));
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toBe('uri is required');
+    expect(json.error).toContain('uri');
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const res = await POST(createFakeRequest(null as unknown as Record<string, unknown>));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('body');
   });
 
   it('returns 400 for invalid URI format', async () => {
@@ -199,14 +206,28 @@ describe('POST /api/v1/credentials/verify', () => {
     const res = await POST(createFakeRequest({ uri: VALID_URI, hash: 'abc123' }));
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toBe('hash must be a 64-character hex string (SHA-256)');
+    expect(json.error).toContain('hash');
+    expect(json.error).toContain('64-character hex string (SHA-256)');
   });
 
   it('returns 400 for invalid decryptionKey format', async () => {
     const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: 'short' }));
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toBe('decryptionKey must be a 64-character hex string');
+    expect(json.error).toContain('decryptionKey');
+    expect(json.error).toContain('64-character hex string');
+  });
+
+  it('returns 400 for an invalid digestMultibase encoding', async () => {
+    mockMultibaseDigestFromString.mockImplementationOnce(() => {
+      throw new Error('invalid multibase');
+    });
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI, digestMultibase: 'not-a-digest' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('digestMultibase');
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   // ── SSRF Protection (400) ────────────────────────────────────────
@@ -319,6 +340,28 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json.error).toBe('Response from storage URI is not valid JSON');
+    expect(json.code).toBe('INVALID_RESPONSE');
+  });
+
+  it('returns 422 when the fetched credential is JSON null', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse('null'));
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Credential content is not a JSON object');
+    expect(json.code).toBe('INVALID_RESPONSE');
+  });
+
+  it('returns 422 when the decrypted credential is JSON null', async () => {
+    mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+    mockIsEncryptedEnvelope.mockReturnValue(true);
+    mockDecryptCredential.mockReturnValue('null');
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Credential content is not a JSON object');
     expect(json.code).toBe('INVALID_RESPONSE');
   });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { apiLogger } from '@/lib/api/logger';
-import { ValidationError } from '@/lib/api/validation';
+import { ValidationError, parseRequestBody } from '@/lib/api/validation';
+import { verifyCredentialRequestSchema } from '@/lib/api/request-schemas/credential';
 import { withPublicRoute } from '@/lib/api/with-public-route';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
@@ -12,7 +13,6 @@ import { decodeJwt } from 'jose';
 
 const logger = apiLogger.child({ route: '/api/v1/credentials/verify' });
 
-const HEX_64 = /^[a-f0-9]{64}$/i;
 const JWT_PREFIX = 'data:application/vc+jwt,';
 const DEFAULT_MAX_CREDENTIAL_SIZE = 10_485_760; // 10 MB
 
@@ -149,19 +149,11 @@ export const POST = withPublicRoute(async (req) => {
   // is fragile across serverless instances.
 
   // ── Step 1: Parse and validate input ────────────────────────────────
-  logger.info('Parsing request body');
-  let body: { uri?: string; digestMultibase?: string; hash?: string; decryptionKey?: string };
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ uri: body.uri }, 'Validating input parameters');
-
-  if (!body.uri || typeof body.uri !== 'string') {
-    throw new ValidationError('uri is required');
-  }
+  // The schema accepts the legacy `hash` field (hex SHA-256) for verify URLs
+  // already issued before the multibase migration; they're out in the wild on
+  // QR codes and can't be reissued. Prefer `digestMultibase` when both are set.
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, verifyCredentialRequestSchema);
 
   let parsedUri: URL;
   try {
@@ -172,31 +164,6 @@ export const POST = withPublicRoute(async (req) => {
 
   if (parsedUri.protocol !== 'http:' && parsedUri.protocol !== 'https:') {
     throw new ValidationError('uri must be a valid HTTP(S) URL');
-  }
-
-  if (body.digestMultibase !== undefined) {
-    if (typeof body.digestMultibase !== 'string') {
-      throw new ValidationError('digestMultibase must be a string');
-    }
-    try {
-      MultibaseDigest.fromString(body.digestMultibase);
-    } catch {
-      throw new ValidationError('digestMultibase must be a valid multibase-encoded multihash');
-    }
-  }
-
-  // Accept the legacy `hash` query parameter (hex SHA-256) for verify URLs
-  // already issued before the multibase migration; they're out in the wild on
-  // QR codes and can't be reissued. Prefer `digestMultibase` when both are set.
-  if (body.hash !== undefined && (typeof body.hash !== 'string' || !HEX_64.test(body.hash))) {
-    throw new ValidationError('hash must be a 64-character hex string (SHA-256)');
-  }
-
-  if (
-    body.decryptionKey !== undefined &&
-    (typeof body.decryptionKey !== 'string' || !HEX_64.test(body.decryptionKey))
-  ) {
-    throw new ValidationError('decryptionKey must be a 64-character hex string');
   }
 
   // ── SSRF protection: block private/reserved network addresses ──────
@@ -261,7 +228,7 @@ export const POST = withPublicRoute(async (req) => {
   // ── Step 3: Detect and handle encryption ───────────────────────────
   logger.info('Detecting credential encryption');
 
-  let credential: Record<string, unknown>;
+  let credentialData: unknown;
 
   if (isEncryptedEnvelope(fetchedData)) {
     if (!body.decryptionKey) {
@@ -281,14 +248,26 @@ export const POST = withPublicRoute(async (req) => {
         tag: fetchedData.tag,
         type: fetchedData.type,
       });
-      credential = JSON.parse(decryptedString);
+      credentialData = JSON.parse(decryptedString);
     } catch (e: unknown) {
       logger.warn({ uri: body.uri, err: e }, 'Credential decryption failed');
       return NextResponse.json({ error: 'Failed to decrypt credential', code: 'DECRYPTION_FAILED' }, { status: 422 });
     }
   } else {
-    credential = fetchedData as Record<string, unknown>;
+    credentialData = fetchedData;
   }
+
+  // A stored JSON scalar (including null) is not a credential; reject it
+  // before any property access.
+  if (credentialData === null || typeof credentialData !== 'object') {
+    logger.warn({ uri: body.uri }, 'Credential content is not a JSON object');
+    return NextResponse.json(
+      { error: 'Credential content is not a JSON object', code: 'INVALID_RESPONSE' },
+      { status: 422 },
+    );
+  }
+
+  const credential = credentialData as Record<string, unknown>;
 
   // ── Step 4: Digest verification ────────────────────────────────────
   // Prefer the multibase digest when provided; fall back to the legacy hex

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -257,9 +257,9 @@ export const POST = withPublicRoute(async (req) => {
     credentialData = fetchedData;
   }
 
-  // A stored JSON scalar (including null) is not a credential; reject it
-  // before any property access.
-  if (credentialData === null || typeof credentialData !== 'object') {
+  // A stored JSON scalar (including null) or array is not a credential;
+  // reject it before any property access.
+  if (credentialData === null || typeof credentialData !== 'object' || Array.isArray(credentialData)) {
     logger.warn({ uri: body.uri }, 'Credential content is not a JSON object');
     return NextResponse.json(
       { error: 'Credential content is not a JSON object', code: 'INVALID_RESPONSE' },

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
@@ -177,6 +177,17 @@ describe('PATCH /api/v1/data-models/:id', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('At least one updatable field must be provided');
+    expect(mockUpdateDataModel).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockUpdateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when name is empty string', async () => {
@@ -185,7 +196,8 @@ describe('PATCH /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toContain('name');
+    expect(mockUpdateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when schemaUrl is empty string', async () => {
@@ -194,7 +206,8 @@ describe('PATCH /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('schemaUrl must be a non-empty string');
+    expect(json.error).toContain('schemaUrl');
+    expect(mockUpdateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when contextUrl is empty string', async () => {
@@ -203,7 +216,8 @@ describe('PATCH /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('contextUrl must be a non-empty string');
+    expect(json.error).toContain('contextUrl');
+    expect(mockUpdateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when websiteUrl is empty string', async () => {
@@ -212,7 +226,18 @@ describe('PATCH /api/v1/data-models/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('websiteUrl must be a non-empty string');
+    expect(json.error).toContain('websiteUrl');
+    expect(mockUpdateDataModel).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when schemaUrl is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { schemaUrl: 42 } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('schemaUrl');
+    expect(mockUpdateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { assertPublicUrl, ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { assertPublicUrl, parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateDataModelRequestSchema } from '@/lib/api/request-schemas/data-model';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getDataModelById, updateDataModel, deleteDataModel } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/data-models/[id]' });
-
-const UPDATABLE_FIELDS = ['name', 'schemaUrl', 'contextUrl', 'websiteUrl'] as const;
 
 /**
  * @swagger
@@ -137,48 +136,18 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ dataModelId: id }, 'Parsing request body');
-  let body: Record<string, unknown>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ dataModelId: id }, 'Validating input parameters');
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
-  if (!hasUpdatableField) {
-    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
-  }
-
-  if (body.name !== undefined && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-  if (body.schemaUrl !== undefined && !isNonEmptyString(body.schemaUrl)) {
-    throw new ValidationError('schemaUrl must be a non-empty string');
-  }
-  if (body.contextUrl !== undefined && !isNonEmptyString(body.contextUrl)) {
-    throw new ValidationError('contextUrl must be a non-empty string');
-  }
-  if (body.websiteUrl !== undefined && !isNonEmptyString(body.websiteUrl)) {
-    throw new ValidationError('websiteUrl must be a non-empty string');
-  }
+  logger.info({ dataModelId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateDataModelRequestSchema);
 
   if (process.env.VERIFY_ALLOW_PRIVATE_URLS !== 'true') {
     logger.info({ dataModelId: id }, 'Validating URLs are not internal');
-    if (isNonEmptyString(body.schemaUrl)) await assertPublicUrl(body.schemaUrl, 'schemaUrl');
-    if (isNonEmptyString(body.contextUrl)) await assertPublicUrl(body.contextUrl, 'contextUrl');
-    if (isNonEmptyString(body.websiteUrl)) await assertPublicUrl(body.websiteUrl, 'websiteUrl');
+    if (body.schemaUrl !== undefined) await assertPublicUrl(body.schemaUrl, 'schemaUrl');
+    if (body.contextUrl !== undefined) await assertPublicUrl(body.contextUrl, 'contextUrl');
+    if (body.websiteUrl !== undefined) await assertPublicUrl(body.websiteUrl, 'websiteUrl');
   }
 
   logger.info({ dataModelId: id }, 'Updating data model');
-  const dataModel = await updateDataModel(id, tenantId, {
-    ...(body.name !== undefined && { name: body.name as string }),
-    ...(body.schemaUrl !== undefined && { schemaUrl: body.schemaUrl as string }),
-    ...(body.contextUrl !== undefined && { contextUrl: body.contextUrl as string }),
-    ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl as string }),
-  });
+  const dataModel = await updateDataModel(id, tenantId, definedFields(body));
 
   logger.info({ dataModelId: id }, 'Data model updated');
   return NextResponse.json(dataModel);

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
@@ -408,6 +408,16 @@ describe('POST /api/v1/data-models', () => {
     expect(mockCreateDataModel).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ isExtension: true }));
   });
 
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when name is missing', async () => {
     const req = createFakeRequest({
       body: {
@@ -422,7 +432,8 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required');
+    expect(json.error).toContain('name');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when credentialType is missing', async () => {
@@ -439,7 +450,8 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('credentialType is required');
+    expect(json.error).toContain('credentialType');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
   });
 
   it('accepts a custom credentialType string', async () => {
@@ -492,7 +504,8 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('version is required');
+    expect(json.error).toContain('version');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when schemaUrl is missing', async () => {
@@ -509,7 +522,8 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('schemaUrl is required');
+    expect(json.error).toContain('schemaUrl');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when contextUrl is missing', async () => {
@@ -526,7 +540,8 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('contextUrl is required');
+    expect(json.error).toContain('contextUrl');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when parentConfigId is missing', async () => {
@@ -543,7 +558,8 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('parentConfigId is required');
+    expect(json.error).toContain('parentConfigId');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 when websiteUrl is empty string', async () => {
@@ -562,7 +578,8 @@ describe('POST /api/v1/data-models', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('websiteUrl must be a non-empty string');
+    expect(json.error).toContain('websiteUrl');
+    expect(mockCreateDataModel).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.ts
@@ -2,12 +2,12 @@ import { apiLogger } from '@/lib/api/logger';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import {
   assertPublicUrl,
-  isNonEmptyString,
   parseBooleanString,
   parseNonNegativeInt,
   parsePositiveInt,
-  ValidationError,
+  parseRequestBody,
 } from '@/lib/api/validation';
+import { createDataModelRequestSchema } from '@/lib/api/request-schemas/data-model';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createDataModel, listDataModels } from '@/lib/prisma/repositories';
 
@@ -199,38 +199,8 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: {
-    name?: string;
-    credentialType?: string;
-    version?: string;
-    schemaUrl?: string;
-    contextUrl?: string;
-    parentConfigId?: string;
-    websiteUrl?: string;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info('Validating input parameters');
-  if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
-
-  if (!isNonEmptyString(body.credentialType)) throw new ValidationError('credentialType is required');
-  const credentialType = body.credentialType;
-
-  if (!isNonEmptyString(body.version)) throw new ValidationError('version is required');
-  if (!isNonEmptyString(body.schemaUrl)) throw new ValidationError('schemaUrl is required');
-  if (!isNonEmptyString(body.contextUrl)) throw new ValidationError('contextUrl is required');
-  if (!isNonEmptyString(body.parentConfigId)) {
-    throw new ValidationError('parentConfigId is required');
-  }
-  if (body.websiteUrl !== undefined && !isNonEmptyString(body.websiteUrl)) {
-    throw new ValidationError('websiteUrl must be a non-empty string');
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createDataModelRequestSchema);
 
   if (process.env.VERIFY_ALLOW_PRIVATE_URLS !== 'true') {
     logger.info('Validating URLs are not internal');
@@ -241,10 +211,10 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     }
   }
 
-  logger.info({ credentialType, name: body.name }, 'Creating data model extension');
+  logger.info({ credentialType: body.credentialType, name: body.name }, 'Creating data model extension');
   const dataModel = await createDataModel(tenantId, {
     name: body.name,
-    credentialType,
+    credentialType: body.credentialType,
     version: body.version,
     schemaUrl: body.schemaUrl,
     contextUrl: body.contextUrl,

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
@@ -136,6 +136,30 @@ describe('PATCH /api/v1/dids/:id', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty-string name instead of silently ignoring it', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isDefault is not a boolean', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { isDefault: 'yes' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when DID not found or access denied', async () => {
     mockUpdateDid.mockRejectedValue(new NotFoundError('DID not found or access denied'));
 

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { ValidationError, parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateDidRequestSchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getDidById, updateDid, deleteDid } from '@/lib/prisma/repositories';
 import { resolveDidService } from '@/lib/services/resolve-did-service';
@@ -129,29 +130,11 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ didId: id }, 'Parsing request body');
-  let body: { name?: string; description?: string; isDefault?: boolean };
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
+  logger.info({ didId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateDidRequestSchema);
 
-  logger.info({ didId: id }, 'Validating update fields');
-  const hasName = isNonEmptyString(body.name);
-  const hasDescription = isNonEmptyString(body.description);
-  const hasIsDefault = typeof body.isDefault === 'boolean';
-
-  if (!hasName && !hasDescription && !hasIsDefault) {
-    throw new ValidationError('At least one of name, description, or isDefault is required');
-  }
-
-  logger.info({ didId: id, fields: { hasName, hasDescription, hasIsDefault } }, 'Updating DID record');
-  const updated = await updateDid(id, tenantId, {
-    ...(hasName && { name: body.name }),
-    ...(hasDescription && { description: body.description }),
-    ...(hasIsDefault && { isDefault: body.isDefault }),
-  });
+  logger.info({ didId: id }, 'Updating DID record');
+  const updated = await updateDid(id, tenantId, definedFields(body));
 
   logger.info({ didId: id }, 'DID updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -7,46 +7,39 @@ jest.mock('next/server', () => ({
   },
 }));
 
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { ConflictError, NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
-      (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
+      (handler: (...args: unknown[]) => unknown) =>
+      async (...args: unknown[]) => {
         try {
-          return await handler(req, ctx);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          if (e instanceof ConflictError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 409 });
-          }
-          if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 500 });
-          }
-          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+          return await handler(...args);
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };
 });
 
 const mockCreateDid = jest.fn();
+const mockGetInstanceByResolution = jest.fn();
 jest.mock('@/lib/prisma/repositories', () => ({
   createDid: (...args: unknown[]) => mockCreateDid(...args),
+  getInstanceByResolution: (...args: unknown[]) => mockGetInstanceByResolution(...args),
 }));
 
-jest.mock('@uncefact/untp-ri-services', () => ({
-  DidMethod: { DID_WEB: 'DID_WEB', DID_WEB_VH: 'DID_WEB_VH' },
-}));
+jest.mock('@uncefact/untp-ri-services', () => {
+  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
+  return {
+    ServiceError,
+    DidMethod: { DID_WEB: 'DID_WEB', DID_WEB_VH: 'DID_WEB_VH' },
+    DidType: { MANAGED: 'MANAGED', SELF_MANAGED: 'SELF_MANAGED' },
+    CREATABLE_DID_TYPES: ['MANAGED', 'SELF_MANAGED'],
+    ServiceType: { IDR: 'IDR', STORAGE: 'STORAGE', VC: 'VC' },
+  };
+});
 
 import { POST } from './route';
 
@@ -86,6 +79,7 @@ describe('POST /api/v1/dids/import', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCreateDid.mockResolvedValue(MOCK_DID_RECORD);
+    mockGetInstanceByResolution.mockResolvedValue({ id: 'inst-1', serviceType: 'VC' });
   });
 
   it('imports a DID and returns 201', async () => {
@@ -146,7 +140,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('serviceInstanceId is required');
+    expect(body.error).toContain('serviceInstanceId');
   });
 
   it('returns 400 when serviceInstanceId is an empty string', async () => {
@@ -161,7 +155,47 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('serviceInstanceId is required');
+    expect(body.error).toContain('serviceInstanceId');
+  });
+
+  it('returns 404 when the service instance does not exist or belongs to another tenant', async () => {
+    mockGetInstanceByResolution.mockResolvedValue(null);
+
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: 'someone-elses-instance',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toContain('Service instance not found');
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('scopes the service instance lookup to the tenant', async () => {
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: 'inst-1',
+    });
+
+    await POST(req, createContext());
+
+    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('tenant-1', 'VC', 'inst-1');
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const res = await POST(createFakeRequest(null), createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('body');
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('sets status to UNVERIFIED', async () => {
@@ -205,7 +239,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('did is required');
+    expect(body.error).toContain('did');
   });
 
   it('returns 400 when keyId is missing', async () => {
@@ -215,7 +249,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('keyId is required');
+    expect(body.error).toContain('keyId');
   });
 
   it('returns 400 when method is missing', async () => {
@@ -225,7 +259,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('method is required');
+    expect(body.error).toContain('method');
   });
 
   it('returns 400 for invalid method', async () => {
@@ -240,7 +274,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('method must be one of');
+    expect(body.error).toContain('method');
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -313,7 +347,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('did is required');
+    expect(body.error).toContain('did');
   });
 
   it('returns 400 when keyId is an empty string', async () => {
@@ -323,7 +357,7 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('keyId is required');
+    expect(body.error).toContain('keyId');
   });
 
   it('returns 400 when method is an empty string', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, validateEnum } from '@/lib/api/validation';
+import { parseRequestBody } from '@/lib/api/validation';
+import { importDidRequestSchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { createDid } from '@/lib/prisma/repositories';
-import { DidMethod } from '@uncefact/untp-ri-services';
+import { ServiceInstanceNotFoundError } from '@/lib/api/errors';
+import { createDid, getInstanceByResolution } from '@/lib/prisma/repositories';
+import { ServiceType } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/dids/import' });
@@ -64,6 +66,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Service instance not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
  *         description: A DID record with this DID already exists
  *         content:
@@ -78,44 +86,24 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  let body: {
-    did?: string;
-    method?: string;
-    keyId?: string;
-    name?: string;
-    description?: string;
-    serviceInstanceId?: string;
-  };
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, importDidRequestSchema);
 
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
+  // The imported record's serviceInstanceId is later used to resolve the
+  // signing service, so the instance must exist and be visible to this tenant
+  // (matching the resolution scoping POST /dids applies).
+  logger.info({ serviceInstanceId: body.serviceInstanceId }, 'Validating service instance reference');
+  const instance = await getInstanceByResolution(tenantId, ServiceType.VC, body.serviceInstanceId);
+  if (!instance) {
+    throw new ServiceInstanceNotFoundError(body.serviceInstanceId);
   }
 
-  logger.info({ did: body.did, method: body.method }, 'Validating import parameters');
-  if (!isNonEmptyString(body.did)) {
-    throw new ValidationError('did is required');
-  }
-  if (!isNonEmptyString(body.keyId)) {
-    throw new ValidationError('keyId is required');
-  }
-  if (!isNonEmptyString(body.serviceInstanceId)) {
-    throw new ValidationError('serviceInstanceId is required');
-  }
-
-  const method = validateEnum(body.method, Object.values(DidMethod), 'method');
-  if (!method) {
-    throw new ValidationError('method is required');
-  }
-
-  logger.info({ did: body.did, method }, 'Saving imported DID record');
+  logger.info({ did: body.did, method: body.method }, 'Saving imported DID record');
   const record = await createDid({
     tenantId,
     did: body.did,
     type: 'SELF_MANAGED',
-    method,
+    method: body.method,
     keyId: body.keyId,
     name: body.name ?? body.did,
     description: body.description,

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -195,7 +195,19 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('type must be');
+    expect(json.error).toContain('type');
+  });
+
+  it('returns 400 for the DEFAULT type (a real DidType that is not creatable)', async () => {
+    const req = createFakeRequest({
+      body: { type: 'DEFAULT', method: DidMethod.DID_WEB, alias: 'test' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('type');
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing type', async () => {
@@ -213,7 +225,7 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('method must be');
+    expect(json.error).toContain('method');
   });
 
   it('returns 400 for missing method', async () => {
@@ -222,7 +234,7 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('method is required');
+    expect(json.error).toContain('method');
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -232,6 +244,28 @@ describe('POST /api/v1/dids', () => {
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('body');
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isDefault is not a boolean', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test', isDefault: 'yes' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('isDefault');
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('returns 500 when DID service fails', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from 'next/server';
 import { resolveDidService } from '@/lib/services/resolve-did-service';
 import { errorMessage, ConflictError, ForbiddenError } from '@/lib/api/errors';
-import { ValidationError, validateEnum, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import {
+  ValidationError,
+  validateEnum,
+  parseRequestBody,
+  parsePositiveInt,
+  parseNonNegativeInt,
+} from '@/lib/api/validation';
+import { createDidRequestSchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createDid, listDids, findDidByAliasAndService } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
-import { CREATABLE_DID_TYPES, DidType, DidMethod, DidStatus, DidConflictError } from '@uncefact/untp-ri-services';
+import { DidType, DidMethod, DidStatus, DidConflictError } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 
@@ -98,33 +105,9 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  let body: {
-    type?: string;
-    method?: string;
-    alias?: string;
-    name?: string;
-    description?: string;
-    isDefault?: boolean;
-    serviceInstanceId?: string;
-  };
-
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ type: body.type, method: body.method, alias: body.alias }, 'Validating input parameters');
-  const type = validateEnum(body.type, CREATABLE_DID_TYPES, 'type');
-  if (!type) throw new ValidationError('type is required');
-
-  const method = validateEnum(body.method, Object.values(DidMethod), 'method');
-  if (!method) throw new ValidationError('method is required');
-
-  if (!body.alias || typeof body.alias !== 'string') {
-    throw new ValidationError('alias is required');
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createDidRequestSchema);
+  const { type, method } = body;
 
   logger.info({ type, method, alias: body.alias }, 'Resolving DID service');
   const { service: didService, instanceId: serviceInstanceId } = await resolveDidService(

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
@@ -131,7 +131,7 @@ describe('PATCH /api/v1/facilities/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('At least one updatable field is required');
+    expect(json.error).toContain('At least one of');
   });
 
   it('returns 400 when name is empty string', async () => {
@@ -140,7 +140,59 @@ describe('PATCH /api/v1/facilities/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toContain('name');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: 'id-1' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('secondaryIdentifierIds');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when operatingOrganisationId is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { operatingOrganisationId: 42 } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('operatingOrganisationId');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: 42 } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('primaryIdentifierId');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('allows clearing primaryIdentifierId with null', async () => {
+    const updated = { id: 'fac-1', name: 'Warehouse Alpha', primaryIdentifierId: null };
+    mockUpdateFacility.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: null } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', { primaryIdentifierId: null });
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -168,6 +220,17 @@ describe('PATCH /api/v1/facilities/:id', () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toContain('Facility not found');
+  });
+
+  it('allows clearing operatingOrganisationId with null', async () => {
+    const updated = { id: 'fac-1', name: 'Warehouse Alpha', operatingOrganisationId: null };
+    mockUpdateFacility.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { operatingOrganisationId: null } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', { operatingOrganisationId: null });
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -1,21 +1,12 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateFacilityRequestSchema } from '@/lib/api/request-schemas/facility';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { getFacilityById, updateFacility, deleteFacility, UpdateFacilityInput } from '@/lib/prisma/repositories';
+import { getFacilityById, updateFacility, deleteFacility } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/facilities/[id]' });
-
-/** Fields that may be updated on a facility. */
-const UPDATABLE_FIELDS = [
-  'name',
-  'description',
-  'location',
-  'operatingOrganisationId',
-  'primaryIdentifierId',
-  'secondaryIdentifierIds',
-] as const;
 
 /**
  * @swagger
@@ -155,36 +146,11 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ facilityId: id }, 'Parsing request body');
-  let body: Record<string, unknown>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ facilityId: id }, 'Validating update fields');
-  // Ensure at least one updatable field is present
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
-  if (!hasUpdatableField) {
-    throw new ValidationError(`At least one updatable field is required: ${UPDATABLE_FIELDS.join(', ')}`);
-  }
-
-  // Validate name if provided — must be a non-empty string
-  if ('name' in body && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-
-  const updateData: Record<string, unknown> = {};
-  for (const field of UPDATABLE_FIELDS) {
-    if (field in body) {
-      updateData[field] = body[field];
-    }
-  }
+  logger.info({ facilityId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateFacilityRequestSchema);
 
   logger.info({ facilityId: id }, 'Updating facility');
-  const updated = await updateFacility(id, tenantId, updateData as UpdateFacilityInput);
+  const updated = await updateFacility(id, tenantId, definedFields(body));
 
   logger.info({ facilityId: id }, 'Facility updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
@@ -134,7 +134,36 @@ describe('POST /api/v1/facilities', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required');
+    expect(json.error).toContain('name');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when an array item is null', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha' }, null] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is not a string', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', primaryIdentifierId: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('primaryIdentifierId');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', secondaryIdentifierIds: 'id-1' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('secondaryIdentifierIds');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { createFacilitiesRequestSchema } from '@/lib/api/request-schemas/facility';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createFacilities, listFacilities } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
@@ -87,29 +88,8 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: unknown;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info('Validating input parameters');
-  if (!Array.isArray(body)) {
-    throw new ValidationError('Request body must be an array');
-  }
-
-  if (body.length === 0) {
-    throw new ValidationError('Request body must not be empty');
-  }
-
-  for (const item of body) {
-    if (!isNonEmptyString(item.name)) {
-      throw new ValidationError('name is required for each facility');
-    }
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createFacilitiesRequestSchema);
 
   logger.info({ count: body.length }, 'Creating facilities');
   const facilities = await createFacilities(tenantId, body);

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.test.ts
@@ -269,6 +269,36 @@ describe('PATCH /api/v1/identifiers/[id]/links/[linkId]', () => {
     expect(body.error).toBe('Invalid JSON body');
   });
 
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest(null);
+    const res = await PATCH(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('body');
+    expect(MOCK_IDR_SERVICE.updateLink).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-string href instead of forwarding it upstream', async () => {
+    const req = createFakeRequest({ href: 42 });
+    const res = await PATCH(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('href');
+    expect(MOCK_IDR_SERVICE.updateLink).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-array hreflang instead of forwarding it upstream', async () => {
+    const req = createFakeRequest({ hreflang: 'en' });
+    const res = await PATCH(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('hreflang');
+    expect(MOCK_IDR_SERVICE.updateLink).not.toHaveBeenCalled();
+  });
+
   it('forwards hreflang, additionalRels, and public to updateLink', async () => {
     const req = createFakeRequest({
       hreflang: ['en', 'de'],
@@ -282,6 +312,15 @@ describe('PATCH /api/v1/identifiers/[id]/links/[linkId]', () => {
       hreflang: ['en', 'de'],
       additionalRels: ['gs1:certificationInfo'],
       public: true,
+    });
+  });
+
+  it('strips unknown fields before forwarding to updateLink', async () => {
+    const req = createFakeRequest({ href: 'https://updated.com/cred.json', unknownField: 'x' });
+    await PATCH(req, createContext());
+
+    expect(MOCK_IDR_SERVICE.updateLink).toHaveBeenCalledWith('idr-link-1', {
+      href: 'https://updated.com/cred.json',
     });
   });
 

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { assertPublicUrl, ValidationError } from '@/lib/api/validation';
+import { assertPublicUrl, parseRequestBody } from '@/lib/api/validation';
+import { updateLinkRequestSchema } from '@/lib/api/request-schemas/link';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import {
   getIdentifierById,
@@ -10,6 +11,7 @@ import {
 } from '@/lib/prisma/repositories';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
 import { IdrLinkNotFoundError } from '@uncefact/untp-ri-services';
+import type { Link } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links/[linkId]' });
@@ -228,15 +230,10 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id: identifierId, linkId } = await params;
 
-  logger.info({ identifierId, linkId }, 'Parsing request body');
-  let body: Record<string, unknown>;
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
+  logger.info({ identifierId, linkId }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateLinkRequestSchema);
 
-  if (typeof body.href === 'string') await assertPublicUrl(body.href, 'href');
+  if (body.href !== undefined) await assertPublicUrl(body.href, 'href');
 
   logger.info({ identifierId, linkId }, 'Looking up identifier and local link record for update');
   const identifier = await getIdentifierById(identifierId, tenantId);
@@ -261,7 +258,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
 
   try {
     logger.info({ identifierId, linkId }, 'Updating link on upstream IDR');
-    const updatedLink = await idrService.updateLink(linkId, body);
+    const updatedLink = await idrService.updateLink(linkId, body as Partial<Link>);
 
     logger.info({ identifierId, linkId }, 'Syncing local record with upstream state');
     await updateLinkRegistration(linkId, identifierId, tenantId, {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
@@ -1,34 +1,13 @@
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
 import { NotFoundError } from '@/lib/api/errors';
-import { assertPublicUrl, ValidationError, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { assertPublicUrl, parseRequestBody, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { publishLinksRequestSchema } from '@/lib/api/request-schemas/link';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getIdentifierById, createManyLinkRegistrations, listLinkRegistrations } from '@/lib/prisma/repositories';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 import type { Link } from '@uncefact/untp-ri-services';
-
-const linkSchema = z.object({
-  href: z.string().url(),
-  rel: z.string().min(1),
-  type: z.string().min(1),
-  title: z.string().optional(),
-  hreflang: z.array(z.string().min(1)).optional(),
-  context: z.string().optional(),
-  default: z.boolean().optional(),
-  method: z.enum(['GET', 'POST']).optional(),
-  encryptionMethod: z.string().optional(),
-  accessRole: z.array(z.string()).optional(),
-  additionalRels: z.array(z.string().min(1)).optional(),
-  public: z.boolean().optional(),
-});
-
-const publishLinksRequestSchema = z.object({
-  links: z.array(linkSchema).min(1),
-  qualifierPath: z.string().optional(),
-  description: z.string().optional(),
-});
 
 const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links' });
 
@@ -158,21 +137,8 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links' });
 export const POST = withTenantAuth(async (req, { tenantId, params }) => {
   const { id: identifierId } = await params;
 
-  logger.info({ identifierId }, 'Parsing request body');
-  let rawBody: unknown;
-  try {
-    rawBody = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ identifierId }, 'Validating input parameters');
-  const parsed = publishLinksRequestSchema.safeParse(rawBody);
-  if (!parsed.success) {
-    const issue = parsed.error.issues[0];
-    throw new ValidationError(`${issue.path.join('.') || 'body'}: ${issue.message}`);
-  }
-  const body = parsed.data;
+  logger.info({ identifierId }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, publishLinksRequestSchema);
 
   // SSRF guard on each link's target URL.
   for (const link of body.links) {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.test.ts
@@ -146,7 +146,7 @@ describe('PATCH /api/v1/identifiers/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('value is required');
+    expect(json.error).toContain('value');
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody } from '@/lib/api/validation';
+import { updateIdentifierRequestSchema } from '@/lib/api/request-schemas/identifier';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getIdentifierById, updateIdentifier, deleteIdentifier } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
@@ -80,11 +81,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         application/json:
  *           schema:
  *             type: object
+ *             required:
+ *               - value
  *             properties:
  *               value:
  *                 type: string
  *                 description: New value for the identifier (re-validated against scheme pattern)
- *             minProperties: 1
  *     responses:
  *       200:
  *         description: Identifier updated successfully
@@ -125,20 +127,8 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ identifierId: id }, 'Parsing request body');
-
-  let body: { value?: string };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ identifierId: id }, 'Validating update fields');
-  if (!isNonEmptyString(body.value)) {
-    throw new ValidationError('value is required');
-  }
+  logger.info({ identifierId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateIdentifierRequestSchema);
 
   logger.info({ identifierId: id }, 'Updating identifier');
   const updated = await updateIdentifier(id, tenantId, {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
@@ -131,7 +131,7 @@ describe('POST /api/v1/identifiers', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('schemeId is required');
+    expect(json.error).toContain('schemeId');
   });
 
   it('returns 400 for missing value', async () => {
@@ -140,7 +140,16 @@ describe('POST /api/v1/identifiers', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('value is required');
+    expect(json.error).toContain('value');
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
   });
 
   it('returns 400 when value fails scheme validation', async () => {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { createIdentifierRequestSchema } from '@/lib/api/request-schemas/identifier';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createIdentifier, listIdentifiers } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
@@ -70,21 +71,8 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: {
-    schemeId?: string;
-    value?: string;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ schemeId: body.schemeId }, 'Validating input parameters');
-  if (!isNonEmptyString(body.schemeId)) throw new ValidationError('schemeId is required');
-  if (!isNonEmptyString(body.value)) throw new ValidationError('value is required');
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createIdentifierRequestSchema);
 
   logger.info({ schemeId: body.schemeId }, 'Creating identifier');
   const identifier = await createIdentifier({

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
@@ -129,7 +129,7 @@ describe('PATCH /api/v1/organisations/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('At least one updatable field must be provided');
+    expect(json.error).toContain('At least one of');
   });
 
   it('returns 400 when name is empty string', async () => {
@@ -138,7 +138,49 @@ describe('PATCH /api/v1/organisations/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toContain('name');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: 42 } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('primaryIdentifierId');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: 'id-1' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('secondaryIdentifierIds');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('accepts an empty secondaryIdentifierIds array to clear all secondary identifiers', async () => {
+    const updated = { id: 'org-ent-1', name: 'Acme', secondaryIdentifierIds: [] };
+    mockUpdateOrganisation.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: [] } });
+    const res = await PATCH(req, createContext('org-ent-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-ent-1', 'org-1', { secondaryIdentifierIds: [] });
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -166,6 +208,17 @@ describe('PATCH /api/v1/organisations/:id', () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toContain('Organisation not found');
+  });
+
+  it('allows clearing primaryIdentifierId with null', async () => {
+    const updated = { id: 'org-a', name: 'Acme Corp', primaryIdentifierId: null };
+    mockUpdateOrganisation.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: null } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-a', 'org-1', { primaryIdentifierId: null });
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -1,18 +1,12 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateOrganisationRequestSchema } from '@/lib/api/request-schemas/organisation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import {
-  getOrganisationById,
-  updateOrganisation,
-  deleteOrganisation,
-  UpdateOrganisationInput,
-} from '@/lib/prisma/repositories';
+import { getOrganisationById, updateOrganisation, deleteOrganisation } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/organisations/[id]' });
-
-const UPDATABLE_FIELDS = ['name', 'description', 'location', 'primaryIdentifierId', 'secondaryIdentifierIds'] as const;
 
 /**
  * @swagger
@@ -99,7 +93,8 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                 description: Updated UNTP location object
  *               primaryIdentifierId:
  *                 type: string
- *                 description: ID of the primary identifier
+ *                 nullable: true
+ *                 description: ID of the primary identifier (set to null to clear)
  *               secondaryIdentifierIds:
  *                 type: array
  *                 items:
@@ -147,34 +142,11 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ organisationId: id }, 'Parsing request body');
-  let body: Record<string, unknown>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ organisationId: id }, 'Validating update fields');
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
-  if (!hasUpdatableField) {
-    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
-  }
-
-  if (body.name !== undefined && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-
-  const updateData: Record<string, unknown> = {};
-  for (const field of UPDATABLE_FIELDS) {
-    if (field in body) {
-      updateData[field] = body[field];
-    }
-  }
+  logger.info({ organisationId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateOrganisationRequestSchema);
 
   logger.info({ organisationId: id }, 'Updating organisation');
-  const updated = await updateOrganisation(id, tenantId, updateData as UpdateOrganisationInput);
+  const updated = await updateOrganisation(id, tenantId, definedFields(body));
 
   logger.info({ organisationId: id }, 'Organisation updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
@@ -111,7 +111,36 @@ describe('POST /api/v1/organisations', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required for each organisation');
+    expect(json.error).toContain('name');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when an array item is null', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp' }, null] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is not a string', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', primaryIdentifierId: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('primaryIdentifierId');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', secondaryIdentifierIds: 'id-1' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('secondaryIdentifierIds');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { createOrganisationsRequestSchema } from '@/lib/api/request-schemas/organisation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createOrganisations, listOrganisations } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
@@ -84,29 +85,8 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: unknown;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info('Validating input parameters');
-  if (!Array.isArray(body)) {
-    throw new ValidationError('Request body must be an array');
-  }
-
-  if (body.length === 0) {
-    throw new ValidationError('Request body must not be empty');
-  }
-
-  for (const item of body) {
-    if (!isNonEmptyString(item.name)) {
-      throw new ValidationError('name is required for each organisation');
-    }
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createOrganisationsRequestSchema);
 
   logger.info({ count: body.length }, 'Creating organisations');
   const organisations = await createOrganisations(tenantId, body);

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
@@ -131,6 +131,17 @@ describe('PATCH /api/v1/products/:id', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('At least one updatable field must be provided');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
   });
 
   it('returns 404 when product not found', async () => {
@@ -180,7 +191,69 @@ describe('PATCH /api/v1/products/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toContain('name');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when parentId is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { parentId: 42 } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('parentId');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when producedByOrganisationId is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { producedByOrganisationId: 42 } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('producedByOrganisationId');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when manufacturingFacilityId is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { manufacturingFacilityId: 42 } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('manufacturingFacilityId');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is not a string', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: 42 } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('primaryIdentifierId');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: 'not-an-array' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('secondaryIdentifierIds');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('allows clearing parentId with null', async () => {
+    const updated = { id: 'p-1', name: 'Widget A', level: 'MODEL', parentId: null };
+    mockUpdateProduct.mockResolvedValue(updated);
+
+    const req = createFakeRequest({ method: 'PATCH', body: { parentId: null } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProduct).toHaveBeenCalledWith('p-1', 'org-1', { parentId: null });
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -1,22 +1,12 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateProductRequestSchema } from '@/lib/api/request-schemas/product';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { getProductById, updateProduct, deleteProduct, UpdateProductInput } from '@/lib/prisma/repositories';
+import { getProductById, updateProduct, deleteProduct } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/products/[id]' });
-
-/** Fields that may be updated via PATCH. Level is immutable. */
-const UPDATABLE_FIELDS = [
-  'name',
-  'description',
-  'parentId',
-  'producedByOrganisationId',
-  'manufacturingFacilityId',
-  'primaryIdentifierId',
-  'secondaryIdentifierIds',
-] as const;
 
 /**
  * @swagger
@@ -102,16 +92,20 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                 description: Updated product description
  *               parentId:
  *                 type: string
- *                 description: Updated parent product ID
+ *                 nullable: true
+ *                 description: Updated parent product ID (set to null to clear)
  *               producedByOrganisationId:
  *                 type: string
- *                 description: Updated producing organisation ID
+ *                 nullable: true
+ *                 description: Updated producing organisation ID (set to null to clear)
  *               manufacturingFacilityId:
  *                 type: string
- *                 description: Updated manufacturing facility ID
+ *                 nullable: true
+ *                 description: Updated manufacturing facility ID (set to null to clear)
  *               primaryIdentifierId:
  *                 type: string
- *                 description: Updated primary identifier ID
+ *                 nullable: true
+ *                 description: Updated primary identifier ID (set to null to clear)
  *               secondaryIdentifierIds:
  *                 type: array
  *                 items:
@@ -159,35 +153,11 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ productId: id }, 'Parsing request body');
-  let body: Record<string, unknown>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ productId: id }, 'Validating update fields');
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
-  if (!hasUpdatableField) {
-    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
-  }
-
-  if (body.name !== undefined && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-
-  // Pick only known updatable fields (level is immutable and silently excluded)
-  const updateData: Record<string, unknown> = {};
-  for (const field of UPDATABLE_FIELDS) {
-    if (field in body) {
-      updateData[field] = body[field];
-    }
-  }
+  logger.info({ productId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateProductRequestSchema);
 
   logger.info({ productId: id }, 'Updating product');
-  const updated = await updateProduct(id, tenantId, updateData as UpdateProductInput);
+  const updated = await updateProduct(id, tenantId, definedFields(body));
 
   logger.info({ productId: id }, 'Product updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/products/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.test.ts
@@ -95,7 +95,8 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('Request body must be an array');
+    expect(json.error).toMatch(/array/i);
+    expect(mockCreateProducts).not.toHaveBeenCalled();
   });
 
   it('returns 400 when body is an empty array', async () => {
@@ -104,7 +105,38 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('Request body must not be empty');
+    expect(json.error).toContain('must not be empty');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when body is not an array', async () => {
+    const req = createFakeRequest({ body: { name: 'Widget', level: 'MODEL' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('must be an array');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a null array item', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget', level: 'MODEL' }, null] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('1');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
   });
 
   it('returns 400 when name is missing', async () => {
@@ -113,7 +145,8 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required for all items');
+    expect(json.error).toContain('name');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
   });
 
   it('returns 400 when level is missing', async () => {
@@ -122,7 +155,8 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('level is required for all items');
+    expect(json.error).toContain('level');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
   });
 
   it('returns 400 when level is not a valid enum value', async () => {
@@ -131,7 +165,60 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('level must be one of: MODEL, BATCH, ITEM');
+    expect(json.error).toContain('level');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when parentId is not a string', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget A', level: 'MODEL', parentId: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('parentId');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when producedByOrganisationId is not a string', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget A', level: 'MODEL', producedByOrganisationId: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('producedByOrganisationId');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when manufacturingFacilityId is not a string', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget A', level: 'MODEL', manufacturingFacilityId: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('manufacturingFacilityId');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is not a string', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget A', level: 'MODEL', primaryIdentifierId: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('primaryIdentifierId');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array', async () => {
+    const req = createFakeRequest({
+      body: [{ name: 'Widget A', level: 'MODEL', secondaryIdentifierIds: 'not-an-array' }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('secondaryIdentifierIds');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/products/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from 'next/server';
-import {
-  ValidationError,
-  isNonEmptyString,
-  parsePositiveInt,
-  parseNonNegativeInt,
-  validateEnum,
-} from '@/lib/api/validation';
+import { parseRequestBody, parsePositiveInt, parseNonNegativeInt, validateEnum } from '@/lib/api/validation';
+import { createProductsRequestSchema } from '@/lib/api/request-schemas/product';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { createProducts, listProducts, CreateProductInput } from '@/lib/prisma/repositories';
+import { createProducts, listProducts } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
@@ -103,41 +98,11 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: Array<{
-    name?: string;
-    level?: string;
-    description?: string;
-    parentId?: string;
-  }>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info('Validating input parameters');
-  if (!Array.isArray(body)) {
-    throw new ValidationError('Request body must be an array');
-  }
-
-  if (body.length === 0) {
-    throw new ValidationError('Request body must not be empty');
-  }
-
-  for (const item of body) {
-    if (!isNonEmptyString(item.name)) {
-      throw new ValidationError('name is required for all items');
-    }
-    if (!isNonEmptyString(item.level)) {
-      throw new ValidationError('level is required for all items');
-    }
-    validateEnum(item.level, PRODUCT_LEVELS, 'level');
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createProductsRequestSchema);
 
   logger.info({ count: body.length }, 'Creating products');
-  const products = await createProducts(tenantId, body as CreateProductInput[]);
+  const products = await createProducts(tenantId, body);
 
   logger.info({ count: products.length }, 'Products created');
   return NextResponse.json(products, { status: 201 });

--- a/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.test.ts
@@ -151,6 +151,26 @@ describe('PATCH /api/v1/registrars/:id', () => {
     expect(json.error).toBe('Invalid JSON body');
   });
 
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('reg-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockUpdateRegistrar).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty-string name instead of silently ignoring it', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('reg-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name');
+    expect(mockUpdateRegistrar).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when registrar not found or access denied', async () => {
     mockUpdateRegistrar.mockRejectedValue(new NotFoundError('Registrar not found or access denied'));
 
@@ -160,6 +180,16 @@ describe('PATCH /api/v1/registrars/:id', () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toContain('Registrar not found');
+  });
+
+  it('returns 400 for an empty-string idrServiceInstanceId', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { idrServiceInstanceId: '' } });
+    const res = await PATCH(req, createContext('reg-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('idrServiceInstanceId');
+    expect(mockUpdateRegistrar).not.toHaveBeenCalled();
   });
 
   it('allows clearing idrServiceInstanceId with null', async () => {

--- a/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateRegistrarRequestSchema } from '@/lib/api/request-schemas/registrar';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getRegistrarById, updateRegistrar, deleteRegistrar } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
@@ -129,40 +130,11 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ registrarId: id }, 'Parsing request body');
+  logger.info({ registrarId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateRegistrarRequestSchema);
 
-  let body: {
-    name?: string;
-    namespace?: string;
-    url?: string;
-    idrServiceInstanceId?: string | null;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  const hasName = isNonEmptyString(body.name);
-  const hasNamespace = isNonEmptyString(body.namespace);
-  const hasUrl = isNonEmptyString(body.url);
-  const hasIdrServiceInstanceId = body.idrServiceInstanceId !== undefined;
-
-  if (!hasName && !hasNamespace && !hasUrl && !hasIdrServiceInstanceId) {
-    throw new ValidationError('At least one of name, namespace, url, or idrServiceInstanceId is required');
-  }
-
-  logger.info(
-    { registrarId: id, fields: { hasName, hasNamespace, hasUrl, hasIdrServiceInstanceId } },
-    'Updating registrar',
-  );
-  const updated = await updateRegistrar(id, tenantId, {
-    ...(hasName && { name: body.name }),
-    ...(hasNamespace && { namespace: body.namespace }),
-    ...(hasUrl && { url: body.url }),
-    ...(hasIdrServiceInstanceId && { idrServiceInstanceId: body.idrServiceInstanceId }),
-  });
+  logger.info({ registrarId: id }, 'Updating registrar');
+  const updated = await updateRegistrar(id, tenantId, definedFields(body));
 
   logger.info({ registrarId: id }, 'Registrar updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/registrars/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/route.test.ts
@@ -115,7 +115,8 @@ describe('POST /api/v1/registrars', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required');
+    expect(json.error).toContain('name');
+    expect(mockCreateRegistrar).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing namespace', async () => {
@@ -124,7 +125,28 @@ describe('POST /api/v1/registrars', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('namespace is required');
+    expect(json.error).toContain('namespace');
+    expect(mockCreateRegistrar).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockCreateRegistrar).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-string name', async () => {
+    const req = createFakeRequest({ body: { name: 42, namespace: 'gs1', url: 'https://gs1.org' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('name');
+    expect(mockCreateRegistrar).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/registrars/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { createRegistrarRequestSchema } from '@/lib/api/request-schemas/registrar';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createRegistrar, listRegistrars } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
@@ -65,24 +66,8 @@ const logger = apiLogger.child({ route: '/api/v1/registrars' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: {
-    name?: string;
-    namespace?: string;
-    url?: string;
-    idrServiceInstanceId?: string;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ name: body.name, namespace: body.namespace }, 'Validating input parameters');
-  if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
-  if (!isNonEmptyString(body.namespace)) throw new ValidationError('namespace is required');
-  if (!isNonEmptyString(body.url)) throw new ValidationError('url is required');
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createRegistrarRequestSchema);
 
   logger.info({ namespace: body.namespace }, 'Creating registrar');
   const registrar = await createRegistrar({

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.test.ts
@@ -231,7 +231,8 @@ describe('PATCH /api/v1/render-templates/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toContain('name');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects storageUrl in body', async () => {
@@ -240,7 +241,18 @@ describe('PATCH /api/v1/render-templates/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toBe('storageUrl cannot be set directly');
+    expect(json.error).toContain('storageUrl');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('rejects hash in body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { hash: 'a'.repeat(64) } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('hash');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects digestMultibase in body', async () => {
@@ -249,7 +261,8 @@ describe('PATCH /api/v1/render-templates/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toBe('digestMultibase cannot be set directly');
+    expect(json.error).toContain('digestMultibase');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects renderMethodType in body', async () => {
@@ -258,7 +271,8 @@ describe('PATCH /api/v1/render-templates/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toBe('renderMethodType cannot be set directly');
+    expect(json.error).toContain('renderMethodType');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('returns 400 when no patchable field provided', async () => {
@@ -268,6 +282,60 @@ describe('PATCH /api/v1/render-templates/:id', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('At least one updatable field must be provided');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when template is an empty string instead of silently skipping the re-upload', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { template: '' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('template');
+    expect(mockResolveStorageService).not.toHaveBeenCalled();
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when template is null instead of silently skipping the re-upload', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { template: null } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('template');
+    expect(mockResolveStorageService).not.toHaveBeenCalled();
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when template is a number instead of silently skipping the re-upload', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { template: 5 } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('template');
+    expect(mockResolveStorageService).not.toHaveBeenCalled();
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isDefault is not a boolean', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { isDefault: 'true' } });
+    const res = await PATCH(req, createContext('rt-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('isDefault');
+    expect(mockUpdateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody } from '@/lib/api/validation';
+import { updateRenderTemplateRequestSchema } from '@/lib/api/request-schemas/render-template';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getRenderTemplateById, deleteRenderTemplate } from '@/lib/prisma/repositories';
 import { updateRenderTemplate } from '@/lib/render-templates/update-render-template';
@@ -9,12 +10,6 @@ import type { ResolvedStorageService } from '@/lib/services/resolve-storage-serv
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/render-templates/[id]' });
-
-// `hash` is in the rejected list (alongside the canonical `digestMultibase`)
-// so PATCH calls from legacy clients that still send the pre-migration field
-// name get a clear error rather than a silent drop.
-const REJECTED_FIELDS = ['storageUrl', 'digestMultibase', 'hash', 'renderMethodType'] as const;
-const PATCHABLE_FIELDS = ['name', 'template', 'isDefault', 'inline', 'mediaType', 'mediaQuery'] as const;
 
 /**
  * @swagger
@@ -108,10 +103,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                 description: Whether to inline the template (RenderTemplate2024 only)
  *               mediaType:
  *                 type: string
- *                 description: Media type of the template (RenderTemplate2024 only)
+ *                 nullable: true
+ *                 description: Media type of the template (RenderTemplate2024 only, set to null to clear)
  *               mediaQuery:
  *                 type: string
- *                 description: CSS media query (RenderTemplate2024 only)
+ *                 nullable: true
+ *                 description: CSS media query (RenderTemplate2024 only, set to null to clear)
  *               storageOptions:
  *                 type: object
  *                 properties:
@@ -154,63 +151,29 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  let body: Record<string, unknown>;
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, updateRenderTemplateRequestSchema);
 
-  // Reject server-managed and immutable fields
-  for (const field of REJECTED_FIELDS) {
-    if (body[field] !== undefined) {
-      throw new ValidationError(`${field} cannot be set directly`);
-    }
-  }
-
-  logger.info({ renderTemplateId: id }, 'Validating update fields');
-  const hasPatchableField = PATCHABLE_FIELDS.some((f) => f in body);
-  if (!hasPatchableField) {
-    throw new ValidationError(`At least one updatable field must be provided: ${PATCHABLE_FIELDS.join(', ')}`);
-  }
-
-  // Resolve storage service if template content is being replaced
+  // Resolve storage service if template content is being replaced. The schema
+  // already guarantees a provided template is a non-empty string.
   let storageService: ResolvedStorageService | undefined;
-  if (isNonEmptyString(body.template)) {
-    const storageOptions = (body.storageOptions as { serviceInstanceId?: string } | undefined) ?? {};
+  if (body.template !== undefined) {
+    const storageOptions = body.storageOptions ?? {};
     logger.info('Resolving storage service for template re-upload');
     storageService = await resolveStorageService(tenantId, storageOptions.serviceInstanceId);
-  }
-
-  // Validate optional field types
-  if (body.name !== undefined && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-  if (body.isDefault !== undefined && typeof body.isDefault !== 'boolean') {
-    throw new ValidationError('isDefault must be a boolean');
-  }
-  if (body.inline !== undefined && typeof body.inline !== 'boolean') {
-    throw new ValidationError('inline must be a boolean');
-  }
-  if (body.mediaType !== undefined && body.mediaType !== null && !isNonEmptyString(body.mediaType)) {
-    throw new ValidationError('mediaType must be a non-empty string');
-  }
-  if (body.mediaQuery !== undefined && body.mediaQuery !== null && !isNonEmptyString(body.mediaQuery)) {
-    throw new ValidationError('mediaQuery must be a non-empty string');
   }
 
   logger.info({ renderTemplateId: id }, 'Updating render template');
   const renderTemplate = await updateRenderTemplate({
     id,
     tenantId,
-    name: body.name as string | undefined,
-    template: body.template as string | undefined,
+    name: body.name,
+    template: body.template,
     storageService,
     isDefault: body.isDefault,
     inline: body.inline,
-    mediaType: body.mediaType as string | undefined,
-    mediaQuery: body.mediaQuery as string | undefined,
+    mediaType: body.mediaType,
+    mediaQuery: body.mediaQuery,
   });
 
   logger.info({ renderTemplateId: id }, 'Render template updated');

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.test.ts
@@ -278,7 +278,8 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('storageUrl cannot be set directly');
+    expect(json.error).toContain('storageUrl');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects when digestMultibase is provided', async () => {
@@ -295,7 +296,8 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('digestMultibase cannot be set directly');
+    expect(json.error).toContain('digestMultibase');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects when legacy hash is provided', async () => {
@@ -312,7 +314,8 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('hash is no longer accepted');
+    expect(json.error).toContain('hash');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects when renderMethodType is missing', async () => {
@@ -327,7 +330,8 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('renderMethodType is required');
+    expect(json.error).toContain('renderMethodType');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects when renderMethodType is invalid', async () => {
@@ -343,7 +347,8 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('renderMethodType must be one of:');
+    expect(json.error).toContain('renderMethodType');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('rejects when template is missing', async () => {
@@ -358,7 +363,8 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('template is required');
+    expect(json.error).toContain('template');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('returns 400 when name is missing', async () => {
@@ -373,7 +379,8 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required');
+    expect(json.error).toContain('name');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('returns 400 when dataModelId is missing', async () => {
@@ -388,7 +395,36 @@ describe('POST /api/v1/render-templates', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('dataModelId is required');
+    expect(json.error).toContain('dataModelId');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isDefault is not a boolean', async () => {
+    const req = createFakeRequest({
+      body: {
+        name: 'Template',
+        dataModelId: 'dm-1',
+        renderMethodType: 'RenderTemplate2024',
+        template: '<div>Hello</div>',
+        isDefault: 'true',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('isDefault');
+    expect(mockCreateRenderTemplate).not.toHaveBeenCalled();
   });
 
   it('passes storageOptions.serviceInstanceId to resolveStorageService', async () => {

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from 'next/server';
-import {
-  ValidationError,
-  isNonEmptyString,
-  validateEnum,
-  parsePositiveInt,
-  parseNonNegativeInt,
-} from '@/lib/api/validation';
+import { parseRequestBody, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { createRenderTemplateRequestSchema } from '@/lib/api/request-schemas/render-template';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { listRenderTemplates } from '@/lib/prisma/repositories';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
-import { RenderMethodType } from '@/lib/prisma/generated';
 import { resolveStorageService } from '@/lib/services/resolve-storage-service';
 import { createRenderTemplate } from '@/lib/render-templates/create-render-template';
 
@@ -136,9 +130,11 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *                 description: Whether the template is inline (applicable to RenderTemplate2024)
  *               mediaType:
  *                 type: string
+ *                 nullable: true
  *                 description: Media type for the render method (applicable to RenderTemplate2024)
  *               mediaQuery:
  *                 type: string
+ *                 nullable: true
  *                 description: CSS media query for the render method (applicable to RenderTemplate2024)
  *               storageOptions:
  *                 type: object
@@ -179,50 +175,10 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  let body: Record<string, unknown>;
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createRenderTemplateRequestSchema);
 
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  // Reject server-managed fields
-  if (body.storageUrl !== undefined) throw new ValidationError('storageUrl cannot be set directly');
-  if (body.digestMultibase !== undefined) throw new ValidationError('digestMultibase cannot be set directly');
-  // Legacy field name still rejected explicitly so callers built against the
-  // pre-migration API surface get a clear error rather than a silent drop.
-  if (body.hash !== undefined) throw new ValidationError('hash is no longer accepted; use digestMultibase');
-
-  // Validate required fields
-  if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
-  if (!isNonEmptyString(body.dataModelId)) throw new ValidationError('dataModelId is required');
-  if (!isNonEmptyString(body.renderMethodType)) throw new ValidationError('renderMethodType is required');
-  if (!isNonEmptyString(body.template)) throw new ValidationError('template is required');
-
-  // Validate optional field types
-  if (body.isDefault !== undefined && typeof body.isDefault !== 'boolean') {
-    throw new ValidationError('isDefault must be a boolean');
-  }
-  if (body.inline !== undefined && typeof body.inline !== 'boolean') {
-    throw new ValidationError('inline must be a boolean');
-  }
-  if (body.mediaType !== undefined && body.mediaType !== null && !isNonEmptyString(body.mediaType)) {
-    throw new ValidationError('mediaType must be a non-empty string');
-  }
-  if (body.mediaQuery !== undefined && body.mediaQuery !== null && !isNonEmptyString(body.mediaQuery)) {
-    throw new ValidationError('mediaQuery must be a non-empty string');
-  }
-
-  logger.info({ renderMethodType: body.renderMethodType }, 'Validating render method type');
-  const renderMethodType = validateEnum(
-    body.renderMethodType as string,
-    Object.values(RenderMethodType),
-    'renderMethodType',
-  )!;
-
-  const storageOptions = (body.storageOptions as { serviceInstanceId?: string } | undefined) ?? {};
+  const storageOptions = body.storageOptions ?? {};
 
   logger.info('Resolving storage service');
   const storageService = await resolveStorageService(tenantId, storageOptions.serviceInstanceId);
@@ -230,15 +186,15 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   logger.info({ dataModelId: body.dataModelId, name: body.name }, 'Creating render template');
   const renderTemplate = await createRenderTemplate({
     tenantId,
-    name: body.name as string,
-    dataModelId: body.dataModelId as string,
-    renderMethodType,
-    template: body.template as string,
+    name: body.name,
+    dataModelId: body.dataModelId,
+    renderMethodType: body.renderMethodType,
+    template: body.template,
     storageService,
     isDefault: body.isDefault,
     inline: body.inline,
-    mediaType: body.mediaType as string | undefined,
-    mediaQuery: body.mediaQuery as string | undefined,
+    mediaType: body.mediaType,
+    mediaQuery: body.mediaQuery,
   });
 
   logger.info({ renderTemplateId: renderTemplate.id }, 'Render template created');

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.test.ts
@@ -175,7 +175,7 @@ describe('PATCH /api/v1/schemes/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier key is required');
+    expect(json.error).toMatch(/qualifiers\.\d+\.key/);
   });
 
   it('returns 400 for invalid qualifier (missing validationPattern)', async () => {
@@ -187,7 +187,7 @@ describe('PATCH /api/v1/schemes/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier validationPattern is required');
+    expect(json.error).toMatch(/qualifiers\.\d+\.validationPattern/);
   });
 
   it('returns 400 for non-array qualifiers', async () => {
@@ -199,7 +199,7 @@ describe('PATCH /api/v1/schemes/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifiers must be an array');
+    expect(json.error).toContain('qualifiers');
   });
 
   it('returns 404 when scheme not found or access denied', async () => {

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateIdentifierSchemeRequestSchema } from '@/lib/api/request-schemas/identifier-scheme';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getIdentifierSchemeById, updateIdentifierScheme, deleteIdentifierScheme } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
@@ -154,81 +155,11 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ schemeId: id }, 'Parsing request body');
+  logger.info({ schemeId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateIdentifierSchemeRequestSchema);
 
-  let body: {
-    name?: string;
-    primaryKey?: string;
-    validationPattern?: string;
-    linkTemplate?: string;
-    idrServiceInstanceId?: string | null;
-    qualifiers?: Array<{
-      key: string;
-      description: string;
-      validationPattern: string;
-      order?: number;
-    }>;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  const hasName = isNonEmptyString(body.name);
-  const hasPrimaryKey = isNonEmptyString(body.primaryKey);
-  const hasValidationPattern = isNonEmptyString(body.validationPattern);
-  const hasLinkTemplate = isNonEmptyString(body.linkTemplate);
-  const hasIdrServiceInstanceId = body.idrServiceInstanceId !== undefined;
-  const hasQualifiers = body.qualifiers !== undefined;
-
-  logger.info({ schemeId: id }, 'Validating update fields');
-  if (
-    !hasName &&
-    !hasPrimaryKey &&
-    !hasValidationPattern &&
-    !hasLinkTemplate &&
-    !hasIdrServiceInstanceId &&
-    !hasQualifiers
-  ) {
-    throw new ValidationError('At least one field is required');
-  }
-
-  // Validate qualifiers if provided
-  if (hasQualifiers) {
-    if (!Array.isArray(body.qualifiers)) {
-      throw new ValidationError('qualifiers must be an array');
-    }
-    for (const q of body.qualifiers!) {
-      if (!isNonEmptyString(q.key)) throw new ValidationError('qualifier key is required');
-      if (!isNonEmptyString(q.description)) throw new ValidationError('qualifier description is required');
-      if (!isNonEmptyString(q.validationPattern)) throw new ValidationError('qualifier validationPattern is required');
-    }
-  }
-
-  logger.info(
-    {
-      schemeId: id,
-      fields: {
-        hasName,
-        hasPrimaryKey,
-        hasValidationPattern,
-        hasLinkTemplate,
-        hasIdrServiceInstanceId,
-        hasQualifiers,
-      },
-    },
-    'Updating scheme',
-  );
-  const updated = await updateIdentifierScheme(id, tenantId, {
-    ...(hasName && { name: body.name }),
-    ...(hasPrimaryKey && { primaryKey: body.primaryKey }),
-    ...(hasValidationPattern && { validationPattern: body.validationPattern }),
-    ...(hasLinkTemplate && { linkTemplate: body.linkTemplate }),
-    ...(hasIdrServiceInstanceId && { idrServiceInstanceId: body.idrServiceInstanceId }),
-    ...(hasQualifiers && { qualifiers: body.qualifiers }),
-  });
+  logger.info({ schemeId: id }, 'Updating scheme');
+  const updated = await updateIdentifierScheme(id, tenantId, definedFields(body));
 
   logger.info({ schemeId: id }, 'Scheme updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
@@ -159,7 +159,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('registrarId is required');
+    expect(json.error).toContain('registrarId');
   });
 
   it('returns 400 for missing name', async () => {
@@ -170,7 +170,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required');
+    expect(json.error).toContain('name');
   });
 
   it('returns 400 for missing primaryKey', async () => {
@@ -181,7 +181,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('primaryKey is required');
+    expect(json.error).toContain('primaryKey');
   });
 
   it('returns 400 for missing validationPattern', async () => {
@@ -192,7 +192,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('validationPattern is required');
+    expect(json.error).toContain('validationPattern');
   });
 
   it('returns 400 for invalid qualifier (missing key)', async () => {
@@ -210,7 +210,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier key is required');
+    expect(json.error).toMatch(/qualifiers\.\d+\.key/);
   });
 
   it('returns 400 for invalid qualifier (missing description)', async () => {
@@ -228,7 +228,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier description is required');
+    expect(json.error).toMatch(/qualifiers\.\d+\.description/);
   });
 
   it('returns 400 for invalid qualifier (missing validationPattern)', async () => {
@@ -246,7 +246,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier validationPattern is required');
+    expect(json.error).toMatch(/qualifiers\.\d+\.validationPattern/);
   });
 
   it('returns 400 for non-array qualifiers', async () => {
@@ -264,7 +264,52 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifiers must be an array');
+    expect(json.error).toContain('qualifiers');
+  });
+
+  it('returns 400 for a non-integer qualifier order', async () => {
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '.*', order: 1.5 }],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('order');
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('body');
+  });
+
+  it('returns 400 for a null qualifier item', async () => {
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [null],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('qualifiers');
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -284,7 +329,7 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('linkTemplate is required');
+    expect(json.error).toContain('linkTemplate');
   });
 
   it('returns 404 when registrarId does not exist', async () => {

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { createIdentifierSchemeRequestSchema } from '@/lib/api/request-schemas/identifier-scheme';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createIdentifierScheme, listIdentifierSchemes, getRegistrarById } from '@/lib/prisma/repositories';
 import { NotFoundError } from '@/lib/api/errors';
@@ -102,46 +103,8 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: {
-    registrarId?: string;
-    name?: string;
-    primaryKey?: string;
-    validationPattern?: string;
-    linkTemplate?: string;
-    idrServiceInstanceId?: string;
-    qualifiers?: Array<{
-      key: string;
-      description: string;
-      validationPattern: string;
-      order?: number;
-    }>;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ registrarId: body.registrarId, name: body.name }, 'Validating input parameters');
-  if (!isNonEmptyString(body.registrarId)) throw new ValidationError('registrarId is required');
-  if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
-  if (!isNonEmptyString(body.primaryKey)) throw new ValidationError('primaryKey is required');
-  if (!isNonEmptyString(body.validationPattern)) throw new ValidationError('validationPattern is required');
-  if (!isNonEmptyString(body.linkTemplate)) throw new ValidationError('linkTemplate is required');
-
-  // Validate qualifiers if provided
-  if (body.qualifiers !== undefined) {
-    if (!Array.isArray(body.qualifiers)) {
-      throw new ValidationError('qualifiers must be an array');
-    }
-    for (const q of body.qualifiers) {
-      if (!isNonEmptyString(q.key)) throw new ValidationError('qualifier key is required');
-      if (!isNonEmptyString(q.description)) throw new ValidationError('qualifier description is required');
-      if (!isNonEmptyString(q.validationPattern)) throw new ValidationError('qualifier validationPattern is required');
-    }
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createIdentifierSchemeRequestSchema);
 
   // Verify the registrar exists and belongs to this tenant
   const registrar = await getRegistrarById(body.registrarId, tenantId);

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.test.ts
@@ -304,7 +304,7 @@ describe('PATCH /api/v1/services/:id', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toMatch(/name must be a non-empty string/i);
+    expect(json.error).toMatch(/name/);
   });
 
   it('returns 400 when config is not an object', async () => {
@@ -313,7 +313,7 @@ describe('PATCH /api/v1/services/:id', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toMatch(/config must be an object/i);
+    expect(json.error).toMatch(/config/);
   });
 
   it('returns 400 when config is an array', async () => {
@@ -322,7 +322,27 @@ describe('PATCH /api/v1/services/:id', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toMatch(/config must be an object/i);
+    expect(json.error).toMatch(/config/);
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('body');
+    expect(mockUpdateServiceInstance).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isPrimary is not a boolean', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { isPrimary: 'yes' } });
+    const res = await PATCH(req, createContext('svc-123') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('isPrimary');
+    expect(mockUpdateServiceInstance).not.toHaveBeenCalled();
   });
 
   it('returns 400 when config schema validation fails after merge', async () => {

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError, ConflictError } from '@/lib/api/errors';
-import { assertPublicUrl, ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { assertPublicUrl, ValidationError, parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateServiceInstanceRequestSchema } from '@/lib/api/request-schemas/service';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
 import {
@@ -147,33 +148,10 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ serviceInstanceId: id }, 'Parsing request body');
-  let body: { name?: string; description?: string; config?: Record<string, unknown>; isPrimary?: boolean };
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  const { name, description, config, isPrimary } = body;
-
-  logger.info({ serviceInstanceId: id }, 'Validating fields');
-  const hasName = name !== undefined;
-  const hasDescription = description !== undefined;
+  logger.info({ serviceInstanceId: id }, 'Parsing and validating request body');
+  const body = await parseRequestBody(req, updateServiceInstanceRequestSchema);
+  const { config, ...updateFields } = body;
   const hasConfig = config !== undefined;
-  const hasIsPrimary = isPrimary !== undefined;
-
-  if (!hasName && !hasDescription && !hasConfig && !hasIsPrimary) {
-    throw new ValidationError('At least one of name, description, config, or isPrimary is required');
-  }
-
-  if (hasName && !isNonEmptyString(name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-
-  if (hasConfig && (typeof config !== 'object' || Array.isArray(config) || config === null)) {
-    throw new ValidationError('config must be an object');
-  }
 
   logger.info({ serviceInstanceId: id }, 'Looking up existing service instance');
   const existing = await getServiceInstanceById(id, tenantId);
@@ -228,16 +206,11 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
     );
   }
 
-  logger.info(
-    { serviceInstanceId: id, fields: { hasName, hasDescription, hasConfig, hasIsPrimary } },
-    'Updating service instance',
-  );
+  logger.info({ serviceInstanceId: id }, 'Updating service instance');
 
   const updated = await updateServiceInstance(id, tenantId, {
-    ...(hasName && { name }),
-    ...(hasDescription && { description }),
+    ...definedFields(updateFields),
     ...(encryptedConfig !== undefined && { config: encryptedConfig }),
-    ...(hasIsPrimary && { isPrimary }),
   });
 
   logger.info({ serviceInstanceId: id }, 'Service instance updated successfully');

--- a/packages/reference-implementation/src/app/api/v1/services/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/route.test.ts
@@ -205,7 +205,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('serviceType is required');
+    expect(json.error).toContain('serviceType');
   });
 
   it('returns 400 when adapterType is missing', async () => {
@@ -216,7 +216,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('adapterType is required');
+    expect(json.error).toContain('adapterType');
   });
 
   it('returns 400 when name is missing', async () => {
@@ -227,7 +227,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('name is required');
+    expect(json.error).toContain('name');
   });
 
   it('returns 400 when name is an empty string', async () => {
@@ -238,7 +238,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('name is required');
+    expect(json.error).toContain('name');
   });
 
   it('returns 400 when config is missing', async () => {
@@ -249,7 +249,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('config must be an object');
+    expect(json.error).toContain('config');
   });
 
   it('returns 400 when config is not an object', async () => {
@@ -260,7 +260,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('config must be an object');
+    expect(json.error).toContain('config');
   });
 
   it('returns 400 when config is an array', async () => {
@@ -271,7 +271,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('config must be an object');
+    expect(json.error).toContain('config');
   });
 
   it('returns 400 for invalid serviceType enum value', async () => {
@@ -282,7 +282,7 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('serviceType must be one of');
+    expect(json.error).toContain('serviceType');
   });
 
   it('returns 400 for invalid adapterType enum value', async () => {
@@ -293,7 +293,37 @@ describe('POST /api/v1/services', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('adapterType must be one of');
+    expect(json.error).toContain('adapterType');
+  });
+
+  it('returns 400 for a JSON null body', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('body');
+    expect(mockCreateServiceInstance).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isPrimary is not a boolean', async () => {
+    const req = createFakeRequest({ body: { ...VALID_BODY, isPrimary: 'yes' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('isPrimary');
+    expect(mockCreateServiceInstance).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is not a string', async () => {
+    const req = createFakeRequest({ body: { ...VALID_BODY, description: 42 } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('description');
+    expect(mockCreateServiceInstance).not.toHaveBeenCalled();
   });
 
   it('returns 400 when adapter type does not match service type (registry lookup fails)', async () => {

--- a/packages/reference-implementation/src/app/api/v1/services/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/route.ts
@@ -3,10 +3,11 @@ import {
   assertPublicUrl,
   ValidationError,
   validateEnum,
-  isNonEmptyString,
+  parseRequestBody,
   parsePositiveInt,
   parseNonNegativeInt,
 } from '@/lib/api/validation';
+import { createServiceInstanceRequestSchema } from '@/lib/api/request-schemas/service';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
 import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
@@ -94,42 +95,9 @@ const logger = apiLogger.child({ route: '/api/v1/services' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  let body: {
-    serviceType?: string;
-    adapterType?: string;
-    name?: string;
-    description?: string;
-    config?: unknown;
-    isPrimary?: boolean;
-  };
-
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  // --- Field validation ---------------------------------------------------
-
-  logger.info(
-    { serviceType: body.serviceType, adapterType: body.adapterType, name: body.name },
-    'Validating input parameters',
-  );
-
-  const serviceType = validateEnum(body.serviceType, Object.values(ServiceType), 'serviceType');
-  if (!serviceType) throw new ValidationError('serviceType is required');
-
-  const adapterType = validateEnum(body.adapterType, Object.values(AdapterType), 'adapterType');
-  if (!adapterType) throw new ValidationError('adapterType is required');
-
-  if (!isNonEmptyString(body.name)) {
-    throw new ValidationError('name is required');
-  }
-
-  if (!body.config || typeof body.config !== 'object' || Array.isArray(body.config)) {
-    throw new ValidationError('config must be an object');
-  }
+  logger.info('Parsing and validating request body');
+  const body = await parseRequestBody(req, createServiceInstanceRequestSchema);
+  const { serviceType, adapterType } = body;
 
   // --- Registry look-up & config schema validation ------------------------
 
@@ -156,10 +124,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   // --- SSRF protection on config URLs --------------------------------------
 
   if (process.env.VERIFY_ALLOW_PRIVATE_URLS !== 'true') {
-    const configObj = body.config as Record<string, unknown>;
-    if (typeof configObj.baseUrl === 'string') {
+    if (typeof body.config.baseUrl === 'string') {
       logger.info('Validating config baseUrl is not internal');
-      await assertPublicUrl(configObj.baseUrl, 'config.baseUrl');
+      await assertPublicUrl(body.config.baseUrl, 'config.baseUrl');
     }
   }
 

--- a/packages/reference-implementation/src/lib/api/request-schemas/credential.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/credential.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
+
+const HEX_64 = /^[a-f0-9]{64}$/i;
+
+/** Storage options accepted by POST /credentials. */
+export const storageOptionsSchema = z.object({
+  serviceInstanceId: z.string().min(1).optional().describe('Storage service instance ID'),
+  encrypt: z.boolean().optional().describe('Whether to encrypt the stored credential'),
+});
+
+/** IDR publishing options accepted by POST /credentials. */
+export const publishingOptionsSchema = z.object({
+  publish: z.boolean().optional().describe('Whether to publish the credential to the Identity Resolver'),
+  linkType: z.string().optional().describe('UNTP link relation type (defaults to gs1:sustainabilityInfo)'),
+  linkTitle: z.string().optional().describe('Title for the published link (defaults to data model name)'),
+  qualifierPath: z
+    .string()
+    .optional()
+    .describe('Qualifier path for sub-identifiers (e.g. /10/LOT123/21/SER456). Defaults to /'),
+  machineVerificationUrl: z.string().optional().describe('Machine verification URL'),
+  humanVerificationUrl: z.string().optional().describe('Human verification URL'),
+  hreflang: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('BCP 47 language tags the credential resource is available in (attached to the credential link only)'),
+  additionalRels: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Additional link relation types qualifying the credential link beyond its primary rel'),
+  public: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether the credential target URL is safe to publish in a public directory. Distinct from access control on the resource content',
+    ),
+});
+
+/** Request body for POST /credentials. */
+export const issueCredentialRequestSchema = z.object({
+  credentialPayload: z.record(z.unknown()),
+  credentialType: z.string().min(1),
+  version: z.string().min(1),
+  storageOptions: storageOptionsSchema.optional(),
+  publishingOptions: publishingOptionsSchema.optional(),
+});
+
+/** Request body for POST /credentials/verify. */
+export const verifyCredentialRequestSchema = z.object({
+  uri: z.string().min(1),
+  digestMultibase: z
+    .string()
+    .refine(
+      (value) => {
+        try {
+          MultibaseDigest.fromString(value);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: 'must be a valid multibase-encoded multihash' },
+    )
+    .optional(),
+  hash: z.string().regex(HEX_64, 'must be a 64-character hex string (SHA-256)').optional(),
+  decryptionKey: z.string().regex(HEX_64, 'must be a 64-character hex string').optional(),
+});

--- a/packages/reference-implementation/src/lib/api/request-schemas/data-model.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/data-model.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { idSchema, requireAtLeastOneField } from './shared';
+
+/** Request body for POST /data-models. isExtension is always true for tenant-created models and is not client-settable. */
+export const createDataModelRequestSchema = z.object({
+  name: z.string().min(1),
+  credentialType: z.string().min(1),
+  version: z.string().min(1),
+  schemaUrl: z.string().min(1),
+  contextUrl: z.string().min(1),
+  parentConfigId: idSchema,
+  websiteUrl: z.string().min(1).optional(),
+});
+
+/** Request body for PATCH /data-models/{id}. */
+export const updateDataModelRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    schemaUrl: z.string().min(1).optional(),
+    contextUrl: z.string().min(1).optional(),
+    websiteUrl: z.string().min(1).optional(),
+  }),
+  'At least one updatable field must be provided: name, schemaUrl, contextUrl, websiteUrl',
+);

--- a/packages/reference-implementation/src/lib/api/request-schemas/did.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/did.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { requireAtLeastOneField } from './shared';
+import { CREATABLE_DID_TYPES, DidMethod, DidType } from '@uncefact/untp-ri-services';
+
+const creatableDidTypeSchema = z.enum([...CREATABLE_DID_TYPES] as [DidType, ...DidType[]]);
+
+/** Request body for POST /dids. */
+export const createDidRequestSchema = z.object({
+  type: creatableDidTypeSchema,
+  method: z.nativeEnum(DidMethod),
+  alias: z.string().min(1),
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  isDefault: z.boolean().optional(),
+  serviceInstanceId: z.string().min(1).optional(),
+});
+
+/** Request body for PATCH /dids/{id}. */
+export const updateDidRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+    isDefault: z.boolean().optional(),
+  }),
+  'At least one of name, description, or isDefault is required',
+);
+
+/** Request body for POST /dids/import. */
+export const importDidRequestSchema = z.object({
+  did: z.string().min(1),
+  method: z.nativeEnum(DidMethod),
+  keyId: z.string().min(1),
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  serviceInstanceId: z.string().min(1),
+});

--- a/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { idSchema, locationSchema, nonEmptyArraySchema, requireAtLeastOneField } from './shared';
+
+/** A single facility within the POST /facilities array body. */
+const facilityCreateItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  location: locationSchema.optional(),
+  operatingOrganisationId: idSchema.optional(),
+  primaryIdentifierId: idSchema.optional(),
+  secondaryIdentifierIds: z.array(idSchema).optional(),
+});
+
+/** Request body for POST /facilities: an array of facilities to create. */
+export const createFacilitiesRequestSchema = nonEmptyArraySchema(facilityCreateItemSchema);
+
+/**
+ * Request body for PATCH /facilities/{id}.
+ * operatingOrganisationId and primaryIdentifierId set to null clear them;
+ * secondaryIdentifierIds set to [] clears all secondary identifiers.
+ */
+export const updateFacilityRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    location: locationSchema.optional(),
+    operatingOrganisationId: idSchema.nullable().optional(),
+    primaryIdentifierId: idSchema.nullable().optional(),
+    secondaryIdentifierIds: z.array(idSchema).optional(),
+  }),
+  'At least one of name, description, location, operatingOrganisationId, primaryIdentifierId, or secondaryIdentifierIds is required',
+);

--- a/packages/reference-implementation/src/lib/api/request-schemas/identifier-scheme.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/identifier-scheme.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { requireAtLeastOneField } from './shared';
+
+const qualifierSchema = z.object({
+  key: z.string().min(1),
+  description: z.string().min(1),
+  validationPattern: z.string().min(1),
+  order: z.number().int().optional(),
+});
+
+/** Request body for POST /schemes. */
+export const createIdentifierSchemeRequestSchema = z.object({
+  registrarId: z.string().min(1),
+  name: z.string().min(1),
+  primaryKey: z.string().min(1),
+  validationPattern: z.string().min(1),
+  linkTemplate: z.string().min(1),
+  idrServiceInstanceId: z.string().min(1).optional(),
+  qualifiers: z.array(qualifierSchema).optional(),
+});
+
+/** Request body for PATCH /schemes/{id}. idrServiceInstanceId set to null clears it. */
+export const updateIdentifierSchemeRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    primaryKey: z.string().min(1).optional(),
+    validationPattern: z.string().min(1).optional(),
+    linkTemplate: z.string().min(1).optional(),
+    idrServiceInstanceId: z.string().min(1).nullable().optional(),
+    qualifiers: z.array(qualifierSchema).optional(),
+  }),
+  'At least one field is required',
+);

--- a/packages/reference-implementation/src/lib/api/request-schemas/identifier.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/identifier.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/** Request body for POST /identifiers. */
+export const createIdentifierRequestSchema = z.object({
+  schemeId: z.string().min(1),
+  value: z.string().min(1),
+});
+
+/** Request body for PATCH /identifiers/{id}. */
+export const updateIdentifierRequestSchema = z.object({
+  value: z.string().min(1),
+});

--- a/packages/reference-implementation/src/lib/api/request-schemas/link.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/link.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+/** A link as accepted by the IDR publish route. */
+export const linkSchema = z.object({
+  href: z.string().url(),
+  rel: z.string().min(1),
+  type: z.string().min(1),
+  title: z.string().optional(),
+  hreflang: z.array(z.string().min(1)).optional(),
+  context: z.string().optional(),
+  default: z.boolean().optional(),
+  method: z.enum(['GET', 'POST']).optional(),
+  encryptionMethod: z.string().optional(),
+  accessRole: z.array(z.string()).optional(),
+  additionalRels: z.array(z.string().min(1)).optional(),
+  public: z.boolean().optional(),
+});
+
+/** Request body for POST /identifiers/{id}/links. */
+export const publishLinksRequestSchema = z.object({
+  links: z.array(linkSchema).min(1),
+  qualifierPath: z.string().optional(),
+  description: z.string().optional(),
+});
+
+/**
+ * Request body for PATCH /identifiers/{id}/links/{linkId}.
+ * A partial link; the upstream IDR applies the provided fields.
+ */
+export const updateLinkRequestSchema = linkSchema.partial();

--- a/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { idSchema, locationSchema, nonEmptyArraySchema, requireAtLeastOneField } from './shared';
+
+/** A single organisation within the POST /organisations array body. */
+const organisationCreateItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  location: locationSchema.optional(),
+  primaryIdentifierId: idSchema.optional(),
+  secondaryIdentifierIds: z.array(idSchema).optional(),
+});
+
+/** Request body for POST /organisations: an array of organisations to create. */
+export const createOrganisationsRequestSchema = nonEmptyArraySchema(organisationCreateItemSchema);
+
+/**
+ * Request body for PATCH /organisations/{id}.
+ * primaryIdentifierId set to null clears it; secondaryIdentifierIds set to [] clears all.
+ */
+export const updateOrganisationRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    location: locationSchema.optional(),
+    primaryIdentifierId: idSchema.nullable().optional(),
+    secondaryIdentifierIds: z.array(idSchema).optional(),
+  }),
+  'At least one of name, description, location, primaryIdentifierId, or secondaryIdentifierIds is required',
+);

--- a/packages/reference-implementation/src/lib/api/request-schemas/product.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/product.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { idSchema, nonEmptyArraySchema, requireAtLeastOneField } from './shared';
+
+const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
+
+const createProductItemSchema = z.object({
+  name: z.string().min(1),
+  level: z.enum(PRODUCT_LEVELS),
+  description: z.string().optional(),
+  parentId: idSchema.optional(),
+  producedByOrganisationId: idSchema.optional(),
+  manufacturingFacilityId: idSchema.optional(),
+  primaryIdentifierId: idSchema.optional(),
+  secondaryIdentifierIds: z.array(idSchema).optional(),
+});
+
+/** Request body for POST /products: one or more products created in a single call. */
+export const createProductsRequestSchema = nonEmptyArraySchema(createProductItemSchema);
+
+/**
+ * Request body for PATCH /products/{id}. Level is immutable and not accepted here.
+ * parentId, producedByOrganisationId, manufacturingFacilityId, and primaryIdentifierId
+ * set to null clear the relation; secondaryIdentifierIds has no null-clear form (send an
+ * empty array to clear it).
+ */
+export const updateProductRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    parentId: idSchema.nullable().optional(),
+    producedByOrganisationId: idSchema.nullable().optional(),
+    manufacturingFacilityId: idSchema.nullable().optional(),
+    primaryIdentifierId: idSchema.nullable().optional(),
+    secondaryIdentifierIds: z.array(idSchema).optional(),
+  }),
+  'At least one updatable field must be provided: name, description, parentId, producedByOrganisationId, manufacturingFacilityId, primaryIdentifierId, secondaryIdentifierIds',
+);

--- a/packages/reference-implementation/src/lib/api/request-schemas/registrar.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/registrar.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { requireAtLeastOneField } from './shared';
+
+/** Request body for POST /registrars. */
+export const createRegistrarRequestSchema = z.object({
+  name: z.string().min(1),
+  namespace: z.string().min(1),
+  url: z.string().min(1),
+  idrServiceInstanceId: z.string().min(1).optional(),
+});
+
+/** Request body for PATCH /registrars/{id}. idrServiceInstanceId set to null clears it. */
+export const updateRegistrarRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    namespace: z.string().min(1).optional(),
+    url: z.string().min(1).optional(),
+    idrServiceInstanceId: z.string().min(1).nullable().optional(),
+  }),
+  'At least one of name, namespace, url, or idrServiceInstanceId is required',
+);

--- a/packages/reference-implementation/src/lib/api/request-schemas/render-template.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/render-template.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { RenderMethodType } from '@/lib/prisma/generated';
+import { idSchema } from './shared';
+
+const storageOptionsSchema = z.object({
+  serviceInstanceId: z.string().min(1).optional(),
+});
+
+const storageUrlRejected = z.undefined({ invalid_type_error: 'cannot be set directly' });
+const digestMultibaseRejected = z.undefined({ invalid_type_error: 'cannot be set directly' });
+const hashRejected = z.undefined({ invalid_type_error: 'is no longer accepted; use digestMultibase' });
+
+/** Request body for POST /render-templates. storageUrl, digestMultibase, and the legacy hash field are server-managed and rejected if present. */
+export const createRenderTemplateRequestSchema = z.object({
+  name: z.string().min(1),
+  dataModelId: idSchema,
+  renderMethodType: z.nativeEnum(RenderMethodType),
+  template: z.string().min(1),
+  isDefault: z.boolean().optional(),
+  inline: z.boolean().optional(),
+  mediaType: z.string().min(1).nullable().optional(),
+  mediaQuery: z.string().min(1).nullable().optional(),
+  storageOptions: storageOptionsSchema.optional(),
+  storageUrl: storageUrlRejected,
+  digestMultibase: digestMultibaseRejected,
+  hash: hashRejected,
+});
+
+/**
+ * Request body for PATCH /render-templates/{id}. storageUrl, digestMultibase, hash, and
+ * renderMethodType are server-managed/immutable and rejected if present. A provided
+ * template must be a non-empty string; the server re-uploads it to storage.
+ */
+export const updateRenderTemplateRequestSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    template: z.string().min(1).optional(),
+    isDefault: z.boolean().optional(),
+    inline: z.boolean().optional(),
+    mediaType: z.string().min(1).nullable().optional(),
+    mediaQuery: z.string().min(1).nullable().optional(),
+    storageOptions: storageOptionsSchema.optional(),
+    storageUrl: storageUrlRejected,
+    digestMultibase: digestMultibaseRejected,
+    hash: hashRejected,
+    renderMethodType: z.undefined({ invalid_type_error: 'cannot be changed after creation' }),
+  })
+  // Bespoke rather than requireAtLeastOneField: storageOptions alone is not an
+  // update (it only qualifies a template re-upload), so it does not count.
+  .refine(
+    (body) =>
+      [body.name, body.template, body.isDefault, body.inline, body.mediaType, body.mediaQuery].some(
+        (value) => value !== undefined,
+      ),
+    {
+      message:
+        'At least one updatable field must be provided: name, template, isDefault, inline, mediaType, mediaQuery',
+    },
+  );

--- a/packages/reference-implementation/src/lib/api/request-schemas/service.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/service.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { requireAtLeastOneField } from './shared';
+import { ServiceType, AdapterType } from '@uncefact/untp-ri-services';
+
+/**
+ * Request body for POST /services. The adapter-specific config content is
+ * validated separately against the adapter's own schema in the route.
+ */
+export const createServiceInstanceRequestSchema = z.object({
+  serviceType: z.nativeEnum(ServiceType),
+  adapterType: z.nativeEnum(AdapterType),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  config: z.record(z.unknown()),
+  isPrimary: z.boolean().optional(),
+});
+
+/** Request body for PATCH /services/{id}. */
+export const updateServiceInstanceRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    config: z.record(z.unknown()).optional(),
+    isPrimary: z.boolean().optional(),
+  }),
+  'At least one of name, description, config, or isPrimary is required',
+);

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
@@ -1,0 +1,33 @@
+/**
+ * Zod request-body schemas for write routes, one file per resource (ADR-037).
+ *
+ * Routes parse bodies with parseRequestBody from '@/lib/api/validation' and
+ * import schemas from the resource file directly (no barrel index; a barrel
+ * transitively loads every resource's dependencies, which breaks tests that
+ * mock those packages). Schemas validate shape and type only; referential
+ * checks (existence, tenant scoping) stay in repositories and services.
+ */
+
+import { z } from 'zod';
+
+/** A database identifier reference (non-empty string). */
+export const idSchema = z.string().min(1);
+
+/**
+ * UNTP location object, accepted as an open JSON object. No field-level
+ * validation is applied anywhere today; a UNTP-shaped location schema is a
+ * tracked follow-up.
+ */
+export const locationSchema = z.record(z.unknown());
+
+/** Wraps an update-body schema so a body providing no fields is rejected. */
+export function requireAtLeastOneField<Schema extends z.SomeZodObject>(schema: Schema, message: string) {
+  return schema.refine((body) => Object.values(body).some((value) => value !== undefined), { message });
+}
+
+/** A bulk-create request body: a non-empty array of items. */
+export function nonEmptyArraySchema<Item extends z.ZodTypeAny>(itemSchema: Item) {
+  return z
+    .array(itemSchema, { invalid_type_error: 'Request body must be an array' })
+    .min(1, 'Request body must not be empty');
+}

--- a/packages/reference-implementation/src/lib/api/validation.test.ts
+++ b/packages/reference-implementation/src/lib/api/validation.test.ts
@@ -3,6 +3,7 @@ jest.mock('@uncefact/untp-ri-services/server', () => ({
   validatePublicUrl: (...args: unknown[]) => mockValidatePublicUrl(...args),
 }));
 
+import { z } from 'zod';
 import {
   ValidationError,
   isNonEmptyString,
@@ -11,7 +12,73 @@ import {
   parseNonNegativeInt,
   parseBooleanString,
   assertPublicUrl,
+  parseRequestBody,
+  definedFields,
 } from './validation';
+
+describe('definedFields', () => {
+  it('drops keys whose value is undefined', () => {
+    expect(definedFields({ a: 1, b: undefined, c: 'x' })).toEqual({ a: 1, c: 'x' });
+  });
+
+  it('keeps null values (null clears a field, it is not absence)', () => {
+    expect(definedFields({ a: null, b: undefined })).toEqual({ a: null });
+  });
+
+  it('keeps falsy defined values', () => {
+    expect(definedFields({ a: false, b: 0, c: '' })).toEqual({ a: false, b: 0, c: '' });
+  });
+
+  it('returns an empty object when every value is undefined', () => {
+    expect(definedFields({ a: undefined })).toEqual({});
+  });
+});
+
+describe('parseRequestBody', () => {
+  const schema = z.object({
+    name: z.string().min(1),
+    count: z.number().optional(),
+  });
+
+  function fakeRequest(body: unknown): { json: () => Promise<unknown> } {
+    return { json: async () => body };
+  }
+
+  it('returns the parsed body for valid input', async () => {
+    await expect(parseRequestBody(fakeRequest({ name: 'a', count: 2 }), schema)).resolves.toEqual({
+      name: 'a',
+      count: 2,
+    });
+  });
+
+  it('strips unknown keys', async () => {
+    await expect(parseRequestBody(fakeRequest({ name: 'a', extra: true }), schema)).resolves.toEqual({ name: 'a' });
+  });
+
+  it('throws ValidationError for malformed JSON', async () => {
+    const req = {
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    };
+    await expect(parseRequestBody(req, schema)).rejects.toThrow(ValidationError);
+    await expect(parseRequestBody(req, schema)).rejects.toThrow('Invalid JSON body');
+  });
+
+  it('throws ValidationError naming the body for a JSON null body', async () => {
+    await expect(parseRequestBody(fakeRequest(null), schema)).rejects.toThrow(ValidationError);
+    await expect(parseRequestBody(fakeRequest(null), schema)).rejects.toThrow(/^body: /);
+  });
+
+  it('throws ValidationError naming the offending field', async () => {
+    await expect(parseRequestBody(fakeRequest({ name: 'a', count: 'two' }), schema)).rejects.toThrow(/^count: /);
+  });
+
+  it('renders nested paths with dots', async () => {
+    const nested = z.object({ items: z.array(z.object({ id: z.string() })) });
+    await expect(parseRequestBody(fakeRequest({ items: [{ id: 1 }] }), nested)).rejects.toThrow(/^items\.0\.id: /);
+  });
+});
 
 describe('isNonEmptyString', () => {
   it('returns true for a non-empty string', () => {

--- a/packages/reference-implementation/src/lib/api/validation.ts
+++ b/packages/reference-implementation/src/lib/api/validation.ts
@@ -5,6 +5,7 @@
  * Routes catch ValidationError and return 400.
  */
 
+import { z } from 'zod';
 import { validatePublicUrl } from '@uncefact/untp-ri-services/server';
 
 export class ValidationError extends Error {
@@ -12,6 +13,43 @@ export class ValidationError extends Error {
     super(message);
     this.name = 'ValidationError';
   }
+}
+
+/**
+ * Parse and validate a JSON request body against a Zod schema (ADR-037).
+ *
+ * Malformed JSON, a literal `null` body, and any shape mismatch throw
+ * ValidationError with the first issue rendered as `field.path: message`,
+ * which the route error mapper returns as a 400.
+ */
+export async function parseRequestBody<Schema extends z.ZodTypeAny>(
+  req: { json: () => Promise<unknown> },
+  schema: Schema,
+): Promise<z.infer<Schema>> {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new ValidationError(`${issue.path.join('.') || 'body'}: ${issue.message}`);
+  }
+  return parsed.data;
+}
+
+/**
+ * Returns a copy of the object containing only the keys whose value is not
+ * undefined, preserving optionality in the result type. Forwards a parsed
+ * PATCH body to a repository update input without per-field conditional
+ * spreads at every call site.
+ */
+export function definedFields<T extends object>(source: T): { [K in keyof T]?: Exclude<T[K], undefined> } {
+  return Object.fromEntries(Object.entries(source).filter(([, value]) => value !== undefined)) as {
+    [K in keyof T]?: Exclude<T[K], undefined>;
+  };
 }
 
 /**

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -25,41 +25,11 @@ import {
   errorResponseSchema,
 } from '@uncefact/untp-ri-services';
 import { paginationMetaSchema } from '@/lib/api/pagination';
+import { storageOptionsSchema, publishingOptionsSchema } from '@/lib/api/request-schemas/credential';
 
 // ============================================================================
 // Credential Schemas (remain local — no credential service directory yet)
 // ============================================================================
-
-const storageOptionsSchema = z.object({
-  serviceInstanceId: z.string().optional().describe('Storage service instance ID'),
-  encrypt: z.boolean().optional().describe('Whether to encrypt the stored credential'),
-});
-
-export const publishingOptionsSchema = z.object({
-  publish: z.boolean().optional().describe('Whether to publish the credential to the Identity Resolver'),
-  linkType: z.string().optional().describe('UNTP link relation type (defaults to gs1:sustainabilityInfo)'),
-  linkTitle: z.string().optional().describe('Title for the published link (defaults to data model name)'),
-  qualifierPath: z
-    .string()
-    .optional()
-    .describe('Qualifier path for sub-identifiers (e.g. /10/LOT123/21/SER456). Defaults to /'),
-  machineVerificationUrl: z.string().optional().describe('Machine verification URL'),
-  humanVerificationUrl: z.string().optional().describe('Human verification URL'),
-  hreflang: z
-    .array(z.string().min(1))
-    .optional()
-    .describe('BCP 47 language tags the credential resource is available in (attached to the credential link only)'),
-  additionalRels: z
-    .array(z.string().min(1))
-    .optional()
-    .describe('Additional link relation types qualifying the credential link beyond its primary rel'),
-  public: z
-    .boolean()
-    .optional()
-    .describe(
-      'Whether the credential target URL is safe to publish in a public directory. Distinct from access control on the resource content',
-    ),
-});
 
 /** Request body for POST /credentials. */
 export const credentialIssueRequestSchema = z.object({


### PR DESCRIPTION
This PR validates every write route's request body with a Zod schema before it reaches a repository or upstream service, so malformed input now returns a 400 naming the offending field instead of a `TypeError`, a Prisma client validation error, or a sanitised 500.

The convention is recorded in ADR-037: schemas live in `src/lib/api/request-schemas/` (one file per resource, imported directly rather than through a barrel), a shared `parseRequestBody` helper maps malformed JSON, `null` bodies, and shape mismatches to 400s, and validation covers shape and type only, with referential checks staying in repositories per ADR-036. A `definedFields` helper replaces the per-field conditional spreads previously duplicated across the PATCH handlers.

Beyond the straight conversion this closes the audit's route-level input gaps: the `storageOptions` schema is now actually applied on POST /credentials, POST /credentials/verify no longer crashes on a stored JSON `null` (422 instead), PATCH /render-templates/{id} rejects an invalid `template` instead of silently skipping the re-upload, PATCH on identifier links validates the partial link shape instead of forwarding the raw body upstream, and POST /dids/import now verifies the `serviceInstanceId` exists and is visible to the tenant (404, matching POST /dids resolution scoping). One deliberate contract change throughout: provided-but-invalid values that the old manual checks silently ignored now return 400s.

Closes #736

## Test plan
- [x] Malformed JSON, JSON `null` bodies, null array items, and wrong-typed fields return 400 naming the offending field on every write route
- [x] Valid inputs behave exactly as before, including null-to-clear semantics on PATCH fields and empty-array clears
- [x] Server-managed render-template fields are rejected with actionable messages; an invalid `template` no longer silently no-ops
- [x] A stored JSON `null` credential returns 422 from /credentials/verify for both plain and decrypted content
- [x] /dids/import returns 404 for a missing or other-tenant service instance, with the lookup tenant-scoped
- [x] Full reference-implementation suite passes (1663 tests, 114 suites)
