### PR TITLE
feat(ri): validate and tighten identifiers endpoint inputs

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.test.ts
@@ -140,13 +140,34 @@ describe('PATCH /api/v1/identifiers/:id', () => {
     expect(json.value).toBe('09520123456799');
   });
 
-  it('returns 400 when no value provided', async () => {
+  it('returns 400 when no value provided and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: {} });
     const res = await PATCH(req, createContext('id-1') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('value is required');
+    expect(json.error).toMatch(/^value:/);
+    expect(mockUpdateIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty value and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { value: '' } });
+    const res = await PATCH(req, createContext('id-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^value:/);
+    expect(mockUpdateIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-string value and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { value: 123 } });
+    const res = await PATCH(req, createContext('id-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^value:/);
+    expect(mockUpdateIdentifier).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody } from '@/lib/api/validation';
+import { updateIdentifierRequestSchema } from '@/lib/api/request-schemas/identifier';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getIdentifierById, updateIdentifier, deleteIdentifier } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
@@ -80,11 +81,13 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         application/json:
  *           schema:
  *             type: object
+ *             required:
+ *               - value
  *             properties:
  *               value:
  *                 type: string
+ *                 minLength: 1
  *                 description: New value for the identifier (re-validated against scheme pattern)
- *             minProperties: 1
  *     responses:
  *       200:
  *         description: Identifier updated successfully
@@ -125,20 +128,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ identifierId: id }, 'Parsing request body');
-
-  let body: { value?: string };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
   logger.info({ identifierId: id }, 'Validating update fields');
-  if (!isNonEmptyString(body.value)) {
-    throw new ValidationError('value is required');
-  }
+
+  const body = await parseRequestBody(req, updateIdentifierRequestSchema);
 
   logger.info({ identifierId: id }, 'Updating identifier');
   const updated = await updateIdentifier(id, tenantId, {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
@@ -59,7 +59,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 
 import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
-import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -125,22 +125,64 @@ describe('POST /api/v1/identifiers', () => {
     });
   });
 
-  it('returns 400 for missing schemeId', async () => {
+  it('returns 400 for missing schemeId and does not call the repository', async () => {
     const req = createFakeRequest({ body: { value: '09520123456788' } });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('schemeId is required');
+    expect(json.error).toMatch(/^schemeId:/);
+    expect(mockCreateIdentifier).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for missing value', async () => {
+  it('returns 400 for missing value and does not call the repository', async () => {
     const req = createFakeRequest({ body: { schemeId: 'sch-1' } });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('value is required');
+    expect(json.error).toMatch(/^value:/);
+    expect(mockCreateIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-string schemeId and does not call the repository', async () => {
+    const req = createFakeRequest({ body: { schemeId: 123, value: '09520123456788' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^schemeId:/);
+    expect(mockCreateIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-string value and does not call the repository', async () => {
+    const req = createFakeRequest({ body: { schemeId: 'sch-1', value: 123 } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^value:/);
+    expect(mockCreateIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty schemeId and does not call the repository', async () => {
+    const req = createFakeRequest({ body: { schemeId: '', value: '09520123456788' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^schemeId:/);
+    expect(mockCreateIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty value and does not call the repository', async () => {
+    const req = createFakeRequest({ body: { schemeId: 'sch-1', value: '' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^value:/);
+    expect(mockCreateIdentifier).not.toHaveBeenCalled();
   });
 
   it('returns 400 when value fails scheme validation', async () => {
@@ -243,6 +285,18 @@ describe('GET /api/v1/identifiers', () => {
     });
   });
 
+  it('clamps limit to MAX_PAGE_LIMIT', async () => {
+    mockListIdentifiers.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/identifiers?limit=500',
+    });
+    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(mockListIdentifiers).toHaveBeenCalledWith('org-1', expect.objectContaining({ limit: MAX_PAGE_LIMIT }));
+  });
+
   it('handles no query parameters', async () => {
     mockListIdentifiers.mockResolvedValue({ data: [], total: 0 });
 
@@ -265,7 +319,7 @@ describe('GET /api/v1/identifiers', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('limit must be a positive integer');
+    expect(json.error).toContain('limit: must be a positive integer');
   });
 
   it('returns 400 for negative offset', async () => {
@@ -277,7 +331,33 @@ describe('GET /api/v1/identifiers', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('offset must be a non-negative integer');
+    expect(json.error).toContain('offset: must be a non-negative integer');
+  });
+
+  it('returns 400 for a repeated query key', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/identifiers?limit=10&limit=20',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListIdentifiers).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty schemeId filter', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/identifiers?schemeId=',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^schemeId:/);
+    expect(mockListIdentifiers).not.toHaveBeenCalled();
   });
 
   it('returns 500 when listIdentifiers throws', async () => {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parseQueryParams } from '@/lib/api/validation';
+import { createIdentifierRequestSchema, listIdentifiersQuerySchema } from '@/lib/api/request-schemas/identifier';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createIdentifier, listIdentifiers } from '@/lib/prisma/repositories';
-import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+import { buildPaginatedResponse, clampLimit } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/identifiers' });
@@ -27,9 +28,11 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers' });
  *             properties:
  *               schemeId:
  *                 type: string
+ *                 minLength: 1
  *                 description: ID of the identifier scheme
  *               value:
  *                 type: string
+ *                 minLength: 1
  *                 description: The identifier value (validated against scheme pattern)
  *     responses:
  *       201:
@@ -70,21 +73,8 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: {
-    schemeId?: string;
-    value?: string;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ schemeId: body.schemeId }, 'Validating input parameters');
-  if (!isNonEmptyString(body.schemeId)) throw new ValidationError('schemeId is required');
-  if (!isNonEmptyString(body.value)) throw new ValidationError('value is required');
+  logger.info('Validating request body');
+  const body = await parseRequestBody(req, createIdentifierRequestSchema);
 
   logger.info({ schemeId: body.schemeId }, 'Creating identifier');
   const identifier = await createIdentifier({
@@ -110,6 +100,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: schemeId
  *         schema:
  *           type: string
+ *           minLength: 1
  *         description: Filter by identifier scheme ID
  *       - in: query
  *         name: limit
@@ -158,11 +149,10 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   logger.info('Parsing query parameters');
-  const url = new URL(req.url);
-  const schemeId = url.searchParams.get('schemeId') ?? undefined;
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  const query = parseQueryParams(new URL(req.url), listIdentifiersQuerySchema);
+  const { schemeId } = query;
+  const limit = clampLimit(query.limit);
+  const offset = query.offset;
 
   logger.info({ schemeId, limit, offset }, 'Listing identifiers');
   const { data, total } = await listIdentifiers(tenantId, { schemeId, limit, offset });

--- a/packages/reference-implementation/src/lib/api/pagination.test.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.test.ts
@@ -1,4 +1,30 @@
-import { buildPaginatedResponse, paginateInMemory, paginationMetaSchema, DEFAULT_PAGE_LIMIT } from './pagination';
+import {
+  buildPaginatedResponse,
+  clampLimit,
+  paginateInMemory,
+  paginationMetaSchema,
+  DEFAULT_PAGE_LIMIT,
+  MAX_PAGE_LIMIT,
+} from './pagination';
+
+describe('clampLimit', () => {
+  it('leaves an absent limit undefined so the repository applies its own default', () => {
+    expect(clampLimit(undefined)).toBeUndefined();
+  });
+
+  it('passes a limit below the cap through unchanged', () => {
+    expect(clampLimit(50)).toBe(50);
+  });
+
+  it('passes the cap value through unchanged', () => {
+    expect(clampLimit(MAX_PAGE_LIMIT)).toBe(MAX_PAGE_LIMIT);
+  });
+
+  it('caps a limit above the maximum at MAX_PAGE_LIMIT', () => {
+    expect(clampLimit(MAX_PAGE_LIMIT + 1)).toBe(MAX_PAGE_LIMIT);
+    expect(clampLimit(100000)).toBe(MAX_PAGE_LIMIT);
+  });
+});
 
 describe('buildPaginatedResponse', () => {
   it('returns correct pagination metadata with explicit limit and offset', () => {

--- a/packages/reference-implementation/src/lib/api/pagination.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.ts
@@ -12,6 +12,15 @@ export type PaginationMeta = z.infer<typeof paginationMetaSchema>;
 export const DEFAULT_PAGE_LIMIT = 20;
 export const MAX_PAGE_LIMIT = 100;
 
+/**
+ * Caps a validated `limit` at MAX_PAGE_LIMIT, leaving an absent limit
+ * undefined so the repository applies its own default. Used by every list
+ * route after parsing the query so a client cannot request an unbounded page.
+ */
+export function clampLimit(limit?: number): number | undefined {
+  return limit !== undefined ? Math.min(limit, MAX_PAGE_LIMIT) : undefined;
+}
+
 export interface PaginatedResponse<T> {
   data: T[];
   pagination: PaginationMeta;

--- a/packages/reference-implementation/src/lib/api/request-schemas/identifier.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/identifier.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { idSchema, paginationQuerySchema } from './shared';
+
+/** Request body for POST /identifiers. */
+export const createIdentifierRequestSchema = z.object({
+  schemeId: idSchema,
+  value: z.string().min(1),
+});
+
+/** Request body for PATCH /identifiers/{id}. */
+export const updateIdentifierRequestSchema = z.object({
+  value: z.string().min(1),
+});
+
+/**
+ * Query parameters for GET /identifiers. Merges the `schemeId` filter ahead
+ * of pagination so a malformed filter is reported before a pagination issue
+ * among the zod schema's own issues (ADR-037). A repeated query key is
+ * rejected by parseQueryParams before schema parsing runs at all, so that
+ * check takes precedence over both.
+ */
+export const listIdentifiersQuerySchema = z
+  .object({
+    schemeId: idSchema.optional(),
+  })
+  .merge(paginationQuerySchema);

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
@@ -625,6 +625,17 @@ describe('withTenantAuth — request context propagation', () => {
     expect(mockUpdateRequestContext).toHaveBeenCalledWith({ userId: 'user-1', tenantId: 'org-1' });
   });
 
+  it('sets the request method and path on the request context under collision-resistant keys so every log entry is attributable to its route', async () => {
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockResolvedValue('org-1');
+
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withTenantAuth(handler);
+    await wrapped(fakeRequest('POST'), emptyRouteContext);
+
+    expect(mockUpdateRequestContext).toHaveBeenCalledWith({ requestMethod: 'POST', requestPath: '/api/v1/test' });
+  });
+
   it('sets userId and tenantId on request context for open mode service account path', async () => {
     mockGetSessionUserId.mockResolvedValue(null);
     mockResolveServiceAccountUser.mockResolvedValue({ userId: 'sa-user-1', tenantId: 'sa-org-1' });
@@ -677,7 +688,10 @@ describe('withTenantAuth — request context propagation', () => {
     const wrapped = withTenantAuth(handler);
     await wrapped(fakeRequest(), emptyRouteContext);
 
-    expect(mockUpdateRequestContext).not.toHaveBeenCalled();
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ userId: expect.anything() }));
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ tenantId: expect.anything() }));
+    // Route attribution is still established before auth so the denial log is attributable.
+    expect(mockUpdateRequestContext).toHaveBeenCalledWith({ requestMethod: 'GET', requestPath: '/api/v1/test' });
   });
 
   it('does not set userId or tenantId on open mode 403 path', async () => {
@@ -688,7 +702,8 @@ describe('withTenantAuth — request context propagation', () => {
     const wrapped = withTenantAuth(handler);
     await wrapped(fakeRequest(), emptyRouteContext);
 
-    expect(mockUpdateRequestContext).not.toHaveBeenCalled();
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ userId: expect.anything() }));
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ tenantId: expect.anything() }));
   });
 
   it('does not set userId or tenantId on closed mode 401 path', async () => {
@@ -700,7 +715,8 @@ describe('withTenantAuth — request context propagation', () => {
     const wrapped = withTenantAuth(handler);
     await wrapped(fakeRequest(), emptyRouteContext);
 
-    expect(mockUpdateRequestContext).not.toHaveBeenCalled();
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ userId: expect.anything() }));
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ tenantId: expect.anything() }));
   });
 
   it('does not set userId or tenantId on closed mode 403 path', async () => {
@@ -715,7 +731,8 @@ describe('withTenantAuth — request context propagation', () => {
     const wrapped = withTenantAuth(handler);
     await wrapped(fakeRequest(), emptyRouteContext);
 
-    expect(mockUpdateRequestContext).not.toHaveBeenCalled();
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ userId: expect.anything() }));
+    expect(mockUpdateRequestContext).not.toHaveBeenCalledWith(expect.objectContaining({ tenantId: expect.anything() }));
   });
 });
 

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
@@ -43,6 +43,13 @@ export function withTenantAuth(handler: RouteHandler) {
       const start = Date.now();
       const tenantConfig = getTenantConfig();
 
+      // Carry the request method and path in the request context so every
+      // downstream log entry, including a centrally-handled error, is
+      // attributable to its route without each handler restating them. The
+      // `request`-prefixed keys avoid colliding with per-log `method` fields
+      // that some handlers already use for a domain concept (e.g. a DID method).
+      updateRequestContext({ requestMethod: method, requestPath: path });
+
       apiLogger.info({ method, path }, 'Request received');
 
       if (tenantConfig.mode === 'closed') {


### PR DESCRIPTION
This PR validates the identifiers endpoints' request bodies and query parameters with Zod schemas at the route boundary (ADR-037), so malformed input returns a clean 400 naming the offending field instead of reaching the repository or being silently coerced. POST /identifiers and PATCH /identifiers/{id} validate their bodies, and GET /identifiers validates its query parameters (the `schemeId` filter and pagination) through the shared helpers, replacing the ad-hoc parsers.

As the first resource adoption of the epic (#788) foundation, it also establishes three shared patterns the remaining resource migrations reuse:

- a `clampLimit` util in `pagination.ts`, replacing the limit cap inlined across the list routes,
- the `Validating` breadcrumb logged before the parse call, so the request trace shows the validation step on both the success and failure paths, and
- `method` and `path` on the request context in `withTenantAuth`, so a centrally-handled error is attributable to its route without each handler restating them.

Closes #790

## Test plan
- [x] POST and PATCH with a missing, empty, or non-string field return a 400 naming the field, with no repository call
- [x] GET with a malformed limit/offset, or a blank `schemeId` filter, returns a 400 naming the parameter
- [x] A repeated query key is rejected
- [x] The limit clamp (via `clampLimit`) and the `schemeId` filter behave unchanged for valid input
- [x] Every log entry, including a centrally-handled error, carries the request method and path
- [x] Full reference-implementation suite passes (1742 tests)
