### PR TITLE
feat(ri): reject over-cap page limits and make the maximum operator-configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,15 @@ VERIFY_ALLOW_PRIVATE_URLS=true
 # Minimum log level: debug, info, warn, error
 LOG_LEVEL=info
 
+# API
+# Maximum number of records a list endpoint returns per page. A request that
+# asks for more is bounded to this maximum, rejected with a 400 on routes using
+# the shared pagination schema and capped to it on the routes still migrating
+# onto that schema. Defaults to 100. Set a positive integer to raise or lower
+# the bound. A value that is not a positive integer is ignored, the default is
+# applied, and a warning is logged at startup.
+# API_MAX_PAGE_LIMIT=100
+
 # UNCEFACT Storage Service (system storage service instance)
 SYSTEM_STORAGE_BASE_URL=http://localhost:3334
 SYSTEM_STORAGE_API_KEY=test123

--- a/documentation/docs/reference-implementation/api/identifiers.md
+++ b/documentation/docs/reference-implementation/api/identifiers.md
@@ -243,7 +243,7 @@ Returns identifiers for the authenticated tenant with optional filtering. Result
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `schemeId` | string | — | Filter by identifier scheme ID |
-| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `limit` | integer | `20` | Maximum results per page. A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---

--- a/documentation/docs/reference-implementation/operations/api-pagination.md
+++ b/documentation/docs/reference-implementation/operations/api-pagination.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 4
+title: API Pagination
+---
+
+# API Pagination
+
+List endpoints return results in pages. A client controls its page with the `limit` (page size) and `offset` (records to skip) query parameters.
+
+## Maximum page size
+
+The `limit` a client may request is capped at a maximum. A request for more than the maximum is rejected with a `400` response that names the maximum, so the client learns the bound and can adjust its request. This keeps a single request from asking for an unbounded page.
+
+The maximum defaults to `100` and is configurable per deployment through the `API_MAX_PAGE_LIMIT` environment variable.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `API_MAX_PAGE_LIMIT` | Maximum number of records a list endpoint returns per page. A request whose `limit` exceeds this is rejected with a 400 naming the maximum. | `100` |
+
+Set it to any positive integer to raise or lower the bound for your deployment. A value that is not a positive integer is ignored, the default is applied, and a warning is logged at startup, so a misconfiguration is visible in the logs rather than silently taking effect.
+
+When the configured maximum is below the default page size (`20`), the default page size is lowered to the configured maximum, so a request that omits `limit` still returns no more than the configured maximum.
+
+## Where the bound is enforced
+
+The maximum is enforced at runtime, by the API rejecting an over-cap request. The published OpenAPI specification does not carry it as a `maximum` constraint on `limit`. The API documentation page is generated as static content at build time, so a value embedded in the specification would reflect the build-time default rather than a deployment's configured value, and would mislead a client of a reconfigured deployment. The `400` response is therefore the authoritative statement of the bound for a given deployment, and this lever is documented here, for operators, rather than in the client-facing specification.

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
@@ -59,7 +59,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 
 import { NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
-import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -285,16 +285,20 @@ describe('GET /api/v1/identifiers', () => {
     });
   });
 
-  it('clamps limit to MAX_PAGE_LIMIT', async () => {
+  it('rejects a limit above the maximum with a 400 and does not query', async () => {
     mockListIdentifiers.mockResolvedValue({ data: [], total: 0 });
 
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/identifiers?limit=500',
     });
-    await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
 
-    expect(mockListIdentifiers).toHaveBeenCalledWith('org-1', expect.objectContaining({ limit: MAX_PAGE_LIMIT }));
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^limit:/);
+    expect(json.error).toContain('maximum');
+    expect(mockListIdentifiers).not.toHaveBeenCalled();
   });
 
   it('handles no query parameters', async () => {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
@@ -3,7 +3,7 @@ import { parseRequestBody, parseQueryParams } from '@/lib/api/validation';
 import { createIdentifierRequestSchema, listIdentifiersQuerySchema } from '@/lib/api/request-schemas/identifier';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createIdentifier, listIdentifiers } from '@/lib/prisma/repositories';
-import { buildPaginatedResponse, clampLimit } from '@/lib/api/pagination';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/identifiers' });
@@ -107,7 +107,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Maximum number of identifiers to return
+ *         description: Number of identifiers to return per page. Defaults to 20. A larger value is rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:
@@ -150,9 +150,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   logger.info('Parsing query parameters');
   const query = parseQueryParams(new URL(req.url), listIdentifiersQuerySchema);
-  const { schemeId } = query;
-  const limit = clampLimit(query.limit);
-  const offset = query.offset;
+  const { schemeId, limit, offset } = query;
 
   logger.info({ schemeId, limit, offset }, 'Listing identifiers');
   const { data, total } = await listIdentifiers(tenantId, { schemeId, limit, offset });

--- a/packages/reference-implementation/src/instrumentation.node.ts
+++ b/packages/reference-implementation/src/instrumentation.node.ts
@@ -13,6 +13,8 @@ import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentation
 import { NodeSDK } from '@opentelemetry/sdk-node';
 
 import { buildResource } from './lib/observability/resource';
+import { apiLogger } from './lib/api/logger';
+import { warnOnRejectedMaxPageLimitOverride } from './lib/api/pagination';
 
 const sdk = new NodeSDK({
   resource: buildResource(),
@@ -23,6 +25,9 @@ const sdk = new NodeSDK({
 });
 
 sdk.start();
+
+// Surface an unusable API_MAX_PAGE_LIMIT to the operator once at startup (issue #834).
+warnOnRejectedMaxPageLimitOverride(apiLogger);
 
 const shutdown = () => {
   sdk.shutdown().catch((err: unknown) => {

--- a/packages/reference-implementation/src/lib/api/pagination.test.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.test.ts
@@ -1,28 +1,107 @@
 import {
   buildPaginatedResponse,
-  clampLimit,
   paginateInMemory,
   paginationMetaSchema,
   DEFAULT_PAGE_LIMIT,
-  MAX_PAGE_LIMIT,
+  resolveMaxPageLimit,
+  warnOnRejectedMaxPageLimitOverride,
 } from './pagination';
 
-describe('clampLimit', () => {
-  it('leaves an absent limit undefined so the repository applies its own default', () => {
-    expect(clampLimit(undefined)).toBeUndefined();
+describe('resolveMaxPageLimit', () => {
+  it('returns the default for an absent variable, without rejecting an override', () => {
+    expect(resolveMaxPageLimit(undefined)).toEqual({ value: 100, overrideRejected: false });
   });
 
-  it('passes a limit below the cap through unchanged', () => {
-    expect(clampLimit(50)).toBe(50);
+  it('applies a valid positive-integer override', () => {
+    expect(resolveMaxPageLimit('250')).toEqual({ value: 250, overrideRejected: false });
+    expect(resolveMaxPageLimit(' 50 ')).toEqual({ value: 50, overrideRejected: false });
+    expect(resolveMaxPageLimit('1')).toEqual({ value: 1, overrideRejected: false });
   });
 
-  it('passes the cap value through unchanged', () => {
-    expect(clampLimit(MAX_PAGE_LIMIT)).toBe(MAX_PAGE_LIMIT);
+  it('rejects a supplied but unusable override and falls back to the default', () => {
+    for (const raw of ['', '   ', '0', '-5', '+5', 'abc', '10.5', '1e3', '0x10', '9'.repeat(400)]) {
+      expect(resolveMaxPageLimit(raw)).toEqual({ value: 100, overrideRejected: true });
+    }
+  });
+});
+
+describe('MAX_PAGE_LIMIT / DEFAULT_PAGE_LIMIT resolution at module load', () => {
+  const original = process.env.API_MAX_PAGE_LIMIT;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.API_MAX_PAGE_LIMIT;
+    } else {
+      process.env.API_MAX_PAGE_LIMIT = original;
+    }
+    jest.resetModules();
   });
 
-  it('caps a limit above the maximum at MAX_PAGE_LIMIT', () => {
-    expect(clampLimit(MAX_PAGE_LIMIT + 1)).toBe(MAX_PAGE_LIMIT);
-    expect(clampLimit(100000)).toBe(MAX_PAGE_LIMIT);
+  it('reads a valid operator override from the environment', async () => {
+    process.env.API_MAX_PAGE_LIMIT = '250';
+    await jest.isolateModulesAsync(async () => {
+      const pagination = await import('./pagination');
+      expect(pagination.MAX_PAGE_LIMIT).toBe(250);
+      expect(pagination.DEFAULT_PAGE_LIMIT).toBe(20);
+    });
+  });
+
+  it('bounds the default page size by a configured maximum below the base default', async () => {
+    process.env.API_MAX_PAGE_LIMIT = '5';
+    await jest.isolateModulesAsync(async () => {
+      const pagination = await import('./pagination');
+      expect(pagination.MAX_PAGE_LIMIT).toBe(5);
+      expect(pagination.DEFAULT_PAGE_LIMIT).toBe(5);
+    });
+  });
+
+  it('applies the override at the pagination schema boundary', async () => {
+    process.env.API_MAX_PAGE_LIMIT = '7';
+    await jest.isolateModulesAsync(async () => {
+      const { paginationQuerySchema } = await import('./request-schemas/shared');
+      expect(paginationQuerySchema.safeParse({ limit: '7' }).success).toBe(true);
+      const over = paginationQuerySchema.safeParse({ limit: '8' });
+      expect(over.success).toBe(false);
+      if (!over.success) {
+        expect(over.error.issues[0].message).toBe('must not exceed the maximum of 7');
+      }
+    });
+  });
+});
+
+describe('warnOnRejectedMaxPageLimitOverride', () => {
+  const original = process.env.API_MAX_PAGE_LIMIT;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.API_MAX_PAGE_LIMIT;
+    } else {
+      process.env.API_MAX_PAGE_LIMIT = original;
+    }
+  });
+
+  it('warns with the raw value and the applied default when the override is unusable', () => {
+    process.env.API_MAX_PAGE_LIMIT = 'not-a-number';
+    const warn = jest.fn();
+
+    warnOnRejectedMaxPageLimitOverride({ warn });
+
+    expect(warn).toHaveBeenCalledWith(
+      { API_MAX_PAGE_LIMIT: 'not-a-number', appliedMaximum: 100 },
+      expect.stringContaining('API_MAX_PAGE_LIMIT'),
+    );
+  });
+
+  it('stays silent when the override is valid or absent', () => {
+    const warn = jest.fn();
+
+    process.env.API_MAX_PAGE_LIMIT = '250';
+    warnOnRejectedMaxPageLimitOverride({ warn });
+
+    delete process.env.API_MAX_PAGE_LIMIT;
+    warnOnRejectedMaxPageLimitOverride({ warn });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/reference-implementation/src/lib/api/pagination.ts
+++ b/packages/reference-implementation/src/lib/api/pagination.ts
@@ -9,17 +9,80 @@ export const paginationMetaSchema = z.object({
 
 export type PaginationMeta = z.infer<typeof paginationMetaSchema>;
 
-export const DEFAULT_PAGE_LIMIT = 20;
-export const MAX_PAGE_LIMIT = 100;
+const BASE_DEFAULT_PAGE_LIMIT = 20;
+const DEFAULT_MAX_PAGE_LIMIT = 100;
 
 /**
- * Caps a validated `limit` at MAX_PAGE_LIMIT, leaving an absent limit
- * undefined so the repository applies its own default. Used by every list
- * route after parsing the query so a client cannot request an unbounded page.
+ * Resolves the maximum page size a list request may ask for from the
+ * `API_MAX_PAGE_LIMIT` environment variable, so an operator can raise or lower
+ * the bound for their deployment. An absent variable resolves to
+ * DEFAULT_MAX_PAGE_LIMIT silently. A supplied value must be a positive integer;
+ * a supplied-but-unusable value (blank, non-integer, below 1) resolves to the
+ * default and sets `overrideRejected`, so the caller can warn the operator that
+ * their setting was not applied (issue #834). An empty string counts as
+ * supplied-but-unusable rather than absent, because a config template that
+ * expands an unset variable to `""` is a mistake worth surfacing.
  */
-export function clampLimit(limit?: number): number | undefined {
-  return limit !== undefined ? Math.min(limit, MAX_PAGE_LIMIT) : undefined;
+export function resolveMaxPageLimit(raw: string | undefined): { value: number; overrideRejected: boolean } {
+  if (raw === undefined) {
+    return { value: DEFAULT_MAX_PAGE_LIMIT, overrideRejected: false };
+  }
+  const trimmed = raw.trim();
+  const parsed = Number(trimmed);
+  if (/^\d+$/.test(trimmed) && Number.isSafeInteger(parsed) && parsed >= 1) {
+    return { value: parsed, overrideRejected: false };
+  }
+  return { value: DEFAULT_MAX_PAGE_LIMIT, overrideRejected: true };
 }
+
+/**
+ * Warns the operator, through the supplied logger, when API_MAX_PAGE_LIMIT was
+ * set to a value that could not be used, so a misconfigured deployment learns
+ * its setting was ignored. Called once from the Node server startup hook
+ * (instrumentation.node.ts). The logger is a parameter so this module holds no
+ * server-only logging import and stays safe in the client bundle, which reaches
+ * this file through DEFAULT_PAGE_LIMIT (issue #834).
+ */
+export function warnOnRejectedMaxPageLimitOverride(logger: {
+  warn: (context: Record<string, unknown>, message: string) => void;
+}): void {
+  const raw = process.env.API_MAX_PAGE_LIMIT;
+  const resolved = resolveMaxPageLimit(raw);
+  if (resolved.overrideRejected) {
+    logger.warn(
+      { API_MAX_PAGE_LIMIT: raw, appliedMaximum: resolved.value },
+      'API_MAX_PAGE_LIMIT must be a positive integer; applying the default maximum page limit instead',
+    );
+  }
+}
+
+const resolvedMaxPageLimit = resolveMaxPageLimit(process.env.API_MAX_PAGE_LIMIT);
+
+/**
+ * Maximum page size a list request may ask for, resolved once at startup from
+ * `API_MAX_PAGE_LIMIT` (default DEFAULT_MAX_PAGE_LIMIT). The route-boundary
+ * pagination schema (paginationQuerySchema) rejects a `limit` above this rather
+ * than clamping it, so a client is told the bound rather than handed a quietly
+ * smaller page (ADR-037). Routes not yet migrated to that schema still clamp to
+ * this value directly. #834 is the foundation change only.
+ *
+ * This bound is deliberately not published as an OpenAPI `maximum` constraint.
+ * The API documentation page is prerendered as static content, so a value in the
+ * specification would freeze at the build-time default and misdescribe a
+ * reconfigured deployment. Making the specification deployment-accurate would add
+ * disproportionate machinery for one value. The runtime 400 above is the single
+ * source of truth for the bound, and the lever is documented for operators (the
+ * API Pagination operations doc), not for the API client (issue #834).
+ */
+export const MAX_PAGE_LIMIT = resolvedMaxPageLimit.value;
+
+/**
+ * Page size applied when a list request omits `limit`, bounded by
+ * MAX_PAGE_LIMIT so that an operator who lowers the maximum below the base
+ * default still receives responses within their configured maximum, including
+ * on the common no-limit request (issue #834).
+ */
+export const DEFAULT_PAGE_LIMIT = Math.min(BASE_DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT);
 
 export interface PaginatedResponse<T> {
   data: T[];
@@ -49,8 +112,8 @@ export function buildPaginatedResponse<T>(
  * Slices a fully-materialised array to the requested page and wraps it. For
  * endpoints that must load the whole result set before paging (e.g. the CVC
  * browse routes, which dedupe across tenant lanes), rather than paging at the
- * database. Pass the same `limit`/`offset` already parsed and capped by the
- * route.
+ * database. Pass the same `limit`/`offset` already parsed and bounded by the
+ * route (rejected above the maximum on schema routes, clamped on legacy ones).
  */
 export function paginateInMemory<T>(items: T[], limit?: number, offset?: number): PaginatedResponse<T> {
   const start = offset ?? 0;

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
@@ -150,6 +150,21 @@ describe('paginationQuerySchema', () => {
     expect(paginationQuerySchema.safeParse({ offset: '0' })).toEqual({ success: true, data: { offset: 0 } });
   });
 
+  it('accepts a limit at the maximum', () => {
+    expect(paginationQuerySchema.safeParse({ limit: '100' })).toEqual({ success: true, data: { limit: 100 } });
+  });
+
+  it('rejects a limit above the maximum, naming the bound', () => {
+    const result = paginationQuerySchema.safeParse({ limit: '101' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]).toMatchObject({
+        path: ['limit'],
+        message: 'must not exceed the maximum of 100',
+      });
+    }
+  });
+
   describe('strict decimal integer matrix', () => {
     const acceptedLimits: Array<[string, number]> = [
       ['5', 5],

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
@@ -17,6 +17,8 @@
 
 import { z } from 'zod';
 
+import { MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+
 /** A database identifier reference (non-empty string). */
 export const idSchema = z.string().min(1);
 
@@ -89,6 +91,10 @@ function strictIntQueryParam(message: string, isInRange: (value: number) => bool
 /**
  * Shared `limit`/`offset` query fragment for list routes (ADR-037).
  *
+ * `limit` above MAX_PAGE_LIMIT is rejected rather than clamped, so a client
+ * that asks for more than the maximum is told the bound rather than handed a
+ * quietly smaller page (issue #834).
+ *
  * A resource merges this onto its own filter schema, pagination last, so a
  * resource's own filter issue is reported before a pagination issue when
  * both are invalid (parseQueryParams renders only the first issue, and
@@ -98,7 +104,10 @@ function strictIntQueryParam(message: string, isInRange: (value: number) => bool
  *   const query = parseQueryParams(new URL(req.url), resourceQuerySchema);
  */
 export const paginationQuerySchema = z.object({
-  limit: strictIntQueryParam('must be a positive integer', (value) => value >= 1),
+  limit: strictIntQueryParam('must be a positive integer', (value) => value >= 1).refine(
+    (value) => value === undefined || value <= MAX_PAGE_LIMIT,
+    `must not exceed the maximum of ${MAX_PAGE_LIMIT}`,
+  ),
   offset: strictIntQueryParam('must be a non-negative integer', (value) => value >= 0),
 });
 


### PR DESCRIPTION
This PR makes list endpoints reject a `limit` above the maximum with a 400 that names the maximum, instead of silently clamping it, so a client that asks for too large a page is told the bound rather than handed a quietly smaller result. The maximum defaults to 100 and is now configurable per deployment via the `API_MAX_PAGE_LIMIT` environment variable.

The cap lives in the shared route-boundary pagination schema (ADR-037), so a list route inherits it on adopting that schema. The identifiers route (the one already migrated) does so here, and the now-redundant `clampLimit` helper is removed. The default page size is bounded by the configured maximum, so a request that omits `limit` never exceeds a maximum set below the default. An `API_MAX_PAGE_LIMIT` that is not a positive integer falls back to the default and logs a warning at startup, so a misconfiguration is visible rather than silent. The lever is documented for operators in a new API Pagination operations page.

The bound is enforced at runtime rather than published as an OpenAPI `maximum`. The API documentation page is prerendered as static content, so a value in the specification would freeze at the build-time default and misdescribe a reconfigured deployment. The runtime 400 is the authoritative statement of the bound; serving a deployment-accurate spec is tracked separately.

Closes #834
