### PR TITLE
fix(ri): validate verification URLs as http(s) before publishing

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -376,7 +376,7 @@ describe('POST /api/v1/credentials', () => {
       expect(json.error).toContain('private or reserved');
     });
 
-    it('skips SSRF validation when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
+    it('skips the private-address SSRF check when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
       process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
 
       const req = createFakeRequest(
@@ -390,6 +390,86 @@ describe('POST /api/v1/credentials', () => {
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
       expect(mockAssertPublicUrl).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-http(s) humanVerificationUrl even when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
+      process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+
+      const req = createFakeRequest(
+        validBody({ publishingOptions: { publish: true, humanVerificationUrl: 'ftp://verify.example.com/ui' } }),
+      );
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toMatch(/http\(s\)/);
+      // The well-formedness/scheme check runs regardless of the SSRF flag, and
+      // the private-address check is still skipped; nothing is issued.
+      expect(mockAssertPublicUrl).not.toHaveBeenCalled();
+      expect(mockIssueCredential).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed humanVerificationUrl even when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
+      process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+
+      const req = createFakeRequest(
+        validBody({ publishingOptions: { publish: true, humanVerificationUrl: 'not a url' } }),
+      );
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(res.status).toBe(400);
+      expect(mockIssueCredential).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-http(s) machineVerificationUrl even when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
+      process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+
+      const req = createFakeRequest(
+        validBody({ publishingOptions: { publish: true, machineVerificationUrl: 'ftp://verify.example.com/api' } }),
+      );
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toMatch(/http\(s\)/);
+      expect(mockAssertPublicUrl).not.toHaveBeenCalled();
+      expect(mockIssueCredential).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed machineVerificationUrl even when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
+      process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+
+      const req = createFakeRequest(
+        validBody({ publishingOptions: { publish: true, machineVerificationUrl: 'not a url' } }),
+      );
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(res.status).toBe(400);
+      expect(mockIssueCredential).not.toHaveBeenCalled();
+    });
+
+    it('rejects a verification URL carrying userinfo, rather than publishing the credential in the link', async () => {
+      process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+
+      const human = createFakeRequest(
+        validBody({
+          publishingOptions: { publish: true, humanVerificationUrl: 'https://user:pass@verify.example.com/ui' },
+        }),
+      );
+      const humanRes = await POST(human, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const humanJson = await humanRes.json();
+      expect(humanRes.status).toBe(400);
+      expect(humanJson.error).toMatch(/username or password/);
+
+      const machine = createFakeRequest(
+        validBody({
+          publishingOptions: { publish: true, machineVerificationUrl: 'https://user:pass@verify.example.com/api' },
+        }),
+      );
+      const machineRes = await POST(machine, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      expect(machineRes.status).toBe(400);
+
+      expect(mockIssueCredential).not.toHaveBeenCalled();
     });
 
     it('returns 400 when publishingOptions.hreflang is a string rather than an array', async () => {
@@ -841,6 +921,42 @@ describe('POST /api/v1/credentials', () => {
         machineVerificationUrl: 'https://verify.example.com/api',
         humanVerificationUrl: 'https://verify.example.com/ui',
       });
+    });
+
+    it('publishes the canonical machine verification URL, not the raw ambiguous caller string', async () => {
+      setupPublishingHappyPath();
+
+      // `https://1.1.1.1\@127.0.0.1/` parses (WHATWG) as host 1.1.1.1, but a
+      // different parser reads the raw string as host 127.0.0.1. Publishing the
+      // canonical href keeps validation and publication on the same host.
+      const req = createFakeRequest(
+        validBody({ publishingOptions: { publish: true, machineVerificationUrl: 'https://1.1.1.1\\@127.0.0.1/' } }),
+      );
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(mockBuildPublishLinks).toHaveBeenCalledWith(
+        STORAGE_RESPONSE,
+        'Digital Product Passport',
+        expect.objectContaining({ machineVerificationUrl: 'https://1.1.1.1/@127.0.0.1/' }),
+      );
+    });
+
+    it('SSRF-checks the canonical machine URL, not the raw string, when protection is enabled', async () => {
+      delete process.env.VERIFY_ALLOW_PRIVATE_URLS;
+      setupPublishingHappyPath();
+      mockAssertPublicUrl.mockResolvedValue(undefined);
+
+      const req = createFakeRequest(
+        validBody({ publishingOptions: { publish: true, machineVerificationUrl: 'https://1.1.1.1\\@127.0.0.1/' } }),
+      );
+      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      // The private-address check sees the same canonical host that is published,
+      // so it cannot be fooled by a raw string a different parser reads as 127.0.0.1.
+      expect(mockAssertPublicUrl).toHaveBeenCalledWith(
+        'https://1.1.1.1/@127.0.0.1/',
+        'publishingOptions.machineVerificationUrl',
+      );
     });
 
     // ── humanVerificationUrl default (issue #491) ──────────────────────

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -6,6 +6,7 @@ import {
   parseNonNegativeInt,
   parseBooleanString,
   assertPublicUrl,
+  assertHttpUrl,
 } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { errorMessage } from '@/lib/api/errors';
@@ -197,13 +198,31 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   }
   const publishingOptions = publishingOptionsParse.data;
 
-  // ── SSRF validation for URL fields ────────────────────────────────────
+  // ── Verification URL validation ───────────────────────────────────────
+  // Caller-supplied verification URLs are always validated as well-formed,
+  // absolute, userinfo-free http(s) URLs before issuance, so a malformed,
+  // non-http(s), or credential-bearing value is rejected up front rather than
+  // published or failing later during link construction. assertHttpUrl returns
+  // the WHATWG-canonical URL, and the canonical `href` (not the raw caller
+  // string) is what is SSRF-checked and published downstream. Validating and
+  // publishing the same canonical form closes a parser-differential SSRF gap:
+  // a value like `https://1.1.1.1\@127.0.0.1/` that this parser reads as host
+  // `1.1.1.1` cannot be re-read as `127.0.0.1` by a different parser once the
+  // canonical `href` (`https://1.1.1.1/@127.0.0.1/`) is what leaves the route.
+  // The private-address / DNS SSRF check is additionally applied unless
+  // VERIFY_ALLOW_PRIVATE_URLS relaxes it for local development.
+  const machineVerificationUrl = publishingOptions.machineVerificationUrl
+    ? assertHttpUrl(publishingOptions.machineVerificationUrl, 'publishingOptions.machineVerificationUrl').href
+    : undefined;
+  const humanVerificationUrl = publishingOptions.humanVerificationUrl
+    ? assertHttpUrl(publishingOptions.humanVerificationUrl, 'publishingOptions.humanVerificationUrl').href
+    : undefined;
   if (process.env.VERIFY_ALLOW_PRIVATE_URLS !== 'true') {
-    if (publishingOptions.machineVerificationUrl) {
-      await assertPublicUrl(publishingOptions.machineVerificationUrl, 'publishingOptions.machineVerificationUrl');
+    if (machineVerificationUrl) {
+      await assertPublicUrl(machineVerificationUrl, 'publishingOptions.machineVerificationUrl');
     }
-    if (publishingOptions.humanVerificationUrl) {
-      await assertPublicUrl(publishingOptions.humanVerificationUrl, 'publishingOptions.humanVerificationUrl');
+    if (humanVerificationUrl) {
+      await assertPublicUrl(humanVerificationUrl, 'publishingOptions.humanVerificationUrl');
     }
   }
 
@@ -214,9 +233,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   // intentionally not SSRF-checked and a localhost RI_APP_URL is accepted in
   // development.
   const effectiveHumanVerificationUrl =
-    publishingOptions.publish === true && !publishingOptions.humanVerificationUrl
-      ? defaultHumanVerificationUrl()
-      : publishingOptions.humanVerificationUrl;
+    publishingOptions.publish === true && !humanVerificationUrl ? defaultHumanVerificationUrl() : humanVerificationUrl;
 
   // ── Step 2: Resolve data model ──────────────────────────────────────────
 
@@ -344,7 +361,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
       const linkTitle = publishingOptions.linkTitle || dataModel.name;
       const links = buildPublishLinks(storageResponse, linkTitle, {
         linkType: publishingOptions.linkType,
-        machineVerificationUrl: publishingOptions.machineVerificationUrl,
+        machineVerificationUrl,
         humanVerificationUrl: effectiveHumanVerificationUrl,
         ...(publishingOptions.hreflang !== undefined ? { hreflang: publishingOptions.hreflang } : {}),
         ...(publishingOptions.additionalRels !== undefined ? { additionalRels: publishingOptions.additionalRels } : {}),

--- a/packages/reference-implementation/src/lib/api/validation.test.ts
+++ b/packages/reference-implementation/src/lib/api/validation.test.ts
@@ -12,6 +12,7 @@ import {
   parseNonNegativeInt,
   parseBooleanString,
   assertPublicUrl,
+  assertHttpUrl,
   parseRequestBody,
   parseQueryParams,
   definedFields,
@@ -139,6 +140,52 @@ describe('parseBooleanString', () => {
 
   it('throws for empty string', () => {
     expect(() => parseBooleanString('', 'active')).toThrow(ValidationError);
+  });
+});
+
+describe('assertHttpUrl', () => {
+  it('returns the parsed URL for an http URL', () => {
+    const url = assertHttpUrl('http://example.com/verify', 'humanVerificationUrl');
+    expect(url).toBeInstanceOf(URL);
+    expect(url.protocol).toBe('http:');
+  });
+
+  it('returns the parsed URL for an https URL', () => {
+    const url = assertHttpUrl('https://example.com/verify', 'humanVerificationUrl');
+    expect(url.protocol).toBe('https:');
+  });
+
+  it('throws ValidationError for a malformed URL', () => {
+    expect(() => assertHttpUrl('not a url', 'humanVerificationUrl')).toThrow(ValidationError);
+    expect(() => assertHttpUrl('not a url', 'humanVerificationUrl')).toThrow(/must be a valid absolute http\(s\) URL/);
+  });
+
+  it('throws ValidationError for a relative URL', () => {
+    expect(() => assertHttpUrl('/verify', 'humanVerificationUrl')).toThrow(/must be a valid absolute http\(s\) URL/);
+  });
+
+  it('throws ValidationError for a non-http(s) scheme', () => {
+    expect(() => assertHttpUrl('ftp://example.com/verify', 'humanVerificationUrl')).toThrow(ValidationError);
+    expect(() => assertHttpUrl('ftp://example.com/verify', 'humanVerificationUrl')).toThrow(/must be an http\(s\) URL/);
+    expect(() => assertHttpUrl('file:///etc/passwd', 'humanVerificationUrl')).toThrow(/must be an http\(s\) URL/);
+  });
+
+  it('accepts an uppercase scheme (normalised by the URL parser)', () => {
+    const url = assertHttpUrl('HTTPS://example.com/verify', 'humanVerificationUrl');
+    expect(url.protocol).toBe('https:');
+  });
+
+  it('throws ValidationError for a URL carrying userinfo', () => {
+    expect(() => assertHttpUrl('https://user:pass@example.com/verify', 'humanVerificationUrl')).toThrow(
+      ValidationError,
+    );
+    expect(() => assertHttpUrl('https://user:pass@example.com/verify', 'humanVerificationUrl')).toThrow(
+      /must not contain a username or password/,
+    );
+    // A username with no password is rejected too.
+    expect(() => assertHttpUrl('https://user@example.com/verify', 'humanVerificationUrl')).toThrow(
+      /must not contain a username or password/,
+    );
   });
 });
 

--- a/packages/reference-implementation/src/lib/api/validation.ts
+++ b/packages/reference-implementation/src/lib/api/validation.ts
@@ -153,6 +153,35 @@ export function parseBooleanString(raw: string | null | undefined, paramName: st
 }
 
 /**
+ * Assert that a string is a well-formed, absolute http(s) URL that carries no
+ * userinfo, returning the parsed {@link URL}. Throws a {@link ValidationError}
+ * otherwise.
+ *
+ * This is the scheme and well-formedness check, independent of the SSRF
+ * private-address check in {@link assertPublicUrl}. It is applied to
+ * caller-supplied URLs regardless of `VERIFY_ALLOW_PRIVATE_URLS`, since that
+ * flag relaxes the private-network check for local development, not the
+ * requirement that a published URL be a usable, safe http(s) address. Userinfo
+ * (a `user:pass@` component) is rejected because such a URL may be published to
+ * a public directory, which would leak the embedded credential.
+ */
+export function assertHttpUrl(url: string, paramName: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new ValidationError(`${paramName} must be a valid absolute http(s) URL`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new ValidationError(`${paramName} must be an http(s) URL`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new ValidationError(`${paramName} must not contain a username or password`);
+  }
+  return parsed;
+}
+
+/**
  * Validate that a URL string is well-formed and does not point to a private
  * or reserved network address (SSRF protection).
  */


### PR DESCRIPTION
This PR always validates caller-supplied verification URLs (`machineVerificationUrl`, `humanVerificationUrl`) as well-formed, absolute, userinfo-free http(s) URLs before a credential is issued, and publishes the same canonical URL it validates, so a malformed, non-http(s), credential-bearing, or parser-ambiguous value is rejected with a `400` up front rather than reaching the Identity Resolver.

Previously these URLs were only validated by `assertPublicUrl`, which checks the host against private/reserved ranges but not the scheme, and which the route skipped entirely when `VERIFY_ALLOW_PRIVATE_URLS` was set (the value shipped in `.env.example` and the Docker Compose files). So a public but non-http(s) URL (e.g. `ftp://example.com/verify`) could be published, and a relative or malformed value could reach link construction and fail late with a `500` after the credential was already stored.

A new `assertHttpUrl` validates that each supplied verification URL is an absolute http(s) URL with no userinfo (a `user:pass@` component, which would otherwise be published into a resolver link), and returns the WHATWG-canonical `URL`. The route uses that canonical `href` as the value it both SSRF-checks and publishes. Publishing the canonical form closes a parser-differential gap: `https://1.1.1.1\@127.0.0.1/` parses here as host `1.1.1.1` (public), but a different parser reads the raw string as `127.0.0.1` (private); the canonical `https://1.1.1.1/@127.0.0.1/` is read as `1.1.1.1` by both, so the address that is checked is the address that is published. The private-address/DNS SSRF check remains gated on `VERIFY_ALLOW_PRIVATE_URLS`.

Closes #822

## Test plan
- [x] Non-http(s) (`ftp:`), malformed, and userinfo-bearing machine and human URLs are rejected with `400` before issuance, even when `VERIFY_ALLOW_PRIVATE_URLS=true`
- [x] The published machine link is the canonical `href`, not the raw ambiguous caller string
- [x] With SSRF protection enabled, `assertPublicUrl` is invoked with the canonical URL (same host that is published)
- [x] `assertHttpUrl` unit tests: http/https accepted, uppercase scheme normalised, relative/malformed/non-http(s)/userinfo rejected
- [x] Full reference-implementation validation and credentials-route suites pass (154 tests); lint clean
