### PR TITLE
feat(ri): add shared zod request and query validation infrastructure

### DIFF
--- a/docs/adrs/037-input-validation-zod-route-boundary.md
+++ b/docs/adrs/037-input-validation-zod-route-boundary.md
@@ -1,0 +1,50 @@
+# ADR-037: Input Validation with Zod Schemas at the Route Boundary
+
+- **Date:** 2026-07-14
+- **Status:** accepted
+
+## Context
+
+Reference implementation API routes validate their inbound inputs inconsistently. Write routes accept request bodies with little runtime shape validation: handlers check one or two fields with `isNonEmptyString` and pass the rest through unchecked type casts, so malformed input fails deep in the stack (a `TypeError` on property access, Prisma's client-side argument validation, or an upstream service call) instead of returning a documented 400. List routes parse query parameters with a scatter of ad-hoc helpers (`parsePositiveInt`, `parseNonNegativeInt`, `validateEnum`, `parseBooleanString`), each hand-called per parameter, so a resource's query contract is implicit and its 400 behaviour varies by route. The sanitised backstop from ADR-036 stops malformed-body responses leaking internals, but the status and message remain wrong: a client receives a generic 500 for what is a malformed request. An API-surface audit catalogued the body gaps route by route (#736): handlers that dereference a JSON `null` body, array fields never checked to be arrays, and a Zod schema that exists for documentation but is never applied.
+
+Separately, several schemas accept format-checkable fields as free strings: URL fields (`registrar.url`, `data-model.schemaUrl`/`contextUrl`/`websiteUrl`, credential verification URLs) typed as any non-empty string, and language-tag arrays (`hreflang`) with no BCP-47 shape. A malformed URL or tag is then accepted at the boundary and only fails, if at all, far downstream.
+
+One route already validates bodies properly: the identifier links publish route defines a Zod schema, parses with `safeParse`, and maps the first issue to a 400 naming the offending field. Zod is already a dependency ([zod.dev](https://zod.dev)), and `src/lib/swagger/schemas.ts` already uses it to generate OpenAPI component schemas. The open question was whether to extend that mechanism across the whole input surface (bodies and query parameters) or to keep growing the manual per-field helpers.
+
+## Decision
+
+Every route validates its inbound inputs with a Zod schema at the route boundary before calling repositories or upstream services: request bodies on write routes, query parameters on list routes. Schemas live in a shared per-resource module, and format-checkable fields are constrained rather than accepted as free strings.
+
+1. **Zod is the validation mechanism at the route boundary, for both bodies and query parameters.** A write route parses the raw body (`req.json()` guarded so malformed JSON and a literal `null` body become a 400) through a body schema with `safeParse`; a list route parses `URLSearchParams` through a query schema via a shared `parseQueryParams` helper that coerces and validates the declared parameters. Both paths throw `ValidationError` with the first issue rendered as `field.path: message`, which the central error mapper returns as a 400. This extends the pattern the links publish route established rather than introducing a new one, and it replaces the per-parameter `parsePositiveInt`/`validateEnum`/`parseBooleanString` calls so a resource's query contract is one declared schema.
+2. **Schemas live in a shared per-resource module** (`src/lib/api/request-schemas/`, one file per resource, holding that resource's create-body, update-body, and list-query schemas). A resource's POST, PATCH, and GET handlers sit in different route files but share field shapes; co-locating schemas in route files would duplicate those shapes and let them drift. Keeping a resource's schemas in one file also makes deriving one from another possible where shapes coincide (the link schemas do this via `.partial()`).
+3. **Consumers import the resource file directly** (`@/lib/api/request-schemas/<resource>`), never through a barrel index. A barrel makes every importer transitively load every schema file and its dependencies (`@uncefact/untp-ri-services`, `@uncefact/untp-utils`), which breaks route tests that mock those packages with partial module factories: a test starts failing when an unrelated resource's schema needs an export the mock does not provide.
+4. **Unknown keys are stripped, not rejected.** Zod's default object behaviour (strip unknown keys) is kept, matching the links route. Clients that have been sending extra fields keep working; the handler only ever sees validated, known fields.
+5. **Validation covers shape, type, and format, not existence or domain membership.** Referential checks (does this identifier exist, does it belong to this tenant) stay in repositories and services, where ADR-036 maps constraint violations. Format tightening applies only where the correct form is closed and checkable: URL fields validate as URLs, `hreflang` entries validate as BCP-47 language tags, and a scheme's `validationPattern` is checked to compile as a regex. Fields whose valid set is an open vocabulary or an undecided shape stay as validated non-empty strings or open objects, with the reason recorded at the field: `linkType` is an open GS1 link-relation vocabulary, and the UNTP-shaped `location` object is a separate deferred design tracked in #804 (it remains `z.record` here). The schema's job ends at "this is a well-formed request", never "this names a thing that exists".
+6. **A schema export is never annotated with a wide type such as `z.ZodTypeAny`.** That annotation silently erases `z.infer<Schema>` to `any` with no compiler signal that inference broke. A schema export's type is left inferred, or checked with `satisfies` where an explicit check is wanted.
+
+## Consequences
+
+- Easier: a malformed request body fails fast with a 400 naming the offending field, instead of a `TypeError`, a Prisma validation error, or a sanitised 500. Malformed query parameters already returned a named 400 through the ad-hoc helpers; folding them into one declared schema per resource makes that contract explicit and consistent rather than scattered across per-parameter calls. Both failure modes are documented and testable per schema rather than per code path.
+- Easier: handlers drop their unchecked `as` casts and their per-parameter parse calls; `parsed.data` is the typed input, so the compiler enforces that only validated fields are used.
+- Easier: a resource's create, update, and query schemas sit in one file, so a field added to one surface is visible next to the others.
+- Easier: a malformed URL or language tag is rejected at the boundary rather than accepted and carried downstream.
+- Harder: request shapes are declared twice, once in the request-schemas module and once in the hand-written Swagger annotations, which can drift; folding documentation generation onto the request schemas is a possible later step, out of scope here.
+- Harder: every new route carries a schema obligation, and schema tests join the test surface.
+
+## Alternatives Considered
+
+- **Manual per-field checks and per-parameter helpers.** Rejected: the audit showed this is exactly what left the body gaps, because per-field discipline does not hold across dozens of fields and routes, and the query-parameter helpers spread the same fragility across list routes (each parameter hand-parsed, nothing enforcing the set was checked). Helpers validate one input at a time, so `null` bodies, non-array arrays, and inconsistent query 400s recur.
+- **Validating bodies now and leaving query parameters on the ad-hoc helpers.** Rejected: it would leave two validation idioms at the same boundary for the same class of failure (malformed external input), so a route's total input contract could not be read from one place, and the query 400 inconsistency would persist. The parse mechanism is identical for both, so one decision covers both.
+- **Co-locating schemas in each route file.** Rejected: a resource's create, update, and query inputs share field shapes but live in different route files, so co-location duplicates the shapes and lets them drift.
+- **Extending `src/lib/swagger/schemas.ts` with the request schemas.** Rejected: that file generates OpenAPI component schemas describing responses; mixing request-validation schemas into it couples two concerns with different change cadences in one growing file. The request-schemas module can still be imported there later if documentation generation is unified.
+- **Rejecting unknown keys (`.strict()`).** Rejected: it turns previously accepted requests into 400s for clients that send extra fields, a behaviour break with no safety gain, since stripped fields never reach the handler.
+- **Validating inside repositories instead of routes.** Rejected: repositories receive typed inputs from many callers (routes, seeds, services) and are the wrong place to re-check shape on every call; the boundary where untyped external input enters the system is the route. This mirrors ADR-036: routes own request semantics, repositories own persistence semantics.
+- **Tightening open-vocabulary fields to enums (`linkType`) or designing the location schema now.** Rejected here: `linkType` draws from an open GS1 link-relation vocabulary with no single closed list to validate against, so an enum would reject valid values; the UNTP-shaped `location` object is a distinct design effort tracked separately. Constraining a field whose valid set is not closed trades false 400s for a false sense of rigour.
+
+## References
+
+- #736 (write-body validation, superseded by the input-validation epic that introduces this ADR), #379 (credentials-route validation, absorbed by #736), #463 (ReDoS protection for scheme validation patterns; the regex-compile check coordinates with it)
+- ADR-036 (database error translation; the sanitised backstop that currently catches malformed-body failures)
+- Existing pattern: `src/app/api/v1/identifiers/[id]/links/route.ts`
+- Zod: https://zod.dev
+- BCP 47 language tags: https://www.rfc-editor.org/info/bcp47

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
@@ -1,0 +1,229 @@
+import { z } from 'zod';
+import {
+  idSchema,
+  locationSchema,
+  requireAtLeastOneField,
+  nonEmptyArraySchema,
+  paginationQuerySchema,
+  booleanQuerySchema,
+} from './shared';
+
+describe('idSchema', () => {
+  it('accepts a non-empty string', () => {
+    expect(idSchema.safeParse('id-123')).toEqual({ success: true, data: 'id-123' });
+  });
+
+  it('rejects an empty string', () => {
+    expect(idSchema.safeParse('').success).toBe(false);
+  });
+
+  it('rejects a non-string value', () => {
+    expect(idSchema.safeParse(123).success).toBe(false);
+  });
+});
+
+describe('locationSchema', () => {
+  it('accepts an arbitrary object', () => {
+    expect(locationSchema.safeParse({ lat: 1, lon: 2 })).toEqual({ success: true, data: { lat: 1, lon: 2 } });
+  });
+
+  it('accepts an empty object', () => {
+    expect(locationSchema.safeParse({})).toEqual({ success: true, data: {} });
+  });
+
+  it('rejects a non-object value', () => {
+    expect(locationSchema.safeParse('somewhere').success).toBe(false);
+  });
+
+  it('rejects an array', () => {
+    expect(locationSchema.safeParse(['somewhere']).success).toBe(false);
+  });
+});
+
+describe('requireAtLeastOneField', () => {
+  const updateSchema = requireAtLeastOneField(
+    z.object({ name: z.string().optional(), age: z.number().optional() }),
+    'At least one field must be provided',
+  );
+
+  it('accepts a body with one defined field', () => {
+    expect(updateSchema.safeParse({ name: 'Widget' })).toEqual({ success: true, data: { name: 'Widget' } });
+  });
+
+  it('accepts a body with every field defined', () => {
+    expect(updateSchema.safeParse({ name: 'Widget', age: 3 })).toEqual({
+      success: true,
+      data: { name: 'Widget', age: 3 },
+    });
+  });
+
+  it('rejects an empty body with the given message', () => {
+    const result = updateSchema.safeParse({});
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('At least one field must be provided');
+    }
+  });
+
+  it('rejects a body whose only keys are explicitly undefined', () => {
+    const result = updateSchema.safeParse({ name: undefined, age: undefined });
+    expect(result.success).toBe(false);
+  });
+
+  it('leaves a non-object body for the wrapped schema to report its own type error', () => {
+    const result = updateSchema.safeParse('not-an-object');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Expected object, received string');
+    }
+  });
+
+  describe('with a defaulted field', () => {
+    const updateSchemaWithDefault = requireAtLeastOneField(
+      z.object({ name: z.string().optional(), age: z.number().default(10) }),
+      'At least one field must be provided',
+    );
+
+    it('rejects an empty body even though a field carries a default', () => {
+      const result = updateSchemaWithDefault.safeParse({});
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('At least one field must be provided');
+      }
+    });
+
+    it('rejects a body whose only key is explicitly undefined, despite the default', () => {
+      const result = updateSchemaWithDefault.safeParse({ age: undefined });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a body with a real field and fills the default for the rest', () => {
+      expect(updateSchemaWithDefault.safeParse({ name: 'Widget' })).toEqual({
+        success: true,
+        data: { name: 'Widget', age: 10 },
+      });
+    });
+  });
+});
+
+describe('nonEmptyArraySchema', () => {
+  const itemsSchema = nonEmptyArraySchema(z.string().min(1));
+
+  it('accepts a non-empty array of valid items', () => {
+    expect(itemsSchema.safeParse(['a', 'b'])).toEqual({ success: true, data: ['a', 'b'] });
+  });
+
+  it('rejects an empty array', () => {
+    const result = itemsSchema.safeParse([]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Request body must not be empty');
+    }
+  });
+
+  it('rejects a non-array value', () => {
+    const result = itemsSchema.safeParse('not-an-array');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Request body must be an array');
+    }
+  });
+
+  it('rejects an array containing an invalid item', () => {
+    expect(itemsSchema.safeParse(['a', '']).success).toBe(false);
+  });
+});
+
+describe('paginationQuerySchema', () => {
+  it('accepts both limit and offset', () => {
+    expect(paginationQuerySchema.safeParse({ limit: '20', offset: '40' })).toEqual({
+      success: true,
+      data: { limit: 20, offset: 40 },
+    });
+  });
+
+  it('accepts neither parameter, leaving both undefined', () => {
+    expect(paginationQuerySchema.safeParse({})).toEqual({ success: true, data: {} });
+  });
+
+  it('accepts an offset of zero', () => {
+    expect(paginationQuerySchema.safeParse({ offset: '0' })).toEqual({ success: true, data: { offset: 0 } });
+  });
+
+  describe('strict decimal integer matrix', () => {
+    const acceptedLimits: Array<[string, number]> = [
+      ['5', 5],
+      ['+5', 5],
+      [' 5 ', 5],
+    ];
+
+    it.each(acceptedLimits)('accepts limit %j as the numeric value %d', (raw, expected) => {
+      expect(paginationQuerySchema.safeParse({ limit: raw })).toEqual({ success: true, data: { limit: expected } });
+    });
+
+    const rejectedLimits = ['1abc', '5.5', '5.0', '1e3', '0x10', '0b101', '0o17', '', '   ', '0', '-1'];
+
+    it.each(rejectedLimits)('rejects limit %j', (raw) => {
+      const result = paginationQuerySchema.safeParse({ limit: raw });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]).toMatchObject({ path: ['limit'], message: 'must be a positive integer' });
+      }
+    });
+
+    const rejectedOffsets = ['1abc', '5.5', '5.0', '1e3', '0x10', '0b101', '0o17', '', '   ', '-1'];
+
+    it.each(rejectedOffsets)('rejects offset %j', (raw) => {
+      const result = paginationQuerySchema.safeParse({ offset: raw });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]).toMatchObject({ path: ['offset'], message: 'must be a non-negative integer' });
+      }
+    });
+
+    it('accepts a signed and whitespace-padded offset, at its numeric value', () => {
+      expect(paginationQuerySchema.safeParse({ offset: ' +0 ' })).toEqual({ success: true, data: { offset: 0 } });
+    });
+  });
+
+  it('composes with a resource-specific filter via merge, pagination last', () => {
+    const resourceQuerySchema = z.object({ status: z.enum(['active', 'inactive']) }).merge(paginationQuerySchema);
+    expect(resourceQuerySchema.safeParse({ limit: '10', status: 'active' })).toEqual({
+      success: true,
+      data: { limit: 10, status: 'active' },
+    });
+  });
+
+  it('reports the resource-filter issue first when both the filter and pagination are invalid', () => {
+    const resourceQuerySchema = z.object({ status: z.enum(['active', 'inactive']) }).merge(paginationQuerySchema);
+    const result = resourceQuerySchema.safeParse({ status: 'bogus', limit: 'abc' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['status']);
+    }
+  });
+});
+
+describe('booleanQuerySchema', () => {
+  const schema = z.object({ active: booleanQuerySchema });
+
+  it('leaves the field undefined when absent', () => {
+    expect(schema.safeParse({})).toEqual({ success: true, data: {} });
+  });
+
+  it('parses "true" as true', () => {
+    expect(schema.safeParse({ active: 'true' })).toEqual({ success: true, data: { active: true } });
+  });
+
+  it('parses "false" as false', () => {
+    expect(schema.safeParse({ active: 'false' })).toEqual({ success: true, data: { active: false } });
+  });
+
+  it.each(['TRUE', '1', 'yes', ''])('rejects %j', (raw) => {
+    const result = schema.safeParse({ active: raw });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]).toMatchObject({ path: ['active'], message: 'must be "true" or "false"' });
+    }
+  });
+});

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
@@ -1,0 +1,114 @@
+/**
+ * Zod request-body and query-parameter schemas shared across resources
+ * (ADR-037).
+ *
+ * Routes parse bodies with parseRequestBody and query parameters with
+ * parseQueryParams, both from '@/lib/api/validation', and import schemas
+ * from the resource file directly (no barrel index; a barrel transitively
+ * loads every resource's dependencies, which breaks tests that mock those
+ * packages). Schemas validate shape and type only; referential checks
+ * (existence, tenant scoping) stay in repositories and services.
+ *
+ * Never annotate a schema export with a wide type such as z.ZodTypeAny:
+ * the annotation silently erases z.infer<Schema> to any with no compiler
+ * signal that inference broke. Leave a schema export's type inferred, or
+ * use `satisfies` where an explicit check is wanted.
+ */
+
+import { z } from 'zod';
+
+/** A database identifier reference (non-empty string). */
+export const idSchema = z.string().min(1);
+
+/**
+ * UNTP location object, accepted as an open JSON object. No field-level
+ * validation is applied anywhere today; a UNTP-shaped location schema is
+ * tracked in #804.
+ */
+export const locationSchema = z.record(z.unknown());
+
+/**
+ * Wraps an update-body schema so a body providing no fields is rejected.
+ * Checks the raw input's own values before the wrapped schema applies any
+ * defaults, so a body of `{}` (or a body whose only keys are explicitly
+ * `undefined`) is rejected even when every field carries a `.default()`;
+ * checking the parsed output instead would let a default mask an empty
+ * body. A non-object raw body is left untouched so the wrapped schema's own
+ * type check produces its usual "Expected object, received X" message.
+ */
+export function requireAtLeastOneField<Schema extends z.SomeZodObject>(schema: Schema, message: string) {
+  return z.preprocess((raw, ctx) => {
+    const isPlainObject = raw !== null && typeof raw === 'object' && !Array.isArray(raw);
+    if (isPlainObject && !Object.values(raw as object).some((value) => value !== undefined)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message });
+      return z.NEVER;
+    }
+    return raw;
+  }, schema);
+}
+
+/** A bulk-create request body: a non-empty array of items. */
+export function nonEmptyArraySchema<Item extends z.ZodTypeAny>(itemSchema: Item) {
+  return z
+    .array(itemSchema, { invalid_type_error: 'Request body must be an array' })
+    .min(1, 'Request body must not be empty');
+}
+
+/**
+ * Coerces a trimmed query-string value to a strict decimal integer, subject
+ * to the given range check. Accepts only an optional leading sign followed
+ * by one or more digits (`5`, `+5`, ` 5 ` once trimmed); rejects everything
+ * a plain integer literal is not, including fractional (`5.5`, `5.0`),
+ * scientific (`1e3`), and hex/binary/octal forms (`0x10`, `0b101`, `0o17`),
+ * trailing garbage (`1abc`), and empty or whitespace-only strings. A
+ * missing key stays `undefined` via the trailing `.optional()`, which
+ * short-circuits before any of this runs.
+ *
+ * This deliberately tightens behaviour versus the parseInt-based
+ * parsePositiveInt/parseNonNegativeInt helpers in '@/lib/api/validation'
+ * that this fragment replaces as resources adopt it: parseInt with radix
+ * 10 parses only a value's leading digits, so it silently accepted
+ * malformed input such as "1abc" (as 1) and "0x10" (as 0, itself wrongly
+ * valid as a non-negative offset).
+ */
+function strictIntQueryParam(message: string, isInRange: (value: number) => boolean) {
+  return z
+    .string()
+    .trim()
+    .regex(/^[+-]?\d+$/, message)
+    .transform((value) => Number(value))
+    .refine(isInRange, message)
+    .optional();
+}
+
+/**
+ * Shared `limit`/`offset` query fragment for list routes (ADR-037).
+ *
+ * A resource merges this onto its own filter schema, pagination last, so a
+ * resource's own filter issue is reported before a pagination issue when
+ * both are invalid (parseQueryParams renders only the first issue, and
+ * this ordering matches what current routes already report):
+ *
+ *   const resourceQuerySchema = z.object({ status: z.enum([...]) }).merge(paginationQuerySchema);
+ *   const query = parseQueryParams(new URL(req.url), resourceQuerySchema);
+ */
+export const paginationQuerySchema = z.object({
+  limit: strictIntQueryParam('must be a positive integer', (value) => value >= 1),
+  offset: strictIntQueryParam('must be a non-negative integer', (value) => value >= 0),
+});
+
+export type PaginationQuery = z.infer<typeof paginationQuerySchema>;
+
+/**
+ * Shared boolean query-parameter schema, accepting exactly "true" or
+ * "false" (case-sensitive) and rejecting everything else, matching the
+ * parseBooleanString helper in '@/lib/api/validation' that this replaces
+ * as resources adopt it. Deliberately not `z.coerce.boolean()`: that
+ * coercion treats any non-empty string, including "false" and "0", as
+ * truthy, which would accept exactly the malformed input this schema
+ * exists to reject.
+ */
+export const booleanQuerySchema = z
+  .enum(['true', 'false'], { message: 'must be "true" or "false"' })
+  .transform((value) => value === 'true')
+  .optional();

--- a/packages/reference-implementation/src/lib/api/validation.test.ts
+++ b/packages/reference-implementation/src/lib/api/validation.test.ts
@@ -3,6 +3,7 @@ jest.mock('@uncefact/untp-ri-services/server', () => ({
   validatePublicUrl: (...args: unknown[]) => mockValidatePublicUrl(...args),
 }));
 
+import { z } from 'zod';
 import {
   ValidationError,
   isNonEmptyString,
@@ -11,7 +12,11 @@ import {
   parseNonNegativeInt,
   parseBooleanString,
   assertPublicUrl,
+  parseRequestBody,
+  parseQueryParams,
+  definedFields,
 } from './validation';
+import { paginationQuerySchema } from './request-schemas/shared';
 
 describe('isNonEmptyString', () => {
   it('returns true for a non-empty string', () => {
@@ -178,5 +183,152 @@ describe('assertPublicUrl', () => {
     mockValidatePublicUrl.mockResolvedValue(undefined);
 
     await expect(assertPublicUrl('https://example.com/schema.json', 'schemaUrl')).resolves.toBeUndefined();
+  });
+});
+
+describe('parseRequestBody', () => {
+  const schema = z.object({ name: z.string().min(1), age: z.number().int().optional() });
+
+  const fakeRequest = (body: unknown): { json: () => Promise<unknown> } => ({
+    json: () => Promise.resolve(body),
+  });
+
+  const fakeMalformedRequest = (): { json: () => Promise<unknown> } => ({
+    json: () => Promise.reject(new SyntaxError('Unexpected token')),
+  });
+
+  it('resolves with the typed data for a valid body', async () => {
+    await expect(parseRequestBody(fakeRequest({ name: 'Widget', age: 3 }), schema)).resolves.toEqual({
+      name: 'Widget',
+      age: 3,
+    });
+  });
+
+  it('strips unknown keys', async () => {
+    await expect(parseRequestBody(fakeRequest({ name: 'Widget', extra: 'x' }), schema)).resolves.toEqual({
+      name: 'Widget',
+    });
+  });
+
+  it('throws ValidationError for malformed JSON', async () => {
+    await expect(parseRequestBody(fakeMalformedRequest(), schema)).rejects.toThrow(ValidationError);
+    await expect(parseRequestBody(fakeMalformedRequest(), schema)).rejects.toThrow('Invalid JSON body');
+  });
+
+  it('throws ValidationError for a literal null body', async () => {
+    await expect(parseRequestBody(fakeRequest(null), schema)).rejects.toThrow(ValidationError);
+    await expect(parseRequestBody(fakeRequest(null), schema)).rejects.toThrow('body: Expected object, received null');
+  });
+
+  it('throws ValidationError for a literal null body even against a schema that would otherwise accept it', async () => {
+    // z.unknown() accepts any value, including null, so the null->400 behaviour
+    // relies on the explicit check in parseRequestBody, not on the schema's own
+    // type check.
+    const permissiveSchema = z.unknown();
+    await expect(parseRequestBody(fakeRequest(null), permissiveSchema)).rejects.toThrow(ValidationError);
+    await expect(parseRequestBody(fakeRequest(null), permissiveSchema)).rejects.toThrow(
+      'body: Expected object, received null',
+    );
+  });
+
+  it('throws ValidationError naming a missing required field', async () => {
+    await expect(parseRequestBody(fakeRequest({}), schema)).rejects.toThrow('name: Required');
+  });
+
+  it('throws ValidationError naming a wrong-typed field', async () => {
+    await expect(parseRequestBody(fakeRequest({ name: 'Widget', age: 'old' }), schema)).rejects.toThrow(
+      'age: Expected number, received string',
+    );
+  });
+});
+
+describe('parseQueryParams', () => {
+  const schema = z.object({
+    status: z.enum(['active', 'inactive']).optional(),
+    limit: z.coerce.number().int().positive().optional(),
+  });
+
+  it('accepts a URLSearchParams and returns the typed, coerced data', () => {
+    const params = new URLSearchParams({ status: 'active', limit: '10' });
+    expect(parseQueryParams(params, schema)).toEqual({ status: 'active', limit: 10 });
+  });
+
+  it('accepts a URL and reads its search params', () => {
+    const url = new URL('https://example.com/api/v1/things?status=inactive');
+    expect(parseQueryParams(url, schema)).toEqual({ status: 'inactive' });
+  });
+
+  it('returns an empty object when no query parameters are present', () => {
+    expect(parseQueryParams(new URLSearchParams(), schema)).toEqual({});
+  });
+
+  it('throws ValidationError naming the first offending parameter', () => {
+    const params = new URLSearchParams({ status: 'bogus' });
+    expect(() => parseQueryParams(params, schema)).toThrow(ValidationError);
+    expect(() => parseQueryParams(params, schema)).toThrow(/^status: /);
+  });
+
+  it('throws ValidationError for a non-integer value', () => {
+    const params = new URLSearchParams({ limit: 'abc' });
+    expect(() => parseQueryParams(params, schema)).toThrow(ValidationError);
+    expect(() => parseQueryParams(params, schema)).toThrow(/^limit: /);
+  });
+
+  it('strips a query key the schema does not declare', () => {
+    const params = new URLSearchParams({ status: 'active', extra: 'ignored' });
+    expect(parseQueryParams(params, schema)).toEqual({ status: 'active' });
+  });
+
+  describe('repeated query keys', () => {
+    it('throws ValidationError naming the repeated key when it repeats first', () => {
+      const params = new URLSearchParams([
+        ['status', 'active'],
+        ['status', 'inactive'],
+      ]);
+      expect(() => parseQueryParams(params, schema)).toThrow(ValidationError);
+      expect(() => parseQueryParams(params, schema)).toThrow('status: repeated query parameter');
+    });
+
+    it('throws ValidationError naming the repeated key when a different key repeats instead', () => {
+      const params = new URLSearchParams([
+        ['status', 'active'],
+        ['limit', '10'],
+        ['limit', '20'],
+      ]);
+      expect(() => parseQueryParams(params, schema)).toThrow(ValidationError);
+      expect(() => parseQueryParams(params, schema)).toThrow('limit: repeated query parameter');
+    });
+
+    it('does not throw when every key appears once', () => {
+      const params = new URLSearchParams([
+        ['status', 'active'],
+        ['limit', '10'],
+      ]);
+      expect(() => parseQueryParams(params, schema)).not.toThrow();
+    });
+  });
+
+  it('renders the full composed pagination error end to end', () => {
+    const params = new URLSearchParams({ limit: '0' });
+    expect(() => parseQueryParams(params, paginationQuerySchema)).toThrow(ValidationError);
+    expect(() => parseQueryParams(params, paginationQuerySchema)).toThrow('limit: must be a positive integer');
+  });
+});
+
+describe('definedFields', () => {
+  it('drops keys whose value is undefined', () => {
+    expect(definedFields({ a: 1, b: undefined, c: 'x' })).toEqual({ a: 1, c: 'x' });
+  });
+
+  it('keeps falsy-but-defined values', () => {
+    expect(definedFields({ a: 0, b: '', c: false, d: null })).toEqual({ a: 0, b: '', c: false, d: null });
+  });
+
+  it('returns an empty object when every value is undefined', () => {
+    expect(definedFields({ a: undefined, b: undefined })).toEqual({});
+  });
+
+  it('returns an equivalent object when no value is undefined', () => {
+    expect(definedFields({ a: 1, b: 'x' })).toEqual({ a: 1, b: 'x' });
   });
 });

--- a/packages/reference-implementation/src/lib/api/validation.ts
+++ b/packages/reference-implementation/src/lib/api/validation.ts
@@ -5,6 +5,7 @@
  * Routes catch ValidationError and return 400.
  */
 
+import { z } from 'zod';
 import { validatePublicUrl } from '@uncefact/untp-ri-services/server';
 
 export class ValidationError extends Error {
@@ -12,6 +13,82 @@ export class ValidationError extends Error {
     super(message);
     this.name = 'ValidationError';
   }
+}
+
+/**
+ * Parse and validate a JSON request body against a Zod schema (ADR-037).
+ *
+ * Malformed JSON, a literal `null` body, and any shape mismatch throw
+ * ValidationError with the first issue rendered as `field.path: message`,
+ * which the route error mapper returns as a 400.
+ */
+export async function parseRequestBody<Schema extends z.ZodTypeAny>(
+  req: { json: () => Promise<unknown> },
+  schema: Schema,
+): Promise<z.infer<Schema>> {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    throw new ValidationError('Invalid JSON body');
+  }
+  // Checked explicitly rather than left to safeParse: a schema that accepts
+  // any shape (e.g. z.unknown()) would otherwise treat a literal `null` body
+  // as valid data instead of a malformed request.
+  if (raw === null) {
+    throw new ValidationError('body: Expected object, received null');
+  }
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new ValidationError(`${issue.path.join('.') || 'body'}: ${issue.message}`);
+  }
+  return parsed.data;
+}
+
+/**
+ * Parse and validate URL query parameters against a Zod schema (ADR-037).
+ *
+ * Accepts either a URLSearchParams or the route's URL directly. Rejects a
+ * query key that appears more than once (e.g. `?status=a&status=b`), since
+ * a resource's query schema declares each parameter as a single scalar; a
+ * multi-value/array query parameter path is deferred until a resource needs
+ * one. Coerces and validates the declared parameters, throwing
+ * ValidationError with the first issue rendered as `param: message` on
+ * failure so body and query 400s look identical (mirrors parseRequestBody's
+ * rendering convention).
+ */
+export function parseQueryParams<Schema extends z.ZodTypeAny>(
+  source: URL | URLSearchParams,
+  schema: Schema,
+): z.infer<Schema> {
+  const searchParams = source instanceof URL ? source.searchParams : source;
+  const seenKeys = new Set<string>();
+  for (const key of searchParams.keys()) {
+    if (seenKeys.has(key)) {
+      throw new ValidationError(`${key}: repeated query parameter`);
+    }
+    seenKeys.add(key);
+  }
+  const raw = Object.fromEntries(searchParams.entries());
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new ValidationError(`${issue.path.join('.') || 'param'}: ${issue.message}`);
+  }
+  return parsed.data;
+}
+
+/**
+ * Returns a copy of the object containing only the keys whose value is not
+ * undefined, preserving optionality in the result type. Forwards a parsed
+ * PATCH body to a repository update input without per-field conditional
+ * spreads at every call site.
+ */
+export function definedFields<T extends object>(source: T): { [K in keyof T]?: Exclude<T[K], undefined> } {
+  return Object.fromEntries(Object.entries(source).filter(([, value]) => value !== undefined)) as {
+    [K in keyof T]?: Exclude<T[K], undefined>;
+  };
 }
 
 /**


### PR DESCRIPTION
This PR adds the shared Zod input-validation infrastructure at the route boundary that the input-validation epic (#788) builds on, so the resource tickets can validate request bodies and query parameters against a declared schema and return a clean 400 that names the offending field.

It provides `parseRequestBody` and `parseQueryParams` in `src/lib/api/validation.ts`, the shared schema helpers with `paginationQuerySchema` and `booleanQuerySchema` in `src/lib/api/request-schemas/`, and records ADR-037. No routes are wired here; each resource ticket consumes the helpers as it migrates. Query pagination uses strict decimal-integer validation and the `param: message` error format, deliberately tightening the previous `parseInt`-based helpers (recorded in ADR-037 and #788): a malformed value the old helpers accepted by accident, for example `?limit=1e3` or `?limit=0x10`, now returns a clean 400.

Closes #789

## Test plan
- [x] Malformed request bodies (malformed JSON, a literal null body, missing or wrong-typed fields) return a 400 naming the offending field
- [x] Malformed query parameters return a 400 naming the parameter; strict decimal-integer pagination rejects hex, scientific, partial-numeric, and non-integer values the old helpers accepted
- [x] A repeated query key is rejected rather than silently collapsed to its last value
- [x] An empty update body is rejected even when a field carries a Zod default
- [x] The shared boolean query helper accepts only "true" and "false"
- [x] Full reference-implementation suite passes (1720 tests)
