### PR TITLE
fix(ri): disable fs auto-instrumentation in the OTel SDK

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -70,7 +70,7 @@ The walking skeleton verifies `local-observability` end-to-end. `observability` 
 
 The reference implementation initialises the SDK via Next.js's instrumentation hook at `packages/reference-implementation/src/instrumentation.ts`, which Next.js calls once per process at startup. The hook guards on `NEXT_RUNTIME === 'nodejs'` so the Node SDK does not get pulled into the Edge runtime bundle. The SDK uses the OTLP gRPC trace exporter; the endpoint is read from `OTEL_EXPORTER_OTLP_ENDPOINT` and defaults to `http://localhost:4317` (suitable for `pnpm dev` against the compose stack). The Docker Compose service for the reference implementation overrides this default to `http://otel-agent:4317` so containerised runs reach the sidecar through the compose network.
 
-Auto-instrumentation is provided by `@opentelemetry/auto-instrumentations-node`, which covers HTTP, fetch, Next.js, Prisma, and other common libraries.
+Auto-instrumentation is provided by `@opentelemetry/auto-instrumentations-node`, which covers HTTP, fetch, Next.js, Prisma, and other common libraries. The `fs` instrumentation is disabled by default (`packages/reference-implementation/src/lib/observability/instrumentations.ts`): it turns every filesystem call Next.js and Node make internally into a span, which floods traces with high-cardinality, low-value noise.
 
 ## Relevant ADRs
 

--- a/packages/reference-implementation/src/instrumentation.node.ts
+++ b/packages/reference-implementation/src/instrumentation.node.ts
@@ -9,9 +9,9 @@
  * @see ../../../docs/observability.md
  */
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 
+import { buildInstrumentations } from './lib/observability/instrumentations';
 import { buildResource } from './lib/observability/resource';
 
 const sdk = new NodeSDK({
@@ -19,7 +19,7 @@ const sdk = new NodeSDK({
   traceExporter: new OTLPTraceExporter({
     url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4317',
   }),
-  instrumentations: [getNodeAutoInstrumentations()],
+  instrumentations: [buildInstrumentations()],
 });
 
 sdk.start();

--- a/packages/reference-implementation/src/instrumentation.node.ts
+++ b/packages/reference-implementation/src/instrumentation.node.ts
@@ -19,7 +19,7 @@ const sdk = new NodeSDK({
   traceExporter: new OTLPTraceExporter({
     url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4317',
   }),
-  instrumentations: [buildInstrumentations()],
+  instrumentations: buildInstrumentations(),
 });
 
 sdk.start();

--- a/packages/reference-implementation/src/lib/observability/instrumentations.test.ts
+++ b/packages/reference-implementation/src/lib/observability/instrumentations.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment node
+ */
+const mockGetNodeAutoInstrumentations = jest.fn().mockReturnValue([]);
+
+jest.mock('@opentelemetry/auto-instrumentations-node', () => ({
+  getNodeAutoInstrumentations: (...args: unknown[]) => mockGetNodeAutoInstrumentations(...args),
+}));
+
+import { buildInstrumentations } from './instrumentations';
+
+describe('buildInstrumentations', () => {
+  beforeEach(() => {
+    mockGetNodeAutoInstrumentations.mockClear();
+  });
+
+  it('disables the fs instrumentation by default', () => {
+    buildInstrumentations();
+
+    expect(mockGetNodeAutoInstrumentations).toHaveBeenCalledWith({
+      '@opentelemetry/instrumentation-fs': { enabled: false },
+    });
+  });
+
+  it('re-enables the fs instrumentation when explicitly requested', () => {
+    buildInstrumentations({ enableFsInstrumentation: true });
+
+    expect(mockGetNodeAutoInstrumentations).toHaveBeenCalledWith({
+      '@opentelemetry/instrumentation-fs': { enabled: true },
+    });
+  });
+
+  it('returns whatever getNodeAutoInstrumentations produces', () => {
+    const instrumentations = [{ instrumentationName: 'fake' }];
+    mockGetNodeAutoInstrumentations.mockReturnValueOnce(instrumentations);
+
+    expect(buildInstrumentations()).toBe(instrumentations);
+  });
+});

--- a/packages/reference-implementation/src/lib/observability/instrumentations.ts
+++ b/packages/reference-implementation/src/lib/observability/instrumentations.ts
@@ -1,0 +1,42 @@
+/**
+ * OpenTelemetry auto-instrumentation configuration.
+ *
+ * `@opentelemetry/auto-instrumentations-node` covers HTTP, fetch,
+ * Next.js, Prisma, and other common libraries out of the box. Its `fs`
+ * instrumentation is disabled here by default: every filesystem call
+ * Next.js and Node make internally becomes a span, which produces a
+ * high-cardinality, low-value flood that drowns the request-level
+ * traces the walking skeleton exists to show (see #640).
+ *
+ * Extracted from `instrumentation.node.ts` so the configuration can be
+ * unit-tested without standing up the SDK, mirroring `resource.ts`.
+ */
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+/**
+ * Options for {@link buildInstrumentations}.
+ */
+export interface BuildInstrumentationsOptions {
+  /** Re-enables the `fs` instrumentation. Defaults to `false`. */
+  enableFsInstrumentation?: boolean;
+}
+
+/**
+ * Build the auto-instrumentation list for the Node SDK.
+ *
+ * The return type is inferred from `getNodeAutoInstrumentations` itself
+ * rather than importing `Instrumentation` from `@opentelemetry/instrumentation`
+ * directly: that package is a transitive dependency reachable only through
+ * `@opentelemetry/sdk-node`, not one this package declares itself.
+ *
+ * @param options Optional overrides. Pass `{ enableFsInstrumentation: true }`
+ *   to restore `fs` spans, e.g. when diagnosing filesystem-level issues locally.
+ * @returns The instrumentation instances to pass to `NodeSDK`.
+ */
+export function buildInstrumentations(
+  options: BuildInstrumentationsOptions = {},
+): ReturnType<typeof getNodeAutoInstrumentations> {
+  return getNodeAutoInstrumentations({
+    '@opentelemetry/instrumentation-fs': { enabled: options.enableFsInstrumentation ?? false },
+  });
+}


### PR DESCRIPTION
This PR disables the `fs` auto-instrumentation in the OpenTelemetry Node SDK, so traces are no longer flooded with high-cardinality, low-value filesystem spans from the internal Next.js and Node `fs` calls, leaving HTTP, Express, and handler spans legible. Re-enabling it for a filesystem investigation is a one-line override.

Closes #640

## Test plan
- [x] `buildInstrumentations()` disables `@opentelemetry/instrumentation-fs` by default and re-enables it when `enableFsInstrumentation: true` is passed (unit-tested, each case mutation-checked)
- [x] Observability doc notes the default and the override
