### PR TITLE
feat(ri): default humanVerificationUrl to the RI verify page when publishing

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -208,6 +208,12 @@ If any of these are missing, publishing is silently skipped and a `PUBLISH_SKIPP
 
 The IDR entry's `description` field is taken from the primary entity's `description`, falling back to the entity's `name` if no description is set.
 
+**Human verification link**: When publishing without an explicit `humanVerificationUrl`, the published link set includes a link to this Reference Implementation's own verify page. The base is derived from the `RI_APP_URL` environment variable, which is parsed as a URL with `/verify` appended to its path (any query or fragment is dropped, a base path is preserved, and a trailing slash is trimmed); for the default `http://localhost:3003` the link is `http://localhost:3003/verify`. `RI_APP_URL` is configured in the RI's environment (the shipped `.env.example` and Docker Compose files default it to `http://localhost:3003`) and is the same base URL that backs the OIDC post-logout redirect (see [Identity provider requirements](../authentication/idp-requirements)). Supplying `humanVerificationUrl` overrides the default, for deployments that host verification elsewhere.
+
+The published link does **not** carry the credential's decryption key. The key is not registered on the Identity Resolver; it is shared out of band, so access to an encrypted credential does not travel with its discovery link (regardless of whether a given resolver is publicly readable). A credential stored encrypted (the storage default) therefore needs its decryption key supplied out of band to verify, and the published link alone verifies a credential stored unencrypted. The issuing tenant can retrieve that decryption key from the credential's [Get a Credential](#get-a-credential) response and share it through a channel of its choosing. This differs from a link shared directly as a single-link capability, which may embed the key (see [the verify page](../verify-page#decryption)).
+
+If `RI_APP_URL` is unset, is not a valid `http(s)` URL, or carries userinfo when the default is needed, the request is rejected (`400`) up front, before the credential is issued, so a misconfigured deployment fails at request time rather than publishing a broken or secret-bearing link. Set `RI_APP_URL`, or pass `humanVerificationUrl`, to resolve it.
+
 | Publishing Option | Type | Description |
 |-------------------|------|-------------|
 | `publish` | boolean | Whether to publish to the identity resolver |
@@ -215,7 +221,7 @@ The IDR entry's `description` field is taken from the primary entity's `descript
 | `linkTitle` | string | Human-readable title for the link (defaults to the data model name) |
 | `qualifierPath` | string | Qualifier path for sub-identifiers, e.g., `/10/LOT123/21/SER456` (defaults to `/`) |
 | `machineVerificationUrl` | string | URL for machine-readable verification of the credential |
-| `humanVerificationUrl` | string | URL for human-readable verification of the credential |
+| `humanVerificationUrl` | string | URL for human-readable verification of the credential (defaults to `${RI_APP_URL}/verify`, this RI's verify page, when publishing) |
 | `hreflang` | string[] | BCP 47 language tags for the link's target content |
 | `additionalRels` | string[] | Additional link relation types to attach beyond `linkType` |
 | `public` | boolean | Whether the published link is publicly resolvable |
@@ -244,7 +250,7 @@ Validates, signs, stores, and optionally publishes a verifiable credential. Retu
 | `publishingOptions.linkTitle` | string | No | Link title (defaults to data model name) |
 | `publishingOptions.qualifierPath` | string | No | Qualifier path (default: `/`) |
 | `publishingOptions.machineVerificationUrl` | string | No | Machine verification URL |
-| `publishingOptions.humanVerificationUrl` | string | No | Human verification URL |
+| `publishingOptions.humanVerificationUrl` | string | No | Human verification URL (defaults to `${RI_APP_URL}/verify` when publishing) |
 | `publishingOptions.hreflang` | string[] | No | BCP 47 language tags for the link's target content |
 | `publishingOptions.additionalRels` | string[] | No | Additional link relation types beyond `linkType` |
 | `publishingOptions.public` | boolean | No | Whether the published link is publicly resolvable |

--- a/documentation/docs/reference-implementation/authentication/idp-requirements.md
+++ b/documentation/docs/reference-implementation/authentication/idp-requirements.md
@@ -61,7 +61,7 @@ See [Tenant Modes](./tenant-modes) for how service accounts are associated with 
 | `AUTH_OIDC_SERVICE_ACCOUNT_AUDIENCE` | Expected audience claim in service account tokens — must match the audience mapper configured on the service account client | Yes | `ri-api` |
 | `AUTH_SECRET` | Secret used to encrypt sessions (generate with `openssl rand -base64 32`) | Yes | — |
 | `AUTH_TRUST_HOST` | Set to `true` when the Reference Implementation runs behind a reverse proxy or in a containerised environment where the host header may differ from the actual origin | No | — |
-| `RI_APP_URL` | Base URL of the Reference Implementation (used for post-logout redirect) | Yes | `http://localhost:3003` |
+| `RI_APP_URL` | Public base URL of the Reference Implementation. Backs the OIDC post-logout redirect and the default human verification link when publishing credentials | Yes | `http://localhost:3003` |
 
 `AUTH_OIDC_AUTHORIZATION_URL` is needed when Keycloak's issuer URL is only reachable from within Docker (e.g., `http://keycloak:8080/...`) but the browser needs a different URL (e.g., `http://localhost:8080/...`). If the issuer URL is reachable from both the server and the browser, this variable is not needed.
 
@@ -128,7 +128,7 @@ The Docker Compose configuration includes two service accounts assigned to separ
 | `AUTH_OIDC_SERVICE_ACCOUNT_AUDIENCE` | Zitadel project resource ID — required for service account token validation | Yes | — |
 | `AUTH_SECRET` | Secret used to encrypt sessions (generate with `openssl rand -base64 32`) | Yes | — |
 | `AUTH_TRUST_HOST` | Set to `true` when the Reference Implementation runs behind a reverse proxy or in a containerised environment where the host header may differ from the actual origin | No | — |
-| `RI_APP_URL` | Base URL of the Reference Implementation (used for post-logout redirect) | Yes | `http://localhost:3003` |
+| `RI_APP_URL` | Public base URL of the Reference Implementation. Backs the OIDC post-logout redirect and the default human verification link when publishing credentials | Yes | `http://localhost:3003` |
 
 ### IDP Configuration
 

--- a/documentation/docs/reference-implementation/verify-page.md
+++ b/documentation/docs/reference-implementation/verify-page.md
@@ -82,4 +82,4 @@ A verification link may include a digest of the credential. When present, the ve
 
 ## Decryption
 
-If the credential is encrypted, the decryption key is included in the verification link. The verify page uses this key to decrypt the credential before proceeding with verification. This allows private credentials to be shared via a single link without requiring the recipient to manage keys separately.
+If the credential is encrypted and the decryption key is included in the verification link, the verify page uses that key to decrypt the credential before proceeding with verification. This allows a private credential to be shared directly via a single link without requiring the recipient to manage keys separately. A link published to the Identity Resolver omits the key, which is shared out of band instead (see [IDR publishing](./api/credentials#stage-8-idr-publishing-optional)).

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -254,6 +254,7 @@ describe('POST /api/v1/credentials', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+    process.env.RI_APP_URL = 'http://localhost:3003';
     setupHappyPath();
   });
 
@@ -762,10 +763,12 @@ describe('POST /api/v1/credentials', () => {
       // resolveIdrService called with scheme IDR only
       expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1');
 
-      // buildPublishLinks called with storage response, link title, and options
+      // buildPublishLinks called with storage response, link title, and options.
+      // humanVerificationUrl defaults to `${RI_APP_URL}/verify` (RI_APP_URL is
+      // set to http://localhost:3003 in beforeEach) since none was supplied.
       expect(mockBuildPublishLinks).toHaveBeenCalledWith(STORAGE_RESPONSE, 'Digital Product Passport', {
         machineVerificationUrl: undefined,
-        humanVerificationUrl: undefined,
+        humanVerificationUrl: 'http://localhost:3003/verify',
       });
 
       // idrService.publishLinks called
@@ -837,6 +840,187 @@ describe('POST /api/v1/credentials', () => {
       expect(mockBuildPublishLinks).toHaveBeenCalledWith(STORAGE_RESPONSE, 'Digital Product Passport', {
         machineVerificationUrl: 'https://verify.example.com/api',
         humanVerificationUrl: 'https://verify.example.com/ui',
+      });
+    });
+
+    // ── humanVerificationUrl default (issue #491) ──────────────────────
+
+    describe('human verification URL default', () => {
+      it('defaults humanVerificationUrl to `${RI_APP_URL}/verify` when publishing without one', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'https://ri.example.com';
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+          STORAGE_RESPONSE,
+          'Digital Product Passport',
+          expect.objectContaining({ humanVerificationUrl: 'https://ri.example.com/verify' }),
+        );
+      });
+
+      it('preserves a base path on RI_APP_URL and trims its trailing slash', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'https://ri.example.com/app/';
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+          STORAGE_RESPONSE,
+          'Digital Product Passport',
+          expect.objectContaining({ humanVerificationUrl: 'https://ri.example.com/app/verify' }),
+        );
+      });
+
+      it('drops a query string on RI_APP_URL rather than appending after it', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'https://ri.example.com?tenant=1';
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+          STORAGE_RESPONSE,
+          'Digital Product Passport',
+          expect.objectContaining({ humanVerificationUrl: 'https://ri.example.com/verify' }),
+        );
+      });
+
+      it('drops a fragment on RI_APP_URL rather than appending after it', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'https://ri.example.com#section';
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+          STORAGE_RESPONSE,
+          'Digital Product Passport',
+          expect.objectContaining({ humanVerificationUrl: 'https://ri.example.com/verify' }),
+        );
+      });
+
+      it('preserves an explicit humanVerificationUrl over the RI_APP_URL default', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'https://ri.example.com';
+
+        const req = createFakeRequest(
+          validBody({
+            publishingOptions: { publish: true, humanVerificationUrl: 'https://verify.example.com/ui' },
+          }),
+        );
+        await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+          STORAGE_RESPONSE,
+          'Digital Product Passport',
+          expect.objectContaining({ humanVerificationUrl: 'https://verify.example.com/ui' }),
+        );
+      });
+
+      it('does not SSRF-check the derived localhost default', async () => {
+        setupPublishingHappyPath();
+        delete process.env.VERIFY_ALLOW_PRIVATE_URLS;
+        process.env.RI_APP_URL = 'http://localhost:3003';
+        mockAssertPublicUrl.mockResolvedValue(undefined);
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(res.status).toBe(201);
+        // No explicit URL was supplied, and the trusted default is not guarded.
+        expect(mockAssertPublicUrl).not.toHaveBeenCalled();
+        expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+          STORAGE_RESPONSE,
+          'Digital Product Passport',
+          expect.objectContaining({ humanVerificationUrl: 'http://localhost:3003/verify' }),
+        );
+      });
+
+      it('fails with 400 before issuance when RI_APP_URL is unset and no humanVerificationUrl is given', async () => {
+        setupPublishingHappyPath();
+        delete process.env.RI_APP_URL;
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toContain('RI_APP_URL');
+        // Failure is early: nothing is signed, stored, or published.
+        expect(mockIssueCredential).not.toHaveBeenCalled();
+        expect(mockPublishLinks).not.toHaveBeenCalled();
+      });
+
+      it('fails with 400 when RI_APP_URL is syntactically not a URL', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'not a url';
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toContain('RI_APP_URL');
+        expect(mockIssueCredential).not.toHaveBeenCalled();
+      });
+
+      it('fails with 400 when RI_APP_URL parses but is not an http(s) URL', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'ftp://ri.example.com';
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toContain('RI_APP_URL');
+        expect(mockIssueCredential).not.toHaveBeenCalled();
+      });
+
+      it('fails with 400 when RI_APP_URL carries userinfo, rather than publishing the secret', async () => {
+        setupPublishingHappyPath();
+        process.env.RI_APP_URL = 'https://user:pass@ri.example.com';
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+        const json = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(json.error).toContain('RI_APP_URL');
+        expect(mockIssueCredential).not.toHaveBeenCalled();
+      });
+
+      it('uses an explicit humanVerificationUrl even when RI_APP_URL is unset', async () => {
+        setupPublishingHappyPath();
+        delete process.env.RI_APP_URL;
+
+        const req = createFakeRequest(
+          validBody({
+            publishingOptions: { publish: true, humanVerificationUrl: 'https://verify.example.com/ui' },
+          }),
+        );
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(res.status).toBe(201);
+        expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+          STORAGE_RESPONSE,
+          'Digital Product Passport',
+          expect.objectContaining({ humanVerificationUrl: 'https://verify.example.com/ui' }),
+        );
+      });
+
+      it('does not require RI_APP_URL when publish is false', async () => {
+        setupPublishingHappyPath();
+        delete process.env.RI_APP_URL;
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: false } }));
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+        expect(res.status).toBe(201);
+        expect(mockBuildPublishLinks).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -37,6 +37,56 @@ type CredentialWarning = {
 
 const logger = apiLogger.child({ route: '/api/v1/credentials' });
 
+/**
+ * Builds the default human verification link base URL from `RI_APP_URL`.
+ *
+ * Used when a caller requests publishing without an explicit
+ * `publishingOptions.humanVerificationUrl`, so every published credential
+ * carries a link to this Reference Implementation's own verify page. `RI_APP_URL`
+ * is the RI's public base URL (the same variable that backs the OIDC
+ * post-logout redirect); the verify page lives at `/verify`.
+ *
+ * Throws a {@link ValidationError} when `RI_APP_URL` is missing, is not a valid
+ * http(s) URL, or carries userinfo (a `user:pass@` component, which would be
+ * published into a public link). A deployment that asked to publish but cannot
+ * build a safe link fails with an actionable message instead of publishing a
+ * broken or secret-bearing link. The caller can also remedy it per-request by
+ * supplying `publishingOptions.humanVerificationUrl`.
+ */
+function defaultHumanVerificationUrl(): string {
+  const base = process.env.RI_APP_URL;
+  if (!base) {
+    throw new ValidationError(
+      'Publishing requires a human verification URL. Set the RI_APP_URL environment variable, or pass publishingOptions.humanVerificationUrl.',
+    );
+  }
+
+  let url: URL | undefined;
+  try {
+    url = new URL(base);
+  } catch {
+    url = undefined;
+  }
+  if (!url || (url.protocol !== 'http:' && url.protocol !== 'https:')) {
+    throw new ValidationError(
+      'RI_APP_URL is not a valid http(s) URL. Set a valid RI_APP_URL, or pass publishingOptions.humanVerificationUrl.',
+    );
+  }
+  if (url.username || url.password) {
+    throw new ValidationError(
+      'RI_APP_URL must not contain a username or password; the verify link is published to a public directory. Remove the userinfo from RI_APP_URL, or pass publishingOptions.humanVerificationUrl.',
+    );
+  }
+
+  // Build from URL components so a query or fragment on RI_APP_URL cannot land
+  // ahead of the appended path segment (e.g. `https://ri/?x=1` must not become
+  // `https://ri/?x=1/verify`). Any base path is preserved.
+  url.search = '';
+  url.hash = '';
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/verify`;
+  return url.toString();
+}
+
 // ---------------------------------------------------------------------------
 // POST /api/v1/credentials
 // ---------------------------------------------------------------------------
@@ -156,6 +206,17 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       await assertPublicUrl(publishingOptions.humanVerificationUrl, 'publishingOptions.humanVerificationUrl');
     }
   }
+
+  // ── Default the human verification link (see defaultHumanVerificationUrl) ─
+  // Resolved here, before issuance (Step 7), so a deployment that requested
+  // publishing but cannot build the link fails before any credential is signed
+  // or stored. The derived default is trusted operator config, so it is
+  // intentionally not SSRF-checked and a localhost RI_APP_URL is accepted in
+  // development.
+  const effectiveHumanVerificationUrl =
+    publishingOptions.publish === true && !publishingOptions.humanVerificationUrl
+      ? defaultHumanVerificationUrl()
+      : publishingOptions.humanVerificationUrl;
 
   // ── Step 2: Resolve data model ──────────────────────────────────────────
 
@@ -284,7 +345,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       const links = buildPublishLinks(storageResponse, linkTitle, {
         linkType: publishingOptions.linkType,
         machineVerificationUrl: publishingOptions.machineVerificationUrl,
-        humanVerificationUrl: publishingOptions.humanVerificationUrl,
+        humanVerificationUrl: effectiveHumanVerificationUrl,
         ...(publishingOptions.hreflang !== undefined ? { hreflang: publishingOptions.hreflang } : {}),
         ...(publishingOptions.additionalRels !== undefined ? { additionalRels: publishingOptions.additionalRels } : {}),
         ...(publishingOptions.public !== undefined ? { public: publishingOptions.public } : {}),

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -44,7 +44,12 @@ export const publishingOptionsSchema = z.object({
     .optional()
     .describe('Qualifier path for sub-identifiers (e.g. /10/LOT123/21/SER456). Defaults to /'),
   machineVerificationUrl: z.string().optional().describe('Machine verification URL'),
-  humanVerificationUrl: z.string().optional().describe('Human verification URL'),
+  humanVerificationUrl: z
+    .string()
+    .optional()
+    .describe(
+      'Human verification URL. When publishing without one, defaults to this RI verify page, ${RI_APP_URL}/verify',
+    ),
   hreflang: z
     .array(z.string().min(1))
     .optional()


### PR DESCRIPTION
This PR defaults `humanVerificationUrl` to this Reference Implementation's own verify page when a credential is published without one, so every published credential carries a human verification link instead of being discoverable through the Identity Resolver with no way to reach a verify page.

The default is derived from the existing `RI_APP_URL` environment variable (the same base URL that backs the OIDC post-logout redirect). `RI_APP_URL` is parsed as a URL and `/verify` is appended to its path, so a query, fragment, or userinfo on the base cannot produce a malformed or secret-bearing link. The default is resolved up front, before the credential is signed or stored, so a deployment that requested publishing but has a missing or invalid `RI_APP_URL` fails at request time rather than persisting a credential with no verify link. The derived default is trusted operator config and is not SSRF-checked, so a localhost `RI_APP_URL` works in development; a caller-supplied `humanVerificationUrl` still is SSRF-guarded and still overrides the default.

The published link deliberately omits the credential's decryption key. The key is not registered on the Identity Resolver; it is exchanged out of band, so access to an encrypted credential does not travel with its discovery link. For an encrypted credential (the storage default) the verifier obtains the key out of band, and the issuing tenant can retrieve it from `GET /api/v1/credentials/{id}`. The documentation for both the credentials API and the verify page is updated to state this.

Globally requiring `RI_APP_URL` at startup, and reclassifying the missing-config failure from 400 to 500 with a dedicated config-error type, are deliberately out of scope here and tracked against #771.

Closes #491

## Test plan
- [x] Publishing without `humanVerificationUrl` registers `${RI_APP_URL}/verify` (base path preserved, trailing slash trimmed, query and fragment dropped)
- [x] An explicit `humanVerificationUrl` overrides the default and is still SSRF-guarded, including when `RI_APP_URL` is unset
- [x] The trusted localhost default is not SSRF-rejected
- [x] Missing, non-URL, non-http(s), or userinfo-bearing `RI_APP_URL` fails with 400 before the credential is issued or published
- [x] `publish: false` requires no `RI_APP_URL`
- [x] Full credentials route suite passes (87 tests); lint clean
