### PR TITLE
feat(playground): add a tabbed artefact surface for credentials, schemes and link sets

### DIFF
--- a/packages/untp-playground/__tests__/app/page.test.tsx
+++ b/packages/untp-playground/__tests__/app/page.test.tsx
@@ -314,4 +314,12 @@ describe('Tabbed artefact surface (#809)', () => {
     expect(screen.getByText('No conformity schemes yet')).toBeInTheDocument();
     expect(screen.queryByTestId('mock-scheme-test-results')).not.toBeInTheDocument();
   });
+
+  it('shows the link sets empty state on the Link Sets tab', async () => {
+    render(<Home />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Link Sets' }));
+
+    expect(screen.getByText('No link sets yet')).toBeInTheDocument();
+  });
 });

--- a/packages/untp-playground/__tests__/app/page.test.tsx
+++ b/packages/untp-playground/__tests__/app/page.test.tsx
@@ -1,16 +1,18 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { toast } from 'sonner';
 import {
   decodeEnvelopedCredential,
   isEnvelopedProof,
   detectCredentialType,
   detectVersion,
+  detectArtefact,
 } from '@/lib/credentialService';
 import { detectExtension, validateCredentialSchema } from '@/lib/schemaValidation';
 import { ArtefactUploader } from '@/components/ArtefactUploader';
 import Home from '@/app/page';
 import { mockCredential } from '../mocks/vc';
-import { permittedCredentialTypes } from '../../constants';
+import { ArtefactKind, permittedCredentialTypes } from '../../constants';
 
 // Mock the dependencies
 jest.mock('sonner', () => ({
@@ -78,6 +80,14 @@ jest.mock('@/components/DownloadCredential', () => ({
   DownloadCredential: () => <div data-testid='mock-download'>Download</div>,
 }));
 
+jest.mock('@/components/GenerateReportDialog', () => ({
+  GenerateReportDialog: () => <div data-testid='mock-generate-report'>Generate Report</div>,
+}));
+
+jest.mock('@/components/DownloadReport', () => ({
+  DownloadReport: () => <div data-testid='mock-download-report'>Download Report</div>,
+}));
+
 describe('Home Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -88,7 +98,8 @@ describe('Home Component', () => {
 
     expect(screen.getByTestId('mock-header')).toBeInTheDocument();
     expect(screen.getByTestId('mock-footer')).toBeInTheDocument();
-    expect(screen.getByTestId('mock-test-results')).toBeInTheDocument();
+    // Credentials start empty, so the placeholder shows in place of the results.
+    expect(screen.getByText('No credentials yet')).toBeInTheDocument();
     expect(screen.getByTestId('mock-uploader')).toBeInTheDocument();
     expect(screen.getByTestId('mock-download')).toBeInTheDocument();
   });
@@ -212,5 +223,95 @@ describe('Home Component', () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to process artefact');
     });
+  });
+});
+
+describe('Tabbed artefact surface (#809)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a tab for each artefact family', () => {
+    render(<Home />);
+
+    expect(screen.getByRole('tab', { name: /Credentials/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Conformity Schemes/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Link Sets/ })).toBeInTheDocument();
+  });
+
+  it('renders the Test artefacts page header above the tab bar', () => {
+    render(<Home />);
+
+    const heading = screen.getByRole('heading', { name: 'Test artefacts' });
+    const tablist = screen.getByRole('tablist');
+    // The header sits above the tab bar. This checks the tablist follows the heading in document order.
+    expect(heading.compareDocumentPosition(tablist) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders the report actions once, above the tab bar (shared across families)', () => {
+    render(<Home />);
+
+    expect(screen.getAllByTestId('mock-generate-report')).toHaveLength(1);
+    expect(screen.getAllByTestId('mock-download-report')).toHaveLength(1);
+
+    const action = screen.getByTestId('mock-generate-report');
+    const tablist = screen.getByRole('tablist');
+    expect(action.compareDocumentPosition(tablist) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('shows no instance counter on any tab while empty', () => {
+    render(<Home />);
+
+    // Exact-name matches: a stray "0" badge would change the accessible name and fail these.
+    expect(screen.getByRole('tab', { name: 'Credentials' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Conformity Schemes' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Link Sets' })).toBeInTheDocument();
+  });
+
+  it('mounts all three family panels so validation is not tied to the active tab', () => {
+    render(<Home />);
+
+    // Force-mounted panels: every family's content is in the DOM regardless of the active tab,
+    // so a family keeps validating even when its tab is not selected.
+    expect(screen.getByText('No credentials yet')).toBeInTheDocument();
+    expect(screen.getByText('No conformity schemes yet')).toBeInTheDocument();
+    expect(screen.getByText('No link sets yet')).toBeInTheDocument();
+  });
+
+  it('renders a single shared uploader, not one per tab', () => {
+    render(<Home />);
+
+    // One hoisted sidebar; force-mounting the panels must not multiply the uploader.
+    expect(screen.getAllByTestId('mock-uploader')).toHaveLength(1);
+  });
+
+  it('replaces a family empty state with its results once an artefact loads', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue({ kind: ArtefactKind.SCHEME, type: 'ConformityScheme' });
+    render(<Home />);
+
+    expect(screen.getByText('No conformity schemes yet')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('No conformity schemes yet')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('mock-scheme-test-results')).toBeInTheDocument();
+  });
+
+  it('shows the credentials empty state when no credential is loaded', () => {
+    render(<Home />);
+
+    expect(screen.getByText('No credentials yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-test-results')).not.toBeInTheDocument();
+  });
+
+  it('shows the schemes empty state on the Conformity Schemes tab', async () => {
+    render(<Home />);
+
+    await userEvent.click(screen.getByRole('tab', { name: /Conformity Schemes/ }));
+
+    expect(screen.getByText('No conformity schemes yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-scheme-test-results')).not.toBeInTheDocument();
   });
 });

--- a/packages/untp-playground/__tests__/components/EmptyState.test.tsx
+++ b/packages/untp-playground/__tests__/components/EmptyState.test.tsx
@@ -1,0 +1,23 @@
+import { EmptyState } from '@/components/EmptyState';
+import { render, screen } from '@testing-library/react';
+
+describe('EmptyState', () => {
+  it('renders the title and guidance', () => {
+    render(<EmptyState title='No credentials yet' guidance='Add a credential from the panel on the right.' />);
+
+    expect(screen.getByText('No credentials yet')).toBeInTheDocument();
+    expect(screen.getByText('Add a credential from the panel on the right.')).toBeInTheDocument();
+  });
+
+  it('renders the icon when one is provided', () => {
+    render(<EmptyState icon={<span data-testid='empty-icon' />} title='No credentials yet' guidance='Add one.' />);
+
+    expect(screen.getByTestId('empty-icon')).toBeInTheDocument();
+  });
+
+  it('omits the icon when none is provided', () => {
+    render(<EmptyState title='No credentials yet' guidance='Add one.' />);
+
+    expect(screen.queryByTestId('empty-icon')).not.toBeInTheDocument();
+  });
+});

--- a/packages/untp-playground/__tests__/components/ReportActions.test.tsx
+++ b/packages/untp-playground/__tests__/components/ReportActions.test.tsx
@@ -1,0 +1,57 @@
+import { ReportActions } from '@/components/ReportActions';
+import { useTestReport } from '@/contexts/TestReportContext';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@/contexts/TestReportContext', () => ({
+  useTestReport: jest.fn(),
+}));
+
+jest.mock('@/components/GenerateReportDialog', () => ({
+  GenerateReportDialog: () => <div data-testid='generate-report'>Generate Report</div>,
+}));
+
+jest.mock('@/components/DownloadReport', () => ({
+  DownloadReport: () => <button data-testid='download-report'>Download Report</button>,
+}));
+
+describe('ReportActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders both the generate and download report actions', () => {
+    (useTestReport as jest.Mock).mockReturnValue({ canDownloadReport: false });
+
+    render(<ReportActions />);
+
+    expect(screen.getByTestId('generate-report')).toBeInTheDocument();
+    expect(screen.getByTestId('download-report')).toBeInTheDocument();
+  });
+
+  it('shows the "generate first" tooltip while a report cannot be downloaded yet', async () => {
+    (useTestReport as jest.Mock).mockReturnValue({ canDownloadReport: false });
+
+    render(<ReportActions />);
+    await userEvent.hover(screen.getByTestId('download-report-button-tooltip-trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('download-report-button-tooltip-content')).toHaveTextContent(
+        'Generate a conformance report first to enable download',
+      );
+    });
+  });
+
+  it('shows the download tooltip once a report is available', async () => {
+    (useTestReport as jest.Mock).mockReturnValue({ canDownloadReport: true });
+
+    render(<ReportActions />);
+    await userEvent.hover(screen.getByTestId('download-report-button-tooltip-trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('download-report-button-tooltip-content')).toHaveTextContent(
+        'Download the generated conformance report',
+      );
+    });
+  });
+});

--- a/packages/untp-playground/__tests__/components/TestResults.test.tsx
+++ b/packages/untp-playground/__tests__/components/TestResults.test.tsx
@@ -1,5 +1,4 @@
 import { TestResults, confettiConfig } from '@/components/TestResults';
-import { useTestReport } from '@/contexts/TestReportContext';
 import { validateContext } from '@/lib/contextValidation';
 import { detectExtension, validateCredentialSchema, validateExtension } from '@/lib/schemaValidation';
 import { detectVcdmVersion } from '@/lib/utils';
@@ -7,7 +6,6 @@ import { validateVcdmRules } from '@/lib/vcdm-validation';
 import { verifyCredential } from '@/lib/verificationService';
 import { Credential } from '@/types/credential';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import confetti from 'canvas-confetti';
 import { CredentialType, TestCaseStatus, TestCaseStepId, VCDMVersion, VCDM_CONTEXT_URLS } from '../../constants';
 
@@ -22,7 +20,6 @@ jest.mock('jsonld', () => ({
   expand: jest.fn(),
   compact: jest.fn(),
 }));
-jest.mock('@/contexts/TestReportContext');
 jest.mock('sonner', () => ({
   toast: {
     error: jest.fn(),
@@ -56,13 +53,6 @@ describe('TestResults Component', () => {
     (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: true });
     (validateContext as jest.Mock).mockResolvedValue({ valid: true, data: {} });
     (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.V1);
-    (useTestReport as jest.Mock).mockReturnValue({
-      canGenerateReport: false,
-      generateReport: jest.fn(),
-      report: null,
-      canDownloadReport: false,
-      downloadReport: jest.fn(),
-    });
   });
 
   it('renders empty state correctly', () => {
@@ -301,108 +291,6 @@ describe('TestResults Component', () => {
       });
 
       expect(confetti).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Report Functionality', () => {
-    it('renders report buttons in correct initial state', async () => {
-      (useTestReport as jest.Mock).mockReturnValue({
-        canGenerateReport: false,
-        generateReport: jest.fn(),
-        report: null,
-        canDownloadReport: false,
-        downloadReport: jest.fn(),
-      });
-
-      render(<TestResults credentials={{}} testResults={mockTestResults} setTestResults={mockSetTestResults} />);
-
-      expect(screen.getByText('Generate Report')).toBeDisabled();
-
-      const generateReportButton = screen.getByTestId('generate-report-button-tooltip-trigger');
-      userEvent.hover(generateReportButton);
-
-      await waitFor(() => {
-        const tooltipContent = screen.getByTestId('generate-report-button-tooltip-content');
-        expect(tooltipContent).toBeInTheDocument();
-        expect(tooltipContent).toHaveTextContent('Upload and validate a credential to generate a conformance report');
-      });
-
-      const button = screen.getByRole('combobox');
-      expect(button).toBeDisabled();
-
-      const downloadReportButton = screen.getByTestId('download-report-button-tooltip-trigger');
-      userEvent.hover(downloadReportButton);
-
-      await waitFor(() => {
-        const tooltipContent = screen.getByTestId('download-report-button-tooltip-content');
-        expect(tooltipContent).toBeInTheDocument();
-        expect(tooltipContent).toHaveTextContent('Generate a conformance report first to enable download');
-      });
-    });
-
-    it('enables generate report button when report can be generated', () => {
-      (useTestReport as jest.Mock).mockReturnValue({
-        canGenerateReport: true,
-        generateReport: jest.fn(),
-        report: null,
-        canDownloadReport: false,
-        downloadReport: jest.fn(),
-      });
-
-      render(<TestResults credentials={{}} testResults={mockTestResults} setTestResults={mockSetTestResults} />);
-      expect(screen.getByText('Generate Report')).toBeEnabled();
-    });
-
-    it('enables download button when report is available', async () => {
-      (useTestReport as jest.Mock).mockReturnValue({
-        canGenerateReport: true,
-        generateReport: jest.fn(),
-        report: { some: 'data' },
-        canDownloadReport: true,
-        downloadReport: jest.fn(),
-      });
-
-      render(<TestResults credentials={{}} testResults={mockTestResults} setTestResults={mockSetTestResults} />);
-      expect(screen.getByText('Download Report')).toBeEnabled();
-
-      const downloadReportButton = screen.getByTestId('download-report-button-tooltip-trigger');
-      userEvent.hover(downloadReportButton);
-
-      await waitFor(() => {
-        const tooltipContent = screen.getByTestId('download-report-button-tooltip-content');
-        expect(tooltipContent).toBeInTheDocument();
-        expect(tooltipContent).toHaveTextContent('Download the generated conformance report');
-      });
-    });
-
-    it('disables generate button when report exists', () => {
-      (useTestReport as jest.Mock).mockReturnValue({
-        canGenerateReport: false,
-        generateReport: jest.fn(),
-        report: { some: 'data' },
-        canDownloadReport: true,
-        downloadReport: jest.fn(),
-      });
-
-      render(<TestResults credentials={{}} testResults={mockTestResults} setTestResults={mockSetTestResults} />);
-      expect(screen.getByText('Generate Report')).toBeDisabled();
-    });
-
-    it('calls downloadReport when download button is clicked', async () => {
-      const mockDownloadReport = jest.fn();
-      (useTestReport as jest.Mock).mockReturnValue({
-        canGenerateReport: true,
-        generateReport: jest.fn(),
-        report: { some: 'data' },
-        canDownloadReport: true,
-        downloadReport: mockDownloadReport,
-      });
-
-      render(<TestResults credentials={{}} testResults={mockTestResults} setTestResults={mockSetTestResults} />);
-
-      fireEvent.click(screen.getByRole('combobox'));
-      fireEvent.click(screen.getByText('JSON'));
-      expect(mockDownloadReport).toHaveBeenCalled();
     });
   });
 });

--- a/packages/untp-playground/e2e/cypress/e2e/conformity-scheme-validation.cy.ts
+++ b/packages/untp-playground/e2e/cypress/e2e/conformity-scheme-validation.cy.ts
@@ -15,6 +15,10 @@ import { CONFORMITY_SCHEME_E2E_VERSIONS } from '../fixtures/conformity-schemes-e
 
 const SCHEME_GROUP_HEADER = 'ConformityScheme-group-header';
 
+// Scheme results render in the Conformity Schemes tab panel, which is hidden while the default
+// Credentials tab is active. Switch to that tab before interacting with the scheme results.
+const openSchemesTab = () => cy.contains('[role="tab"]', 'Conformity Schemes').click();
+
 CONFORMITY_SCHEME_E2E_VERSIONS.forEach((spec) => {
   describe(`ConformityScheme v${spec.version}`, () => {
     beforeEach(() => {
@@ -23,6 +27,7 @@ CONFORMITY_SCHEME_E2E_VERSIONS.forEach((spec) => {
 
     it('valid sample reaches success on every pipeline step', () => {
       cy.uploadCredential(spec.validSample);
+      openSchemesTab();
       cy.get(`[data-testid="${SCHEME_GROUP_HEADER}"]`).click();
 
       cy.checkValidationStatus('Version Detection', 'success');
@@ -35,6 +40,7 @@ CONFORMITY_SCHEME_E2E_VERSIONS.forEach((spec) => {
         const malformed = invalidCase.mutate(JSON.parse(JSON.stringify(spec.validSample)));
 
         cy.uploadCredential(malformed);
+        openSchemesTab();
         cy.get(`[data-testid="${SCHEME_GROUP_HEADER}"]`).click();
 
         cy.checkValidationStatus(invalidCase.failsAt, 'failure');

--- a/packages/untp-playground/package.json
+++ b/packages/untp-playground/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.1.8",
     "ajv": "^8.0.0",
     "ajv-formats": "^3.0.1",

--- a/packages/untp-playground/src/app/page.tsx
+++ b/packages/untp-playground/src/app/page.tsx
@@ -5,9 +5,12 @@ import { toast } from 'sonner';
 
 import { ArtefactUploader, type ArtefactSource } from '@/components/ArtefactUploader';
 import { DownloadCredential } from '@/components/DownloadCredential';
+import { EmptyState } from '@/components/EmptyState';
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
+import { ReportActions } from '@/components/ReportActions';
 import { SchemeTestResults } from '@/components/SchemeTestResults';
+import { SectionHeader } from '@/components/SectionHeader';
 import { TestResults } from '@/components/TestResults';
 import { TestReportProvider } from '@/contexts/TestReportContext';
 import {
@@ -21,6 +24,8 @@ import { isPermittedCredentialType, validateNormalizedCredential } from '@/lib/u
 import type { PermittedCredentialType, StoredCredential, StoredScheme, TestStep } from '@/types';
 import { useError } from '@/contexts/ErrorContext';
 import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { FileText, Link2, Server } from 'lucide-react';
 import { ArtefactKind, permittedCredentialTypes, SchemeType } from '../../constants';
 
 export default function Home() {
@@ -40,6 +45,14 @@ export default function Home() {
   const { dispatchError, errors, setIsDetailsOpen } = useError();
 
   const shouldDisplayUploadDetailBtn = errors && errors.length > 0;
+
+  // Whether each family has instances loaded. schemesCount drives both the Conformity Schemes
+  // empty state and its tab count. credentialsCount drives only the Credentials empty state (that
+  // tab has no count). linkSetsCount drives only the Link Sets tab count; its empty state stays
+  // unconditional until #811 adds real data.
+  const credentialsCount = Object.keys(credentials).length;
+  const schemesCount = Object.keys(schemes).length;
+  const linkSetsCount = 0; // Link Sets family lands in #811.
 
   const handleArtefactUpload = async (rawArtefact: any, source?: ArtefactSource) => {
     try {
@@ -102,45 +115,103 @@ export default function Home() {
     }
   };
 
+  // The shared sidebar (uploader + sample downloads), rendered once beside the tab panels.
+  // Per-tab copy lands in #676. For now the same uploader serves every family.
+  const sidebar = (
+    <div className='flex flex-col space-y-8'>
+      <div>
+        <h2 className='text-xl font-semibold mb-6'>Add new artefact</h2>
+        <ArtefactUploader onArtefactUpload={handleArtefactUpload} setFileCount={setFileCount} />
+      </div>
+      {shouldDisplayUploadDetailBtn && (
+        <div>
+          <h2 className='text-sm font-semibold hover:cursor-pointer'>
+            <Button onClick={() => setIsDetailsOpen(true)}>View Upload Detail</Button>
+          </h2>
+        </div>
+      )}
+      <div>
+        <h2 className='text-xl font-semibold mb-6'>Download test files</h2>
+        <DownloadCredential />
+      </div>
+    </div>
+  );
+
   return (
     <div className='min-h-screen flex flex-col'>
       <Header />
       <main className='container mx-auto p-8 max-w-7xl flex-1'>
-        <div className='flex flex-col md:flex-row gap-8'>
-          <div className='md:w-2/3 space-y-10'>
-            <TestReportProvider
-              testResults={testResults}
-              credentials={credentials}
-              schemes={schemes}
-              schemeTestResults={schemeTestResults}
-            >
-              <TestResults credentials={credentials} testResults={testResults} setTestResults={setTestResults} />
-              <SchemeTestResults
-                schemes={schemes}
-                testResults={schemeTestResults}
-                setTestResults={setSchemeTestResults}
-              />
-            </TestReportProvider>
-          </div>
-          <div className='md:w-1/3 flex flex-col space-y-8'>
-            <div>
-              <h2 className='text-xl font-semibold mb-6'>Add new artefact</h2>
-              <ArtefactUploader onArtefactUpload={handleArtefactUpload} setFileCount={setFileCount} />
-            </div>
-            {shouldDisplayUploadDetailBtn && (
-              <div>
-                <h2 className='text-sm font-semibold hover:cursor-pointer'>
-                  <Button onClick={() => setIsDetailsOpen(true)}>View Upload Detail</Button>
-                </h2>
-              </div>
-            )}
+        <TestReportProvider
+          testResults={testResults}
+          credentials={credentials}
+          schemes={schemes}
+          schemeTestResults={schemeTestResults}
+        >
+          <SectionHeader title='Test artefacts'>
+            <ReportActions />
+          </SectionHeader>
 
-            <div>
-              <h2 className='text-xl font-semibold mb-6'>Download test files</h2>
-              <DownloadCredential />
+          <Tabs defaultValue='credentials'>
+            <TabsList>
+              <TabsTrigger value='credentials'>Credentials</TabsTrigger>
+              <TabsTrigger value='schemes'>
+                Conformity Schemes
+                {schemesCount > 0 && <span className='text-xs tabular-nums text-muted-foreground'>{schemesCount}</span>}
+              </TabsTrigger>
+              <TabsTrigger value='linksets'>
+                Link Sets
+                {linkSetsCount > 0 && (
+                  <span className='text-xs tabular-nums text-muted-foreground'>{linkSetsCount}</span>
+                )}
+              </TabsTrigger>
+            </TabsList>
+
+            {/* Panels stay force-mounted (hidden when inactive) so a family keeps validating even
+                while its tab is not selected. The sidebar is shared, rendered once beside them. */}
+            <div className='mt-6 flex flex-col md:flex-row gap-8'>
+              <div className='md:w-2/3'>
+                <TabsContent value='credentials' forceMount>
+                  {credentialsCount === 0 ? (
+                    <EmptyState
+                      icon={<FileText size={28} />}
+                      title='No credentials yet'
+                      guidance='Add a credential from the panel on the right. Drop a JSON / JWT file or paste a URL. Each credential you add appears here and in the generated report.'
+                    />
+                  ) : (
+                    <TestResults credentials={credentials} testResults={testResults} setTestResults={setTestResults} />
+                  )}
+                </TabsContent>
+
+                <TabsContent value='schemes' forceMount>
+                  {schemesCount === 0 ? (
+                    <EmptyState
+                      icon={<Server size={28} />}
+                      title='No conformity schemes yet'
+                      guidance='Add a scheme from the panel on the right. Drop a JSON-LD file or paste a URL. Each scheme you add appears here and in the generated report.'
+                    />
+                  ) : (
+                    <SchemeTestResults
+                      schemes={schemes}
+                      testResults={schemeTestResults}
+                      setTestResults={setSchemeTestResults}
+                    />
+                  )}
+                </TabsContent>
+
+                <TabsContent value='linksets' forceMount>
+                  {/* Provisional Link Sets empty state. The final copy is an open decision in
+                      #809 and is settled with the Link Sets family in #811. */}
+                  <EmptyState
+                    icon={<Link2 size={28} />}
+                    title='No link sets yet'
+                    guidance='Add a link set from the panel on the right. Drop a JSON file or resolve from an identity resolver service. Each link set you add appears here and in the generated report.'
+                  />
+                </TabsContent>
+              </div>
+              <div className='md:w-1/3'>{sidebar}</div>
             </div>
-          </div>
-        </div>
+          </Tabs>
+        </TestReportProvider>
       </main>
       <Footer />
     </div>

--- a/packages/untp-playground/src/app/page.tsx
+++ b/packages/untp-playground/src/app/page.tsx
@@ -125,9 +125,7 @@ export default function Home() {
       </div>
       {shouldDisplayUploadDetailBtn && (
         <div>
-          <h2 className='text-sm font-semibold hover:cursor-pointer'>
-            <Button onClick={() => setIsDetailsOpen(true)}>View Upload Detail</Button>
-          </h2>
+          <Button onClick={() => setIsDetailsOpen(true)}>View Upload Detail</Button>
         </div>
       )}
       <div>

--- a/packages/untp-playground/src/components/EmptyState.tsx
+++ b/packages/untp-playground/src/components/EmptyState.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  guidance: string;
+}
+
+/**
+ * Borderless, centred placeholder shown in a tab's card-list column when that family
+ * has no instances loaded. The surrounding panel provides no border or fill.
+ */
+export function EmptyState({ icon, title, guidance }: EmptyStateProps) {
+  return (
+    <div className='flex h-full min-h-[24rem] w-full flex-col items-center justify-center px-6 text-center'>
+      {icon && <div className='mb-4 text-muted-foreground'>{icon}</div>}
+      <p className='text-base font-medium'>{title}</p>
+      <p className='mt-1 max-w-sm text-sm text-muted-foreground'>{guidance}</p>
+    </div>
+  );
+}

--- a/packages/untp-playground/src/components/ReportActions.tsx
+++ b/packages/untp-playground/src/components/ReportActions.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTestReport } from '@/contexts/TestReportContext';
+
+import { DownloadReport } from './DownloadReport';
+import { GenerateReportDialog } from './GenerateReportDialog';
+import { TooltipWrapper } from './TooltipWrapper';
+
+/**
+ * The report actions (generate + download) shown in the page header. A report spans
+ * every artefact family, so these sit above the tab bar rather than inside any one
+ * family's panel. Must render inside a TestReportProvider.
+ */
+export function ReportActions() {
+  const { canDownloadReport } = useTestReport();
+
+  return (
+    <>
+      <GenerateReportDialog />
+      <TooltipWrapper
+        content={
+          !canDownloadReport
+            ? 'Generate a conformance report first to enable download'
+            : 'Download the generated conformance report'
+        }
+        dataTestId='download-report-button'
+      >
+        <DownloadReport />
+      </TooltipWrapper>
+    </>
+  );
+}

--- a/packages/untp-playground/src/components/SchemeTestResults.tsx
+++ b/packages/untp-playground/src/components/SchemeTestResults.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { SectionHeader } from '@/components/SectionHeader';
 import { SourceCaption } from '@/components/SourceCaption';
 import { StatusIcon } from '@/components/StatusIcon';
 import { Card } from '@/components/ui/card';
@@ -68,7 +67,6 @@ export function SchemeTestResults({ schemes, testResults, setTestResults }: Sche
 
   return (
     <section className='space-y-4' data-testid='scheme-results'>
-      <SectionHeader title='Conformity Schemes' />
       {(Object.values(SchemeType) as SchemeType[]).map((type) => (
         <SchemeCard key={type} type={type} scheme={schemes[type]} steps={testResults[type] ?? []} />
       ))}

--- a/packages/untp-playground/src/components/TestResults.tsx
+++ b/packages/untp-playground/src/components/TestResults.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { StatusIcon } from '@/components/StatusIcon';
-import { TooltipWrapper } from '@/components/TooltipWrapper';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { useTestReport } from '@/contexts/TestReportContext';
 import { validateContext } from '@/lib/contextValidation';
 import { detectVersion, isEnvelopedProof } from '@/lib/credentialService';
 import { detectExtension, validateCredentialSchema, validateExtension } from '@/lib/schemaValidation';
@@ -27,9 +25,6 @@ import {
   VCDMVersion,
   VCProofType,
 } from '../../constants';
-import { GenerateReportDialog } from './GenerateReportDialog';
-import { SectionHeader } from './SectionHeader';
-import { DownloadReport } from './DownloadReport';
 import ValidationDetailsSheet from './ValidationDetailsSheet';
 
 // Add this type to help with tracking previous credentials
@@ -188,7 +183,6 @@ export function TestResults({ credentials, testResults, setTestResults }: TestRe
   const previousCredentialsRef = useRef<
     Partial<Record<PermittedCredentialType, { original: any; decoded: Credential }>>
   >({});
-  const { canDownloadReport, downloadReport } = useTestReport();
 
   const initializeTestSteps = (credential?: { original: any; decoded: Credential }) => {
     if (!credential) {
@@ -557,19 +551,6 @@ export function TestResults({ credentials, testResults, setTestResults }: TestRe
 
   return (
     <div className='space-y-4'>
-      <SectionHeader title='Verifiable Credentials'>
-        <GenerateReportDialog />
-        <TooltipWrapper
-          content={
-            !canDownloadReport
-              ? 'Generate a conformance report first to enable download'
-              : 'Download the generated conformance report'
-          }
-          dataTestId='download-report-button'
-        >
-          <DownloadReport />
-        </TooltipWrapper>
-      </SectionHeader>
       {permittedCredentialTypes.map((type) => {
         const credential = credentials[type];
         const steps = testResults[type] || [];

--- a/packages/untp-playground/src/components/ui/tabs.tsx
+++ b/packages/untp-playground/src/components/ui/tabs.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn('flex items-center gap-6 border-b border-border', className)}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center gap-2 -mb-px border-b-2 border-transparent pb-3 pt-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-sm disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-foreground data-[state=active]:text-foreground',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset data-[state=inactive]:hidden',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.4(@types/react@19.2.4)(react@19.2.4)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tooltip':
         specifier: ^1.1.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
This PR restructures the UNTP Playground homepage into a three-tab artefact surface (Credentials, Conformity Schemes, Link Sets), so a user validates each artefact family in its own tab, with the report actions shared in a header above the tabs and a per-tab empty state guiding what to add.

This is the walking skeleton for the phase-2 multi-artefact work. It lands the tab shell, the shared report header, the per-tab empty states, and the family counts, while the families keep their current validation behaviour. Each family's result panel stays mounted across tab switches, so an artefact validates regardless of which tab is active. The failing and verifying tab-meta indicators, the per-tab uploader copy (#676), and the Link Sets family (#811) land in later stories.

Part of #808
Part of #809

## Test plan
- [x] Three tabs render with the report actions shared above them, not duplicated per tab
- [x] Per-tab empty states show the correct copy when a family has no instances, centred in the panel
- [x] One uploader is shared across all tabs
- [x] All family panels stay mounted, so an artefact uploaded on any tab validates and its empty state is replaced by results
- [x] Existing credential and scheme validation behaviour is unchanged (full suite green)
