### PR TITLE
fix(ri): validate DATA_ENCRYPTION_KEY at startup against stored envelopes

### DIFF
--- a/documentation/docs/reference-implementation/operations/startup.md
+++ b/documentation/docs/reference-implementation/operations/startup.md
@@ -72,7 +72,7 @@ The seed creates the following defaults. Each category is independent — if a r
 
 For example, if `DATA_ENCRYPTION_KEY` is not set, the service instances, default DID, and render templates are all skipped — but the system tenant, registrars, identifier schemes, and data models are still created. The skipped items must be configured before the system can issue, store, or resolve credentials — ensure all required environment variables are set.
 
-When `DATA_ENCRYPTION_KEY` is set, the seed validates it against any existing encrypted data before writing anything: see [Encryption Key Validation](#encryption-key-validation) below for what this checks and how it fails.
+When `DATA_ENCRYPTION_KEY` is set, the seed validates it against any existing encrypted data before it writes any service instance configuration (the system tenant and other non-encrypted records may already exist by that point): see [Encryption Key Validation](#encryption-key-validation) below for what this checks and how it fails.
 
 ### Customising seed data
 
@@ -90,7 +90,7 @@ Once migrations and seeding are complete, the application starts and begins acce
 
 ### Encryption Key Validation
 
-Before the application accepts its first request, it validates the active `DATA_ENCRYPTION_KEY` by decrypting one existing encrypted value — a service instance configuration, or (if none exists yet) a protected credential decryption key. This runs once per process start, using the same check the [seed](#step-2-database-seed) already runs before it writes.
+Before the application accepts its first request, it validates the active `DATA_ENCRYPTION_KEY` by decrypting one existing encrypted value — a service instance configuration, or (when no service instance has a usable one, whether because none exists yet or because every existing configuration is corrupted) a protected credential decryption key. This runs once per process start, using the same check the [seed](#step-2-database-seed) already runs before it writes.
 
 | Situation | Result |
 |-----------|--------|

--- a/documentation/docs/reference-implementation/operations/startup.md
+++ b/documentation/docs/reference-implementation/operations/startup.md
@@ -72,6 +72,8 @@ The seed creates the following defaults. Each category is independent — if a r
 
 For example, if `DATA_ENCRYPTION_KEY` is not set, the service instances, default DID, and render templates are all skipped — but the system tenant, registrars, identifier schemes, and data models are still created. The skipped items must be configured before the system can issue, store, or resolve credentials — ensure all required environment variables are set.
 
+When `DATA_ENCRYPTION_KEY` is set, the seed validates it against any existing encrypted data before writing anything: see [Encryption Key Validation](#encryption-key-validation) below for what this checks and how it fails.
+
 ### Customising seed data
 
 The seed script is located at `packages/reference-implementation/prisma/seed.ts` in the [repository](https://github.com/uncefact/tests-untp). Organisations that need to modify what gets seeded — for example, adding custom identifier schemes or registrars — can edit this file directly.
@@ -85,3 +87,18 @@ A mechanism for supplying custom seed data (such as render templates) via Docker
 ## Step 3: Application Start
 
 Once migrations and seeding are complete, the application starts and begins accepting requests on port 3003.
+
+### Encryption Key Validation
+
+Before the application accepts its first request, it validates the active `DATA_ENCRYPTION_KEY` by decrypting one existing encrypted value — a service instance configuration, or (if none exists yet) a protected credential decryption key. This runs once per process start, using the same check the [seed](#step-2-database-seed) already runs before it writes.
+
+| Situation | Result |
+|-----------|--------|
+| The key decrypts the sample value | Startup proceeds normally |
+| Nothing is encrypted yet (fresh deployment, `DATA_ENCRYPTION_KEY` not yet configured) | Startup proceeds normally — there is nothing to validate against |
+| The key cannot decrypt the sample value | Startup fails with a named error identifying the row that failed to decrypt |
+| `DATA_ENCRYPTION_KEY` is still the placeholder value from `.env.example` | Startup fails outside local development (`DEPLOYMENT_ENVIRONMENT` unset or `local` is treated as local development); a warning is logged and startup proceeds within it |
+
+Without this check, a `DATA_ENCRYPTION_KEY` that does not match the key data was encrypted under only surfaces once a real request tries to decrypt something — for example a `ConfigDecryptionError` when a service instance resolves. Validating at startup turns that into an immediate, loud failure instead of an intermittent one discovered by end users.
+
+If startup fails this check, verify `DATA_ENCRYPTION_KEY` matches the key the application was previously running with. Key rotation is not supported (tracked in [#720](https://github.com/uncefact/tests-untp/issues/720)), so a changed key is not recoverable — restore the previous key rather than trying to move data onto a new one.

--- a/packages/reference-implementation/Dockerfile
+++ b/packages/reference-implementation/Dockerfile
@@ -159,6 +159,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/encryption ./src/lib/encryption
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/prisma/database-url.ts ./src/lib/prisma/database-url.ts
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/decryption-key-protection.ts ./src/lib/credentials/decryption-key-protection.ts
+# Encryption key startup validation, required by prisma/seed.ts (#762)
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts ./src/lib/credentials/validate-encryption-key-startup.ts
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.ts ./src/lib/credentials/backfill-decryption-keys.ts
 # Operator-run maintenance scripts (run via node_modules/.bin/tsx; see each
 # script's header for the in-image invocation)

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -33,6 +33,10 @@ import {
   warnIfDeprecatedEncryptionKeyName,
 } from '../src/lib/encryption/resolve-data-encryption-key.js';
 import {
+  assertNotPlaceholderEncryptionKey,
+  validateEncryptionKeyAtStartup,
+} from '../src/lib/credentials/validate-encryption-key-startup.js';
+import {
   SYSTEM_TENANT_ID,
   SYSTEM_IDR_SERVICE_ID,
   SYSTEM_STORAGE_SERVICE_ID,
@@ -88,7 +92,15 @@ async function main() {
   const ENCRYPTION_KEY = resolvedEncryptionKey.key;
   let encryptionService: AesGcmEncryptionAdapter | null = null;
   if (ENCRYPTION_KEY) {
+    // Refuse (or warn, in local development) the .env.example placeholder
+    // before touching any existing envelope, then confirm the key can
+    // actually decrypt what is already stored — same preflight the
+    // backfill:decryption-keys script runs, so a wrong key is caught here
+    // rather than after this seed re-encrypts the system service instances
+    // under it.
+    assertNotPlaceholderEncryptionKey(ENCRYPTION_KEY, { deploymentEnvironment: process.env.DEPLOYMENT_ENVIRONMENT });
     encryptionService = new AesGcmEncryptionAdapter(ENCRYPTION_KEY, logger);
+    await validateEncryptionKeyAtStartup(prisma, encryptionService);
   } else {
     logger.warn(
       'DATA_ENCRYPTION_KEY not set; skipping service instance seeds (IDR, storage, VC). ' +

--- a/packages/reference-implementation/src/instrumentation.node.ts
+++ b/packages/reference-implementation/src/instrumentation.node.ts
@@ -1,12 +1,17 @@
 /**
- * Node-side OpenTelemetry SDK initialisation.
+ * Node-side process boot: encryption key validation, then OpenTelemetry SDK
+ * initialisation.
  *
  * Loaded dynamically by `instrumentation.ts` at process startup when
- * running under the Node.js runtime. The OTLP exporter targets the
- * local OTel agent sidecar; the SDK does not crash the app on export
- * failure, so running without an observability profile is safe.
+ * running under the Node.js runtime. `register()` there awaits
+ * {@link registerNode}, and Next.js does not start serving requests until
+ * that promise settles (and crashes startup if it rejects), which is what
+ * makes this the right place for a fail-fast check: a DATA_ENCRYPTION_KEY
+ * that cannot decrypt existing data is caught here instead of on the first
+ * request that happens to touch it (#762).
  *
  * @see ../../../docs/observability.md
+ * @see ../../../documentation/docs/reference-implementation/operations/startup.md
  */
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { NodeSDK } from '@opentelemetry/sdk-node';
@@ -15,26 +20,64 @@ import { buildInstrumentations } from './lib/observability/instrumentations';
 import { buildResource } from './lib/observability/resource';
 import { apiLogger } from './lib/api/logger';
 import { warnOnRejectedMaxPageLimitOverride } from './lib/api/pagination';
+import { resolveDataEncryptionKey } from './lib/encryption/resolve-data-encryption-key';
+import { getEncryptionService } from './lib/encryption/encryption';
+import { prisma } from './lib/prisma/prisma';
+import {
+  assertNotPlaceholderEncryptionKey,
+  validateEncryptionKeyAtStartup,
+} from './lib/credentials/validate-encryption-key-startup';
 
-const sdk = new NodeSDK({
-  resource: buildResource(),
-  traceExporter: new OTLPTraceExporter({
-    url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4317',
-  }),
-  instrumentations: buildInstrumentations(),
-});
+export async function registerNode(): Promise<void> {
+  await validateEncryptionKeyOnBoot();
+  startOpenTelemetry();
+}
 
-sdk.start();
+/**
+ * Skipped entirely when DATA_ENCRYPTION_KEY is not set: a deployment with no
+ * encryption configured yet is a supported state (the seed and the service
+ * resolution chain both already tolerate it), so there is nothing to
+ * validate. `resolveDataEncryptionKey` still throws here for divergent
+ * DATA_ENCRYPTION_KEY / SERVICE_ENCRYPTION_KEY values, same as it always
+ * has — this just makes that failure surface at boot instead of on first
+ * use. The deprecated-name warning is left to `getEncryptionService()`
+ * below (it logs the same warning internally) rather than duplicated here.
+ */
+async function validateEncryptionKeyOnBoot(): Promise<void> {
+  const resolved = resolveDataEncryptionKey();
+  if (!resolved.key) {
+    return;
+  }
 
-// Surface an unusable API_MAX_PAGE_LIMIT to the operator once at startup (issue #834).
-warnOnRejectedMaxPageLimitOverride(apiLogger);
+  assertNotPlaceholderEncryptionKey(resolved.key, { deploymentEnvironment: process.env.DEPLOYMENT_ENVIRONMENT });
+  await validateEncryptionKeyAtStartup(prisma, getEncryptionService());
+}
 
-const shutdown = () => {
-  sdk.shutdown().catch((err: unknown) => {
-    // eslint-disable-next-line no-console
-    console.error('OpenTelemetry SDK shutdown failed', err);
+/**
+ * The OpenTelemetry Node SDK only runs in the Node runtime (guarded by the
+ * caller); it does not crash the app on export failure, so running without
+ * an observability profile is safe.
+ */
+function startOpenTelemetry(): void {
+  const sdk = new NodeSDK({
+    resource: buildResource(),
+    traceExporter: new OTLPTraceExporter({
+      url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? 'http://localhost:4317',
+    }),
+    instrumentations: buildInstrumentations(),
   });
-};
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+  sdk.start();
+
+  // Surface an unusable API_MAX_PAGE_LIMIT to the operator once at startup (issue #834).
+  warnOnRejectedMaxPageLimitOverride(apiLogger);
+
+  const shutdown = () => {
+    sdk.shutdown().catch((err: unknown) => {
+      // eslint-disable-next-line no-console
+      console.error('OpenTelemetry SDK shutdown failed', err);
+    });
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}

--- a/packages/reference-implementation/src/instrumentation.ts
+++ b/packages/reference-implementation/src/instrumentation.ts
@@ -2,15 +2,17 @@
  * Next.js instrumentation hook entry point.
  *
  * Next.js 15 fires `register()` once per process at startup, in both
- * the Node and Edge runtimes. The OpenTelemetry Node SDK only runs in
- * the Node runtime, so we guard on `NEXT_RUNTIME` and dynamic-import
- * the Node-side initialiser to keep its dependencies out of the Edge
- * bundle.
+ * the Node and Edge runtimes, and does not start serving requests until
+ * the returned promise settles. Encryption key validation and the
+ * OpenTelemetry Node SDK only run in the Node runtime, so we guard on
+ * `NEXT_RUNTIME` and dynamic-import the Node-side initialiser to keep
+ * its dependencies out of the Edge bundle.
  *
  * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
  */
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    await import('./instrumentation.node');
+    const { registerNode } = await import('./instrumentation.node');
+    await registerNode();
   }
 }

--- a/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.test.ts
@@ -202,6 +202,26 @@ describe('backfillDecryptionKeys', () => {
     expect(rows[0].decryptionKey).toBe('b'.repeat(64));
   });
 
+  it('aborts on a service instance configuration with every required key but null fields, not a confusing crypto error', async () => {
+    const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
+
+    // Has cipherText/iv/tag/type — a presence-only envelope check would
+    // wrongly call this protected, attempt to decrypt it, and abort with a
+    // crypto error ("Unsupported algorithm: null") that reads as a key
+    // problem. It must instead be classified as "not a valid envelope" up
+    // front, hitting the backfill's existing, accurate abort message.
+    const rows: Row[] = [{ id: 'cred-1', decryptionKey: 'b'.repeat(64) }];
+    const serviceInstances: ServiceInstanceRow[] = [
+      { id: 'svc-1', config: '{"cipherText":null,"iv":null,"tag":null,"type":null}' },
+    ];
+    const client = createFakeClient(rows, serviceInstances);
+
+    await expect(backfillDecryptionKeys(client)).rejects.toThrow(
+      'Service instance svc-1 holds a configuration that is not a valid encrypted envelope',
+    );
+    expect(client.credential.update).not.toHaveBeenCalled();
+  });
+
   it('aborts before writing when a service instance configuration cannot be decrypted', async () => {
     const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
 
@@ -261,6 +281,27 @@ describe('backfillDecryptionKeys', () => {
     expect(result.wrapped).toBe(1);
     expect(rows[1].decryptionKey).toBe(suspect);
     expect(isProtectedDecryptionKey(rows[2].decryptionKey as string)).toBe(true);
+  });
+
+  it('skips a credential row with every required key but null fields or an unsupported algorithm, as a suspect row', async () => {
+    const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
+    const { protectDecryptionKey } = await import('./decryption-key-protection');
+
+    // Has cipherText/iv/tag/type — a presence-only envelope check would
+    // wrongly count this as already-protected and skip it silently. It
+    // must instead be flagged as a suspect row for the operator to
+    // investigate, same as any other corrupted envelope-shaped value.
+    const nullFields = '{"cipherText":null,"iv":null,"tag":null,"type":null}';
+    const rows: Row[] = [
+      { id: 'cred-1', decryptionKey: protectDecryptionKey('b'.repeat(64)) },
+      { id: 'cred-2', decryptionKey: nullFields },
+    ];
+    const client = createFakeClient(rows);
+
+    const result = await backfillDecryptionKeys(client);
+
+    expect(result.suspectRowIds).toEqual(['cred-2']);
+    expect(rows[1].decryptionKey).toBe(nullFields);
   });
 
   it('continues past rows deleted between fetch and update, counting them', async () => {

--- a/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.test.ts
@@ -222,6 +222,26 @@ describe('backfillDecryptionKeys', () => {
     expect(client.credential.update).not.toHaveBeenCalled();
   });
 
+  it('aborts on a service instance configuration whose IV is valid Base64 but the wrong decoded length', async () => {
+    const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
+    const { protectDecryptionKey } = await import('./decryption-key-protection');
+
+    // Valid Base64, right shape, right algorithm — but the IV is 8 decoded
+    // bytes, not the 12 AES-256-GCM requires. Node does not reject this at
+    // construction, and the eventual failure throws the exact same error a
+    // genuinely wrong key produces, so this can only be caught structurally.
+    const rows: Row[] = [{ id: 'cred-1', decryptionKey: 'b'.repeat(64) }];
+    const tampered = JSON.parse(protectDecryptionKey('{"apiUrl":"x"}') as string);
+    tampered.iv = Buffer.from('12345678').toString('base64');
+    const serviceInstances: ServiceInstanceRow[] = [{ id: 'svc-1', config: JSON.stringify(tampered) }];
+    const client = createFakeClient(rows, serviceInstances);
+
+    await expect(backfillDecryptionKeys(client)).rejects.toThrow(
+      'Service instance svc-1 holds a configuration that is not a valid encrypted envelope',
+    );
+    expect(client.credential.update).not.toHaveBeenCalled();
+  });
+
   it('aborts before writing when a service instance configuration cannot be decrypted', async () => {
     const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
 
@@ -302,6 +322,25 @@ describe('backfillDecryptionKeys', () => {
 
     expect(result.suspectRowIds).toEqual(['cred-2']);
     expect(rows[1].decryptionKey).toBe(nullFields);
+  });
+
+  it('flags a credential row whose tag is valid Base64 but the wrong decoded length, as a suspect row', async () => {
+    const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
+    const { protectDecryptionKey } = await import('./decryption-key-protection');
+
+    const tampered = JSON.parse(protectDecryptionKey('c'.repeat(64)) as string);
+    tampered.tag = Buffer.from('too-short').toString('base64');
+    const wrongLengthTag = JSON.stringify(tampered);
+    const rows: Row[] = [
+      { id: 'cred-1', decryptionKey: protectDecryptionKey('b'.repeat(64)) },
+      { id: 'cred-2', decryptionKey: wrongLengthTag },
+    ];
+    const client = createFakeClient(rows);
+
+    const result = await backfillDecryptionKeys(client);
+
+    expect(result.suspectRowIds).toEqual(['cred-2']);
+    expect(rows[1].decryptionKey).toBe(wrongLengthTag);
   });
 
   it('continues past rows deleted between fetch and update, counting them', async () => {

--- a/packages/reference-implementation/src/lib/credentials/decryption-key-protection.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/decryption-key-protection.test.ts
@@ -73,6 +73,20 @@ describe('isProtectedDecryptionKey', () => {
     expect(isProtectedDecryptionKey('{"cipherText":null,"iv":null,"tag":null,"type":null}')).toBe(false);
     expect(isProtectedDecryptionKey('{"cipherText":"a","iv":"b","tag":"c","type":"des-ede3-cbc"}')).toBe(false);
   });
+
+  it('returns false for a genuinely well-formed-JSON envelope whose IV decodes to the wrong byte length', async () => {
+    const { protectDecryptionKey, isProtectedDecryptionKey } = await import('./decryption-key-protection');
+
+    // Valid Base64, right shape, right algorithm — but the IV is 8 decoded
+    // bytes, not the 12 AES-256-GCM requires. Node does not reject this
+    // until decrypt's final auth check, with the same error a wrong key
+    // produces, so this can only be caught structurally, before decrypt.
+    const stored = protectDecryptionKey('b'.repeat(64)) as string;
+    const tampered = JSON.parse(stored);
+    tampered.iv = Buffer.from('12345678').toString('base64');
+
+    expect(isProtectedDecryptionKey(JSON.stringify(tampered))).toBe(false);
+  });
 });
 
 describe('looksEnvelopeLikeButInvalid', () => {
@@ -86,6 +100,16 @@ describe('looksEnvelopeLikeButInvalid', () => {
     const { looksEnvelopeLikeButInvalid } = await import('./decryption-key-protection');
     expect(looksEnvelopeLikeButInvalid('{"cipherText":null,"iv":null,"tag":null,"type":null}')).toBe(true);
     expect(looksEnvelopeLikeButInvalid('{"cipherText":"a","iv":"b","tag":"c","type":"des-ede3-cbc"}')).toBe(true);
+  });
+
+  it('flags a well-formed-JSON envelope whose tag decodes to the wrong byte length', async () => {
+    const { protectDecryptionKey, looksEnvelopeLikeButInvalid } = await import('./decryption-key-protection');
+
+    const stored = protectDecryptionKey('b'.repeat(64)) as string;
+    const tampered = JSON.parse(stored);
+    tampered.tag = Buffer.from('too-short').toString('base64');
+
+    expect(looksEnvelopeLikeButInvalid(JSON.stringify(tampered))).toBe(true);
   });
 
   it('accepts genuine envelopes and plausible legacy plaintext', async () => {
@@ -134,6 +158,19 @@ describe('revealDecryptionKey', () => {
     // would throw "Unsupported algorithm: null" — a corruption problem,
     // not a DATA_ENCRYPTION_KEY mismatch, so it must not surface as one.
     const corrupted = '{"cipherText":null,"iv":null,"tag":null,"type":null}';
+
+    expect(revealDecryptionKey(corrupted)).toBe(corrupted);
+    expect(mockWarn).toHaveBeenCalled();
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('warns and returns unchanged for a well-formed-JSON envelope whose IV decodes to the wrong byte length, rather than misreporting it as a key mismatch', async () => {
+    const { protectDecryptionKey, revealDecryptionKey } = await import('./decryption-key-protection');
+
+    const stored = protectDecryptionKey('b'.repeat(64)) as string;
+    const tampered = JSON.parse(stored);
+    tampered.iv = Buffer.from('12345678').toString('base64');
+    const corrupted = JSON.stringify(tampered);
 
     expect(revealDecryptionKey(corrupted)).toBe(corrupted);
     expect(mockWarn).toHaveBeenCalled();

--- a/packages/reference-implementation/src/lib/credentials/decryption-key-protection.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/decryption-key-protection.test.ts
@@ -64,6 +64,15 @@ describe('isProtectedDecryptionKey', () => {
     expect(isProtectedDecryptionKey('1'.repeat(64))).toBe(false);
     expect(isProtectedDecryptionKey('{"foo":"bar"}')).toBe(false);
   });
+
+  it('returns false for a value with the right keys but null fields or an unsupported algorithm', async () => {
+    const { isProtectedDecryptionKey } = await import('./decryption-key-protection');
+    // Has every required key (so a presence-only check would wrongly call
+    // this "protected"), but none of the values are usable — corruption,
+    // not a genuine envelope.
+    expect(isProtectedDecryptionKey('{"cipherText":null,"iv":null,"tag":null,"type":null}')).toBe(false);
+    expect(isProtectedDecryptionKey('{"cipherText":"a","iv":"b","tag":"c","type":"des-ede3-cbc"}')).toBe(false);
+  });
 });
 
 describe('looksEnvelopeLikeButInvalid', () => {
@@ -71,6 +80,12 @@ describe('looksEnvelopeLikeButInvalid', () => {
     const { looksEnvelopeLikeButInvalid } = await import('./decryption-key-protection');
     expect(looksEnvelopeLikeButInvalid('{"cipherText":"q1w2')).toBe(true);
     expect(looksEnvelopeLikeButInvalid('{"foo":"bar"}')).toBe(true);
+  });
+
+  it('flags a value with every required key but null fields or an unsupported algorithm', async () => {
+    const { looksEnvelopeLikeButInvalid } = await import('./decryption-key-protection');
+    expect(looksEnvelopeLikeButInvalid('{"cipherText":null,"iv":null,"tag":null,"type":null}')).toBe(true);
+    expect(looksEnvelopeLikeButInvalid('{"cipherText":"a","iv":"b","tag":"c","type":"des-ede3-cbc"}')).toBe(true);
   });
 
   it('accepts genuine envelopes and plausible legacy plaintext', async () => {
@@ -109,6 +124,20 @@ describe('revealDecryptionKey', () => {
 
     expect(revealDecryptionKey(truncatedEnvelope)).toBe(truncatedEnvelope);
     expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('warns and returns unchanged for a value with every required key but null fields, rather than misreporting it as a key mismatch', async () => {
+    const { revealDecryptionKey } = await import('./decryption-key-protection');
+
+    // Every field present (so the old, presence-only predicate treated this
+    // as a genuine envelope), but the values are null. Decrypting this
+    // would throw "Unsupported algorithm: null" — a corruption problem,
+    // not a DATA_ENCRYPTION_KEY mismatch, so it must not surface as one.
+    const corrupted = '{"cipherText":null,"iv":null,"tag":null,"type":null}';
+
+    expect(revealDecryptionKey(corrupted)).toBe(corrupted);
+    expect(mockWarn).toHaveBeenCalled();
+    expect(mockError).not.toHaveBeenCalled();
   });
 
   it('returns a legacy all-digit key unchanged', async () => {

--- a/packages/reference-implementation/src/lib/credentials/decryption-key-protection.ts
+++ b/packages/reference-implementation/src/lib/credentials/decryption-key-protection.ts
@@ -75,7 +75,14 @@ export function looksEnvelopeLikeButInvalid(stored: string): boolean {
   return stored.startsWith('{') && parseEnvelope(stored) === null;
 }
 
-function parseEnvelope(stored: string): EncryptedEnvelope | null {
+/**
+ * Parses a stored value as an encrypted envelope, returning `null` when it
+ * is not valid JSON or does not have the envelope shape. Exported so other
+ * modules that need the same "is this a genuine envelope" check (rather
+ * than just decrypting) do not re-implement the JSON.parse-plus-shape-check
+ * pairing — see validate-encryption-key-startup.ts.
+ */
+export function parseEnvelope(stored: string): EncryptedEnvelope | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(stored);

--- a/packages/reference-implementation/src/lib/credentials/decryption-key-protection.ts
+++ b/packages/reference-implementation/src/lib/credentials/decryption-key-protection.ts
@@ -1,4 +1,8 @@
-import { EncryptionAlgorithm, isEncryptedEnvelope } from '@uncefact/untp-ri-services/encryption';
+import {
+  EncryptionAlgorithm,
+  isEncryptedEnvelope,
+  hasValidEnvelopeStructure,
+} from '@uncefact/untp-ri-services/encryption';
 import type { EncryptedEnvelope } from '@uncefact/untp-ri-services/encryption';
 // Relative imports (not the @/ alias): this module runs inside the Docker
 // image via tsx, where no tsconfig.json exists to resolve path aliases.
@@ -77,10 +81,15 @@ export function looksEnvelopeLikeButInvalid(stored: string): boolean {
 
 /**
  * Parses a stored value as an encrypted envelope, returning `null` when it
- * is not valid JSON or does not have the envelope shape. Exported so other
- * modules that need the same "is this a genuine envelope" check (rather
- * than just decrypting) do not re-implement the JSON.parse-plus-shape-check
- * pairing — see validate-encryption-key-startup.ts.
+ * is not valid JSON, does not have the envelope shape, or is envelope-shaped
+ * with fields that decode to the wrong byte length for its algorithm (a
+ * genuine IV/tag length problem, not a `DATA_ENCRYPTION_KEY` mismatch — see
+ * `hasValidEnvelopeStructure`'s own doc comment for why this must be
+ * checked before decrypting rather than inferred from decrypt's error).
+ * Exported so other modules that need the same "is this a genuine,
+ * decrypt-safe envelope" check (rather than just decrypting) do not
+ * re-implement the parse-shape-structure pipeline — see
+ * validate-encryption-key-startup.ts.
  */
 export function parseEnvelope(stored: string): EncryptedEnvelope | null {
   let parsed: unknown;
@@ -89,7 +98,10 @@ export function parseEnvelope(stored: string): EncryptedEnvelope | null {
   } catch {
     return null;
   }
-  return isEncryptedEnvelope(parsed) ? parsed : null;
+  if (!isEncryptedEnvelope(parsed)) {
+    return null;
+  }
+  return hasValidEnvelopeStructure(parsed) ? parsed : null;
 }
 
 function warnIfEnvelopeLike(stored: string): void {

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
@@ -218,6 +218,28 @@ describe('validateEncryptionKeyAtStartup', () => {
     });
   });
 
+  it('finds a valid service instance candidate on the second page, proving cursor traversal past the first batch', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // The scan fetches 100 rows per batch; the first 100 (page 1) are all
+    // corrupted, and only the 101st (page 2) is a genuine, valid envelope.
+    // If cursor pagination stopped after the first batch, this candidate
+    // would never be reached and the check would wrongly conclude nothing
+    // encrypted exists.
+    const serviceInstances: ServiceInstanceRow[] = Array.from({ length: 100 }, (_, index) => ({
+      id: `svc-${String(index).padStart(3, '0')}`,
+      config: '{"cipherText":"truncated',
+    }));
+    serviceInstances.push({ id: 'svc-100', config: await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}') });
+    const client = createFakeClient(serviceInstances);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'service-instance', id: 'svc-100' });
+    expect(client.serviceInstance.findMany).toHaveBeenCalledTimes(2);
+  });
+
   it('falls back to a protected credential decryption key when no service instance exists', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
     const encryptionService = await buildEncryptionService(ACTIVE_KEY);
@@ -333,6 +355,27 @@ describe('validateEncryptionKeyAtStartup', () => {
       orderBy: { id: 'asc' },
       take: 100,
     });
+  });
+
+  it('finds a valid credential candidate on the second page, proving cursor traversal past the first batch', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // Same shape as the service instance pagination test: the first 100
+    // candidates (page 1) are all corrupted, and only the 101st (page 2)
+    // genuinely validates. If cursor pagination stopped after the first
+    // batch, the check would wrongly conclude nothing encrypted exists.
+    const credentials: CredentialRow[] = Array.from({ length: 100 }, (_, index) => ({
+      id: `cred-${String(index).padStart(3, '0')}`,
+      decryptionKey: '{"cipherText":"truncated',
+    }));
+    credentials.push({ id: 'cred-100', decryptionKey: await encryptUnder(ACTIVE_KEY, 'b'.repeat(64)) });
+    const client = createFakeClient([], credentials);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'credential', id: 'cred-100' });
+    expect(client.credential.findMany).toHaveBeenCalledTimes(2);
   });
 
   it('prefers a valid service instance over a credential when both exist', async () => {

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
@@ -1,0 +1,236 @@
+export {};
+
+import fs from 'fs';
+import path from 'path';
+
+const mockWarn = jest.fn();
+const mockError = jest.fn();
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: { child: () => ({ info: jest.fn(), warn: mockWarn, error: mockError }) },
+}));
+
+const originalEnv = process.env;
+
+const ACTIVE_KEY = 'a'.repeat(64);
+const OTHER_KEY = 'd'.repeat(64);
+const PLACEHOLDER_KEY = '0'.repeat(64);
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  process.env = { ...originalEnv, DATA_ENCRYPTION_KEY: ACTIVE_KEY };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+type ServiceInstanceRow = { id: string; config: string };
+type CredentialRow = { id: string; decryptionKey: string | null };
+
+function createFakeClient(serviceInstances: ServiceInstanceRow[] = [], credentials: CredentialRow[] = []) {
+  return {
+    serviceInstance: {
+      findFirst: jest.fn(async () => serviceInstances[0] ?? null),
+    },
+    credential: {
+      findFirst: jest.fn(async () => credentials.find((row) => row.decryptionKey?.startsWith('{')) ?? null),
+    },
+  };
+}
+
+async function encryptUnder(key: string, plaintext: string): Promise<string> {
+  const { AesGcmEncryptionAdapter, EncryptionAlgorithm } = await import('@uncefact/untp-ri-services/encryption');
+  const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+  logger.child.mockReturnValue(logger);
+  const adapter = new AesGcmEncryptionAdapter(key, logger as never);
+  return JSON.stringify(adapter.encrypt(plaintext, EncryptionAlgorithm.AES_256_GCM));
+}
+
+describe('validateEncryptionKeyAtStartup', () => {
+  it('validates against a service instance configuration and returns its id', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    const config = await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}');
+    const client = createFakeClient([{ id: 'svc-1', config }]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'service-instance', id: 'svc-1' });
+  });
+
+  it('throws a named EncryptionKeyValidationError naming the service instance when the key cannot decrypt it', async () => {
+    const { validateEncryptionKeyAtStartup, EncryptionKeyValidationError } = await import(
+      './validate-encryption-key-startup'
+    );
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    // Config was encrypted under a key different from the one the app is
+    // now running with — exactly the "wrong key deployed" scenario #762
+    // exists to catch before a real request hits it.
+    const config = await encryptUnder(OTHER_KEY, '{"apiUrl":"x"}');
+    const client = createFakeClient([{ id: 'svc-1', config }]);
+
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow(
+      EncryptionKeyValidationError,
+    );
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('svc-1');
+    expect(mockError).toHaveBeenCalled();
+  });
+
+  it('falls back to a protected credential decryption key when no service instance exists', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    const decryptionKey = await encryptUnder(ACTIVE_KEY, 'b'.repeat(64));
+    const client = createFakeClient([], [{ id: 'cred-1', decryptionKey }]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'credential', id: 'cred-1' });
+  });
+
+  it('throws naming the credential when its envelope was encrypted under a different key', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    const decryptionKey = await encryptUnder(OTHER_KEY, 'b'.repeat(64));
+    const client = createFakeClient([], [{ id: 'cred-1', decryptionKey }]);
+
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('cred-1');
+  });
+
+  it('returns validated: false when nothing encrypted exists anywhere, so startup proceeds normally', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    const client = createFakeClient([], []);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: false });
+  });
+
+  it('returns validated: false when only legacy plaintext credential keys exist, not treating them as an envelope', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    const client = createFakeClient([], [{ id: 'cred-1', decryptionKey: 'b'.repeat(64) }]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: false });
+  });
+
+  it('returns validated: false for a corrupted envelope-like credential row instead of misreporting it as a key mismatch', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    // Starts with "{" (so the DB-level startsWith filter would return it as
+    // a candidate) but is not a valid encrypted envelope — corruption, not
+    // a key mismatch. isProtectedDecryptionKey must reject this before the
+    // code ever attempts to decrypt it as a validation sample.
+    const client = createFakeClient([], [{ id: 'cred-1', decryptionKey: '{"cipherText":"truncated' }]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: false });
+  });
+
+  it('prefers the service instance over a credential when both exist', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+
+    const config = await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}');
+    const decryptionKey = await encryptUnder(OTHER_KEY, 'b'.repeat(64));
+    const client = createFakeClient([{ id: 'svc-1', config }], [{ id: 'cred-1', decryptionKey }]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    // The credential envelope is under a different key, but it is never
+    // consulted because a service instance was found first.
+    expect(result).toEqual({ validated: true, source: 'service-instance', id: 'svc-1' });
+    expect(client.credential.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertNotPlaceholderEncryptionKey', () => {
+  it('does nothing for a real key regardless of environment', async () => {
+    const { assertNotPlaceholderEncryptionKey } = await import('./validate-encryption-key-startup');
+    expect(() => assertNotPlaceholderEncryptionKey(ACTIVE_KEY, { deploymentEnvironment: 'production' })).not.toThrow();
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('warns and proceeds for the placeholder key in local development', async () => {
+    const { assertNotPlaceholderEncryptionKey } = await import('./validate-encryption-key-startup');
+    expect(() => assertNotPlaceholderEncryptionKey(PLACEHOLDER_KEY, { deploymentEnvironment: 'local' })).not.toThrow();
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('defaults to local (and warns rather than throws) when DEPLOYMENT_ENVIRONMENT is unset', async () => {
+    const { assertNotPlaceholderEncryptionKey } = await import('./validate-encryption-key-startup');
+    delete process.env.DEPLOYMENT_ENVIRONMENT;
+    expect(() => assertNotPlaceholderEncryptionKey(PLACEHOLDER_KEY)).not.toThrow();
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('refuses the placeholder key outside local development', async () => {
+    const { assertNotPlaceholderEncryptionKey, PlaceholderEncryptionKeyError } = await import(
+      './validate-encryption-key-startup'
+    );
+    expect(() => assertNotPlaceholderEncryptionKey(PLACEHOLDER_KEY, { deploymentEnvironment: 'production' })).toThrow(
+      PlaceholderEncryptionKeyError,
+    );
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty or whitespace-only DEPLOYMENT_ENVIRONMENT as absent (defaults to local)', async () => {
+    const { assertNotPlaceholderEncryptionKey } = await import('./validate-encryption-key-startup');
+    expect(() => assertNotPlaceholderEncryptionKey(PLACEHOLDER_KEY, { deploymentEnvironment: '   ' })).not.toThrow();
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('matches "local" case-insensitively', async () => {
+    const { assertNotPlaceholderEncryptionKey } = await import('./validate-encryption-key-startup');
+    expect(() => assertNotPlaceholderEncryptionKey(PLACEHOLDER_KEY, { deploymentEnvironment: 'Local' })).not.toThrow();
+    expect(mockWarn).toHaveBeenCalled();
+  });
+});
+
+describe('.env.example placeholder stays in sync with the detector', () => {
+  it('matches the DATA_ENCRYPTION_KEY committed in .env.example', () => {
+    const envExamplePath = path.resolve(__dirname, '../../../../../.env.example');
+    const contents = fs.readFileSync(envExamplePath, 'utf-8');
+    const match = contents.match(/^DATA_ENCRYPTION_KEY=(.*)$/m);
+
+    expect(match).not.toBeNull();
+    // If .env.example ever changes this value, the detector must change
+    // with it, or it silently stops recognising the published placeholder.
+    expect(match?.[1]).toBe('0'.repeat(64));
+  });
+});

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
@@ -27,6 +27,12 @@ afterAll(() => {
 
 type ServiceInstanceRow = { id: string; config: string };
 type CredentialRow = { id: string; decryptionKey: string | null };
+type ServiceInstanceFindManyArgs = {
+  where?: { id: { gt: string } };
+  select: { id: true; config: true };
+  orderBy: { id: 'asc' };
+  take: number;
+};
 type CredentialFindManyArgs = {
   where: { decryptionKey: { startsWith: string }; id?: { gt: string } };
   select: { id: true; decryptionKey: true };
@@ -38,13 +44,20 @@ type CredentialFindManyArgs = {
  * Mirrors backfill-decryption-keys.test.ts's fake client: it actually
  * applies the `where`/cursor/`take` arguments the code sends (rather than
  * ignoring them and returning canned data), so a test can prove the
- * production code queries with the right filter — see "queries credential
- * candidates with the expected filter" below.
+ * production code queries with the right filter — see the two "queries ...
+ * with the expected" tests below.
  */
 function createFakeClient(serviceInstances: ServiceInstanceRow[] = [], credentials: CredentialRow[] = []) {
   return {
     serviceInstance: {
-      findFirst: jest.fn(async () => serviceInstances[0] ?? null),
+      findMany: jest.fn(
+        async (args: ServiceInstanceFindManyArgs): Promise<ServiceInstanceRow[]> =>
+          serviceInstances
+            .filter((row) => (args.where ? row.id > args.where.id.gt : true))
+            .sort((a, b) => a.id.localeCompare(b.id))
+            .slice(0, args.take)
+            .map((row) => ({ id: row.id, config: row.config })),
+      ),
     },
     credential: {
       findMany: jest.fn(
@@ -107,34 +120,76 @@ describe('validateEncryptionKeyAtStartup', () => {
     expect(mockError).toHaveBeenCalled();
   });
 
-  it('throws a CorruptedEnvelopeError (not a key-mismatch error) for a service instance configuration that is not valid JSON', async () => {
-    const { validateEncryptionKeyAtStartup, CorruptedEnvelopeError, EncryptionKeyValidationError } = await import(
-      './validate-encryption-key-startup'
-    );
+  it('skips a corrupted service instance candidate and validates against a later genuinely valid one', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
     const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
-    // Truncated JSON: every service instance config is written encrypted
-    // (no legacy plaintext form), so a value that doesn't even parse is
-    // corruption, not evidence the key is wrong. Attributing this to
-    // DATA_ENCRYPTION_KEY would send an operator chasing the wrong fix.
-    const client = createFakeClient([{ id: 'svc-1', config: '{"cipherText":"truncated' }]);
+    // "a-corrupt" sorts before "z-valid" in id order, so it is the first
+    // candidate the scan reaches. A damaged config on one row must not stop
+    // startup from finding and validating against another, genuinely valid
+    // one — a multi-tenant deployment can have many service instances.
+    const client = createFakeClient([
+      { id: 'a-corrupt', config: '{"cipherText":"truncated' },
+      { id: 'z-valid', config: await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}') },
+    ]);
 
-    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow(CorruptedEnvelopeError);
-    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('svc-1');
-    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.not.toThrow(
-      EncryptionKeyValidationError,
-    );
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'service-instance', id: 'z-valid' });
+    expect(mockWarn).toHaveBeenCalled();
   });
 
-  it('throws a CorruptedEnvelopeError for a service instance configuration that is valid JSON but not envelope-shaped', async () => {
-    const { validateEncryptionKeyAtStartup, CorruptedEnvelopeError } = await import(
+  it('skips a corrupted service instance candidate and still catches a wrong key on a later valid one', async () => {
+    const { validateEncryptionKeyAtStartup, EncryptionKeyValidationError } = await import(
       './validate-encryption-key-startup'
     );
     const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
-    const client = createFakeClient([{ id: 'svc-1', config: '{"foo":"bar"}' }]);
+    // The corrupted row must not be mistaken for "nothing to validate" and
+    // let a genuinely wrong key on "w-wrongkey" survive startup.
+    const client = createFakeClient([
+      { id: 'a-corrupt', config: '{"cipherText":"truncated' },
+      { id: 'w-wrongkey', config: await encryptUnder(OTHER_KEY, '{"apiUrl":"x"}') },
+    ]);
 
-    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow(CorruptedEnvelopeError);
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow(
+      EncryptionKeyValidationError,
+    );
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('w-wrongkey');
+  });
+
+  it('falls through to a credential when every service instance candidate is corrupted', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // No service instance is usable as a sample, but that must not crash
+    // the process, and must not stop the check falling through to a
+    // credential envelope that can still validate the key.
+    const decryptionKey = await encryptUnder(ACTIVE_KEY, 'b'.repeat(64));
+    const client = createFakeClient(
+      [{ id: 'svc-corrupt', config: '{"cipherText":"truncated' }],
+      [{ id: 'cred-1', decryptionKey }],
+    );
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'credential', id: 'cred-1' });
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('queries service instance candidates with the expected selection and ordering', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    const client = createFakeClient([], []);
+
+    await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(client.serviceInstance.findMany).toHaveBeenCalledWith({
+      select: { id: true, config: true },
+      orderBy: { id: 'asc' },
+      take: 100,
+    });
   });
 
   it('falls back to a protected credential decryption key when no service instance exists', async () => {
@@ -196,7 +251,7 @@ describe('validateEncryptionKeyAtStartup', () => {
     expect(result).toEqual({ validated: false });
   });
 
-  it('scans past a corrupted candidate to a genuinely wrong-key row, instead of reporting nothing encrypted', async () => {
+  it('scans past a corrupted candidate to a genuinely wrong-key credential row, instead of reporting nothing encrypted', async () => {
     const { validateEncryptionKeyAtStartup, EncryptionKeyValidationError } = await import(
       './validate-encryption-key-startup'
     );
@@ -221,7 +276,7 @@ describe('validateEncryptionKeyAtStartup', () => {
     await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('w-wrongkey');
   });
 
-  it('scans past a corrupted candidate to find a genuinely valid envelope under the active key', async () => {
+  it('scans past a corrupted candidate to find a genuinely valid credential envelope under the active key', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
     const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
@@ -254,7 +309,7 @@ describe('validateEncryptionKeyAtStartup', () => {
     });
   });
 
-  it('prefers the service instance over a credential when both exist', async () => {
+  it('prefers a valid service instance over a credential when both exist', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
     const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
@@ -265,7 +320,7 @@ describe('validateEncryptionKeyAtStartup', () => {
     const result = await validateEncryptionKeyAtStartup(client, encryptionService);
 
     // The credential envelope is under a different key, but it is never
-    // consulted because a service instance was found first.
+    // consulted because a valid service instance was found first.
     expect(result).toEqual({ validated: true, source: 'service-instance', id: 'svc-1' });
     expect(client.credential.findMany).not.toHaveBeenCalled();
   });

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
@@ -184,6 +184,65 @@ describe('validateEncryptionKeyAtStartup', () => {
     expect(mockError).not.toHaveBeenCalled();
   });
 
+  it('warn-skips a service instance candidate whose cipherText/iv/tag decode to 0 bytes, instead of crash-looping', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // Exact reported repro: single-character fields decode leniently to 0
+    // bytes via Node's Buffer.from(str, 'base64') instead of throwing, so a
+    // shape-and-type-only check waved this through. That reached decrypt(),
+    // which threw "Invalid initialization vector" — a structural error
+    // decryptOrThrow used to mislabel as EncryptionKeyValidationError and
+    // crash-loop the whole process.
+    const zeroByteFields = '{"cipherText":"a","iv":"b","tag":"c","type":"aes-256-gcm"}';
+    const client = createFakeClient([
+      { id: 'a-zero-byte-fields', config: zeroByteFields },
+      { id: 'z-valid', config: await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}') },
+    ]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'service-instance', id: 'z-valid' });
+    expect(mockWarn).toHaveBeenCalled();
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('degrades to validated: false, not a crash, when the only candidate has zero-byte fields', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    const zeroByteFields = '{"cipherText":"a","iv":"b","tag":"c","type":"aes-256-gcm"}';
+    const client = createFakeClient([{ id: 'a-zero-byte-fields', config: zeroByteFields }]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: false });
+  });
+
+  it('warn-skips a service instance candidate whose IV is valid Base64 but the wrong decoded length', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // Distinct from the 0-byte case: this IV is properly-formatted,
+    // non-empty Base64 that decodes to 8 bytes instead of the 12
+    // AES-256-GCM requires. Node does not reject this at construction, and
+    // the eventual failure throws the identical error a genuinely wrong key
+    // produces, so this can only be caught by checking the decoded length
+    // before decrypting.
+    const goodEnvelope = JSON.parse(await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}'));
+    const wrongLengthIv = { ...goodEnvelope, iv: Buffer.from('12345678').toString('base64') };
+    const client = createFakeClient([
+      { id: 'a-wrong-iv-length', config: JSON.stringify(wrongLengthIv) },
+      { id: 'z-valid', config: await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}') },
+    ]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'service-instance', id: 'z-valid' });
+    expect(mockWarn).toHaveBeenCalled();
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
   it('falls through to a credential when every service instance candidate is corrupted', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
     const encryptionService = await buildEncryptionService(ACTIVE_KEY);
@@ -339,6 +398,32 @@ describe('validateEncryptionKeyAtStartup', () => {
     const result = await validateEncryptionKeyAtStartup(client, encryptionService);
 
     expect(result).toEqual({ validated: true, source: 'credential', id: 'z-valid' });
+  });
+
+  it('warn-skips a credential candidate whose IV is valid Base64 but the wrong decoded length', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // Same class as the service instance case: valid, non-empty Base64
+    // that decodes to the wrong byte count. Node does not reject this
+    // until decrypt's final auth check, with the identical error a
+    // genuinely wrong key produces, so this can only be caught
+    // structurally, before decrypt.
+    const goodEnvelope = JSON.parse(await encryptUnder(ACTIVE_KEY, 'b'.repeat(64)));
+    const wrongLengthIv = { ...goodEnvelope, iv: Buffer.from('12345678').toString('base64') };
+    const client = createFakeClient(
+      [],
+      [
+        { id: 'a-wrong-iv-length', decryptionKey: JSON.stringify(wrongLengthIv) },
+        { id: 'z-valid', decryptionKey: await encryptUnder(ACTIVE_KEY, 'b'.repeat(64)) },
+      ],
+    );
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'credential', id: 'z-valid' });
+    expect(mockWarn).toHaveBeenCalled();
+    expect(mockError).not.toHaveBeenCalled();
   });
 
   it('queries credential candidates with the expected filter, selection, and ordering', async () => {

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
@@ -158,6 +158,32 @@ describe('validateEncryptionKeyAtStartup', () => {
     await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('w-wrongkey');
   });
 
+  it('warn-skips a service instance candidate with an unsupported algorithm, instead of throwing it as a key mismatch', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // Has every required key (cipherText/iv/tag/type), so a presence-only
+    // envelope check would call this genuine and attempt to decrypt it,
+    // which throws "Unsupported algorithm: des-ede3-cbc" — a corruption
+    // problem, not a DATA_ENCRYPTION_KEY mismatch. It must be classified as
+    // shape-invalid up front and skipped like any other corrupted
+    // candidate, falling through to a later valid one instead.
+    const unsupportedAlgorithm = '{"cipherText":"a","iv":"b","tag":"c","type":"des-ede3-cbc"}';
+    const client = createFakeClient([
+      { id: 'a-unsupported-algo', config: unsupportedAlgorithm },
+      { id: 'z-valid', config: await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}') },
+    ]);
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    // Resolving to a valid result (rather than rejecting with
+    // EncryptionKeyValidationError) is itself the proof that the
+    // unsupported-algorithm candidate was skipped, not decrypted-and-failed.
+    expect(result).toEqual({ validated: true, source: 'service-instance', id: 'z-valid' });
+    expect(mockWarn).toHaveBeenCalled();
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
   it('falls through to a credential when every service instance candidate is corrupted', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
     const encryptionService = await buildEncryptionService(ACTIVE_KEY);

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.test.ts
@@ -27,14 +27,35 @@ afterAll(() => {
 
 type ServiceInstanceRow = { id: string; config: string };
 type CredentialRow = { id: string; decryptionKey: string | null };
+type CredentialFindManyArgs = {
+  where: { decryptionKey: { startsWith: string }; id?: { gt: string } };
+  select: { id: true; decryptionKey: true };
+  orderBy: { id: 'asc' };
+  take: number;
+};
 
+/**
+ * Mirrors backfill-decryption-keys.test.ts's fake client: it actually
+ * applies the `where`/cursor/`take` arguments the code sends (rather than
+ * ignoring them and returning canned data), so a test can prove the
+ * production code queries with the right filter — see "queries credential
+ * candidates with the expected filter" below.
+ */
 function createFakeClient(serviceInstances: ServiceInstanceRow[] = [], credentials: CredentialRow[] = []) {
   return {
     serviceInstance: {
       findFirst: jest.fn(async () => serviceInstances[0] ?? null),
     },
     credential: {
-      findFirst: jest.fn(async () => credentials.find((row) => row.decryptionKey?.startsWith('{')) ?? null),
+      findMany: jest.fn(
+        async (args: CredentialFindManyArgs): Promise<CredentialRow[]> =>
+          credentials
+            .filter((row) => row.decryptionKey?.startsWith(args.where.decryptionKey.startsWith) ?? false)
+            .filter((row) => (args.where.id ? row.id > args.where.id.gt : true))
+            .sort((a, b) => a.id.localeCompare(b.id))
+            .slice(0, args.take)
+            .map((row) => ({ id: row.id, decryptionKey: row.decryptionKey })),
+      ),
     },
   };
 }
@@ -47,13 +68,17 @@ async function encryptUnder(key: string, plaintext: string): Promise<string> {
   return JSON.stringify(adapter.encrypt(plaintext, EncryptionAlgorithm.AES_256_GCM));
 }
 
+async function buildEncryptionService(key: string) {
+  const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+  const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+  logger.child.mockReturnValue(logger);
+  return new AesGcmEncryptionAdapter(key, logger as never);
+}
+
 describe('validateEncryptionKeyAtStartup', () => {
   it('validates against a service instance configuration and returns its id', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
     const config = await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}');
     const client = createFakeClient([{ id: 'svc-1', config }]);
@@ -67,10 +92,7 @@ describe('validateEncryptionKeyAtStartup', () => {
     const { validateEncryptionKeyAtStartup, EncryptionKeyValidationError } = await import(
       './validate-encryption-key-startup'
     );
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
     // Config was encrypted under a key different from the one the app is
     // now running with — exactly the "wrong key deployed" scenario #762
@@ -85,12 +107,39 @@ describe('validateEncryptionKeyAtStartup', () => {
     expect(mockError).toHaveBeenCalled();
   });
 
+  it('throws a CorruptedEnvelopeError (not a key-mismatch error) for a service instance configuration that is not valid JSON', async () => {
+    const { validateEncryptionKeyAtStartup, CorruptedEnvelopeError, EncryptionKeyValidationError } = await import(
+      './validate-encryption-key-startup'
+    );
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // Truncated JSON: every service instance config is written encrypted
+    // (no legacy plaintext form), so a value that doesn't even parse is
+    // corruption, not evidence the key is wrong. Attributing this to
+    // DATA_ENCRYPTION_KEY would send an operator chasing the wrong fix.
+    const client = createFakeClient([{ id: 'svc-1', config: '{"cipherText":"truncated' }]);
+
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow(CorruptedEnvelopeError);
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('svc-1');
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.not.toThrow(
+      EncryptionKeyValidationError,
+    );
+  });
+
+  it('throws a CorruptedEnvelopeError for a service instance configuration that is valid JSON but not envelope-shaped', async () => {
+    const { validateEncryptionKeyAtStartup, CorruptedEnvelopeError } = await import(
+      './validate-encryption-key-startup'
+    );
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    const client = createFakeClient([{ id: 'svc-1', config: '{"foo":"bar"}' }]);
+
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow(CorruptedEnvelopeError);
+  });
+
   it('falls back to a protected credential decryption key when no service instance exists', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
     const decryptionKey = await encryptUnder(ACTIVE_KEY, 'b'.repeat(64));
     const client = createFakeClient([], [{ id: 'cred-1', decryptionKey }]);
@@ -102,10 +151,7 @@ describe('validateEncryptionKeyAtStartup', () => {
 
   it('throws naming the credential when its envelope was encrypted under a different key', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
     const decryptionKey = await encryptUnder(OTHER_KEY, 'b'.repeat(64));
     const client = createFakeClient([], [{ id: 'cred-1', decryptionKey }]);
@@ -115,10 +161,7 @@ describe('validateEncryptionKeyAtStartup', () => {
 
   it('returns validated: false when nothing encrypted exists anywhere, so startup proceeds normally', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
     const client = createFakeClient([], []);
 
@@ -129,10 +172,7 @@ describe('validateEncryptionKeyAtStartup', () => {
 
   it('returns validated: false when only legacy plaintext credential keys exist, not treating them as an envelope', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
     const client = createFakeClient([], [{ id: 'cred-1', decryptionKey: 'b'.repeat(64) }]);
 
@@ -141,17 +181,14 @@ describe('validateEncryptionKeyAtStartup', () => {
     expect(result).toEqual({ validated: false });
   });
 
-  it('returns validated: false for a corrupted envelope-like credential row instead of misreporting it as a key mismatch', async () => {
+  it('returns validated: false when the only credential row is corrupted envelope-shaped data, not misreporting it as a key mismatch', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
-    // Starts with "{" (so the DB-level startsWith filter would return it as
-    // a candidate) but is not a valid encrypted envelope — corruption, not
-    // a key mismatch. isProtectedDecryptionKey must reject this before the
-    // code ever attempts to decrypt it as a validation sample.
+    // Starts with "{" (so the DB-level startsWith filter returns it as a
+    // candidate) but does not parse as a valid encrypted envelope —
+    // corruption, not a key mismatch, and there is nothing else to
+    // validate against.
     const client = createFakeClient([], [{ id: 'cred-1', decryptionKey: '{"cipherText":"truncated' }]);
 
     const result = await validateEncryptionKeyAtStartup(client, encryptionService);
@@ -159,12 +196,67 @@ describe('validateEncryptionKeyAtStartup', () => {
     expect(result).toEqual({ validated: false });
   });
 
+  it('scans past a corrupted candidate to a genuinely wrong-key row, instead of reporting nothing encrypted', async () => {
+    const { validateEncryptionKeyAtStartup, EncryptionKeyValidationError } = await import(
+      './validate-encryption-key-startup'
+    );
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    // "a-corrupt" sorts before "w-wrongkey" in id order, so it is the first
+    // candidate the scan reaches. If a corrupted first candidate were
+    // treated as proof nothing is encrypted, the wrong key on the second
+    // row would never be caught and the app would boot unable to decrypt
+    // its own data.
+    const client = createFakeClient(
+      [],
+      [
+        { id: 'a-corrupt', decryptionKey: '{"cipherText":"truncated' },
+        { id: 'w-wrongkey', decryptionKey: await encryptUnder(OTHER_KEY, 'b'.repeat(64)) },
+      ],
+    );
+
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow(
+      EncryptionKeyValidationError,
+    );
+    await expect(validateEncryptionKeyAtStartup(client, encryptionService)).rejects.toThrow('w-wrongkey');
+  });
+
+  it('scans past a corrupted candidate to find a genuinely valid envelope under the active key', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    const client = createFakeClient(
+      [],
+      [
+        { id: 'a-corrupt', decryptionKey: '{"cipherText":"truncated' },
+        { id: 'z-valid', decryptionKey: await encryptUnder(ACTIVE_KEY, 'b'.repeat(64)) },
+      ],
+    );
+
+    const result = await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(result).toEqual({ validated: true, source: 'credential', id: 'z-valid' });
+  });
+
+  it('queries credential candidates with the expected filter, selection, and ordering', async () => {
+    const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
+
+    const client = createFakeClient([], []);
+
+    await validateEncryptionKeyAtStartup(client, encryptionService);
+
+    expect(client.credential.findMany).toHaveBeenCalledWith({
+      where: { decryptionKey: { startsWith: '{' } },
+      select: { id: true, decryptionKey: true },
+      orderBy: { id: 'asc' },
+      take: 100,
+    });
+  });
+
   it('prefers the service instance over a credential when both exist', async () => {
     const { validateEncryptionKeyAtStartup } = await import('./validate-encryption-key-startup');
-    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
-    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
-    logger.child.mockReturnValue(logger);
-    const encryptionService = new AesGcmEncryptionAdapter(ACTIVE_KEY, logger as never);
+    const encryptionService = await buildEncryptionService(ACTIVE_KEY);
 
     const config = await encryptUnder(ACTIVE_KEY, '{"apiUrl":"x"}');
     const decryptionKey = await encryptUnder(OTHER_KEY, 'b'.repeat(64));
@@ -175,7 +267,7 @@ describe('validateEncryptionKeyAtStartup', () => {
     // The credential envelope is under a different key, but it is never
     // consulted because a service instance was found first.
     expect(result).toEqual({ validated: true, source: 'service-instance', id: 'svc-1' });
-    expect(client.credential.findFirst).not.toHaveBeenCalled();
+    expect(client.credential.findMany).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts
@@ -1,8 +1,8 @@
-import type { EncryptedEnvelope, IEncryptionService } from '@uncefact/untp-ri-services/encryption';
+import type { IEncryptionService } from '@uncefact/untp-ri-services/encryption';
 // Relative imports (not the @/ alias): this module runs both inside the
 // Next.js app (instrumentation.node.ts) and via tsx (prisma/seed.ts), which
 // has no tsconfig.json to resolve path aliases.
-import { isProtectedDecryptionKey } from './decryption-key-protection';
+import { parseEnvelope } from './decryption-key-protection';
 import { apiLogger } from '../api/logger';
 
 const logger = apiLogger.child({ module: 'validate-encryption-key-startup' });
@@ -43,6 +43,28 @@ export class EncryptionKeyValidationError extends Error {
 }
 
 /**
+ * Thrown when the sample value startup picked to validate against is not a
+ * well-formed encrypted envelope — it failed to parse as JSON, or parsed
+ * but does not have the envelope shape. This is corruption, not a key
+ * problem: unlike a credential's decryption key (which can legitimately
+ * hold a pre-#697 plaintext value), a service instance configuration has no
+ * legacy unencrypted form, so every writer already guarantees it is a valid
+ * envelope. Distinct from {@link EncryptionKeyValidationError} so an
+ * operator is not sent chasing DATA_ENCRYPTION_KEY for a problem that
+ * changing the key cannot fix.
+ */
+export class CorruptedEnvelopeError extends Error {
+  constructor(source: 'service instance configuration', id: string) {
+    super(
+      `Existing ${source} ("${id}") is not a valid encrypted envelope: it failed to parse as JSON, or does not ` +
+        'have the shape of one. This is data corruption, not a DATA_ENCRYPTION_KEY mismatch — changing the key ' +
+        `will not fix it. Investigate the row directly. See ${DOCS_URL}`,
+    );
+    this.name = 'CorruptedEnvelopeError';
+  }
+}
+
+/**
  * Refuses the DATA_ENCRYPTION_KEY placeholder published in .env.example
  * outside local development; warns and proceeds within it. "Local
  * development" is read from DEPLOYMENT_ENVIRONMENT, the same signal already
@@ -76,19 +98,28 @@ function firstNonEmpty(value: string | undefined): string | undefined {
 type ServiceInstanceRow = { id: string; config: string };
 type CredentialRow = { id: string; decryptionKey: string | null };
 
+const CANDIDATE_BATCH_SIZE = 100;
+
 /**
  * The subset of the Prisma client this check needs; structural so tests can
- * supply an in-memory fake (same approach as BackfillClient).
+ * supply an in-memory fake (same approach as BackfillClient). Credentials
+ * are fetched via cursor-paginated `findMany`, not `findFirst`: the
+ * `startsWith` filter only narrows to envelope-*shaped* candidates (a
+ * truncated/corrupted value can also start with "{"), and the first
+ * candidate is not necessarily a valid one, so the caller must be able to
+ * keep scanning past it.
  */
 export type EncryptionKeyValidationClient = {
   serviceInstance: {
     findFirst(args: { select: { id: true; config: true } }): Promise<ServiceInstanceRow | null>;
   };
   credential: {
-    findFirst(args: {
-      where: { decryptionKey: { startsWith: string } };
+    findMany(args: {
+      where: { decryptionKey: { startsWith: string }; id?: { gt: string } };
       select: { id: true; decryptionKey: true };
-    }): Promise<CredentialRow | null>;
+      orderBy: { id: 'asc' };
+      take: number;
+    }): Promise<CredentialRow[]>;
   };
 };
 
@@ -102,17 +133,23 @@ export type EncryptionKeyValidationResult =
  * boot instead of on the first request that happens to touch it.
  *
  * Mirrors the `backfill:decryption-keys` preflight (decrypt one envelope,
- * abort on failure, proceed when nothing exists), but stops at the first
- * envelope found rather than checking every row: this runs on every process
- * boot, not as a one-off migration, so it favours a cheap, bounded check
- * over exhaustive verification.
+ * abort on failure, proceed when nothing exists): this runs on every
+ * process boot, not as a one-off migration, so it favours a cheap, bounded
+ * check over exhaustively verifying every row.
  *
  * Prefers a service instance configuration: every writer encrypts it before
- * persistence, so any row is a valid sample. Falls back to a credential's
- * protected decryption key only when no service instance exists yet.
- * Returns `{ validated: false }` (not an error) when nothing encrypted
- * exists anywhere, so a deployment with nothing encrypted yet starts
- * normally.
+ * persistence, so any row is a valid sample, and a row that fails to parse
+ * as an envelope is corruption (see {@link CorruptedEnvelopeError}), not a
+ * legacy-plaintext possibility. Falls back to a credential's decryption key
+ * only when no service instance exists yet — credentials predating #697
+ * can legitimately hold plaintext, so candidates are scanned in
+ * deterministic (id) order until one actually parses as an envelope,
+ * skipping corrupted-but-envelope-shaped rows along the way rather than
+ * treating the first candidate's shape failure as "nothing encrypted": a
+ * corrupted row must never mask a genuinely wrong key sitting in a later
+ * row. Returns `{ validated: false }` (not an error) only once every
+ * candidate is exhausted with nothing to validate against, so a deployment
+ * with nothing encrypted yet starts normally.
  */
 export async function validateEncryptionKeyAtStartup(
   client: EncryptionKeyValidationClient,
@@ -120,32 +157,57 @@ export async function validateEncryptionKeyAtStartup(
 ): Promise<EncryptionKeyValidationResult> {
   const instance = await client.serviceInstance.findFirst({ select: { id: true, config: true } });
   if (instance) {
-    decryptOrThrow(
-      () => encryptionService.decrypt(JSON.parse(instance.config) as EncryptedEnvelope),
-      'service instance configuration',
-      instance.id,
-    );
+    const envelope = parseEnvelope(instance.config);
+    if (envelope === null) {
+      logger.error({ instanceId: instance.id }, 'Service instance configuration is not a valid encrypted envelope');
+      throw new CorruptedEnvelopeError('service instance configuration', instance.id);
+    }
+    decryptOrThrow(() => encryptionService.decrypt(envelope), 'service instance configuration', instance.id);
     return { validated: true, source: 'service-instance', id: instance.id };
   }
 
-  // Envelopes are JSON objects, so a plaintext legacy key (a bare hex
-  // string) never matches this filter; the DB does the row-shape filtering
-  // instead of pulling every keyed credential into the process.
-  const credential = await client.credential.findFirst({
-    where: { decryptionKey: { startsWith: '{' } },
-    select: { id: true, decryptionKey: true },
-  });
-  if (credential?.decryptionKey && isProtectedDecryptionKey(credential.decryptionKey)) {
-    const decryptionKey = credential.decryptionKey;
-    decryptOrThrow(
-      () => encryptionService.decrypt(JSON.parse(decryptionKey) as EncryptedEnvelope),
-      'credential decryption key',
-      credential.id,
-    );
-    return { validated: true, source: 'credential', id: credential.id };
+  for await (const row of eachCandidateCredential(client)) {
+    const envelope = parseEnvelope(row.decryptionKey);
+    if (envelope === null) {
+      // Envelope-shaped (starts with "{") but not a genuine envelope:
+      // corruption or a coincidental legacy value. Neither proves anything
+      // about the key, so keep scanning rather than reporting "nothing
+      // encrypted" on the strength of one bad row.
+      continue;
+    }
+    decryptOrThrow(() => encryptionService.decrypt(envelope), 'credential decryption key', row.id);
+    return { validated: true, source: 'credential', id: row.id };
   }
 
   return { validated: false };
+}
+
+/**
+ * Iterates credential rows whose decryption key looks envelope-shaped, in
+ * id order via cursor pagination — same approach as the backfill script's
+ * `eachKeyedRow`, so a row deleted mid-scan cannot skip a surviving one.
+ */
+async function* eachCandidateCredential(
+  client: EncryptionKeyValidationClient,
+): AsyncGenerator<{ id: string; decryptionKey: string }> {
+  let cursor: string | undefined;
+  for (;;) {
+    const rows = await client.credential.findMany({
+      where: { decryptionKey: { startsWith: '{' }, ...(cursor !== undefined && { id: { gt: cursor } }) },
+      select: { id: true, decryptionKey: true },
+      orderBy: { id: 'asc' },
+      take: CANDIDATE_BATCH_SIZE,
+    });
+    if (rows.length === 0) {
+      return;
+    }
+    cursor = rows[rows.length - 1].id;
+    for (const row of rows) {
+      if (row.decryptionKey !== null) {
+        yield { id: row.id, decryptionKey: row.decryptionKey };
+      }
+    }
+  }
 }
 
 function decryptOrThrow(

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts
@@ -1,0 +1,162 @@
+import type { EncryptedEnvelope, IEncryptionService } from '@uncefact/untp-ri-services/encryption';
+// Relative imports (not the @/ alias): this module runs both inside the
+// Next.js app (instrumentation.node.ts) and via tsx (prisma/seed.ts), which
+// has no tsconfig.json to resolve path aliases.
+import { isProtectedDecryptionKey } from './decryption-key-protection';
+import { apiLogger } from '../api/logger';
+
+const logger = apiLogger.child({ module: 'validate-encryption-key-startup' });
+
+const DOCS_URL =
+  'https://uncefact.github.io/tests-untp/docs/next/reference-implementation/operations/startup#encryption-key-validation';
+
+/**
+ * The DATA_ENCRYPTION_KEY placeholder committed in .env.example. It is a
+ * valid 64-character hex string, so it passes AesGcmEncryptionAdapter's
+ * format check same as a real key, but it is public: anything encrypted
+ * under it is recoverable by anyone who has read the file.
+ */
+const PLACEHOLDER_ENCRYPTION_KEY = '0'.repeat(64);
+
+const LOCAL_DEPLOYMENT_ENVIRONMENT = 'local';
+
+export class PlaceholderEncryptionKeyError extends Error {
+  constructor() {
+    super(
+      'DATA_ENCRYPTION_KEY is still set to the placeholder value published in .env.example. ' +
+        'That value is public, so anything encrypted under it is not protected. Set a unique key ' +
+        `(openssl rand -hex 32) before running outside local development. See ${DOCS_URL}`,
+    );
+    this.name = 'PlaceholderEncryptionKeyError';
+  }
+}
+
+export class EncryptionKeyValidationError extends Error {
+  constructor(source: 'service instance configuration' | 'credential decryption key', id: string, cause: unknown) {
+    super(
+      `DATA_ENCRYPTION_KEY cannot decrypt an existing ${source} ("${id}"). ` +
+        `The configured key does not match the key the data was encrypted under. See ${DOCS_URL}`,
+      { cause },
+    );
+    this.name = 'EncryptionKeyValidationError';
+  }
+}
+
+/**
+ * Refuses the DATA_ENCRYPTION_KEY placeholder published in .env.example
+ * outside local development; warns and proceeds within it. "Local
+ * development" is read from DEPLOYMENT_ENVIRONMENT, the same signal already
+ * used to tag OpenTelemetry resources (see lib/observability/resource.ts),
+ * defaulting to "local" when unset, which is the default a fresh checkout
+ * gets before anyone has touched the variable.
+ */
+export function assertNotPlaceholderEncryptionKey(key: string, options: { deploymentEnvironment?: string } = {}): void {
+  if (key !== PLACEHOLDER_ENCRYPTION_KEY) {
+    return;
+  }
+
+  const environment = firstNonEmpty(options.deploymentEnvironment ?? process.env.DEPLOYMENT_ENVIRONMENT);
+  if ((environment ?? LOCAL_DEPLOYMENT_ENVIRONMENT).toLowerCase() === LOCAL_DEPLOYMENT_ENVIRONMENT) {
+    logger.warn(
+      'DATA_ENCRYPTION_KEY is the placeholder value from .env.example. This is fine for local development ' +
+        `but must be replaced before running anywhere else. See ${DOCS_URL}`,
+    );
+    return;
+  }
+
+  throw new PlaceholderEncryptionKeyError();
+}
+
+function firstNonEmpty(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+type ServiceInstanceRow = { id: string; config: string };
+type CredentialRow = { id: string; decryptionKey: string | null };
+
+/**
+ * The subset of the Prisma client this check needs; structural so tests can
+ * supply an in-memory fake (same approach as BackfillClient).
+ */
+export type EncryptionKeyValidationClient = {
+  serviceInstance: {
+    findFirst(args: { select: { id: true; config: true } }): Promise<ServiceInstanceRow | null>;
+  };
+  credential: {
+    findFirst(args: {
+      where: { decryptionKey: { startsWith: string } };
+      select: { id: true; decryptionKey: true };
+    }): Promise<CredentialRow | null>;
+  };
+};
+
+export type EncryptionKeyValidationResult =
+  | { validated: true; source: 'service-instance' | 'credential'; id: string }
+  | { validated: false };
+
+/**
+ * Validates the active DATA_ENCRYPTION_KEY by decrypting one existing
+ * encrypted envelope, so a key that cannot decrypt stored data fails fast at
+ * boot instead of on the first request that happens to touch it.
+ *
+ * Mirrors the `backfill:decryption-keys` preflight (decrypt one envelope,
+ * abort on failure, proceed when nothing exists), but stops at the first
+ * envelope found rather than checking every row: this runs on every process
+ * boot, not as a one-off migration, so it favours a cheap, bounded check
+ * over exhaustive verification.
+ *
+ * Prefers a service instance configuration: every writer encrypts it before
+ * persistence, so any row is a valid sample. Falls back to a credential's
+ * protected decryption key only when no service instance exists yet.
+ * Returns `{ validated: false }` (not an error) when nothing encrypted
+ * exists anywhere, so a deployment with nothing encrypted yet starts
+ * normally.
+ */
+export async function validateEncryptionKeyAtStartup(
+  client: EncryptionKeyValidationClient,
+  encryptionService: Pick<IEncryptionService, 'decrypt'>,
+): Promise<EncryptionKeyValidationResult> {
+  const instance = await client.serviceInstance.findFirst({ select: { id: true, config: true } });
+  if (instance) {
+    decryptOrThrow(
+      () => encryptionService.decrypt(JSON.parse(instance.config) as EncryptedEnvelope),
+      'service instance configuration',
+      instance.id,
+    );
+    return { validated: true, source: 'service-instance', id: instance.id };
+  }
+
+  // Envelopes are JSON objects, so a plaintext legacy key (a bare hex
+  // string) never matches this filter; the DB does the row-shape filtering
+  // instead of pulling every keyed credential into the process.
+  const credential = await client.credential.findFirst({
+    where: { decryptionKey: { startsWith: '{' } },
+    select: { id: true, decryptionKey: true },
+  });
+  if (credential?.decryptionKey && isProtectedDecryptionKey(credential.decryptionKey)) {
+    const decryptionKey = credential.decryptionKey;
+    decryptOrThrow(
+      () => encryptionService.decrypt(JSON.parse(decryptionKey) as EncryptedEnvelope),
+      'credential decryption key',
+      credential.id,
+    );
+    return { validated: true, source: 'credential', id: credential.id };
+  }
+
+  return { validated: false };
+}
+
+function decryptOrThrow(
+  decrypt: () => string,
+  source: 'service instance configuration' | 'credential decryption key',
+  id: string,
+): void {
+  try {
+    decrypt();
+  } catch (error) {
+    logger.error({ err: error, source, id }, 'DATA_ENCRYPTION_KEY failed to decrypt an existing envelope at startup');
+    throw new EncryptionKeyValidationError(source, id, error);
+  }
+}

--- a/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts
@@ -43,28 +43,6 @@ export class EncryptionKeyValidationError extends Error {
 }
 
 /**
- * Thrown when the sample value startup picked to validate against is not a
- * well-formed encrypted envelope — it failed to parse as JSON, or parsed
- * but does not have the envelope shape. This is corruption, not a key
- * problem: unlike a credential's decryption key (which can legitimately
- * hold a pre-#697 plaintext value), a service instance configuration has no
- * legacy unencrypted form, so every writer already guarantees it is a valid
- * envelope. Distinct from {@link EncryptionKeyValidationError} so an
- * operator is not sent chasing DATA_ENCRYPTION_KEY for a problem that
- * changing the key cannot fix.
- */
-export class CorruptedEnvelopeError extends Error {
-  constructor(source: 'service instance configuration', id: string) {
-    super(
-      `Existing ${source} ("${id}") is not a valid encrypted envelope: it failed to parse as JSON, or does not ` +
-        'have the shape of one. This is data corruption, not a DATA_ENCRYPTION_KEY mismatch — changing the key ' +
-        `will not fix it. Investigate the row directly. See ${DOCS_URL}`,
-    );
-    this.name = 'CorruptedEnvelopeError';
-  }
-}
-
-/**
  * Refuses the DATA_ENCRYPTION_KEY placeholder published in .env.example
  * outside local development; warns and proceeds within it. "Local
  * development" is read from DEPLOYMENT_ENVIRONMENT, the same signal already
@@ -102,16 +80,24 @@ const CANDIDATE_BATCH_SIZE = 100;
 
 /**
  * The subset of the Prisma client this check needs; structural so tests can
- * supply an in-memory fake (same approach as BackfillClient). Credentials
- * are fetched via cursor-paginated `findMany`, not `findFirst`: the
- * `startsWith` filter only narrows to envelope-*shaped* candidates (a
- * truncated/corrupted value can also start with "{"), and the first
- * candidate is not necessarily a valid one, so the caller must be able to
- * keep scanning past it.
+ * supply an in-memory fake (same approach as BackfillClient). Both resource
+ * types are fetched via cursor-paginated `findMany`, in id order, never
+ * `findFirst`: a single unordered sample is not safe to trust as "the"
+ * validation candidate. A row can be envelope-*shaped* without being a
+ * genuine envelope (a truncated/corrupted value can also start with "{",
+ * and a service instance config can be corrupted the same way), so the
+ * caller must be able to skip a bad candidate and keep scanning rather than
+ * either crashing on it or reporting "nothing encrypted" on the strength of
+ * one bad row.
  */
 export type EncryptionKeyValidationClient = {
   serviceInstance: {
-    findFirst(args: { select: { id: true; config: true } }): Promise<ServiceInstanceRow | null>;
+    findMany(args: {
+      where?: { id: { gt: string } };
+      select: { id: true; config: true };
+      orderBy: { id: 'asc' };
+      take: number;
+    }): Promise<ServiceInstanceRow[]>;
   };
   credential: {
     findMany(args: {
@@ -137,30 +123,37 @@ export type EncryptionKeyValidationResult =
  * process boot, not as a one-off migration, so it favours a cheap, bounded
  * check over exhaustively verifying every row.
  *
- * Prefers a service instance configuration: every writer encrypts it before
- * persistence, so any row is a valid sample, and a row that fails to parse
- * as an envelope is corruption (see {@link CorruptedEnvelopeError}), not a
- * legacy-plaintext possibility. Falls back to a credential's decryption key
- * only when no service instance exists yet — credentials predating #697
- * can legitimately hold plaintext, so candidates are scanned in
- * deterministic (id) order until one actually parses as an envelope,
- * skipping corrupted-but-envelope-shaped rows along the way rather than
- * treating the first candidate's shape failure as "nothing encrypted": a
- * corrupted row must never mask a genuinely wrong key sitting in a later
- * row. Returns `{ validated: false }` (not an error) only once every
- * candidate is exhausted with nothing to validate against, so a deployment
- * with nothing encrypted yet starts normally.
+ * Prefers service instance configurations, scanned in id order: every
+ * writer encrypts one before persistence, so any row is a valid sample.
+ * Falls back to scanning credential decryption keys only once every service
+ * instance candidate is exhausted — credentials predating #697 can
+ * legitimately hold plaintext, so those candidates are narrowed to
+ * envelope-shaped values before scanning.
+ *
+ * In both scans, a candidate that does not actually parse as an envelope
+ * (corrupted or otherwise malformed) is logged and skipped rather than
+ * treated as proof the key is wrong or that nothing is encrypted: a single
+ * damaged row must never crash startup, or mask a genuinely wrong key
+ * sitting in a later row, when other valid envelopes exist. Only a
+ * genuine envelope that fails to *decrypt* is a key mismatch, and that
+ * throws {@link EncryptionKeyValidationError} immediately. Returns
+ * `{ validated: false }` (not an error) once every candidate across both
+ * scans is exhausted with nothing to validate against, so a deployment
+ * with nothing encrypted yet — or, in the pathological case, nothing but
+ * corrupted rows — starts normally rather than crash-looping.
  */
 export async function validateEncryptionKeyAtStartup(
   client: EncryptionKeyValidationClient,
   encryptionService: Pick<IEncryptionService, 'decrypt'>,
 ): Promise<EncryptionKeyValidationResult> {
-  const instance = await client.serviceInstance.findFirst({ select: { id: true, config: true } });
-  if (instance) {
+  for await (const instance of eachCandidateServiceInstance(client)) {
     const envelope = parseEnvelope(instance.config);
     if (envelope === null) {
-      logger.error({ instanceId: instance.id }, 'Service instance configuration is not a valid encrypted envelope');
-      throw new CorruptedEnvelopeError('service instance configuration', instance.id);
+      logger.warn(
+        { instanceId: instance.id },
+        'Service instance configuration is not a valid encrypted envelope; skipping it as a validation sample',
+      );
+      continue;
     }
     decryptOrThrow(() => encryptionService.decrypt(envelope), 'service instance configuration', instance.id);
     return { validated: true, source: 'service-instance', id: instance.id };
@@ -169,10 +162,10 @@ export async function validateEncryptionKeyAtStartup(
   for await (const row of eachCandidateCredential(client)) {
     const envelope = parseEnvelope(row.decryptionKey);
     if (envelope === null) {
-      // Envelope-shaped (starts with "{") but not a genuine envelope:
-      // corruption or a coincidental legacy value. Neither proves anything
-      // about the key, so keep scanning rather than reporting "nothing
-      // encrypted" on the strength of one bad row.
+      logger.warn(
+        { credentialId: row.id },
+        'Credential decryption key is not a valid encrypted envelope; skipping it as a validation sample',
+      );
       continue;
     }
     decryptOrThrow(() => encryptionService.decrypt(envelope), 'credential decryption key', row.id);
@@ -180,6 +173,31 @@ export async function validateEncryptionKeyAtStartup(
   }
 
   return { validated: false };
+}
+
+/**
+ * Iterates every service instance row in id order via cursor pagination —
+ * same approach as the backfill script's `eachServiceInstanceRow`, so a row
+ * deleted mid-scan cannot skip a surviving one. No content filter: every
+ * service instance config is written encrypted, so any row is a candidate.
+ */
+async function* eachCandidateServiceInstance(
+  client: EncryptionKeyValidationClient,
+): AsyncGenerator<ServiceInstanceRow> {
+  let cursor: string | undefined;
+  for (;;) {
+    const rows = await client.serviceInstance.findMany({
+      ...(cursor !== undefined && { where: { id: { gt: cursor } } }),
+      select: { id: true, config: true },
+      orderBy: { id: 'asc' },
+      take: CANDIDATE_BATCH_SIZE,
+    });
+    if (rows.length === 0) {
+      return;
+    }
+    cursor = rows[rows.length - 1].id;
+    yield* rows;
+  }
 }
 
 /**

--- a/packages/services/src/encryption/encryption.interface.ts
+++ b/packages/services/src/encryption/encryption.interface.ts
@@ -21,7 +21,11 @@ export interface EncryptedEnvelope {
   type: EncryptionAlgorithm;
 }
 
-const permittedAlgorithms = new Set<string>(Object.values(EncryptionAlgorithm));
+// Exported so isEncryptedEnvelope can check `type` against the same
+// allow-list assertPermittedAlgorithm enforces at decrypt time, rather than
+// duplicating it — a second, drifting copy is how a shape check and the
+// actual algorithm gate quietly disagree.
+export const permittedAlgorithms = new Set<string>(Object.values(EncryptionAlgorithm));
 
 export function assertPermittedAlgorithm(algorithm: string): asserts algorithm is EncryptionAlgorithm {
   if (!permittedAlgorithms.has(algorithm)) {

--- a/packages/services/src/encryption/encryption.interface.ts
+++ b/packages/services/src/encryption/encryption.interface.ts
@@ -33,6 +33,25 @@ export function assertPermittedAlgorithm(algorithm: string): asserts algorithm i
   }
 }
 
+/**
+ * Decoded byte-length each algorithm's IV and auth tag must have. Used to
+ * detect a structurally malformed envelope (right shape, wrong decoded byte
+ * count) before attempting to decrypt it: Node's AES-GCM implementation
+ * does not reliably reject a wrong-length IV or tag at construction, and a
+ * wrong length that is accepted fails later with the identical error a
+ * genuinely wrong key produces ("Unsupported state or unable to
+ * authenticate data"), so byte length has to be checked up front rather
+ * than inferred from whatever decrypt() throws.
+ *
+ * Values are what this package's own adapter produces, not an external
+ * spec: `AesGcmEncryptionAdapter.encrypt` generates a 12-byte IV
+ * (`crypto.randomBytes(12)`) and Node's AES-256-GCM `cipher.getAuthTag()`
+ * returns a 16-byte tag by default (no `authTagLength` override is set).
+ */
+export const ALGORITHM_FIELD_LENGTHS: Record<EncryptionAlgorithm, { ivBytes: number; tagBytes: number }> = {
+  [EncryptionAlgorithm.AES_256_GCM]: { ivBytes: 12, tagBytes: 16 },
+};
+
 export interface IEncryptionService {
   encrypt(plaintext: string, algorithm: EncryptionAlgorithm): EncryptedEnvelope;
   decrypt(envelope: EncryptedEnvelope): string;

--- a/packages/services/src/encryption/index.ts
+++ b/packages/services/src/encryption/index.ts
@@ -5,4 +5,4 @@ export { EncryptionAlgorithm, assertPermittedAlgorithm } from './encryption.inte
 export type { EncryptedEnvelope, IEncryptionService } from './encryption.interface.js';
 export { decryptCredential } from './decrypt-credential.js';
 export type { DecryptionParams } from './decrypt-credential.js';
-export { isEncryptedEnvelope } from './is-encrypted-envelope.js';
+export { isEncryptedEnvelope, hasValidEnvelopeStructure } from './is-encrypted-envelope.js';

--- a/packages/services/src/encryption/is-encrypted-envelope.test.ts
+++ b/packages/services/src/encryption/is-encrypted-envelope.test.ts
@@ -20,4 +20,31 @@ describe('isEncryptedEnvelope', () => {
   it('returns false for an empty object', () => {
     expect(isEncryptedEnvelope({})).toBe(false);
   });
+
+  it('returns false when all required fields are present but null', () => {
+    // Passes a "has these keys" check but is not decryptable data — must
+    // be classified as corrupted, not as a genuine envelope, or a
+    // downstream decrypt attempt fails with a confusing crypto error
+    // (or "Unsupported algorithm: null") instead of a clear corruption
+    // signal.
+    expect(isEncryptedEnvelope({ cipherText: null, iv: null, tag: null, type: null })).toBe(false);
+  });
+
+  it('returns false when a field has the wrong type', () => {
+    expect(isEncryptedEnvelope({ cipherText: 1, iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(false);
+    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 2, tag: 'c', type: 'aes-256-gcm' })).toBe(false);
+    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 3, type: 'aes-256-gcm' })).toBe(false);
+  });
+
+  it('returns false for an unsupported algorithm in type', () => {
+    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 'des-ede3-cbc' })).toBe(false);
+  });
+
+  it('returns false when type is not a string', () => {
+    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 123 })).toBe(false);
+  });
+
+  it('still returns true for a well-formed envelope with a permitted algorithm', () => {
+    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(true);
+  });
 });

--- a/packages/services/src/encryption/is-encrypted-envelope.test.ts
+++ b/packages/services/src/encryption/is-encrypted-envelope.test.ts
@@ -1,8 +1,19 @@
-import { isEncryptedEnvelope } from './is-encrypted-envelope.js';
+import { isEncryptedEnvelope, hasValidEnvelopeStructure } from './is-encrypted-envelope.js';
+import { AesGcmEncryptionAdapter } from './adapters/aes-gcm/aes-gcm.adapter.js';
+import { EncryptionAlgorithm } from './encryption.interface.js';
+import crypto from 'crypto';
+
+const NOOP_LOGGER = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child: () => NOOP_LOGGER };
+
+/** A genuine envelope produced by the real adapter — valid Base64, correct field lengths. */
+function realEnvelope() {
+  const adapter = new AesGcmEncryptionAdapter('a'.repeat(64), NOOP_LOGGER as never);
+  return adapter.encrypt('hello world', EncryptionAlgorithm.AES_256_GCM);
+}
 
 describe('isEncryptedEnvelope', () => {
-  it('returns true for an object with all required fields', () => {
-    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(true);
+  it('returns true for a genuine envelope produced by the real adapter', () => {
+    expect(isEncryptedEnvelope(realEnvelope())).toBe(true);
   });
 
   it('returns false for null', () => {
@@ -14,7 +25,9 @@ describe('isEncryptedEnvelope', () => {
   });
 
   it('returns false when cipherText is missing', () => {
-    expect(isEncryptedEnvelope({ iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(false);
+    expect(isEncryptedEnvelope({ iv: 'YWJjZGVmZ2hpams=', tag: 'YWJjZGVmZ2hpamtsbW5vcA==', type: 'aes-256-gcm' })).toBe(
+      false,
+    );
   });
 
   it('returns false for an empty object', () => {
@@ -31,20 +44,88 @@ describe('isEncryptedEnvelope', () => {
   });
 
   it('returns false when a field has the wrong type', () => {
-    expect(isEncryptedEnvelope({ cipherText: 1, iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(false);
-    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 2, tag: 'c', type: 'aes-256-gcm' })).toBe(false);
-    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 3, type: 'aes-256-gcm' })).toBe(false);
+    const envelope = realEnvelope();
+    expect(isEncryptedEnvelope({ ...envelope, cipherText: 1 })).toBe(false);
+    expect(isEncryptedEnvelope({ ...envelope, iv: 2 })).toBe(false);
+    expect(isEncryptedEnvelope({ ...envelope, tag: 3 })).toBe(false);
   });
 
   it('returns false for an unsupported algorithm in type', () => {
-    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 'des-ede3-cbc' })).toBe(false);
+    const envelope = realEnvelope();
+    expect(isEncryptedEnvelope({ ...envelope, type: 'des-ede3-cbc' })).toBe(false);
   });
 
   it('returns false when type is not a string', () => {
-    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 123 })).toBe(false);
+    const envelope = realEnvelope();
+    expect(isEncryptedEnvelope({ ...envelope, type: 123 })).toBe(false);
   });
 
-  it('still returns true for a well-formed envelope with a permitted algorithm', () => {
-    expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(true);
+  describe('Base64 field validation', () => {
+    // Reproduces the reported crash: 'a', 'iv': 'b', 'tag': 'c' each decode
+    // leniently to 0 bytes via Node's Buffer.from(str, 'base64') instead of
+    // throwing, so a presence-and-type-only check waves them through. That
+    // sent a caller into decrypt(), which threw "Invalid initialization
+    // vector" at createDecipheriv — a structural error misreported as a
+    // DATA_ENCRYPTION_KEY mismatch.
+    it('returns false for single-character fields that decode to 0 bytes', () => {
+      expect(isEncryptedEnvelope({ cipherText: 'a', iv: 'b', tag: 'c', type: 'aes-256-gcm' })).toBe(false);
+    });
+
+    it('returns false for an empty string field', () => {
+      const envelope = realEnvelope();
+      expect(isEncryptedEnvelope({ ...envelope, cipherText: '' })).toBe(false);
+      expect(isEncryptedEnvelope({ ...envelope, iv: '' })).toBe(false);
+      expect(isEncryptedEnvelope({ ...envelope, tag: '' })).toBe(false);
+    });
+
+    it('returns false for a field containing non-Base64 characters', () => {
+      const envelope = realEnvelope();
+      expect(isEncryptedEnvelope({ ...envelope, cipherText: 'not base64!!' })).toBe(false);
+      expect(isEncryptedEnvelope({ ...envelope, iv: 'not base64!!' })).toBe(false);
+      expect(isEncryptedEnvelope({ ...envelope, tag: 'not base64!!' })).toBe(false);
+    });
+
+    it('returns false for a field whose length is mathematically impossible for Base64 (length % 4 === 1)', () => {
+      const envelope = realEnvelope();
+      // Five well-formed Base64 characters is not a length any Base64
+      // encoder can produce (each 4-character group encodes 3 bytes; a
+      // trailing group can only be 2, 3, or 4 characters, never 1).
+      expect(isEncryptedEnvelope({ ...envelope, cipherText: 'AAAAA' })).toBe(false);
+    });
+  });
+});
+
+describe('hasValidEnvelopeStructure', () => {
+  it('returns true for a genuine envelope produced by the real adapter', () => {
+    expect(hasValidEnvelopeStructure(realEnvelope())).toBe(true);
+  });
+
+  it('returns false for an IV that is valid Base64 but the wrong decoded length', () => {
+    // Node's AES-GCM does not reject this at construction — a caller that
+    // only inspects decrypt()'s thrown error cannot tell this apart from a
+    // genuinely wrong key (both throw "Unsupported state or unable to
+    // authenticate data" from the same call), so this must be checked
+    // structurally, before decrypt is ever attempted.
+    const envelope = realEnvelope();
+    const wrongLengthIv = crypto.randomBytes(8).toString('base64');
+    expect(hasValidEnvelopeStructure({ ...envelope, iv: wrongLengthIv })).toBe(false);
+  });
+
+  it('returns false for a tag that is valid Base64 but the wrong decoded length', () => {
+    const envelope = realEnvelope();
+    const wrongLengthTag = crypto.randomBytes(8).toString('base64');
+    expect(hasValidEnvelopeStructure({ ...envelope, tag: wrongLengthTag })).toBe(false);
+  });
+
+  it('returns false for an IV one byte short of the required length', () => {
+    const envelope = realEnvelope();
+    const almostRightIv = crypto.randomBytes(11).toString('base64');
+    expect(hasValidEnvelopeStructure({ ...envelope, iv: almostRightIv })).toBe(false);
+  });
+
+  it('returns false for a tag one byte longer than the required length', () => {
+    const envelope = realEnvelope();
+    const almostRightTag = crypto.randomBytes(17).toString('base64');
+    expect(hasValidEnvelopeStructure({ ...envelope, tag: almostRightTag })).toBe(false);
   });
 });

--- a/packages/services/src/encryption/is-encrypted-envelope.ts
+++ b/packages/services/src/encryption/is-encrypted-envelope.ts
@@ -1,15 +1,41 @@
-import { permittedAlgorithms } from './encryption.interface.js';
+import { permittedAlgorithms, ALGORITHM_FIELD_LENGTHS } from './encryption.interface.js';
 import type { EncryptedEnvelope } from './encryption.interface.js';
+
+// cipherText/iv/tag are the Base64 encoding of the envelope contract every
+// consumer of this predicate relies on, so validating the encoding here is
+// contract-safe rather than an algorithm-specific detail. A length of 1 mod
+// 4 can never be produced by a Base64 encoder (a trailing group is 2, 3, or
+// 4 characters, never 1), which is what closes the reported hole: fields
+// like 'a' / 'b' / 'c' pass a presence-and-type check but decode leniently
+// to 0 bytes via Node's Buffer.from(str, 'base64') instead of throwing.
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function isValidBase64(value: string): boolean {
+  if (value.length === 0 || value.length % 4 === 1) {
+    return false;
+  }
+  if (!BASE64_PATTERN.test(value)) {
+    return false;
+  }
+  return Buffer.from(value, 'base64').length > 0;
+}
 
 /**
  * Checks whether the given value is a well-formed encrypted envelope: has
- * cipherText, iv, and tag fields that are strings, and a type field naming
- * a permitted algorithm. Field presence alone is not enough — a value with
- * the right keys but null or wrongly-typed fields (or an unsupported
- * algorithm) is not decryptable data, and treating it as a genuine envelope
- * sends a caller into `decrypt()`, which fails with a confusing crypto
- * error (or "Unsupported algorithm: ...") that reads as a key problem
- * rather than the corruption it actually is.
+ * cipherText, iv, and tag fields that are non-empty, validly-encoded
+ * Base64, and a type field naming a permitted algorithm. Field presence
+ * alone is not enough — a value with the right keys but null, wrongly-typed,
+ * or malformed-Base64 fields (or an unsupported algorithm) is not
+ * decryptable data, and treating it as a genuine envelope sends a caller
+ * into `decrypt()`, which fails with a confusing crypto error ("Invalid
+ * initialization vector", "Unsupported algorithm: ...") that reads as a key
+ * problem rather than the corruption it actually is.
+ *
+ * This checks Base64 *encoding* validity only, not algorithm-specific
+ * decoded byte lengths (AES-256-GCM's 12-byte IV / 16-byte tag) — that is
+ * left to callers that already know which algorithm they are decrypting
+ * with, so this shared, algorithm-agnostic predicate does not encode
+ * AES-GCM's structural specifics.
  */
 export function isEncryptedEnvelope(data: unknown): data is EncryptedEnvelope {
   if (typeof data !== 'object' || data === null) {
@@ -24,6 +50,36 @@ export function isEncryptedEnvelope(data: unknown): data is EncryptedEnvelope {
     typeof iv === 'string' &&
     typeof tag === 'string' &&
     typeof type === 'string' &&
-    permittedAlgorithms.has(type)
+    permittedAlgorithms.has(type) &&
+    isValidBase64(cipherText) &&
+    isValidBase64(iv) &&
+    isValidBase64(tag)
+  );
+}
+
+/**
+ * Checks that an envelope already confirmed by {@link isEncryptedEnvelope}
+ * also has the correct decoded byte length for its algorithm's IV and auth
+ * tag ({@link ALGORITHM_FIELD_LENGTHS}). This is deliberately a separate
+ * function rather than folded into `isEncryptedEnvelope`: field presence,
+ * type, and Base64 validity are algorithm-agnostic facts about the
+ * envelope's shape, but "how many decoded bytes an IV/tag must be" is
+ * specific to the named algorithm, so callers that need this check compose
+ * it explicitly rather than the shared shape predicate assuming one
+ * algorithm's structure for all of them.
+ *
+ * This must run before `decrypt()` is attempted, not be inferred from
+ * whatever it throws: Node's AES-GCM implementation does not reliably
+ * reject a wrong-length IV or tag at construction, and when it does not,
+ * the eventual failure throws the exact same error a genuinely wrong key
+ * produces ("Unsupported state or unable to authenticate data"), so
+ * catching and inspecting that error cannot distinguish corruption from a
+ * key mismatch after the fact.
+ */
+export function hasValidEnvelopeStructure(envelope: EncryptedEnvelope): boolean {
+  const lengths = ALGORITHM_FIELD_LENGTHS[envelope.type];
+  return (
+    Buffer.from(envelope.iv, 'base64').length === lengths.ivBytes &&
+    Buffer.from(envelope.tag, 'base64').length === lengths.tagBytes
   );
 }

--- a/packages/services/src/encryption/is-encrypted-envelope.ts
+++ b/packages/services/src/encryption/is-encrypted-envelope.ts
@@ -1,11 +1,29 @@
+import { permittedAlgorithms } from './encryption.interface.js';
 import type { EncryptedEnvelope } from './encryption.interface.js';
 
 /**
- * Checks whether the given value looks like an encrypted envelope
- * (has cipherText, iv, tag, and type fields).
+ * Checks whether the given value is a well-formed encrypted envelope: has
+ * cipherText, iv, and tag fields that are strings, and a type field naming
+ * a permitted algorithm. Field presence alone is not enough — a value with
+ * the right keys but null or wrongly-typed fields (or an unsupported
+ * algorithm) is not decryptable data, and treating it as a genuine envelope
+ * sends a caller into `decrypt()`, which fails with a confusing crypto
+ * error (or "Unsupported algorithm: ...") that reads as a key problem
+ * rather than the corruption it actually is.
  */
 export function isEncryptedEnvelope(data: unknown): data is EncryptedEnvelope {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  if (!('cipherText' in data) || !('iv' in data) || !('tag' in data) || !('type' in data)) {
+    return false;
+  }
+  const { cipherText, iv, tag, type } = data as Record<'cipherText' | 'iv' | 'tag' | 'type', unknown>;
   return (
-    typeof data === 'object' && data !== null && 'cipherText' in data && 'iv' in data && 'tag' in data && 'type' in data
+    typeof cipherText === 'string' &&
+    typeof iv === 'string' &&
+    typeof tag === 'string' &&
+    typeof type === 'string' &&
+    permittedAlgorithms.has(type)
   );
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -33,7 +33,7 @@ export { EncryptionAlgorithm, assertPermittedAlgorithm } from './encryption/encr
 export type { EncryptedEnvelope, IEncryptionService } from './encryption/encryption.interface.js';
 export { decryptCredential } from './encryption/decrypt-credential.js';
 export type { DecryptionParams } from './encryption/decrypt-credential.js';
-export { isEncryptedEnvelope } from './encryption/is-encrypted-envelope.js';
+export { isEncryptedEnvelope, hasValidEnvelopeStructure } from './encryption/is-encrypted-envelope.js';
 export type { IKeyGenerator, IKeyStore } from './key-provider/key-provider.interface.js';
 export { LocalKeyGenerator } from './key-provider/adapters/local/local.adapter.js';
 


### PR DESCRIPTION
This PR validates the active DATA_ENCRYPTION_KEY at process startup by decrypting one existing encrypted envelope, so a key that cannot decrypt stored data fails fast at boot with an actionable error rather than surfacing on the first request that touches encrypted data.

The validation runs in the Node instrumentation register() hook, which Next.js awaits before serving requests and which crash-stops startup on rejection. It scans service instance configurations first, falling back to credential decryption keys, both in deterministic id order via cursor pagination, and skips a structurally-invalid or corrupted candidate with a warning instead of crash-looping on one bad row or misreporting corruption as a key mismatch. Only a genuine envelope the key cannot decrypt fails the boot. The placeholder key published in .env.example is refused outside local development.

Closes #762
