### PR TITLE
fix(ri): reject pagination values too large for an exact integer

### DIFF
--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
@@ -161,7 +161,22 @@ describe('paginationQuerySchema', () => {
       expect(paginationQuerySchema.safeParse({ limit: raw })).toEqual({ success: true, data: { limit: expected } });
     });
 
-    const rejectedLimits = ['1abc', '5.5', '5.0', '1e3', '0x10', '0b101', '0o17', '', '   ', '0', '-1'];
+    // 9007199254740993 is 2^53 + 1, the first integer Number cannot represent exactly.
+    const rejectedLimits = [
+      '1abc',
+      '5.5',
+      '5.0',
+      '1e3',
+      '0x10',
+      '0b101',
+      '0o17',
+      '',
+      '   ',
+      '0',
+      '-1',
+      '9007199254740993',
+      '99999999999999999999',
+    ];
 
     it.each(rejectedLimits)('rejects limit %j', (raw) => {
       const result = paginationQuerySchema.safeParse({ limit: raw });
@@ -171,7 +186,20 @@ describe('paginationQuerySchema', () => {
       }
     });
 
-    const rejectedOffsets = ['1abc', '5.5', '5.0', '1e3', '0x10', '0b101', '0o17', '', '   ', '-1'];
+    const rejectedOffsets = [
+      '1abc',
+      '5.5',
+      '5.0',
+      '1e3',
+      '0x10',
+      '0b101',
+      '0o17',
+      '',
+      '   ',
+      '-1',
+      '9007199254740993',
+      '99999999999999999999',
+    ];
 
     it.each(rejectedOffsets)('rejects offset %j', (raw) => {
       const result = paginationQuerySchema.safeParse({ offset: raw });
@@ -179,6 +207,13 @@ describe('paginationQuerySchema', () => {
       if (!result.success) {
         expect(result.error.issues[0]).toMatchObject({ path: ['offset'], message: 'must be a non-negative integer' });
       }
+    });
+
+    it('rejects an all-digit value large enough to overflow Number to Infinity', () => {
+      const overflowing = '9'.repeat(400);
+      expect(Number(overflowing)).toBe(Infinity);
+      expect(paginationQuerySchema.safeParse({ limit: overflowing }).success).toBe(false);
+      expect(paginationQuerySchema.safeParse({ offset: overflowing }).success).toBe(false);
     });
 
     it('accepts a signed and whitespace-padded offset, at its numeric value', () => {

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
@@ -70,6 +70,11 @@ export function nonEmptyArraySchema<Item extends z.ZodTypeAny>(itemSchema: Item)
  * 10 parses only a value's leading digits, so it silently accepted
  * malformed input such as "1abc" (as 1) and "0x10" (as 0, itself wrongly
  * valid as a non-negative offset).
+ *
+ * A digit string too large for an exact double is rejected: the safe-integer
+ * check catches both a value that overflows to Infinity (which passes a bare
+ * range check) and a value above Number.MAX_SAFE_INTEGER that Number would
+ * round to a different integer than the client sent.
  */
 function strictIntQueryParam(message: string, isInRange: (value: number) => boolean) {
   return z
@@ -77,7 +82,7 @@ function strictIntQueryParam(message: string, isInRange: (value: number) => bool
     .trim()
     .regex(/^[+-]?\d+$/, message)
     .transform((value) => Number(value))
-    .refine(isInRange, message)
+    .refine((value) => Number.isSafeInteger(value) && isInRange(value), message)
     .optional();
 }
 


### PR DESCRIPTION
The strict pagination query schema added in #807 validates a `limit`/`offset` value with a digit regex and then `Number()`, and its range check accepted any resulting number. A digit string large enough to overflow to `Infinity` (or above `Number.MAX_SAFE_INTEGER`) therefore passed validation and reached the repository, where the previous `parseInt`-based helpers returned a 400 because `Number.isFinite` rejected the `Infinity`. For example `GET /identifiers?offset=` followed by 400 nines produced `{ offset: Infinity }`.

This restores the rejection: the range refine in `strictIntQueryParam` now also requires `Number.isSafeInteger`, so an overflowing or precision-losing pagination value returns a clean 400 naming the parameter. This is the correct contract for pagination and closes the regression before the query pattern is adopted by the remaining resource routes.

Related to #788

## Test plan
- [x] An `Infinity`-overflowing all-digit limit or offset returns a 400
- [x] A value above Number.MAX_SAFE_INTEGER (2^53 + 1, and a 20-digit value) returns a 400
- [x] Ordinary valid and previously-rejected values behave unchanged
- [x] Full reference-implementation suite passes
