### PR TITLE
fix(services): construct verify links via the URL API so a base query or fragment is preserved

### DIFF
--- a/packages/services/src/utils/helpers.test.ts
+++ b/packages/services/src/utils/helpers.test.ts
@@ -57,7 +57,7 @@ describe('constructVerifyURL', () => {
 
     expect(url).toContain('https://example.com/verify?');
     const parsed = new URL(url);
-    const q = JSON.parse(decodeURIComponent(parsed.searchParams.get('q')!));
+    const q = JSON.parse(parsed.searchParams.get('q')!);
     expect(q.payload.uri).toBe('https://store/cred.json');
     expect(q.payload.digestMultibase).toBe('zabc123');
     expect(q.payload.decryptionKey).toBeUndefined();
@@ -72,7 +72,7 @@ describe('constructVerifyURL', () => {
     });
 
     const parsed = new URL(url);
-    const q = JSON.parse(decodeURIComponent(parsed.searchParams.get('q')!));
+    const q = JSON.parse(parsed.searchParams.get('q')!);
     expect(q.payload.decryptionKey).toBe('deadbeef');
   });
 
@@ -84,8 +84,61 @@ describe('constructVerifyURL', () => {
     });
 
     const parsed = new URL(url);
-    const q = JSON.parse(decodeURIComponent(parsed.searchParams.get('q')!));
+    const q = JSON.parse(parsed.searchParams.get('q')!);
     expect(Object.keys(q.payload)).toEqual(['uri', 'digestMultibase']);
+  });
+
+  it('preserves an existing query parameter on the base and appends q', () => {
+    const url = constructVerifyURL({
+      baseUrl: 'https://example.com/verify?tenant=acme',
+      uri: 'https://store/cred.json',
+      digestMultibase: 'zabc123',
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('tenant')).toBe('acme');
+    const q = JSON.parse(parsed.searchParams.get('q')!);
+    expect(q.payload.uri).toBe('https://store/cred.json');
+  });
+
+  it('places q in the query, not after a fragment, when the base has a fragment', () => {
+    const url = constructVerifyURL({
+      baseUrl: 'https://example.com/verify#section',
+      uri: 'https://store/cred.json',
+      digestMultibase: 'zabc123',
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.hash).toBe('#section');
+    const q = JSON.parse(parsed.searchParams.get('q')!);
+    expect(q.payload.digestMultibase).toBe('zabc123');
+  });
+
+  it('drops reserved payload keys from the base query so they cannot shadow the q payload', () => {
+    const url = constructVerifyURL({
+      baseUrl: 'https://example.com/verify?uri=https://stale.example/decoy.json&tenant=acme',
+      uri: 'https://store/cred.json',
+      digestMultibase: 'zabc123',
+    });
+
+    const parsed = new URL(url);
+    // The reserved direct-param key is stripped; an unrelated param is kept.
+    expect(parsed.searchParams.get('uri')).toBeNull();
+    expect(parsed.searchParams.get('tenant')).toBe('acme');
+    const q = JSON.parse(parsed.searchParams.get('q')!);
+    expect(q.payload.uri).toBe('https://store/cred.json');
+  });
+
+  it('overwrites an existing q parameter on the base with the verify payload', () => {
+    const url = constructVerifyURL({
+      baseUrl: 'https://example.com/verify?q=stale',
+      uri: 'https://store/cred.json',
+      digestMultibase: 'zabc123',
+    });
+
+    const parsed = new URL(url);
+    const q = JSON.parse(parsed.searchParams.get('q')!);
+    expect(q.payload.uri).toBe('https://store/cred.json');
   });
 
   it('falls back to window.location with /verify path when baseUrl is not provided', () => {

--- a/packages/services/src/utils/helpers.ts
+++ b/packages/services/src/utils/helpers.ts
@@ -27,6 +27,21 @@ export const constructVerifyURL = ({
   const payload: Record<string, string> = { uri, digestMultibase };
   if (decryptionKey) payload.decryptionKey = decryptionKey;
 
-  const queryString = `q=${encodeURIComponent(JSON.stringify({ payload }))}`;
-  return `${baseUrl}?${queryString}`;
+  // Build the URL through the URL API so the `q` payload is added as a proper
+  // query parameter. A base that already carries its own query or fragment
+  // (e.g. a verify page that routes by query) keeps them: the query is
+  // preserved and `q` is appended, and the fragment stays after the query
+  // rather than swallowing it.
+  const url = new URL(baseUrl);
+
+  // The verify page reads `uri`, `digestMultibase`, `hash`, and `decryptionKey`
+  // as direct query parameters in preference to the `q` payload, so a base URL
+  // that already carries any of them (or its own `q`) would shadow this link's
+  // own payload. Drop those reserved keys before setting `q`; other parameters
+  // are preserved.
+  for (const reserved of ['uri', 'digestMultibase', 'hash', 'decryptionKey', 'q']) {
+    url.searchParams.delete(reserved);
+  }
+  url.searchParams.set('q', JSON.stringify({ payload }));
+  return url.toString();
 };


### PR DESCRIPTION
This PR builds verify links through the URL API in `constructVerifyURL`, so a caller-supplied verification base URL that already carries a query string or fragment produces a valid link instead of a malformed one.

Previously the payload was appended by string concatenation, so a base such as `https://verify.example.com/ui?tenant=1` became `...?tenant=1?q=...` (two `?`, no `q` parameter), and a base with a fragment placed the payload after the `#`, where the verify page never reads it. The link is now built with the URL API, which preserves the base's own query and fragment and adds `q` as a proper parameter.

It also strips the reserved keys the verify page reads as direct parameters (`uri`, `digestMultibase`, `hash`, `decryptionKey`) from the base's query before setting `q`, so a base URL that incidentally carries one of them cannot shadow this link's own payload.

Closes #821

## Test plan
- [x] A base with an existing query parameter keeps it and gains a valid `q`
- [x] A base with a fragment keeps the fragment and places `q` in the query
- [x] A base carrying a reserved key (`uri`) has it stripped so it cannot shadow the payload
- [x] Full services helper and publish-credential suites pass (25 tests); lint clean
