### PR TITLE
fix(untp-utils): surface SSRF rejections from JSON-LD expansion on the native error cause chain

### DIFF
--- a/packages/untp-utils/src/validation/validate-jsonld.ssrf.test.ts
+++ b/packages/untp-utils/src/validation/validate-jsonld.ssrf.test.ts
@@ -99,4 +99,26 @@ describe('validateJsonLd SSRF guard (real jsonld + guarded loader)', () => {
     // into jsonld.js's proprietary `details.cause`.
     expect((error.cause as Error).cause).toBeInstanceOf(UrlValidationError);
   });
+
+  it('never contacts a private scoped (term-level) @context URL during expansion', async () => {
+    // A term can declare its own remote @context (JSON-LD 1.1 scoped contexts).
+    // jsonld.js resolves it through the same guarded loader as a top-level
+    // @context, so it must be rejected the same way.
+    const malicious = {
+      '@context': { myTerm: { '@id': 'http://schema.org/myTerm', '@context': `${baseUrl}/internal-scoped-context` } },
+      myTerm: 'value',
+    };
+
+    const error = await validateJsonLd(malicious).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(JsonLdExpansionFailedError);
+    // The rejection came from the SSRF guard, reachable by plain .cause hops.
+    // jsonld.js's scoped-context branch (lib/context.js) discards the loader
+    // failure entirely and throws a fresh 'invalid scoped context' JsonLdError
+    // with no `details.cause` of its own, so this can only pass if
+    // validateJsonLd recovers the guard's rejection some other way (tracking
+    // it at the document-loader call, see `validate-jsonld.ts`).
+    expect(nativeCauseChain(error)).toContainEqual(expect.any(UrlValidationError));
+    // The security property: the loopback canary was never reached.
+    expect(hits).toBe(0);
+  });
 });

--- a/packages/untp-utils/src/validation/validate-jsonld.ssrf.test.ts
+++ b/packages/untp-utils/src/validation/validate-jsonld.ssrf.test.ts
@@ -5,13 +5,22 @@ import { JsonLdExpansionFailedError } from './errors.js';
 import { UrlValidationError } from '../node/errors.js';
 
 /**
- * Digs the guard's rejection out of an expansion failure. jsonld.js wraps a
- * document loader's error in its own JsonLdError, which stores the original
- * at the non-standard `details.cause` and never sets native `Error.cause`.
+ * Walks the native `Error.cause` chain from `error`, collecting every link.
+ * jsonld.js's own `JsonLdError` buries a document loader's rejection at the
+ * non-standard `details.cause` and never sets native `Error.cause`;
+ * `validateJsonLd` rehydrates it onto `error.cause` when wrapping an
+ * expansion failure (see `validate-jsonld.ts`), so a plain `.cause` walk
+ * reaches the SSRF guard's rejection the same way it does on the
+ * schema-fetch path (`schema-loader.ssrf.test.ts`).
  */
-function buriedLoaderError(error: unknown): unknown {
-  const jsonldError = (error as JsonLdExpansionFailedError).cause as { details?: { cause?: unknown } } | undefined;
-  return jsonldError?.details?.cause;
+function nativeCauseChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  let current: unknown = error;
+  while (current instanceof Error && current.cause !== undefined) {
+    chain.push(current.cause);
+    current = current.cause;
+  }
+  return chain;
 }
 
 /**
@@ -57,7 +66,7 @@ describe('validateJsonLd SSRF guard (real jsonld + guarded loader)', () => {
     const error = await validateJsonLd(malicious).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(JsonLdExpansionFailedError);
     // The rejection came from the SSRF guard, not an unrelated expansion failure.
-    expect(buriedLoaderError(error)).toBeInstanceOf(UrlValidationError);
+    expect(nativeCauseChain(error)).toContainEqual(expect.any(UrlValidationError));
     // The security property: the loopback canary was never reached.
     expect(hits).toBe(0);
   });
@@ -67,7 +76,7 @@ describe('validateJsonLd SSRF guard (real jsonld + guarded loader)', () => {
 
     const error = await validateJsonLd(malicious).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(JsonLdExpansionFailedError);
-    expect(buriedLoaderError(error)).toBeInstanceOf(UrlValidationError);
+    expect(nativeCauseChain(error)).toContainEqual(expect.any(UrlValidationError));
   });
 
   it('expands a document with an inline @context without any network fetch', async () => {
@@ -75,5 +84,19 @@ describe('validateJsonLd SSRF guard (real jsonld + guarded loader)', () => {
 
     await expect(validateJsonLd(document)).resolves.toBeUndefined();
     expect(hits).toBe(0);
+  });
+
+  it('reaches the UrlValidationError by plain .cause hops, matching the schema-fetch path shape', async () => {
+    const malicious = { '@context': `${baseUrl}/internal-context`, name: 'value' };
+
+    const error = (await validateJsonLd(malicious).catch((e: unknown) => e)) as JsonLdExpansionFailedError;
+
+    // First hop: jsonld.js's own JsonLdError (still carries `.details` for
+    // callers that want the raw jsonld diagnostic).
+    expect(error.cause).toBeInstanceOf(Error);
+    expect((error.cause as Error).name).toBe('jsonld.InvalidUrl');
+    // Second hop: the guard's rejection itself, reachable without digging
+    // into jsonld.js's proprietary `details.cause`.
+    expect((error.cause as Error).cause).toBeInstanceOf(UrlValidationError);
   });
 });

--- a/packages/untp-utils/src/validation/validate-jsonld.test.ts
+++ b/packages/untp-utils/src/validation/validate-jsonld.test.ts
@@ -54,6 +54,62 @@ describe('validateJsonLd', () => {
     await expect(validateJsonLd({})).rejects.toMatchObject({ cause });
   });
 
+  describe('rehydrating a buried jsonld.js loader error', () => {
+    // jsonld.js's own JsonLdError stores a document loader's rejection at
+    // the proprietary `details.cause` and never sets native `Error.cause`
+    // (jsonld@8.3.3 `lib/JsonLdError.js`, loader wrap in
+    // `lib/ContextResolver.js`). `validateJsonLd` rehydrates it onto the
+    // caught error's native `cause` so a plain `.cause` walk reaches it,
+    // matching the schema-fetch path (see `validate-jsonld.ssrf.test.ts`).
+
+    it('rehydrates the buried loader error onto the native cause chain', async () => {
+      const buried = new Error('SSRF rejected');
+      const jsonldError = Object.assign(new Error('Dereferencing a URL did not result in a valid JSON-LD object.'), {
+        name: 'jsonld.InvalidUrl',
+        details: { code: 'loading remote context failed', url: 'https://internal.example', cause: buried },
+      });
+      toRDF.mockRejectedValue(jsonldError as never);
+
+      const error = await validateJsonLd({}).catch((e: unknown) => e);
+
+      expect((error as JsonLdExpansionFailedError).cause).toBe(jsonldError);
+      // Without the rehydration, jsonldError.cause stays unset (jsonld.js
+      // never sets it), so this hop would be absent.
+      expect(jsonldError.cause).toBe(buried);
+    });
+
+    it('does not add a spurious cause when the jsonld error has no buried loader error', async () => {
+      // A malformed @context never reaches the document loader, so jsonld.js's
+      // details carry no `cause` to rehydrate.
+      const jsonldError = Object.assign(new Error('Invalid JSON-LD syntax; @context must be an object.'), {
+        name: 'jsonld.SyntaxError',
+        details: { code: 'invalid @context' },
+      });
+      toRDF.mockRejectedValue(jsonldError as never);
+
+      await validateJsonLd({}).catch(() => undefined);
+
+      // Asserts absence, not merely `undefined`: an implementation that sets
+      // `error.cause = undefined` unconditionally would pass a `toBeUndefined()`
+      // check but still fabricate a `cause` property that was never there.
+      expect('cause' in jsonldError).toBe(false);
+    });
+
+    it('does not clobber an existing native cause on the jsonld error', async () => {
+      const existingCause = new Error('existing, legitimate native cause');
+      const buried = new Error('buried loader error, must not overwrite the existing cause');
+      const jsonldError = Object.assign(new Error('wrapped', { cause: existingCause }), {
+        name: 'jsonld.InvalidUrl',
+        details: { cause: buried },
+      });
+      toRDF.mockRejectedValue(jsonldError as never);
+
+      await validateJsonLd({}).catch(() => undefined);
+
+      expect(jsonldError.cause).toBe(existingCause);
+    });
+  });
+
   it('throws JsonLdInvalidShapeError when the document is not an object', async () => {
     await expect(validateJsonLd('not-an-object')).rejects.toMatchObject({
       name: 'JsonLdInvalidShapeError',

--- a/packages/untp-utils/src/validation/validate-jsonld.test.ts
+++ b/packages/untp-utils/src/validation/validate-jsonld.test.ts
@@ -24,6 +24,7 @@ const { validateJsonLd } = await import('./validate-jsonld.js');
 describe('validateJsonLd', () => {
   beforeEach(() => {
     toRDF.mockReset();
+    documentLoader.mockReset();
     createJsonLdDocumentLoader.mockClear();
   });
 
@@ -108,6 +109,71 @@ describe('validateJsonLd', () => {
 
       expect(jsonldError.cause).toBe(existingCause);
     });
+
+    // A term's own remote @context (a JSON-LD 1.1 "scoped context") is
+    // resolved through the same document loader, but on failure jsonld.js's
+    // scoped-context branch (lib/context.js) discards the loader's error
+    // entirely and throws a fresh JsonLdError with no `details.cause` at
+    // all (see validate-jsonld.ssrf.test.ts for the real-jsonld
+    // reproduction). validateJsonLd recovers it by tracking the last error
+    // the document loader threw during the call and using that as a
+    // fallback cause.
+    describe('recovering via the tracked-loader fallback', () => {
+      /** Simulates toRDF calling the documentLoader it was given, then rejecting as jsonld.js would. */
+      function rejectAfterCallingLoader(url: string, rejection: unknown) {
+        toRDF.mockImplementation(async (...args: unknown[]) => {
+          const opts = args[1] as { documentLoader: (u: string) => Promise<unknown> };
+          await opts.documentLoader(url).catch(() => undefined);
+          throw rejection;
+        });
+      }
+
+      it('recovers the tracked loader error when the jsonld error has no buried cause of its own', async () => {
+        const loaderError = new Error('SSRF rejected, recorded from the tracked loader');
+        documentLoader.mockRejectedValue(loaderError as never);
+        const scopedContextError = Object.assign(new Error('Invalid JSON-LD syntax; invalid scoped context.'), {
+          name: 'jsonld.SyntaxError',
+          details: { code: 'invalid scoped context', context: 'https://internal.example', term: 'myTerm' },
+        });
+        rejectAfterCallingLoader('https://internal.example', scopedContextError);
+
+        await validateJsonLd({}).catch(() => undefined);
+
+        // Without the fallback, this jsonld error's details carry no `cause`
+        // at all, so scopedContextError.cause would stay unset.
+        expect(scopedContextError.cause).toBe(loaderError);
+      });
+
+      it('prefers the buried details.cause over the fallback when jsonld.js kept both', async () => {
+        const buried = new Error('buried on details.cause, should win');
+        const fallbackLoaderError = new Error('recorded from the tracked loader, should lose');
+        documentLoader.mockRejectedValue(fallbackLoaderError as never);
+        const jsonldError = Object.assign(new Error('wrapped'), {
+          name: 'jsonld.InvalidUrl',
+          details: { cause: buried },
+        });
+        rejectAfterCallingLoader('https://example.com', jsonldError);
+
+        await validateJsonLd({}).catch(() => undefined);
+
+        expect(jsonldError.cause).toBe(buried);
+      });
+
+      it('does not fabricate a cause when the loader never threw during the call', async () => {
+        // The loader succeeds (or is never called); the eventual rejection
+        // is for an unrelated reason, so there is nothing to fall back to.
+        documentLoader.mockResolvedValue({ documentUrl: 'https://example.com', document: {} } as never);
+        const unrelatedError = Object.assign(new Error('Invalid JSON-LD syntax; @context must be an object.'), {
+          name: 'jsonld.SyntaxError',
+          details: { code: 'invalid @context' },
+        });
+        rejectAfterCallingLoader('https://example.com', unrelatedError);
+
+        await validateJsonLd({}).catch(() => undefined);
+
+        expect('cause' in unrelatedError).toBe(false);
+      });
+    });
   });
 
   it('throws JsonLdInvalidShapeError when the document is not an object', async () => {
@@ -158,13 +224,20 @@ describe('validateJsonLd', () => {
     expect(createJsonLdDocumentLoader).toHaveBeenCalledWith({ cache: contextCache });
   });
 
-  it('passes the created document loader to toRDF', async () => {
+  it('passes toRDF a loader that delegates to the one createJsonLdDocumentLoader created', async () => {
     toRDF.mockResolvedValue([] as never);
+    const remoteDoc = { documentUrl: 'https://example.com', document: {} };
+    documentLoader.mockResolvedValue(remoteDoc as never);
 
     await validateJsonLd({ '@context': 'https://example.com' });
 
     expect(createJsonLdDocumentLoader).toHaveBeenCalledWith({ cache: undefined });
-    expect(toRDF).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ documentLoader }));
+    // validateJsonLd wraps the created loader (to record failures for
+    // rehydrateJsonLdCause's fallback, see validate-jsonld.ts), so toRDF
+    // receives a different function reference; assert delegation instead.
+    const passedOptions = toRDF.mock.calls[0]?.[1] as { documentLoader: (url: string) => Promise<unknown> };
+    await expect(passedOptions.documentLoader('https://example.com')).resolves.toBe(remoteDoc);
+    expect(documentLoader).toHaveBeenCalledWith('https://example.com');
   });
 
   it('handles non-Error thrown values', async () => {

--- a/packages/untp-utils/src/validation/validate-jsonld.ts
+++ b/packages/untp-utils/src/validation/validate-jsonld.ts
@@ -27,23 +27,38 @@ export interface ValidateJsonLdOptions {
  * `error.details.cause`, unlike the schema-fetch path (`schema-loader.ts`),
  * which surfaces the same class of rejection on the native chain.
  *
- * Rehydrates the buried error onto `error.cause` so a plain `.cause` walk
- * reaches it on both paths. Mutates and returns the same object jsonld.js
- * just threw for this call (safe: nothing else holds a reference to it), and
- * only when there is something buried and jsonld.js has not already set a
- * `cause` itself, so a malformed `@context` (which never reaches the
- * document loader, and so has nothing at `details.cause`) does not gain a
- * spurious one.
+ * A term's own remote `@context` (a JSON-LD 1.1 "scoped context") loses even
+ * that: jsonld.js resolves it through the same loader, but on failure its
+ * scoped-context branch (`lib/context.js`) discards the loader's error
+ * entirely and throws a fresh `JsonLdError` whose `details` carry no `cause`
+ * at all. `fallback` recovers the guard's rejection in that case: `toRDF`'s
+ * `documentLoader` is wrapped ({@link validateJsonLd}) to record the last
+ * error it threw during the call, and that call-scoped record is passed here
+ * as `fallback`. Because jsonld.js resolves `@context` documents one at a
+ * time and any loader throw immediately aborts the whole call (no later,
+ * unrelated loader call can follow one that failed), a recorded loader error
+ * is always the proximate cause of whatever expansion failure this function
+ * is asked to rehydrate, whether or not jsonld.js chose to keep its own
+ * reference to it.
+ *
+ * Rehydrates the recovered error (preferring `details.cause` when jsonld.js
+ * kept it) onto `error.cause` so a plain `.cause` walk reaches it. Mutates
+ * and returns the same object jsonld.js just threw for this call (safe:
+ * nothing else holds a reference to it), and only when there is something to
+ * recover and jsonld.js has not already set a `cause` itself, so a malformed
+ * `@context` that never reached the document loader (and so has nothing
+ * buried and no fallback recorded) does not gain a spurious one.
  *
  * @see https://github.com/uncefact/tests-untp/issues/773
  */
-function rehydrateJsonLdCause(error: unknown): unknown {
+function rehydrateJsonLdCause(error: unknown, fallback?: unknown): unknown {
   if (!(error instanceof Error) || error.cause !== undefined) {
     return error;
   }
   const buried = (error as Error & { details?: { cause?: unknown } }).details?.cause;
-  if (buried !== undefined) {
-    error.cause = buried;
+  const recovered = buried !== undefined ? buried : fallback;
+  if (recovered !== undefined) {
+    error.cause = recovered;
   }
   return error;
 }
@@ -80,15 +95,27 @@ export async function validateJsonLd(document: unknown, options?: ValidateJsonLd
   const { createJsonLdDocumentLoader } = await import('../loaders/jsonld-document-loader.js');
   const documentLoader = createJsonLdDocumentLoader({ cache: options?.contextCache });
 
+  // Recorded for rehydrateJsonLdCause's fallback: the last error the loader
+  // threw during this call (undefined if every fetch it made succeeded).
+  let lastLoaderError: unknown;
+  const trackedDocumentLoader = async (url: string): Promise<LoadedRemoteDocument> => {
+    try {
+      return await documentLoader(url);
+    } catch (loaderError) {
+      lastLoaderError = loaderError;
+      throw loaderError;
+    }
+  };
+
   try {
     // The options cast bridges @types/jsonld, which types documentLoader with
     // a legacy callback signature; jsonld.js itself accepts the
     // single-argument promise-returning loader used here.
     await jsonld.toRDF(
       document as JsonLdDocument,
-      { safe: options?.safe ?? true, documentLoader } as Parameters<typeof jsonld.toRDF>[1],
+      { safe: options?.safe ?? true, documentLoader: trackedDocumentLoader } as Parameters<typeof jsonld.toRDF>[1],
     );
   } catch (cause) {
-    throw new JsonLdExpansionFailedError(rehydrateJsonLdCause(cause));
+    throw new JsonLdExpansionFailedError(rehydrateJsonLdCause(cause, lastLoaderError));
   }
 }

--- a/packages/untp-utils/src/validation/validate-jsonld.ts
+++ b/packages/untp-utils/src/validation/validate-jsonld.ts
@@ -18,6 +18,37 @@ export interface ValidateJsonLdOptions {
 }
 
 /**
+ * jsonld.js's own `JsonLdError` wraps a document loader's rejection in the
+ * proprietary `details.cause` and never sets native `Error.cause`
+ * (jsonld@8.3.3 `lib/JsonLdError.js`, loader wrap in
+ * `lib/ContextResolver.js`), so a plain `.cause` walk over a caught
+ * expansion failure dead-ends one hop early: the SSRF guard's rejection
+ * (see `createJsonLdDocumentLoader`) is reachable only via the non-standard
+ * `error.details.cause`, unlike the schema-fetch path (`schema-loader.ts`),
+ * which surfaces the same class of rejection on the native chain.
+ *
+ * Rehydrates the buried error onto `error.cause` so a plain `.cause` walk
+ * reaches it on both paths. Mutates and returns the same object jsonld.js
+ * just threw for this call (safe: nothing else holds a reference to it), and
+ * only when there is something buried and jsonld.js has not already set a
+ * `cause` itself, so a malformed `@context` (which never reaches the
+ * document loader, and so has nothing at `details.cause`) does not gain a
+ * spurious one.
+ *
+ * @see https://github.com/uncefact/tests-untp/issues/773
+ */
+function rehydrateJsonLdCause(error: unknown): unknown {
+  if (!(error instanceof Error) || error.cause !== undefined) {
+    return error;
+  }
+  const buried = (error as Error & { details?: { cause?: unknown } }).details?.cause;
+  if (buried !== undefined) {
+    error.cause = buried;
+  }
+  return error;
+}
+
+/**
  * Catches malformed contexts, undefined terms, and structurally invalid
  * linked data by expanding to RDF in safe mode (unless explicitly disabled).
  *
@@ -30,7 +61,9 @@ export interface ValidateJsonLdOptions {
  * @see ../../../../docs/adrs/033-cvc-architecture.md ADR-033 §7 (Security considerations).
  * @throws {JsonLdInvalidShapeError} if `document` is not a non-null object.
  * @throws {JsonLdExpansionFailedError} if `jsonld.toRDF` rejects (which
- *   includes a remote `@context` failing the SSRF guard).
+ *   includes a remote `@context` failing the SSRF guard; the guard's
+ *   rejection is reachable via native `.cause` hops off the thrown error,
+ *   see {@link rehydrateJsonLdCause}).
  */
 export async function validateJsonLd(document: unknown, options?: ValidateJsonLdOptions): Promise<void> {
   if (typeof document !== 'object' || document === null) {
@@ -56,6 +89,6 @@ export async function validateJsonLd(document: unknown, options?: ValidateJsonLd
       { safe: options?.safe ?? true, documentLoader } as Parameters<typeof jsonld.toRDF>[1],
     );
   } catch (cause) {
-    throw new JsonLdExpansionFailedError(cause);
+    throw new JsonLdExpansionFailedError(rehydrateJsonLdCause(cause));
   }
 }


### PR DESCRIPTION
This PR surfaces SSRF rejections from JSON-LD expansion on the native error cause chain, so a `UrlValidationError` from the SSRF guard on a remote `@context` is reachable by plain `.cause` hops off the thrown `JsonLdExpansionFailedError`, matching the schema-fetch path and letting incident response distinguish a blocked internal or cloud-metadata `@context` from a merely malformed one.

jsonld.js's `JsonLdError` stores a document loader's rejection at its proprietary `details.cause` and never sets native `Error.cause`, so a plain cause walk dead-ended one hop early. For a top-level `@context`, `validateJsonLd` now rehydrates that buried error onto the native cause. For a term-scoped `@context` (one inside a term definition), jsonld.js discards the loader error entirely, so `validateJsonLd` also records the last error its document loader threw during the call and uses it as the fallback, recovering the guard's rejection in both cases. Because jsonld.js resolves `@context` documents one at a time and any loader throw aborts the whole call, that recorded error is always the proximate cause. The SSRF network block is unchanged; this only makes the rejection diagnosable. The RI-side surfacing of the distinction (a log line or ingest status) is a separate later step.

Closes #773

## Test plan
- [x] A top-level remote `@context` blocked by the SSRF guard is reachable as `error.cause.cause` (a `UrlValidationError`)
- [x] A term-scoped remote `@context` blocked by the guard recovers the rejection via the tracked-loader fallback (real end-to-end, network never reached)
- [x] A malformed `@context` that never reaches the loader gains no spurious cause; an existing native cause is not clobbered
- [x] Full untp-utils suite green (437 tests); lint clean
