### PR TITLE
feat(ri): validate and tighten schemes endpoint inputs and align its Swagger

### DIFF
--- a/docs/adrs/037-input-validation-zod-route-boundary.md
+++ b/docs/adrs/037-input-validation-zod-route-boundary.md
@@ -2,6 +2,7 @@
 
 - **Date:** 2026-07-14
 - **Status:** accepted
+- **Update (2026-07-15):** The per-resource rollout (pilot #791) pairs this posture with an API-contract congruence pass on each migrated route, establishing conventions the remaining domains follow. A shared `int32Schema` validates Prisma `Int` body fields to the signed int4 range, so an out-of-range value is a 400 at the boundary rather than a 500 from the database. A `requireAtLeastOneField` PATCH request body is represented in OpenAPI as an `anyOf` of its updatable fields, so the published schema matches the runtime recognised-key rule (unknown keys stay allowed, matching the strip). The `403` that `withTenantAuth` returns is documented on every wrapped route, and a route's response `$ref` matches the repository's Prisma includes (a nested object is required only where every path that uses the `$ref` includes it, optional for list-versus-detail asymmetry). #791 also fixed a `requireAtLeastOneField` bug where an all-unknown-key body satisfied the precondition and became a silent no-op update.
 
 ## Context
 

--- a/documentation/docs/reference-implementation/api/identifiers.md
+++ b/documentation/docs/reference-implementation/api/identifiers.md
@@ -37,7 +37,7 @@ A scheme can optionally define **qualifiers** — sub-identifier dimensions that
 | `key` | Machine-readable key (e.g. `"lot"`, `"ser"`) |
 | `description` | Human-readable label |
 | `validationPattern` | Regex for validating qualifier values |
-| `order` | Optional sort order for display |
+| `order` | Optional non-negative precedence for URI resolution, ascending |
 
 When updating a scheme's qualifiers, the entire qualifier set is replaced — existing qualifiers are deleted and the new list is created in their place.
 
@@ -98,13 +98,13 @@ Creates a new identifier scheme with optional nested qualifiers. The scheme is a
 | `registrarId` | ID of the parent registrar |
 | `name` | Human-readable scheme name |
 | `primaryKey` | Key identifier used in URI construction (e.g. `"gtin"`) |
-| `validationPattern` | Regex for validating identifier values |
+| `validationPattern` | Regex for validating identifier values. Rejected with a 400 if it does not compile as a regular expression |
 | `linkTemplate` | ISO 18975 link template for URI construction |
 
 | Optional Field | Description |
 |----------------|-------------|
 | `idrServiceInstanceId` | Override IDR service instance for this scheme |
-| `qualifiers` | Array of qualifier definitions (each requires `key`, `description`, `validationPattern`) |
+| `qualifiers` | Array of qualifier definitions (each requires `key`, `description`, `validationPattern`; `order` is optional, a non-negative 32-bit integer, defaults to 0) |
 
 ```mermaid
 sequenceDiagram
@@ -131,12 +131,12 @@ sequenceDiagram
 GET /api/v1/schemes
 ```
 
-Returns identifier schemes for the authenticated tenant (including system defaults) with optional filtering. Results are paginated.
+Returns identifier schemes for the authenticated tenant (including system defaults) with optional filtering. Results are paginated. Each list item includes its qualifiers but omits the parent registrar object (unlike the single-record, create, and update responses, which include it).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `registrarId` | string | — | Filter by registrar ID |
-| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `limit` | integer | Defaults to 20, or the configured maximum when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---
@@ -163,10 +163,10 @@ Updates one or more fields of an existing identifier scheme. At least one updata
 |-----------------|-------------|
 | `name` | Scheme name (must be non-empty if provided) |
 | `primaryKey` | Primary key identifier |
-| `validationPattern` | Regex validation pattern |
+| `validationPattern` | Regex validation pattern. Rejected with a 400 if it does not compile as a regular expression |
 | `linkTemplate` | ISO 18975 link template |
 | `idrServiceInstanceId` | IDR service instance ID (set to `null` to clear) |
-| `qualifiers` | Replacement qualifier array (replaces all existing qualifiers) |
+| `qualifiers` | Replacement qualifier array (each item requires `key`, `description`, `validationPattern`; `order` is optional, a non-negative 32-bit integer, defaults to 0). Replaces all existing qualifiers |
 
 ---
 

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.test.ts
@@ -35,8 +35,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   deleteIdentifierScheme: (id: string, tenantId: string) => mockDeleteIdentifierScheme(id, tenantId),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError } from '@/lib/api/validation';
+import { NotFoundError, ConflictError } from '@/lib/api/errors';
 import { GET, PATCH, DELETE } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -141,6 +140,108 @@ describe('PATCH /api/v1/schemes/:id', () => {
     );
   });
 
+  it('updates with a qualifier order and forwards it to the repository', async () => {
+    const updated = {
+      id: 'sch-1',
+      qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 2 }],
+    };
+    mockUpdateIdentifierScheme.mockResolvedValue(updated);
+
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: {
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 2 }],
+      },
+    });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateIdentifierScheme).toHaveBeenCalledWith(
+      'sch-1',
+      'org-1',
+      expect.objectContaining({
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 2 }],
+      }),
+    );
+  });
+
+  it.each([
+    ['zero', 0],
+    ['the int32 maximum', 2147483647],
+  ])('accepts a qualifier order of %s and forwards it to the repository', async (_label, order) => {
+    const updated = {
+      id: 'sch-1',
+      qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order }],
+    };
+    mockUpdateIdentifierScheme.mockResolvedValue(updated);
+
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: {
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order }],
+      },
+    });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateIdentifierScheme).toHaveBeenCalledWith(
+      'sch-1',
+      'org-1',
+      expect.objectContaining({
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order }],
+      }),
+    );
+  });
+
+  it('returns 400 for a negative qualifier order and does not call the repository', async () => {
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: {
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: -5 }],
+      },
+    });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^qualifiers\.0\.order:/);
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-integer qualifier order and does not call the repository', async () => {
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: {
+        qualifiers: [
+          { key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 'first' },
+        ],
+      },
+    });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^qualifiers\.0\.order:/);
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an out-of-range qualifier order and does not call the repository', async () => {
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: {
+        qualifiers: [
+          { key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 3000000000 },
+        ],
+      },
+    });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^qualifiers\.0\.order:/);
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when no fields provided', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: {} });
     const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
@@ -148,6 +249,17 @@ describe('PATCH /api/v1/schemes/:id', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('At least one field is required');
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body only has an unrecognised (typo) field name', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { neme: 'Updated GTIN' } });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one field is required');
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -169,13 +281,14 @@ describe('PATCH /api/v1/schemes/:id', () => {
   it('returns 400 for invalid qualifier (missing key)', async () => {
     const req = createFakeRequest({
       method: 'PATCH',
-      body: { qualifiers: [{ description: 'Lot number' }] },
+      body: { qualifiers: [{ description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$' }] },
     });
     const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier key is required');
+    expect(json.error).toMatch(/^qualifiers\.0\.key:/);
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid qualifier (missing validationPattern)', async () => {
@@ -187,7 +300,8 @@ describe('PATCH /api/v1/schemes/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier validationPattern is required');
+    expect(json.error).toMatch(/^qualifiers\.0\.validationPattern:/);
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
   });
 
   it('returns 400 for non-array qualifiers', async () => {
@@ -199,7 +313,31 @@ describe('PATCH /api/v1/schemes/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifiers must be an array');
+    expect(json.error).toMatch(/^qualifiers:/);
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a validationPattern that does not compile as a regular expression', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { validationPattern: '[invalid' } });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('validationPattern: must be a valid regular expression');
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a qualifier validationPattern that does not compile as a regular expression', async () => {
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: { qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '[invalid' }] },
+    });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('qualifiers.0.validationPattern: must be a valid regular expression');
+    expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
   });
 
   it('returns 404 when scheme not found or access denied', async () => {
@@ -224,15 +362,20 @@ describe('PATCH /api/v1/schemes/:id', () => {
     expect(mockUpdateIdentifierScheme).toHaveBeenCalledWith('sch-1', 'org-1', { idrServiceInstanceId: null });
   });
 
-  it('returns 400 when repository throws ValidationError', async () => {
-    mockUpdateIdentifierScheme.mockRejectedValue(new ValidationError('Invalid pattern'));
+  it('returns 409 when repository reports a qualifier key conflict', async () => {
+    mockUpdateIdentifierScheme.mockRejectedValue(
+      new ConflictError('A qualifier with this key already exists for the scheme'),
+    );
 
-    const req = createFakeRequest({ method: 'PATCH', body: { validationPattern: '[invalid' } });
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: { qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$' }] },
+    });
     const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
-    expect(res.status).toBe(400);
-    expect(json.error).toContain('Invalid pattern');
+    expect(res.status).toBe(409);
+    expect(json.error).toContain('A qualifier with this key already exists for the scheme');
   });
 });
 

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateSchemeRequestSchema } from '@/lib/api/request-schemas/scheme';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getIdentifierSchemeById, updateIdentifierScheme, deleteIdentifierScheme } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
@@ -31,6 +32,12 @@ const logger = apiLogger.child({ route: '/api/v1/schemes/[id]' });
  *               $ref: '#/components/schemas/IdentifierScheme'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -76,6 +83,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         description: The database ID of the scheme
  *     requestBody:
  *       required: true
+ *       description: At least one recognised field is required; unknown keys are ignored.
  *       content:
  *         application/json:
  *           schema:
@@ -83,18 +91,23 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             properties:
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: New name for the scheme
  *               primaryKey:
  *                 type: string
+ *                 minLength: 1
  *                 description: New primary key identifier
  *               validationPattern:
  *                 type: string
- *                 description: New validation pattern
+ *                 minLength: 1
+ *                 description: New validation pattern. Rejected with a 400 if it does not compile as a regular expression.
  *               linkTemplate:
  *                 type: string
+ *                 minLength: 1
  *                 description: New ISO 18975 link template for URI construction
  *               idrServiceInstanceId:
  *                 type: string
+ *                 minLength: 1
  *                 nullable: true
  *                 description: New IDR service instance ID (set to null to clear)
  *               qualifiers:
@@ -109,11 +122,27 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                   properties:
  *                     key:
  *                       type: string
+ *                       minLength: 1
  *                     description:
  *                       type: string
+ *                       minLength: 1
  *                     validationPattern:
  *                       type: string
- *             minProperties: 1
+ *                       minLength: 1
+ *                       description: Rejected with a 400 if it does not compile as a regular expression.
+ *                     order:
+ *                       type: integer
+ *                       format: int32
+ *                       minimum: 0
+ *                       maximum: 2147483647
+ *                       description: Qualifier precedence in URI ordering (ascending). Defaults to 0.
+ *             anyOf:
+ *               - required: [name]
+ *               - required: [primaryKey]
+ *               - required: [validationPattern]
+ *               - required: [linkTemplate]
+ *               - required: [idrServiceInstanceId]
+ *               - required: [qualifiers]
  *     responses:
  *       200:
  *         description: Scheme updated successfully
@@ -122,13 +151,19 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/IdentifierScheme'
  *       400:
- *         description: Validation error - at least one field required
+ *         description: Validation error (e.g. no fields provided, a validationPattern that does not compile as a regular expression, a duplicate qualifier key, an idrServiceInstanceId that does not reference an existing service instance)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -154,81 +189,13 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-  logger.info({ schemeId: id }, 'Parsing request body');
-
-  let body: {
-    name?: string;
-    primaryKey?: string;
-    validationPattern?: string;
-    linkTemplate?: string;
-    idrServiceInstanceId?: string | null;
-    qualifiers?: Array<{
-      key: string;
-      description: string;
-      validationPattern: string;
-      order?: number;
-    }>;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  const hasName = isNonEmptyString(body.name);
-  const hasPrimaryKey = isNonEmptyString(body.primaryKey);
-  const hasValidationPattern = isNonEmptyString(body.validationPattern);
-  const hasLinkTemplate = isNonEmptyString(body.linkTemplate);
-  const hasIdrServiceInstanceId = body.idrServiceInstanceId !== undefined;
-  const hasQualifiers = body.qualifiers !== undefined;
-
   logger.info({ schemeId: id }, 'Validating update fields');
-  if (
-    !hasName &&
-    !hasPrimaryKey &&
-    !hasValidationPattern &&
-    !hasLinkTemplate &&
-    !hasIdrServiceInstanceId &&
-    !hasQualifiers
-  ) {
-    throw new ValidationError('At least one field is required');
-  }
 
-  // Validate qualifiers if provided
-  if (hasQualifiers) {
-    if (!Array.isArray(body.qualifiers)) {
-      throw new ValidationError('qualifiers must be an array');
-    }
-    for (const q of body.qualifiers!) {
-      if (!isNonEmptyString(q.key)) throw new ValidationError('qualifier key is required');
-      if (!isNonEmptyString(q.description)) throw new ValidationError('qualifier description is required');
-      if (!isNonEmptyString(q.validationPattern)) throw new ValidationError('qualifier validationPattern is required');
-    }
-  }
+  const body = await parseRequestBody(req, updateSchemeRequestSchema);
+  const fields = definedFields(body);
 
-  logger.info(
-    {
-      schemeId: id,
-      fields: {
-        hasName,
-        hasPrimaryKey,
-        hasValidationPattern,
-        hasLinkTemplate,
-        hasIdrServiceInstanceId,
-        hasQualifiers,
-      },
-    },
-    'Updating scheme',
-  );
-  const updated = await updateIdentifierScheme(id, tenantId, {
-    ...(hasName && { name: body.name }),
-    ...(hasPrimaryKey && { primaryKey: body.primaryKey }),
-    ...(hasValidationPattern && { validationPattern: body.validationPattern }),
-    ...(hasLinkTemplate && { linkTemplate: body.linkTemplate }),
-    ...(hasIdrServiceInstanceId && { idrServiceInstanceId: body.idrServiceInstanceId }),
-    ...(hasQualifiers && { qualifiers: body.qualifiers }),
-  });
+  logger.info({ schemeId: id, fields: Object.keys(fields) }, 'Updating scheme');
+  const updated = await updateIdentifierScheme(id, tenantId, fields);
 
   logger.info({ schemeId: id }, 'Scheme updated');
   return NextResponse.json(updated);
@@ -254,6 +221,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *         description: Scheme deleted successfully
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
@@ -34,7 +34,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   getRegistrarById: (id: string, tenantId: string) => mockGetRegistrarById(id, tenantId),
 }));
 
-import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -129,6 +129,122 @@ describe('POST /api/v1/schemes', () => {
     );
   });
 
+  it('creates a scheme with a qualifier order and forwards it to the repository', async () => {
+    const scheme = {
+      id: 'sch-1',
+      name: 'GTIN',
+      qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 2 }],
+    };
+    mockCreateIdentifierScheme.mockResolvedValue(scheme);
+
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 2 }],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateIdentifierScheme).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 2 }],
+      }),
+    );
+  });
+
+  it.each([
+    ['zero', 0],
+    ['the int32 maximum', 2147483647],
+  ])('accepts a qualifier order of %s and forwards it to the repository', async (_label, order) => {
+    mockCreateIdentifierScheme.mockResolvedValue({ id: 'sch-1' });
+
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order }],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateIdentifierScheme).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order }],
+      }),
+    );
+  });
+
+  it('returns 400 for a negative qualifier order and does not call the repository', async () => {
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: -5 }],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^qualifiers\.0\.order:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-integer qualifier order and does not call the repository', async () => {
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 1.5 }],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^qualifiers\.0\.order:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an out-of-range qualifier order and does not call the repository', async () => {
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [
+          { key: 'lot', description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$', order: 3000000000 },
+        ],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^qualifiers\.0\.order:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
+  });
+
   it('creates a scheme with optional fields', async () => {
     mockCreateIdentifierScheme.mockResolvedValue({ id: 'sch-1' });
 
@@ -153,46 +269,83 @@ describe('POST /api/v1/schemes', () => {
 
   it('returns 400 for missing registrarId', async () => {
     const req = createFakeRequest({
-      body: { name: 'GTIN', primaryKey: 'gtin', validationPattern: '^\\d{14}$' },
+      body: { name: 'GTIN', primaryKey: 'gtin', validationPattern: '^\\d{14}$', linkTemplate: '/{primaryKey}/{value}' },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('registrarId is required');
+    expect(json.error).toMatch(/^registrarId:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing name', async () => {
     const req = createFakeRequest({
-      body: { registrarId: 'reg-1', primaryKey: 'gtin', validationPattern: '^\\d{14}$' },
+      body: {
+        registrarId: 'reg-1',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+      },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required');
+    expect(json.error).toMatch(/^name:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing primaryKey', async () => {
     const req = createFakeRequest({
-      body: { registrarId: 'reg-1', name: 'GTIN', validationPattern: '^\\d{14}$' },
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+      },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('primaryKey is required');
+    expect(json.error).toMatch(/^primaryKey:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing validationPattern', async () => {
     const req = createFakeRequest({
-      body: { registrarId: 'reg-1', name: 'GTIN', primaryKey: 'gtin' },
+      body: { registrarId: 'reg-1', name: 'GTIN', primaryKey: 'gtin', linkTemplate: '/{primaryKey}/{value}' },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('validationPattern is required');
+    expect(json.error).toMatch(/^validationPattern:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a validationPattern that does not compile as a regular expression', async () => {
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '[invalid',
+        linkTemplate: '/{primaryKey}/{value}',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('validationPattern: must be a valid regular expression');
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid qualifier (missing key)', async () => {
@@ -203,14 +356,16 @@ describe('POST /api/v1/schemes', () => {
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
         linkTemplate: '/{primaryKey}/{value}',
-        qualifiers: [{ description: 'Lot number' }],
+        qualifiers: [{ description: 'Lot number', validationPattern: '^[A-Za-z0-9]{1,20}$' }],
       },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier key is required');
+    expect(json.error).toMatch(/^qualifiers\.0\.key:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid qualifier (missing description)', async () => {
@@ -221,14 +376,16 @@ describe('POST /api/v1/schemes', () => {
         primaryKey: 'gtin',
         validationPattern: '^\\d{14}$',
         linkTemplate: '/{primaryKey}/{value}',
-        qualifiers: [{ key: 'lot' }],
+        qualifiers: [{ key: 'lot', validationPattern: '^[A-Za-z0-9]{1,20}$' }],
       },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier description is required');
+    expect(json.error).toMatch(/^qualifiers\.0\.description:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid qualifier (missing validationPattern)', async () => {
@@ -246,7 +403,29 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifier validationPattern is required');
+    expect(json.error).toMatch(/^qualifiers\.0\.validationPattern:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a qualifier validationPattern that does not compile as a regular expression', async () => {
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [{ key: 'lot', description: 'Lot number', validationPattern: '[invalid' }],
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('qualifiers.0.validationPattern: must be a valid regular expression');
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for non-array qualifiers', async () => {
@@ -264,7 +443,9 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('qualifiers must be an array');
+    expect(json.error).toMatch(/^qualifiers:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -274,6 +455,8 @@ describe('POST /api/v1/schemes', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toBe('Invalid JSON body');
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 400 for missing linkTemplate', async () => {
@@ -284,7 +467,9 @@ describe('POST /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('linkTemplate is required');
+    expect(json.error).toMatch(/^linkTemplate:/);
+    expect(mockCreateIdentifierScheme).not.toHaveBeenCalled();
+    expect(mockGetRegistrarById).not.toHaveBeenCalled();
   });
 
   it('returns 404 when registrarId does not exist', async () => {
@@ -399,7 +584,7 @@ describe('GET /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('limit must be a positive integer');
+    expect(json.error).toContain('limit: must be a positive integer');
   });
 
   it('returns 400 for negative offset', async () => {
@@ -411,7 +596,48 @@ describe('GET /api/v1/schemes', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('offset must be a non-negative integer');
+    expect(json.error).toContain('offset: must be a non-negative integer');
+  });
+
+  it('rejects a limit above the maximum with a 400 and does not query', async () => {
+    mockListIdentifierSchemes.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: `http://localhost/api/v1/schemes?limit=${MAX_PAGE_LIMIT + 1}`,
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^limit:/);
+    expect(mockListIdentifierSchemes).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty registrarId filter', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/schemes?registrarId=',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^registrarId:/);
+    expect(mockListIdentifierSchemes).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a repeated query key', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/schemes?limit=10&limit=20',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListIdentifierSchemes).not.toHaveBeenCalled();
   });
 
   it('returns 500 when listIdentifierSchemes throws', async () => {

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parseQueryParams } from '@/lib/api/validation';
+import { createSchemeRequestSchema, listSchemesQuerySchema } from '@/lib/api/request-schemas/scheme';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createIdentifierScheme, listIdentifierSchemes, getRegistrarById } from '@/lib/prisma/repositories';
 import { NotFoundError } from '@/lib/api/errors';
-import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/schemes' });
@@ -31,21 +32,27 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *             properties:
  *               registrarId:
  *                 type: string
+ *                 minLength: 1
  *                 description: ID of the parent registrar
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: Human-readable name for the scheme
  *               primaryKey:
  *                 type: string
+ *                 minLength: 1
  *                 description: Primary key identifier (e.g. "gtin", "sscc")
  *               validationPattern:
  *                 type: string
- *                 description: Regular expression pattern for validating identifier values
+ *                 minLength: 1
+ *                 description: Regular expression pattern for validating identifier values. Rejected with a 400 if it does not compile as a regular expression.
  *               linkTemplate:
  *                 type: string
+ *                 minLength: 1
  *                 description: ISO 18975 link template for URI construction (e.g. "/{primaryKey}/{value}")
  *               idrServiceInstanceId:
  *                 type: string
+ *                 minLength: 1
  *                 description: Optional IDR service instance ID
  *               qualifiers:
  *                 type: array
@@ -59,10 +66,20 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *                   properties:
  *                     key:
  *                       type: string
+ *                       minLength: 1
  *                     description:
  *                       type: string
+ *                       minLength: 1
  *                     validationPattern:
  *                       type: string
+ *                       minLength: 1
+ *                       description: Rejected with a 400 if it does not compile as a regular expression.
+ *                     order:
+ *                       type: integer
+ *                       format: int32
+ *                       minimum: 0
+ *                       maximum: 2147483647
+ *                       description: Qualifier precedence in URI ordering (ascending). Defaults to 0.
  *     responses:
  *       201:
  *         description: Scheme created successfully
@@ -71,13 +88,19 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *             schema:
  *               $ref: '#/components/schemas/IdentifierScheme'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. missing required field, a validationPattern that does not compile as a regular expression, a duplicate qualifier key, an idrServiceInstanceId that does not reference an existing service instance)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -102,46 +125,8 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: {
-    registrarId?: string;
-    name?: string;
-    primaryKey?: string;
-    validationPattern?: string;
-    linkTemplate?: string;
-    idrServiceInstanceId?: string;
-    qualifiers?: Array<{
-      key: string;
-      description: string;
-      validationPattern: string;
-      order?: number;
-    }>;
-  };
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ registrarId: body.registrarId, name: body.name }, 'Validating input parameters');
-  if (!isNonEmptyString(body.registrarId)) throw new ValidationError('registrarId is required');
-  if (!isNonEmptyString(body.name)) throw new ValidationError('name is required');
-  if (!isNonEmptyString(body.primaryKey)) throw new ValidationError('primaryKey is required');
-  if (!isNonEmptyString(body.validationPattern)) throw new ValidationError('validationPattern is required');
-  if (!isNonEmptyString(body.linkTemplate)) throw new ValidationError('linkTemplate is required');
-
-  // Validate qualifiers if provided
-  if (body.qualifiers !== undefined) {
-    if (!Array.isArray(body.qualifiers)) {
-      throw new ValidationError('qualifiers must be an array');
-    }
-    for (const q of body.qualifiers) {
-      if (!isNonEmptyString(q.key)) throw new ValidationError('qualifier key is required');
-      if (!isNonEmptyString(q.description)) throw new ValidationError('qualifier description is required');
-      if (!isNonEmptyString(q.validationPattern)) throw new ValidationError('qualifier validationPattern is required');
-    }
-  }
+  logger.info('Validating request body');
+  const body = await parseRequestBody(req, createSchemeRequestSchema);
 
   // Verify the registrar exists and belongs to this tenant
   const registrar = await getRegistrarById(body.registrarId, tenantId);
@@ -185,13 +170,14 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: registrarId
  *         schema:
  *           type: string
+ *           minLength: 1
  *         description: Filter by registrar ID
  *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Maximum number of schemes to return
+ *         description: Number of schemes to return per page. Defaults to 20, or the configured maximum when it is lower. A larger value is rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:
@@ -213,13 +199,19 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *                 pagination:
  *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. a limit above the maximum, a repeated query parameter, an empty registrarId filter)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -233,11 +225,8 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   logger.info('Parsing query parameters');
-  const url = new URL(req.url);
-  const registrarId = url.searchParams.get('registrarId') ?? undefined;
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  const query = parseQueryParams(new URL(req.url), listSchemesQuerySchema);
+  const { registrarId, limit, offset } = query;
 
   logger.info({ registrarId, limit, offset }, 'Listing schemes');
   const { data, total } = await listIdentifierSchemes(tenantId, { registrarId, limit, offset });

--- a/packages/reference-implementation/src/lib/api/request-schemas/scheme.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/scheme.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+import { idSchema, int32Schema, paginationQuerySchema, requireAtLeastOneField } from './shared';
+
+/**
+ * A scheme or qualifier validation pattern, checked to compile as a regular
+ * expression (ADR-037). This is a well-formedness check only; ReDoS
+ * protection against a pattern that compiles but is pathologically slow to
+ * evaluate is a separate concern tracked in #463.
+ */
+const validationPatternSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (pattern) => {
+      try {
+        new RegExp(pattern);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'must be a valid regular expression' },
+  );
+
+/**
+ * A qualifier definition nested under a scheme's `qualifiers` array. `order`
+ * is left optional here to match the repository, which defaults an omitted
+ * order to 0 via the Prisma column default rather than the schema. `order`
+ * is a non-negative position for URI resolution (ascending, from 0); the
+ * upper bound matches the int4 range of the underlying Postgres column, so
+ * an out-of-range value is a 400 at the boundary rather than a 500 from the
+ * database.
+ */
+const schemeQualifierInputSchema = z.object({
+  key: z.string().min(1),
+  description: z.string().min(1),
+  validationPattern: validationPatternSchema,
+  order: int32Schema.min(0).optional(),
+});
+
+/** Request body for POST /schemes. */
+export const createSchemeRequestSchema = z.object({
+  registrarId: idSchema,
+  name: z.string().min(1),
+  primaryKey: z.string().min(1),
+  validationPattern: validationPatternSchema,
+  // Not a URL: an ISO 18975 link template such as "/{primaryKey}/{value}".
+  linkTemplate: z.string().min(1),
+  idrServiceInstanceId: idSchema.optional(),
+  qualifiers: z.array(schemeQualifierInputSchema).optional(),
+});
+
+/** Request body for PATCH /schemes/{id}. Replaces the qualifiers array wholesale when provided. */
+export const updateSchemeRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    primaryKey: z.string().min(1).optional(),
+    validationPattern: validationPatternSchema.optional(),
+    linkTemplate: z.string().min(1).optional(),
+    idrServiceInstanceId: idSchema.nullable().optional(),
+    qualifiers: z.array(schemeQualifierInputSchema).optional(),
+  }),
+  'At least one field is required',
+);
+
+/**
+ * Query parameters for GET /schemes. Merges the `registrarId` filter ahead
+ * of pagination so a malformed filter is reported before a pagination issue
+ * (ADR-037).
+ */
+export const listSchemesQuerySchema = z
+  .object({
+    registrarId: idSchema.optional(),
+  })
+  .merge(paginationQuerySchema);

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.test.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   idSchema,
+  int32Schema,
   locationSchema,
   requireAtLeastOneField,
   nonEmptyArraySchema,
@@ -19,6 +20,37 @@ describe('idSchema', () => {
 
   it('rejects a non-string value', () => {
     expect(idSchema.safeParse(123).success).toBe(false);
+  });
+});
+
+describe('int32Schema', () => {
+  it('accepts zero', () => {
+    expect(int32Schema.safeParse(0)).toEqual({ success: true, data: 0 });
+  });
+
+  it('accepts a negative value', () => {
+    expect(int32Schema.safeParse(-5)).toEqual({ success: true, data: -5 });
+  });
+
+  it('accepts the int32 boundaries', () => {
+    expect(int32Schema.safeParse(-2147483648).success).toBe(true);
+    expect(int32Schema.safeParse(2147483647).success).toBe(true);
+  });
+
+  it('rejects a value above the int32 maximum', () => {
+    expect(int32Schema.safeParse(2147483648).success).toBe(false);
+  });
+
+  it('rejects a value below the int32 minimum', () => {
+    expect(int32Schema.safeParse(-2147483649).success).toBe(false);
+  });
+
+  it('rejects a non-integer number', () => {
+    expect(int32Schema.safeParse(1.5).success).toBe(false);
+  });
+
+  it('rejects a non-numeric value', () => {
+    expect(int32Schema.safeParse('5').success).toBe(false);
   });
 });
 
@@ -68,6 +100,17 @@ describe('requireAtLeastOneField', () => {
   it('rejects a body whose only keys are explicitly undefined', () => {
     const result = updateSchema.safeParse({ name: undefined, age: undefined });
     expect(result.success).toBe(false);
+  });
+
+  it('rejects a body whose only key is unrecognised, exactly like an empty body', () => {
+    // A typo'd field name (e.g. `neme` instead of `name`) must not satisfy the
+    // precondition: it is not one of the schema's own keys, so the wrapped
+    // schema would otherwise strip it to `{}` and silently no-op.
+    const result = updateSchema.safeParse({ neme: 'Widget' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('At least one field must be provided');
+    }
   });
 
   it('leaves a non-object body for the wrapped schema to report its own type error', () => {

--- a/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/shared.ts
@@ -23,6 +23,19 @@ import { MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 export const idSchema = z.string().min(1);
 
 /**
+ * A signed 32-bit integer, matching a Prisma `Int`/Postgres int4 column, so
+ * an out-of-range value is a 400 at the boundary rather than a 500 from the
+ * database. A consumer narrows this further where the column has its own
+ * constraint (e.g. the scheme qualifier `order` field applies `.min(0)` on
+ * top of this, since a qualifier's position cannot be negative). The
+ * services package cannot import this schema (it does not depend on this
+ * package), so its response schema for the same column
+ * (`schemeQualifierSchema.order` in identity-resolver/schemas.ts) inlines the
+ * same (narrowed) bounds; keep the two in sync if either range ever changes.
+ */
+export const int32Schema = z.number().int().min(-2147483648).max(2147483647);
+
+/**
  * UNTP location object, accepted as an open JSON object. No field-level
  * validation is applied anywhere today; a UNTP-shaped location schema is
  * tracked in #804.
@@ -37,13 +50,23 @@ export const locationSchema = z.record(z.unknown());
  * checking the parsed output instead would let a default mask an empty
  * body. A non-object raw body is left untouched so the wrapped schema's own
  * type check produces its usual "Expected object, received X" message.
+ *
+ * Checks only the schema's own recognised keys, not every key present on the
+ * raw body: a body whose only key is unrecognised (e.g. a typo'd field name)
+ * would otherwise satisfy this precondition, get stripped to `{}` by the
+ * wrapped schema's default unknown-key behaviour, and return a silent no-op
+ * 200 instead of a 400.
  */
 export function requireAtLeastOneField<Schema extends z.SomeZodObject>(schema: Schema, message: string) {
   return z.preprocess((raw, ctx) => {
     const isPlainObject = raw !== null && typeof raw === 'object' && !Array.isArray(raw);
-    if (isPlainObject && !Object.values(raw as object).some((value) => value !== undefined)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message });
-      return z.NEVER;
+    if (isPlainObject) {
+      const record = raw as Record<string, unknown>;
+      const hasRecognisedField = Object.keys(schema.shape).some((key) => record[key] !== undefined);
+      if (!hasRecognisedField) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message });
+        return z.NEVER;
+      }
     }
     return raw;
   }, schema);

--- a/packages/services/src/identity-resolver/schemas.ts
+++ b/packages/services/src/identity-resolver/schemas.ts
@@ -27,13 +27,23 @@ export const schemeQualifierSchema = z.object({
   key: z.string().describe('Qualifier key / application identifier code'),
   description: z.string().describe('Human-readable description'),
   validationPattern: z.string().describe('Regex for validating qualifier values'),
-  order: z.number().int().describe('Qualifier precedence in URI ordering (ascending)'),
+  // Non-negative, bounded at the top by the int4 range of the underlying
+  // Postgres column. Mirrors the non-negative int32 bound used for the
+  // request `order` (int32Schema.min(0) in the RI package's
+  // request-schemas/shared.ts; not importable here as this package does not
+  // depend on the RI package), so keep the two in sync.
+  order: z.number().int().min(0).max(2147483647).describe('Qualifier precedence in URI ordering (ascending)'),
   createdAt: z.string().datetime().describe('Timestamp when created'),
   updatedAt: z.string().datetime().describe('Timestamp when last updated'),
 });
 
 /**
- * Identifier scheme record as returned by the REST API.
+ * Identifier scheme record as returned by the REST API. The create, get-by-id,
+ * update, and list handlers all include `qualifiers`; create, get-by-id, and
+ * update also include `registrar`, but list does not, so `registrar` is
+ * marked optional here to match that asymmetry rather than overstating what
+ * the list endpoint returns. (The delete handler returns 204 with no body,
+ * so it has no bearing on this schema.)
  */
 export const identifierSchemeSchema = z.object({
   id: z.string().describe('Database ID'),
@@ -44,6 +54,8 @@ export const identifierSchemeSchema = z.object({
   validationPattern: z.string().describe('Regex for validating identifier values'),
   linkTemplate: z.string().describe('ISO 18975 link template for URI construction'),
   idrServiceInstanceId: z.string().nullable().describe('Associated IDR service instance'),
+  qualifiers: z.array(schemeQualifierSchema).describe('Qualifier definitions attached to this scheme'),
+  registrar: registrarSchema.optional().describe('Parent registrar (omitted on list items)'),
   createdAt: z.string().datetime().describe('Timestamp when created'),
   updatedAt: z.string().datetime().describe('Timestamp when last updated'),
 });


### PR DESCRIPTION
This PR migrates the identifier-schemes routes' request-input validation to a per-resource Zod schema at the route boundary (ADR-037) and runs a comprehensive Swagger congruence pass, so the schemes API documentation matches what the routes actually accept and return.

The POST and PATCH bodies are validated by createSchemeRequestSchema and updateSchemeRequestSchema (reusing the shared idSchema, the validationPattern regex-compile check, and the new int32Schema for the qualifier order field), and the GET list query by listSchemesQuerySchema. A malformed body or query now returns a 400 naming the field, and an over-cap limit is rejected with a 400 rather than silently clamped.

The @swagger blocks are made congruent with the implementation. The 403 that withTenantAuth returns is documented on every route, the PATCH recognised-key rule is expressed as an anyOf of the updatable fields, request and response carry the int32 bounds, and the response $ref matches the repository's Prisma includes.

As the pilot for the input-validation rollout, this change also lands two shared foundation pieces the remaining domains inherit: a reusable int32Schema for Prisma Int body fields, and a fix to requireAtLeastOneField so an all-unknown-key PATCH body is rejected rather than silently accepted as a no-op update. ADR-037 gains a dated Update line recording the fleet conventions.

Closes #791
