### PR TITLE
fix(services): align the DIA v0.7.0 bridge with the lowercase registerType code list

### DIFF
--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.test.ts
@@ -104,23 +104,23 @@ describe('buildDiaSubject (v0.7.0)', () => {
   // ── registerType mapping ────────────────────────────────────────────────────
 
   describe('registerType mapping', () => {
-    it('sets registerType to Business when built from organisation', () => {
+    it('sets registerType to business when built from organisation', () => {
       const subject = bridge.buildSubject(createBridgeEntities());
-      expect(subject.registerType).toBe('Business');
+      expect(subject.registerType).toBe('business');
     });
 
-    it('sets registerType to Facility when built from facility', () => {
+    it('sets registerType to facility when built from facility', () => {
       const subject = bridge.buildSubject(
         createBridgeEntities({ organisation: undefined, facility: createFacility(), product: undefined }),
       );
-      expect(subject.registerType).toBe('Facility');
+      expect(subject.registerType).toBe('facility');
     });
 
-    it('sets registerType to Product when built from product', () => {
+    it('sets registerType to product when built from product', () => {
       const subject = bridge.buildSubject(
         createBridgeEntities({ organisation: undefined, facility: undefined, product: createProduct() }),
       );
-      expect(subject.registerType).toBe('Product');
+      expect(subject.registerType).toBe('product');
     });
 
     it('omits registerType when no entity is provided', () => {

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/builder.ts
@@ -8,12 +8,15 @@ export function buildDiaSubject(entities: BridgeEntities): CredentialSubject {
   // entities.conformity is silently ignored.
   const entity = entities.organisation ?? entities.facility ?? entities.product;
 
+  // The v0.7.0 registerType code list is lowercase, unlike v0.6.x's capitalised
+  // values. See the RegisteredIdentity definition in
+  // https://untp.unece.org/artefacts/schema/v0.7.0/dia/DigitalIdentityAnchor.json
   const registerType = entities.organisation
-    ? 'Business'
+    ? 'business'
     : entities.facility
-      ? 'Facility'
+      ? 'facility'
       : entities.product
-        ? 'Product'
+        ? 'product'
         : undefined;
 
   return {

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.test.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.test.ts
@@ -36,40 +36,40 @@ describe('extractDiaRefs (v0.7.0)', () => {
   // ── registerType routing ───────────────────────────────────────────────────
 
   describe('registerType routing', () => {
-    it('places ref in organisations when registerType is Business', () => {
+    it('places ref in organisations when registerType is business', () => {
       const refs = bridge.extractRefs({
         type: ['RegisteredIdentity'],
         registeredId: '9520123456788',
-        registerType: 'Business',
+        registerType: 'business',
       });
       expect(refs.organisations).toEqual([{ id: '9520123456788' }]);
       expect(refs.facilities).toEqual([]);
       expect(refs.products).toEqual([]);
     });
 
-    it('places ref in facilities when registerType is Facility', () => {
+    it('places ref in facilities when registerType is facility', () => {
       const refs = bridge.extractRefs({
         type: ['RegisteredIdentity'],
         registeredId: '4012345000009',
-        registerType: 'Facility',
+        registerType: 'facility',
       });
       expect(refs.facilities).toEqual([{ id: '4012345000009' }]);
     });
 
-    it('places ref in products when registerType is Product', () => {
+    it('places ref in products when registerType is product', () => {
       const refs = bridge.extractRefs({
         type: ['RegisteredIdentity'],
         registeredId: '9520123456788',
-        registerType: 'Product',
+        registerType: 'product',
       });
       expect(refs.products).toEqual([{ id: '9520123456788' }]);
     });
 
-    it('places ref in facilities when registerType is Land', () => {
+    it('places ref in facilities when registerType is land', () => {
       const refs = bridge.extractRefs({
         type: ['RegisteredIdentity'],
         registeredId: 'LAND-001',
-        registerType: 'Land',
+        registerType: 'land',
       });
       expect(refs.facilities).toEqual([{ id: 'LAND-001' }]);
     });
@@ -84,11 +84,22 @@ describe('extractDiaRefs (v0.7.0)', () => {
       expect(refs.products).toEqual([]);
     });
 
-    it('returns empty arrays when registerType is Trademark', () => {
+    it('returns empty arrays when registerType is trademark', () => {
       const refs = bridge.extractRefs({
         type: ['RegisteredIdentity'],
         registeredId: 'TM-12345',
-        registerType: 'Trademark',
+        registerType: 'trademark',
+      });
+      expect(refs.organisations).toEqual([]);
+      expect(refs.facilities).toEqual([]);
+      expect(refs.products).toEqual([]);
+    });
+
+    it('returns empty arrays when registerType is accreditation', () => {
+      const refs = bridge.extractRefs({
+        type: ['RegisteredIdentity'],
+        registeredId: 'poc-001',
+        registerType: 'accreditation',
       });
       expect(refs.organisations).toEqual([]);
       expect(refs.facilities).toEqual([]);

--- a/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.ts
+++ b/packages/services/src/data-model-bridges/data-models/dia/versions/v070/extractor.ts
@@ -23,9 +23,12 @@ export function extractDiaRefs(subject: CredentialSubject): ExtractedRefs {
   const ref = { id: dia.registeredId };
   const registerType = dia.registerType;
 
+  // The v0.7.0 registerType code list is lowercase, unlike v0.6.x's capitalised
+  // values. See the RegisteredIdentity definition in
+  // https://untp.unece.org/artefacts/schema/v0.7.0/dia/DigitalIdentityAnchor.json
   return {
-    organisations: registerType === 'Business' ? [ref] : [],
-    facilities: registerType === 'Facility' || registerType === 'Land' ? [ref] : [],
-    products: registerType === 'Product' ? [ref] : [],
+    organisations: registerType === 'business' ? [ref] : [],
+    facilities: registerType === 'facility' || registerType === 'land' ? [ref] : [],
+    products: registerType === 'product' ? [ref] : [],
   };
 }


### PR DESCRIPTION
This PR aligns the DIA v0.7.0 bridge's registerType handling with the lowercase code list published in the UNTP v0.7.0 DIA schema, which results in schema-valid v0.7.0 DIA credentials once again resolving entity links and, when requested, publishing to the identity resolver. The v0.6.x bridge keeps the capitalised values, which remain correct for the v0.6.0 code list, and both files now cite the schema definition they encode.

Closes #739

Related to #738

## Test plan
- [x] Lowercase `business`, `facility`, `land`, and `product` route the registered identifier to the correct entity bucket
- [x] Register types with no master-data mapping (`accreditation`, `trademark`, absent) yield empty refs
- [x] The builder emits the lowercase code list values
- [x] The v0.6.x DIA suites still pass unchanged with the capitalised values
- [x] Full data-model-bridges suite passes (28 suites, 743 tests) and the services package compiles
