### PR TITLE
feat(playground): support multiple conformity schemes

### DIFF
--- a/docs/adrs/041-playground-shared-per-instance-artefact-model.md
+++ b/docs/adrs/041-playground-shared-per-instance-artefact-model.md
@@ -1,0 +1,78 @@
+# ADR-041: Playground shared per-instance artefact model
+
+- **Date:** 2026-07-15
+- **Status:** accepted
+
+## Context
+
+The UNTP Playground validates artefacts a user uploads or resolves. Until #809 it held one slot per artefact kind: credentials keyed by `PermittedCredentialType` (five type slots) and conformity schemes keyed by the single-member `SchemeType` enum, where each new upload of a kind overwrote the previous one (`src/app/page.tsx`). The phase-2 restructure (#808) turns each of three families (Credentials, Conformity Schemes, Link Sets) into a collection of independently validated instances.
+
+The first of those, multiple conformity schemes (#677), needs an instance to have a stable identity, a way to dedupe a re-upload against a loaded instance, replacement in place when they match, and removal. Credentials (#810) and link sets (#811) need the identical behaviour. Three hand-rolled copies would drift on exactly the parts that must stay consistent.
+
+Four forces, each verified against the current code, shape the design and rule out the naive "the shared model owns the instance array, each family owns its own results" boundary.
+
+- **Results and payload were already split, and that split is the bug.** Scheme documents lived in `schemes` and their pipeline results in a parallel `schemeTestResults` map, joined by the type key. With one slot per type this was invisible; with a collection it produces replace-flash, orphaned results after a remove, and no clean join for the report.
+- **There was no write-side staleness guard.** `validatedRef`/`confettiShownRef` in `SchemeTestResults.tsx` only decided whether to _start_ a run; `runPipeline`'s `setStep` wrote results with no check that the instance was still current. Because replace-in-place re-runs an asynchronous pipeline (schema fetch, JSON-LD expansion), a superseded run's late write could land in the wrong card.
+- **Report readiness treated "no results" as success.** `reportService.ts` computed status with `steps.every(...)`, and `[].every()` is `true`, so an instance with empty or missing results was marked SUCCESS.
+- **A document id is not a reliable identity.** A JSON-LD `id` can be absent, and for an enveloped credential the outer `id` is the `data:application/vc+jwt,...` envelope, not the document (`credentialService.ts` decodes it). A filename is only a basename, so two different documents saved as `scheme.json` collide. Matching on id-then-url-then-filename therefore has to carry a conflict case and still mishandles these.
+
+A domain fact also matters: a conformity scheme is not independently versioned. The `(v0.7.0)` on a card is the UNTP release detected from the document `@context`, not a version of the scheme's content, so identity must ignore it.
+
+## Decision
+
+Introduce one **family-agnostic per-instance collection** that schemes (#677) now, and credentials (#810) and link sets (#811) later, all reuse. It lives in `packages/untp-playground/src/types/artefact.ts` (types) and `packages/untp-playground/src/lib/artefactCollection.ts` (pure functions), names no family, and owns the ordered instances, their opaque results, and the run token that guards writes. It does not own any family's pipeline, copy, hashing, or UI.
+
+### Identity is the content hash
+
+An instance is identified by the hash of its content (`hashContent` over the family's document, in `src/lib/hash.ts`). Identical content is one instance; different content is a separate one. This is unambiguous where a document id is not: it needs no id, is unaffected by an envelope wrapper (the family hashes its decoded document), never conflates two different documents that share a filename, and carries no conflict case. The detected UNTP context version is part of the content, but two genuinely different versions of a scheme are different documents and so different instances, which matches the domain. The URL and filename survive only as the card title and source caption, never as identity.
+
+### Shape and operations
+
+```ts
+type InstanceId = string; // immutable, minted per instance, stable across in-place replace
+type RunId = string; // minted per pipeline run; the write token
+
+type ArtefactSlot<P, R> = {
+  instanceId: InstanceId;
+  contentHash: string;
+  payload: P;
+  result: R | undefined; // undefined = no snapshot yet / cleared for a new run
+  runId: RunId | null; // null = idle (never run, or just replaced)
+};
+type CollectionState<P, R> = { items: ArtefactSlot<P, R>[] };
+```
+
+Pure functions: `emptyCollection`, `matchTarget` (by content hash), `upsert`, `remove`, `beginRun`, `commitResult`.
+
+- `upsert` appends a new instance in upload order, or, on a matching content hash, replaces it at its existing index (keeping its `instanceId`, clearing its result and `runId`). Re-uploading identical content is idempotent; different content always appends. Re-populating a URL-sourced instance is re-submitting it through the family's normal ingest, which replaces the card when the content is unchanged and adds a new one when the content has changed.
+- `beginRun` mints a `RunId` and sets the pending result, but only for an idle slot, so a repeated effect (React StrictMode's double invocation) cannot start a duplicate pipeline. `commitResult` is the only path that writes a result and applies only if the slot still holds that `RunId`, so a superseded or removed run's late completion, and its toasts and confetti, are dropped.
+- `remove` deletes an instance. There is no undo: the family confirms a removal with a dialog before deleting, so the destructive action is deliberate rather than reversible after the fact. `runId` stays set on a finished run (it is not cleared on completion) because per-run confetti dedupe keys on it; only `upsert` clears it.
+
+### Scope boundary
+
+The shared model owns the ordered instances, the opaque payload `P` and result `R`, the `runId`, and the transitions above. Each family owns: the `P`/`R` shapes, the pipeline that produces `R` (committed only via `commitResult`), the content-hash of its document, title/subtitle copy, the removal confirmation copy, confetti, its grouping views, and its report projection. Credentials are one flat `CollectionState` for the family, with the five typed cards and the `n / 5` checklist as views over the detected type, and the content hash taken from the decoded credential (never the envelope), so a re-ingest whose detected type changed moves the same `instanceId` between groups. Report readiness requires every loaded family instance to have a terminal result (a non-empty result whose steps have all settled), joined by `instanceId`; it is enforced in the UI gate and again inside `generateReport`, so a still-validating artefact holds generation rather than being recorded as a spurious pass or failure.
+
+## Consequences
+
+- One identity, dedupe, replace and run-guard implementation backs all three families, so #810 and #811 add a family by supplying a content-hash function, `P`, `R`, and a pipeline, rather than re-deriving the mechanics or the race handling.
+- Content-hash identity is unambiguous and removes the id/url/filename matcher, its conflict case, and the same-filename and envelope-id footguns. The trade-off: re-fetching a URL whose content has changed produces a new card rather than replacing the old one, which treats changed content as the genuinely different document it is; the stale card is removed with the confirmation flow.
+- The stale asynchronous write is closed by construction: `commitResult` is the only write path and checks the run token, so a consumer that writes any other way is out of contract and caught in review.
+- Removal is a confirmation dialog rather than delete-with-undo, so the collection carries no undo snapshot or conditional-restore state, and there is no silent-undo failure mode to convey.
+- Report vacuity is fixed at the source: readiness requires a terminal result per loaded instance in every present family, so an empty, orphaned, or mid-pipeline artefact can no longer read as success, and a report cannot be generated across a still-validating family.
+- Migrating schemes off the `SchemeType`-keyed objects touches several consumers together (`page.tsx` state, `reportService.ts`, `TestReportContext.tsx`, `SchemeTestResults.tsx`, the report result type, the E2E selectors), so the migration lands as one coherent change.
+
+## Alternatives Considered
+
+- **Identity by document id, then source URL, then filename.** Rejected. A JSON-LD id can be absent, is the envelope string for an enveloped credential, and does not distinguish two different documents that share a filename, so the matcher needed a conflict case and still mishandled these. The content hash is unambiguous and needs none of that.
+- **Identity by `id` plus the detected version.** Rejected. A conformity scheme is not independently versioned; the detected version is part of the content, so two versions are two documents under content hashing, without a special rule.
+- **Content hash plus a remembered source URL, so re-fetching the same URL replaces even when the content changed.** Rejected in favour of pure content hashing: changed content is a different document, and keeping source-URL matching would reintroduce the provenance-tracking the content hash exists to avoid.
+- **Delete-with-undo (a "Removed" toast with an Undo action).** Rejected in favour of a confirmation dialog. Undo required a single-level `pendingUndo` snapshot, a conditional `restore` (rejecting stale tokens and re-occupied identities), and careful toast-dismissal to avoid a silent no-op when the Undo could not complete; a confirmation dialog is simpler and makes the destructive action deliberate up front.
+- **The shared model owns the instance array only; each family owns its own results map.** Rejected. Results and payload split across two stores is the defect that produced replace-flash, orphaned results, and report vacuity; co-locating an opaque `R` on the slot adds no family knowledge and removes the drift.
+- **A shared `useInstancePipeline` hook that runs each family's pipeline.** Rejected. The pipeline shapes differ materially (schemes run three mostly-synchronous steps, credentials run verification plus multiple schema steps plus an extension branch, link sets resolve then fan out), so a shared runner would either encode a pretence or accumulate family branching. The shared layer owns a guarded `commitResult` transition and leaves the pipeline to the family.
+
+## References
+
+- Story #677 (multiple conformity schemes, first consumer), ticket #819 (this shared model), epic #808 (phase-2 tabbed artefact surface).
+- Reused by #810 (credentials instance groups) and #811 (link sets).
+- Builds on the tabbed surface from #809 (merged in #835).
+- Related to ADR-029 (test-layer taxonomy and decision rules), which governs where the collection, the guarded commit, the card, and the page wiring are tested.

--- a/packages/untp-playground/__tests__/app/page.test.tsx
+++ b/packages/untp-playground/__tests__/app/page.test.tsx
@@ -299,6 +299,52 @@ describe('Tabbed artefact surface (#809)', () => {
     expect(screen.getByTestId('mock-scheme-test-results')).toBeInTheDocument();
   });
 
+  it('loads two distinct schemes as separate instances instead of overwriting', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue({ kind: ArtefactKind.SCHEME, type: 'ConformityScheme' });
+    // Identity is the content hash, so each upload must carry distinct content to be a new instance.
+    let marker = 0;
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() => onArtefactUpload({ verifiableCredential: { type: ['ConformityScheme'], marker: marker++ } })}
+        >
+          Upload
+        </button>
+      ),
+    );
+    render(<Home />);
+
+    const uploader = screen.getByTestId('mock-uploader');
+    fireEvent.click(uploader);
+    fireEvent.click(uploader);
+
+    // The Conformity Schemes tab count reflects the number of loaded instances, not a single slot.
+    expect(await screen.findByRole('tab', { name: /Conformity Schemes\s*2/ })).toBeInTheDocument();
+  });
+
+  it('replaces in place when the same scheme content is uploaded twice', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue({ kind: ArtefactKind.SCHEME, type: 'ConformityScheme' });
+    // Identical content each click -> same content hash -> the second upload replaces the first.
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() => onArtefactUpload({ verifiableCredential: { type: ['ConformityScheme'] } })}
+        >
+          Upload
+        </button>
+      ),
+    );
+    render(<Home />);
+
+    const uploader = screen.getByTestId('mock-uploader');
+    fireEvent.click(uploader);
+    fireEvent.click(uploader);
+
+    expect(await screen.findByRole('tab', { name: /Conformity Schemes\s*1/ })).toBeInTheDocument();
+  });
+
   it('shows the credentials empty state when no credential is loaded', () => {
     render(<Home />);
 

--- a/packages/untp-playground/__tests__/components/GenerateReportDialog.test.tsx
+++ b/packages/untp-playground/__tests__/components/GenerateReportDialog.test.tsx
@@ -50,7 +50,9 @@ describe('GenerateReportDialog', () => {
       () => {
         const tooltipContent = screen.getByTestId('generate-report-button-tooltip-content');
         expect(tooltipContent).toBeInTheDocument();
-        expect(tooltipContent).toHaveTextContent('Upload and validate a credential to generate a conformance report');
+        expect(tooltipContent).toHaveTextContent(
+          'Upload and validate a credential or conformity scheme to generate a conformance report',
+        );
       },
       { timeout: 2000 },
     );

--- a/packages/untp-playground/__tests__/components/SchemeTestResults.test.tsx
+++ b/packages/untp-playground/__tests__/components/SchemeTestResults.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect, useRef } from 'react';
+import { SchemeTestResults } from '@/components/SchemeTestResults';
+import { useArtefactCollection } from '@/hooks/useArtefactCollection';
+import { upsert } from '@/lib/artefactCollection';
+import { schemeContentHash } from '@/lib/schemeCollection';
+import { newId } from '@/lib/id';
+import { detectSchemeVersion, validateSchemeSchema } from '@/lib/schemeValidation';
+import { validateContext } from '@/lib/contextValidation';
+import type { StoredScheme, TestStep } from '@/types';
+
+jest.mock('canvas-confetti', () => jest.fn());
+jest.mock('@/components/TestResults', () => ({ confettiConfig: {}, TestResults: () => null }));
+jest.mock('@/lib/schemeValidation', () => ({
+  ...jest.requireActual('@/lib/schemeValidation'),
+  detectSchemeVersion: jest.fn(),
+  validateSchemeSchema: jest.fn(),
+}));
+jest.mock('@/lib/contextValidation', () => ({ validateContext: jest.fn() }));
+
+const scheme = (decoded: Record<string, unknown>, source?: StoredScheme['source']): StoredScheme => ({
+  original: decoded,
+  decoded,
+  source,
+});
+
+// Harness: drives the real collection hook so the pipeline runs and the cards re-render on commit.
+function Harness({ schemes }: { schemes: StoredScheme[] }) {
+  const collection = useArtefactCollection<StoredScheme, TestStep[]>();
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current) return;
+    seeded.current = true;
+    for (const s of schemes) {
+      collection.dispatch((state) =>
+        upsert(state, { payload: s, contentHash: schemeContentHash(s.decoded), mintInstanceId: newId }),
+      );
+    }
+  }, [schemes, collection]);
+  return <SchemeTestResults collection={collection.state} dispatch={collection.dispatch} />;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (detectSchemeVersion as jest.Mock).mockReturnValue('0.7.0');
+  (validateSchemeSchema as jest.Mock).mockResolvedValue({ valid: true });
+  (validateContext as jest.Mock).mockResolvedValue({ valid: true });
+});
+
+describe('SchemeTestResults', () => {
+  it('renders one card per instance in upload order', async () => {
+    render(<Harness schemes={[scheme({ id: 'a', name: 'Alpha Scheme' }), scheme({ id: 'b', name: 'Beta Scheme' })]} />);
+
+    const titles = await screen.findAllByRole('heading', { level: 3 });
+    expect(titles.map((h) => h.textContent)).toEqual(['Alpha Scheme', 'Beta Scheme']);
+  });
+
+  it('shows the always-on family subtitle with the detected version, even for a nameless scheme', async () => {
+    render(<Harness schemes={[scheme({ id: 'x' }, { kind: 'file', filename: 'x.json' })]} />);
+
+    expect(await screen.findByText('Conformity Scheme (v0.7.0)')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('x.json');
+  });
+
+  it('uses the scheme name as the title when present', async () => {
+    render(<Harness schemes={[scheme({ id: 'x', name: 'Mining Assurance' })]} />);
+    expect(await screen.findByRole('heading', { level: 3, name: 'Mining Assurance' })).toBeInTheDocument();
+  });
+
+  it('surfaces the unchanged version-detection failure copy and exactly two skipped steps', async () => {
+    (detectSchemeVersion as jest.Mock).mockReturnValue(undefined);
+    render(<Harness schemes={[scheme({ id: 'x', name: 'No Context Scheme' })]} />);
+
+    await userEvent.click(await screen.findByTestId('scheme-group-header'));
+
+    expect(await screen.findByText(/Could not detect a UNTP version from the @context/)).toBeInTheDocument();
+    // Both the schema-validation and context-validation steps are skipped.
+    expect(screen.getAllByText('Skipped: version detection failed.')).toHaveLength(2);
+  });
+
+  it('removes a card only after the confirmation dialog is confirmed', async () => {
+    render(<Harness schemes={[scheme({ id: 'x', name: 'Removable Scheme' })]} />);
+    expect(await screen.findByRole('heading', { level: 3, name: 'Removable Scheme' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Removable Scheme' }));
+    expect(await screen.findByText('Remove Removable Scheme?')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { level: 3, name: 'Removable Scheme' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the card when the removal is cancelled', async () => {
+    render(<Harness schemes={[scheme({ id: 'x', name: 'Keep Me' })]} />);
+    await screen.findByRole('heading', { level: 3, name: 'Keep Me' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Keep Me' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Keep Me' })).toBeInTheDocument();
+  });
+});

--- a/packages/untp-playground/__tests__/contexts/TestReportContext.test.tsx
+++ b/packages/untp-playground/__tests__/contexts/TestReportContext.test.tsx
@@ -27,6 +27,21 @@ const mockTestResults: Partial<Record<CredentialType, TestStep[]>> = {
   ],
 };
 
+const schemeDoc = {
+  '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+  type: ['ConformityScheme'],
+};
+const terminalSchemeInstance = {
+  scheme: { original: schemeDoc, decoded: schemeDoc },
+  steps: [{ id: TestCaseStepId.SCHEME_VERSION_DETECTION, status: TestCaseStatus.SUCCESS, name: 'Version Detection' }],
+};
+const pendingSchemeInstance = {
+  scheme: { original: schemeDoc, decoded: schemeDoc },
+  steps: [
+    { id: TestCaseStepId.SCHEME_VERSION_DETECTION, status: TestCaseStatus.IN_PROGRESS, name: 'Version Detection' },
+  ],
+};
+
 const mockReport: TestReport = {
   implementation: { name: 'Test Implementation' },
   reportName: 'UNTP',
@@ -88,6 +103,65 @@ describe('TestReportContext', () => {
     expect(result.current.canGenerateReport).toBeFalsy();
   });
 
+  it('does not allow generation while a scheme instance is still validating', () => {
+    const { result } = renderHook(() => useTestReport(), {
+      wrapper: ({ children }) => (
+        <TestReportProvider testResults={{}} credentials={{}} schemeInstances={[pendingSchemeInstance]}>
+          {children}
+        </TestReportProvider>
+      ),
+    });
+    expect(result.current.canGenerateReport).toBeFalsy();
+  });
+
+  it('allows generation when every loaded scheme instance is terminal', () => {
+    const { result } = renderHook(() => useTestReport(), {
+      wrapper: ({ children }) => (
+        <TestReportProvider testResults={{}} credentials={{}} schemeInstances={[terminalSchemeInstance]}>
+          {children}
+        </TestReportProvider>
+      ),
+    });
+    expect(result.current.canGenerateReport).toBeTruthy();
+  });
+
+  it('does not let a ready credential unlock generation while a scheme is still validating', () => {
+    const { result } = renderHook(() => useTestReport(), {
+      wrapper: ({ children }) => (
+        <TestReportProvider
+          testResults={mockTestResults}
+          credentials={mockCredentials}
+          schemeInstances={[pendingSchemeInstance]}
+        >
+          {children}
+        </TestReportProvider>
+      ),
+    });
+    expect(result.current.canGenerateReport).toBeFalsy();
+  });
+
+  it('invalidates a generated report when the last artefact is removed', async () => {
+    let schemes = [terminalSchemeInstance];
+    const { result, rerender } = renderHook(() => useTestReport(), {
+      wrapper: ({ children }) => (
+        <TestReportProvider testResults={{}} credentials={{}} schemeInstances={schemes}>
+          {children}
+        </TestReportProvider>
+      ),
+    });
+
+    await act(async () => {
+      await result.current.generateReport('Test Implementation');
+    });
+    expect(result.current.report).toEqual(mockReport);
+
+    schemes = [];
+    rerender();
+
+    expect(result.current.report).toBeNull();
+    expect(result.current.canDownloadReport).toBe(false);
+  });
+
   const runGenerateReportTest = async (expectedReport: any) => {
     (generateReport as jest.Mock).mockResolvedValue(expectedReport);
 
@@ -101,6 +175,7 @@ describe('TestReportContext', () => {
       implementationName: 'Test Implementation',
       credentials: mockCredentials,
       testResults: mockTestResults,
+      schemeInstances: [],
       passStatuses: [TestCaseStatus.SUCCESS, TestCaseStatus.WARNING],
     });
     expect(toast.success).toHaveBeenCalledWith('Report generated successfully');

--- a/packages/untp-playground/__tests__/lib/artefactCollection.test.ts
+++ b/packages/untp-playground/__tests__/lib/artefactCollection.test.ts
@@ -1,0 +1,160 @@
+import { emptyCollection, matchTarget, upsert, remove, beginRun, commitResult } from '@/lib/artefactCollection';
+import type { CollectionState } from '@/types/artefact';
+
+// Test doubles for the opaque family payload P and result R.
+type P = { name: string };
+type R = { steps: number; done: boolean };
+
+function counter(prefix: string): () => string {
+  let n = 0;
+  return () => `${prefix}-${++n}`;
+}
+
+function seed(...entries: Array<{ payload: P; contentHash: string }>): {
+  state: CollectionState<P, R>;
+  mintId: () => string;
+} {
+  const mintId = counter('i');
+  let state = emptyCollection<P, R>();
+  for (const e of entries) {
+    state = upsert(state, { ...e, mintInstanceId: mintId }).state;
+  }
+  return { state, mintId };
+}
+
+describe('matchTarget', () => {
+  const items = [
+    { instanceId: 'A', contentHash: 'hash-a' },
+    { instanceId: 'B', contentHash: 'hash-b' },
+  ];
+
+  it('finds the instance with the matching content hash', () => {
+    expect(matchTarget(items, 'hash-b')).toEqual({ kind: 'one', instanceId: 'B' });
+  });
+
+  it('returns none when no content hash matches', () => {
+    expect(matchTarget(items, 'hash-z')).toEqual({ kind: 'none' });
+  });
+});
+
+describe('upsert', () => {
+  it('appends a new instance when the content hash is new', () => {
+    const { state } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    expect(state.items).toHaveLength(1);
+    expect(state.items[0]).toMatchObject({ instanceId: 'i-1', contentHash: 'h1', result: undefined, runId: null });
+  });
+
+  it('appends in upload order', () => {
+    const { state } = seed(
+      { payload: { name: 'one' }, contentHash: 'h1' },
+      { payload: { name: 'two' }, contentHash: 'h2' },
+    );
+    expect(state.items.map((i) => i.payload.name)).toEqual(['one', 'two']);
+  });
+
+  it('appends different content as separate instances even when other fields would collide', () => {
+    const { state } = seed(
+      { payload: { name: 'scheme-a' }, contentHash: 'h1' },
+      { payload: { name: 'scheme-b' }, contentHash: 'h2' },
+    );
+    expect(state.items).toHaveLength(2);
+  });
+
+  it('replaces in place on a matching hash, keeping the instanceId and index, clearing result and runId', () => {
+    const mintId = counter('i');
+    let state = emptyCollection<P, R>();
+    state = upsert(state, { payload: { name: 'a' }, contentHash: 'h1', mintInstanceId: mintId }).state;
+    state = upsert(state, { payload: { name: 'b' }, contentHash: 'h2', mintInstanceId: mintId }).state;
+    state = beginRun(state, 'i-1', { steps: 1, done: false }, () => 'run-x').state;
+
+    const { state: next, outcome } = upsert(state, {
+      payload: { name: 'a-again' },
+      contentHash: 'h1',
+      mintInstanceId: mintId,
+    });
+
+    expect(outcome).toEqual({ kind: 'replaced', instanceId: 'i-1', index: 0 });
+    expect(next.items).toHaveLength(2);
+    expect(next.items[0]).toMatchObject({ instanceId: 'i-1', result: undefined, runId: null });
+    expect(next.items[0].payload).toEqual({ name: 'a-again' });
+  });
+
+  it('is idempotent for identical content (same hash re-uploaded stays one instance)', () => {
+    const { state, mintId } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    const { state: next } = upsert(state, { payload: { name: 'one' }, contentHash: 'h1', mintInstanceId: mintId });
+    expect(next.items).toHaveLength(1);
+  });
+});
+
+describe('remove', () => {
+  it('removes an instance', () => {
+    const { state } = seed(
+      { payload: { name: 'one' }, contentHash: 'h1' },
+      { payload: { name: 'two' }, contentHash: 'h2' },
+    );
+    const { state: after, removed } = remove(state, 'i-1');
+    expect(removed).toBe(true);
+    expect(after.items.map((i) => i.payload.name)).toEqual(['two']);
+  });
+
+  it('is a no-op when the instance is missing', () => {
+    const { state } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    const { state: after, removed } = remove(state, 'nope');
+    expect(removed).toBe(false);
+    expect(after).toBe(state);
+  });
+});
+
+describe('beginRun and commitResult (stale-write guard)', () => {
+  it('beginRun mints a run token and sets the pending result', () => {
+    const { state } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    const { state: running, runId } = beginRun(state, 'i-1', { steps: 0, done: false }, () => 'r1');
+    expect(runId).toBe('r1');
+    expect(running.items[0].runId).toBe('r1');
+    expect(running.items[0].result).toEqual({ steps: 0, done: false });
+  });
+
+  it('beginRun on a missing instance is a no-op returning a null run', () => {
+    const { state } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    const { state: after, runId } = beginRun(state, 'nope', { steps: 0, done: false }, () => 'r1');
+    expect(runId).toBeNull();
+    expect(after).toBe(state);
+  });
+
+  it('beginRun on an already-running slot is a no-op (no duplicate pipeline under a repeated effect)', () => {
+    const { state } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    const running = beginRun(state, 'i-1', { steps: 0, done: false }, () => 'r1').state;
+    const { state: after, runId } = beginRun(running, 'i-1', { steps: 0, done: false }, () => 'r2');
+    expect(runId).toBeNull();
+    expect(after.items[0].runId).toBe('r1');
+  });
+
+  it('applies a write that carries the current run token', () => {
+    const { state } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    const running = beginRun(state, 'i-1', { steps: 0, done: false }, () => 'r1').state;
+    const { state: written, applied } = commitResult(running, {
+      instanceId: 'i-1',
+      runId: 'r1',
+      result: { steps: 3, done: true },
+    });
+    expect(applied).toBe(true);
+    expect(written.items[0].result).toEqual({ steps: 3, done: true });
+  });
+
+  it('drops a superseded run’s late write after a replace re-runs the instance', () => {
+    const { state, mintId } = seed({ payload: { name: 'v1' }, contentHash: 'h1' });
+    const running = beginRun(state, 'i-1', { steps: 0, done: false }, () => 'r1').state;
+    // Same content re-uploaded (replace) clears the run token.
+    const replaced = upsert(running, { payload: { name: 'v1' }, contentHash: 'h1', mintInstanceId: mintId }).state;
+    const { applied } = commitResult(replaced, { instanceId: 'i-1', runId: 'r1', result: { steps: 3, done: true } });
+    expect(applied).toBe(false);
+  });
+
+  it('drops a write for an instance that has been removed', () => {
+    const { state } = seed({ payload: { name: 'one' }, contentHash: 'h1' });
+    const running = beginRun(state, 'i-1', { steps: 0, done: false }, () => 'r1').state;
+    const removed = remove(running, 'i-1').state;
+    const { applied } = commitResult(removed, { instanceId: 'i-1', runId: 'r1', result: { steps: 3, done: true } });
+    expect(applied).toBe(false);
+  });
+});

--- a/packages/untp-playground/__tests__/lib/reportService.test.ts
+++ b/packages/untp-playground/__tests__/lib/reportService.test.ts
@@ -248,32 +248,31 @@ describe('generateReport', () => {
   });
 
   it('includes scheme results, top-level metadata, and source when a scheme is provided', async () => {
-    const schemes = {
-      ConformityScheme: {
-        original: {},
-        decoded: {
-          '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'],
-          type: ['ConformityScheme'],
-          id: 'https://example.com/scheme/1',
-          name: 'Sample Scheme',
+    const schemeInstances = [
+      {
+        scheme: {
+          original: {},
+          decoded: {
+            '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+            type: ['ConformityScheme'],
+            id: 'https://example.com/scheme/1',
+            name: 'Sample Scheme',
+          },
+          source: { kind: 'url' as const, url: 'https://example.com/scheme/1.json' },
         },
-        source: { kind: 'url' as const, url: 'https://example.com/scheme/1.json' },
+        steps: [
+          { id: 'scheme-version-detection', name: 'Version Detection', status: TestCaseStatus.SUCCESS },
+          { id: 'scheme-schema-validation', name: 'Schema Validation', status: TestCaseStatus.SUCCESS },
+          { id: 'context', name: 'Context Validation', status: TestCaseStatus.SUCCESS },
+        ],
       },
-    };
-    const schemeTestResults = {
-      ConformityScheme: [
-        { id: 'scheme-version-detection', name: 'Version Detection', status: TestCaseStatus.SUCCESS },
-        { id: 'scheme-schema-validation', name: 'Schema Validation', status: TestCaseStatus.SUCCESS },
-        { id: 'context', name: 'Context Validation', status: TestCaseStatus.SUCCESS },
-      ],
-    };
+    ];
 
     const report = await generateReport({
       implementationName: mockImplementationName,
       credentials: {},
       testResults: {},
-      schemes,
-      schemeTestResults,
+      schemeInstances,
       passStatuses: mockPassStatuses,
     });
 
@@ -291,33 +290,72 @@ describe('generateReport', () => {
   });
 
   it('marks the report as failed when any scheme step fails', async () => {
-    const schemes = {
-      ConformityScheme: {
-        original: {},
-        decoded: {
-          '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'],
-          type: ['ConformityScheme'],
+    const schemeInstances = [
+      {
+        scheme: {
+          original: {},
+          decoded: {
+            '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+            type: ['ConformityScheme'],
+          },
         },
+        steps: [
+          { id: 'scheme-version-detection', name: 'Version Detection', status: TestCaseStatus.SUCCESS },
+          { id: 'scheme-schema-validation', name: 'Schema Validation', status: TestCaseStatus.FAILURE },
+          { id: 'context', name: 'Context Validation', status: TestCaseStatus.SUCCESS },
+        ],
       },
-    };
-    const schemeTestResults = {
-      ConformityScheme: [
-        { id: 'scheme-version-detection', name: 'Version Detection', status: TestCaseStatus.SUCCESS },
-        { id: 'scheme-schema-validation', name: 'Schema Validation', status: TestCaseStatus.FAILURE },
-        { id: 'context', name: 'Context Validation', status: TestCaseStatus.SUCCESS },
-      ],
-    };
+    ];
 
     const report = await generateReport({
       implementationName: mockImplementationName,
       credentials: {},
       testResults: {},
-      schemes,
-      schemeTestResults,
+      schemeInstances,
       passStatuses: mockPassStatuses,
     });
 
     expect(report.pass).toBe(false);
     expect(report.conformitySchemeResults?.[0].status).toBe(TestCaseStatus.FAILURE);
+  });
+
+  it('refuses to generate a report while a scheme instance is still validating', async () => {
+    await expect(
+      generateReport({
+        implementationName: mockImplementationName,
+        credentials: {},
+        testResults: {},
+        schemeInstances: [
+          {
+            scheme: {
+              original: {},
+              decoded: {
+                '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'],
+                type: ['ConformityScheme'],
+              },
+            },
+            steps: [], // no settled steps yet
+          },
+        ],
+        passStatuses: mockPassStatuses,
+      }),
+    ).rejects.toThrow('Cannot generate a report while a scheme is still validating.');
+  });
+
+  it('refuses to generate a report while a credential is still validating', async () => {
+    await expect(
+      generateReport({
+        implementationName: mockImplementationName,
+        credentials: {
+          DigitalProductPassport: {
+            original: {},
+            decoded: { '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'] },
+          },
+        },
+        testResults: {}, // credential loaded but no results yet
+        schemeInstances: [],
+        passStatuses: mockPassStatuses,
+      }),
+    ).rejects.toThrow('Cannot generate a report while a credential is still validating.');
   });
 });

--- a/packages/untp-playground/__tests__/lib/schemeCollection.test.ts
+++ b/packages/untp-playground/__tests__/lib/schemeCollection.test.ts
@@ -25,6 +25,12 @@ describe('schemeContentHash', () => {
     expect(schemeContentHash(doc)).toBe(schemeContentHash({ ...doc }));
   });
 
+  it('is invariant to key order, so a re-serialised document is still one instance', () => {
+    expect(schemeContentHash({ id: 'x', name: 'S', meta: { a: 1, b: 2 } })).toBe(
+      schemeContentHash({ meta: { b: 2, a: 1 }, name: 'S', id: 'x' }),
+    );
+  });
+
   it('differs for different content', () => {
     expect(schemeContentHash({ id: 'a' })).not.toBe(schemeContentHash({ id: 'b' }));
   });

--- a/packages/untp-playground/__tests__/lib/schemeCollection.test.ts
+++ b/packages/untp-playground/__tests__/lib/schemeCollection.test.ts
@@ -1,0 +1,85 @@
+import { schemeContentHash, schemeIsTerminal, schemeTitle, schemeSubtitle } from '@/lib/schemeCollection';
+import type { StoredScheme, TestStep } from '@/types';
+import { TestCaseStatus, TestCaseStepId } from '../../constants';
+
+jest.mock('@/lib/schemeValidation', () => ({
+  detectSchemeVersion: jest.fn(),
+}));
+import { detectSchemeVersion } from '@/lib/schemeValidation';
+
+const step = (status: TestCaseStatus): TestStep => ({
+  id: TestCaseStepId.SCHEME_VERSION_DETECTION,
+  name: 'x',
+  status,
+});
+
+const scheme = (decoded: Record<string, unknown>, source?: StoredScheme['source']): StoredScheme => ({
+  original: decoded,
+  decoded,
+  source,
+});
+
+describe('schemeContentHash', () => {
+  it('is stable for identical content', () => {
+    const doc = { id: 'x', name: 'Scheme', '@context': ['https://vocabulary.uncefact.org/untp/0.7.0/context/'] };
+    expect(schemeContentHash(doc)).toBe(schemeContentHash({ ...doc }));
+  });
+
+  it('differs for different content', () => {
+    expect(schemeContentHash({ id: 'a' })).not.toBe(schemeContentHash({ id: 'b' }));
+  });
+
+  it('differs for two documents that share a filename-worthy shape but differ in content', () => {
+    // Two schemes a user might both save as scheme.json still hash differently.
+    expect(schemeContentHash({ name: 'Scheme A', id: '1' })).not.toBe(schemeContentHash({ name: 'Scheme B', id: '2' }));
+  });
+});
+
+describe('schemeIsTerminal', () => {
+  it('is false for an empty step list', () => {
+    expect(schemeIsTerminal([])).toBe(false);
+  });
+
+  it('is false while any step is pending or in progress', () => {
+    expect(schemeIsTerminal([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.IN_PROGRESS)])).toBe(false);
+    expect(schemeIsTerminal([step(TestCaseStatus.PENDING)])).toBe(false);
+  });
+
+  it('is true when every step has settled to success or failure', () => {
+    expect(schemeIsTerminal([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.SUCCESS)])).toBe(true);
+    expect(schemeIsTerminal([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.FAILURE)])).toBe(true);
+    expect(schemeIsTerminal([step(TestCaseStatus.FAILURE)])).toBe(true);
+  });
+});
+
+describe('schemeTitle', () => {
+  it('uses the scheme name when present', () => {
+    expect(schemeTitle(scheme({ name: 'Mining Assurance Scheme' }))).toBe('Mining Assurance Scheme');
+  });
+
+  it('uses the final path segment of a url source, never the raw url', () => {
+    const title = schemeTitle(scheme({}, { kind: 'url', url: 'https://s.example/schemes/mas.json' }));
+    expect(title).toBe('mas.json');
+    expect(title).not.toContain('https://');
+  });
+
+  it('uses the filename for a file source when there is no name', () => {
+    expect(schemeTitle(scheme({}, { kind: 'file', filename: 'my-scheme.json' }))).toBe('my-scheme.json');
+  });
+
+  it('falls back to the family label when there is no name or source', () => {
+    expect(schemeTitle(scheme({}))).toBe('Conformity Scheme');
+  });
+});
+
+describe('schemeSubtitle', () => {
+  it('shows the family label with the detected context version', () => {
+    (detectSchemeVersion as jest.Mock).mockReturnValue('0.7.0');
+    expect(schemeSubtitle(scheme({}))).toBe('Conformity Scheme (v0.7.0)');
+  });
+
+  it('shows the family label alone when no version is detected', () => {
+    (detectSchemeVersion as jest.Mock).mockReturnValue(undefined);
+    expect(schemeSubtitle(scheme({}))).toBe('Conformity Scheme');
+  });
+});

--- a/packages/untp-playground/e2e/cypress/e2e/conformity-scheme-validation.cy.ts
+++ b/packages/untp-playground/e2e/cypress/e2e/conformity-scheme-validation.cy.ts
@@ -13,7 +13,7 @@ import { CONFORMITY_SCHEME_E2E_VERSIONS } from '../fixtures/conformity-schemes-e
  * not need to change.
  */
 
-const SCHEME_GROUP_HEADER = 'ConformityScheme-group-header';
+const SCHEME_GROUP_HEADER = 'scheme-group-header';
 
 // Scheme results render in the Conformity Schemes tab panel, which is hidden while the default
 // Credentials tab is active. Switch to that tab before interacting with the scheme results.

--- a/packages/untp-playground/src/app/page.tsx
+++ b/packages/untp-playground/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { ArtefactUploader, type ArtefactSource } from '@/components/ArtefactUploader';
@@ -13,6 +13,10 @@ import { SchemeTestResults } from '@/components/SchemeTestResults';
 import { SectionHeader } from '@/components/SectionHeader';
 import { TestResults } from '@/components/TestResults';
 import { TestReportProvider } from '@/contexts/TestReportContext';
+import { useArtefactCollection } from '@/hooks/useArtefactCollection';
+import { upsert } from '@/lib/artefactCollection';
+import { newId } from '@/lib/id';
+import { schemeContentHash, schemeTitle } from '@/lib/schemeCollection';
 import {
   decodeEnvelopedCredential,
   detectArtefact,
@@ -26,21 +30,16 @@ import { useError } from '@/contexts/ErrorContext';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { FileText, Link2, Server } from 'lucide-react';
-import { ArtefactKind, permittedCredentialTypes, SchemeType } from '../../constants';
+import { ArtefactKind, permittedCredentialTypes } from '../../constants';
 
 export default function Home() {
   const [credentials, setCredentials] = useState<{
     [key in PermittedCredentialType]?: StoredCredential;
   }>({});
-  const [schemes, setSchemes] = useState<{
-    [key in SchemeType]?: StoredScheme;
-  }>({});
   const [testResults, setTestResults] = useState<{
     [key in PermittedCredentialType]?: TestStep[];
   }>({});
-  const [schemeTestResults, setSchemeTestResults] = useState<{
-    [key in SchemeType]?: TestStep[];
-  }>({});
+  const scheme = useArtefactCollection<StoredScheme, TestStep[]>();
   const [fileCount, setFileCount] = useState(0);
   const { dispatchError, errors, setIsDetailsOpen } = useError();
 
@@ -51,22 +50,28 @@ export default function Home() {
   // tab has no count). linkSetsCount drives only the Link Sets tab count; its empty state stays
   // unconditional until #811 adds real data.
   const credentialsCount = Object.keys(credentials).length;
-  const schemesCount = Object.keys(schemes).length;
+  const schemesCount = scheme.state.items.length;
   const linkSetsCount = 0; // Link Sets family lands in #811.
+
+  // Recomputed only when the scheme instances change (add, replace, remove, or a result commit), so
+  // an unrelated re-render does not create a fresh array and re-run the report-reset effect.
+  const schemeInstances = useMemo(
+    () => scheme.state.items.map((item) => ({ scheme: item.payload, steps: item.result ?? [] })),
+    [scheme.state.items],
+  );
 
   const handleArtefactUpload = async (rawArtefact: any, source?: ArtefactSource) => {
     try {
       const detected = detectArtefact(rawArtefact?.verifiableCredential ?? rawArtefact);
 
       if (detected?.kind === ArtefactKind.SCHEME) {
-        setSchemes((prev) => ({
-          ...prev,
-          [detected.type]: {
-            original: rawArtefact,
-            decoded: rawArtefact,
-            source,
-          },
-        }));
+        const stored: StoredScheme = { original: rawArtefact, decoded: rawArtefact, source };
+        const { outcome } = scheme.dispatch((state) =>
+          upsert(state, { payload: stored, contentHash: schemeContentHash(stored.decoded), mintInstanceId: newId }),
+        );
+        if (outcome.kind === 'replaced') {
+          toast.success(`Replaced ${schemeTitle(stored)}`);
+        }
         return;
       }
 
@@ -139,12 +144,7 @@ export default function Home() {
     <div className='min-h-screen flex flex-col'>
       <Header />
       <main className='container mx-auto p-8 max-w-7xl flex-1'>
-        <TestReportProvider
-          testResults={testResults}
-          credentials={credentials}
-          schemes={schemes}
-          schemeTestResults={schemeTestResults}
-        >
+        <TestReportProvider testResults={testResults} credentials={credentials} schemeInstances={schemeInstances}>
           <SectionHeader title='Test artefacts'>
             <ReportActions />
           </SectionHeader>
@@ -188,11 +188,7 @@ export default function Home() {
                       guidance='Add a scheme from the panel on the right. Drop a JSON-LD file or paste a URL. Each scheme you add appears here and in the generated report.'
                     />
                   ) : (
-                    <SchemeTestResults
-                      schemes={schemes}
-                      testResults={schemeTestResults}
-                      setTestResults={setSchemeTestResults}
-                    />
+                    <SchemeTestResults collection={scheme.state} dispatch={scheme.dispatch} />
                   )}
                 </TabsContent>
 

--- a/packages/untp-playground/src/components/GenerateReportDialog.tsx
+++ b/packages/untp-playground/src/components/GenerateReportDialog.tsx
@@ -36,7 +36,7 @@ export function GenerateReportDialog() {
     report !== null
       ? 'A report has already been generated'
       : !canGenerateReport
-        ? 'Upload and validate a credential to generate a conformance report'
+        ? 'Upload and validate a credential or conformity scheme to generate a conformance report'
         : 'Generate UNTP conformance report';
 
   return (

--- a/packages/untp-playground/src/components/SchemeTestResults.tsx
+++ b/packages/untp-playground/src/components/SchemeTestResults.tsx
@@ -298,7 +298,10 @@ function SchemeCard({ item, onRemove }: { item: SchemeSlot; onRemove: () => void
       <button
         type='button'
         aria-label={`Remove ${title}`}
-        onClick={onRemove}
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
         // Revealed only when the pointer is over the delete region itself (the right edge), or when
         // the control is keyboard-focused, rather than on hover of the whole card.
         className='absolute bottom-0 right-0 top-0 flex w-12 items-center justify-center bg-red-400 text-white opacity-0 transition-opacity hover:bg-red-500 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100'

--- a/packages/untp-playground/src/components/SchemeTestResults.tsx
+++ b/packages/untp-playground/src/components/SchemeTestResults.tsx
@@ -2,25 +2,37 @@
 
 import { SourceCaption } from '@/components/SourceCaption';
 import { StatusIcon } from '@/components/StatusIcon';
-import { Card } from '@/components/ui/card';
-import { validateContext } from '@/lib/contextValidation';
-import { detectSchemeVersion, SchemaFetchError, validateSchemeSchema } from '@/lib/schemeValidation';
-import type { StoredScheme, TestStep } from '@/types';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import confetti from 'canvas-confetti';
-import { SchemeType, TestCaseStatus, TestCaseStepId } from '../../constants';
 import { confettiConfig } from '@/components/TestResults';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { beginRun, commitResult, remove } from '@/lib/artefactCollection';
+import { validateContext } from '@/lib/contextValidation';
+import { newId } from '@/lib/id';
+import { schemeSubtitle, schemeTitle } from '@/lib/schemeCollection';
+import { detectSchemeVersion, SchemaFetchError, validateSchemeSchema } from '@/lib/schemeValidation';
+import type { ArtefactSlot, CollectionState, InstanceId, RunId } from '@/types/artefact';
+import type { StoredScheme, TestStep } from '@/types';
+import confetti from 'canvas-confetti';
+import { ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { TestCaseStatus, TestCaseStepId } from '../../constants';
+
+type SchemeCollection = CollectionState<StoredScheme, TestStep[]>;
+type SchemeDispatch = <Res extends { state: SchemeCollection }>(transition: (current: SchemeCollection) => Res) => Res;
+type SchemeSlot = ArtefactSlot<StoredScheme, TestStep[]>;
 
 interface SchemeTestResultsProps {
-  schemes: { [key in SchemeType]?: StoredScheme };
-  testResults: { [key in SchemeType]?: TestStep[] };
-  setTestResults: React.Dispatch<React.SetStateAction<{ [key in SchemeType]?: TestStep[] }>>;
+  collection: SchemeCollection;
+  dispatch: SchemeDispatch;
 }
-
-const SCHEME_DISPLAY_LABEL: Record<SchemeType, string> = {
-  [SchemeType.CONFORMITY_SCHEME]: 'ConformityScheme',
-};
 
 const initialSteps: TestStep[] = [
   { id: TestCaseStepId.SCHEME_VERSION_DETECTION, name: 'Version Detection', status: TestCaseStatus.PENDING },
@@ -32,61 +44,93 @@ const initialSteps: TestStep[] = [
   },
 ];
 
-export function SchemeTestResults({ schemes, testResults, setTestResults }: SchemeTestResultsProps) {
-  const validatedRef = useRef<{ [key in SchemeType]?: unknown }>({});
-  const confettiShownRef = useRef<{ [key in SchemeType]?: unknown }>({});
+const freshSteps = (): TestStep[] => initialSteps.map((step) => ({ ...step }));
+
+export function SchemeTestResults({ collection, dispatch }: SchemeTestResultsProps) {
+  // Confetti fires once per (instance, run) so it does not re-fire on unrelated re-renders.
+  const confettiShownRef = useRef<Set<string>>(new Set());
+  const [pendingRemoval, setPendingRemoval] = useState<SchemeSlot | null>(null);
+
+  // Start the pipeline for any instance that has no live run and no result yet (freshly added or
+  // replaced). beginRun no-ops on an already-running slot, so a repeated effect cannot double-start.
+  useEffect(() => {
+    for (const item of collection.items) {
+      if (item.runId === null && item.result === undefined) {
+        const { runId } = dispatch((state) => beginRun(state, item.instanceId, freshSteps(), newId));
+        if (runId) void runSchemePipeline(item.instanceId, runId, item.payload, dispatch);
+      }
+    }
+  }, [collection.items, dispatch]);
 
   useEffect(() => {
-    (Object.values(SchemeType) as SchemeType[]).forEach((type) => {
-      const stored = schemes[type];
-      if (!stored) return;
+    for (const item of collection.items) {
+      const steps = item.result;
+      if (!steps || item.runId === null) continue;
+      const key = `${item.instanceId}:${item.runId}`;
+      if (confettiShownRef.current.has(key)) continue;
+      if (steps.length > 0 && steps.every((step) => step.status === TestCaseStatus.SUCCESS)) {
+        confettiShownRef.current.add(key);
+        confetti(confettiConfig);
+      }
+    }
+  }, [collection.items]);
 
-      const alreadyValidated = validatedRef.current[type] === stored.original;
-      if (alreadyValidated) return;
-
-      validatedRef.current[type] = stored.original;
-      confettiShownRef.current[type] = undefined;
-      setTestResults((prev) => ({ ...prev, [type]: initialSteps.map((step) => ({ ...step })) }));
-
-      void runPipeline(type, stored, setTestResults);
-    });
-  }, [schemes, setTestResults]);
-
-  useEffect(() => {
-    (Object.values(SchemeType) as SchemeType[]).forEach((type) => {
-      const stored = schemes[type];
-      const steps = testResults[type];
-      if (!stored || !steps || steps.length === 0) return;
-      const allPassed = steps.every((step) => step.status === TestCaseStatus.SUCCESS);
-      if (!allPassed) return;
-      if (confettiShownRef.current[type] === stored.original) return;
-      confettiShownRef.current[type] = stored.original;
-      confetti(confettiConfig);
-    });
-  }, [schemes, testResults]);
+  const confirmRemoval = () => {
+    if (!pendingRemoval) return;
+    dispatch((state) => remove(state, pendingRemoval.instanceId));
+    setPendingRemoval(null);
+  };
 
   return (
     <section className='space-y-4' data-testid='scheme-results'>
-      {(Object.values(SchemeType) as SchemeType[]).map((type) => (
-        <SchemeCard key={type} type={type} scheme={schemes[type]} steps={testResults[type] ?? []} />
+      {collection.items.map((item) => (
+        <SchemeCard key={item.instanceId} item={item} onRemove={() => setPendingRemoval(item)} />
       ))}
+
+      <Dialog open={pendingRemoval !== null} onOpenChange={(open) => !open && setPendingRemoval(null)}>
+        <DialogContent className='sm:max-w-[425px]'>
+          <DialogHeader>
+            <DialogTitle>Remove {pendingRemoval ? schemeTitle(pendingRemoval.payload) : 'scheme'}?</DialogTitle>
+            <DialogDescription>
+              This removes the scheme and its validation results from this session. You can add it again by uploading
+              it.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant='outline' onClick={() => setPendingRemoval(null)}>
+              Cancel
+            </Button>
+            <Button variant='destructive' onClick={confirmRemoval}>
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }
 
-async function runPipeline(
-  type: SchemeType,
+async function runSchemePipeline(
+  instanceId: InstanceId,
+  runId: RunId,
   stored: StoredScheme,
-  setTestResults: React.Dispatch<React.SetStateAction<{ [key in SchemeType]?: TestStep[] }>>,
-) {
-  const setStep = (stepId: TestCaseStepId, patch: Partial<TestStep>) => {
-    setTestResults((prev) => ({
-      ...prev,
-      [type]: prev[type]?.map((step) => (step.id === stepId ? { ...step, ...patch } : step)),
-    }));
+  dispatch: SchemeDispatch,
+): Promise<void> {
+  const steps = freshSteps();
+
+  // The only write path: commit the whole step list through the run guard. Returns false once the
+  // run has been superseded (replaced or removed), so a stale run stops writing.
+  const setStep = (stepId: TestCaseStepId, patch: Partial<TestStep>): boolean => {
+    const index = steps.findIndex((step) => step.id === stepId);
+    if (index !== -1) steps[index] = { ...steps[index], ...patch };
+    const { applied } = dispatch((state) =>
+      commitResult(state, { instanceId, runId, result: steps.map((step) => ({ ...step })) }),
+    );
+    return applied;
   };
 
-  setStep(TestCaseStepId.SCHEME_VERSION_DETECTION, { status: TestCaseStatus.IN_PROGRESS });
+  if (!setStep(TestCaseStepId.SCHEME_VERSION_DETECTION, { status: TestCaseStatus.IN_PROGRESS })) return;
+
   const version = detectSchemeVersion(stored.decoded);
   if (!version) {
     const message =
@@ -105,9 +149,9 @@ async function runPipeline(
     });
     return;
   }
-  setStep(TestCaseStepId.SCHEME_VERSION_DETECTION, { status: TestCaseStatus.SUCCESS });
+  if (!setStep(TestCaseStepId.SCHEME_VERSION_DETECTION, { status: TestCaseStatus.SUCCESS })) return;
 
-  setStep(TestCaseStepId.SCHEME_SCHEMA_VALIDATION, { status: TestCaseStatus.IN_PROGRESS });
+  if (!setStep(TestCaseStepId.SCHEME_SCHEMA_VALIDATION, { status: TestCaseStatus.IN_PROGRESS })) return;
   try {
     const result = await validateSchemeSchema(stored.decoded, version);
     setStep(TestCaseStepId.SCHEME_SCHEMA_VALIDATION, {
@@ -121,7 +165,7 @@ async function runPipeline(
     });
   }
 
-  setStep(TestCaseStepId.CONTEXT_VALIDATION, { status: TestCaseStatus.IN_PROGRESS });
+  if (!setStep(TestCaseStepId.CONTEXT_VALIDATION, { status: TestCaseStatus.IN_PROGRESS })) return;
   try {
     const contextResult = await validateContext(stored.decoded);
     setStep(TestCaseStepId.CONTEXT_VALIDATION, {
@@ -165,10 +209,7 @@ function schemaFetchError(err: unknown): DisplayableError {
   if (err instanceof SchemaFetchError) {
     switch (err.reason) {
       case 'timeout':
-        return {
-          message: 'The schema service did not respond in time. Please try again.',
-          supportable: true,
-        };
+        return { message: 'The schema service did not respond in time. Please try again.', supportable: true };
       case 'not-found':
         return {
           message: `No schema is published at ${err.schemaUrl}. Check that the scheme's @context references a UNTP version with a published schema.`,
@@ -180,10 +221,7 @@ function schemaFetchError(err: unknown): DisplayableError {
         };
       case 'network':
       default:
-        return {
-          message: 'We could not reach the schema service. Please try again.',
-          supportable: true,
-        };
+        return { message: 'We could not reach the schema service. Please try again.', supportable: true };
     }
   }
   return {
@@ -192,30 +230,13 @@ function schemaFetchError(err: unknown): DisplayableError {
   };
 }
 
-function schemeName(scheme: StoredScheme | undefined): string | undefined {
-  const name = scheme?.decoded?.name;
-  return typeof name === 'string' && name.length > 0 ? name : undefined;
-}
-
-function schemeVersion(scheme: StoredScheme | undefined): string | undefined {
-  if (!scheme) return undefined;
-  return detectSchemeVersion(scheme.decoded) ?? undefined;
-}
-
-function SchemeCard({
-  type,
-  scheme,
-  steps,
-}: {
-  type: SchemeType;
-  scheme: StoredScheme | undefined;
-  steps: TestStep[];
-}) {
+function SchemeCard({ item, onRemove }: { item: SchemeSlot; onRemove: () => void }) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const hasScheme = scheme !== undefined;
+  const scheme = item.payload;
+  const steps = item.result ?? [];
+  const title = schemeTitle(scheme);
 
   const overallStatus = useMemo(() => {
-    if (!hasScheme) return TestCaseStatus.PENDING;
     if (steps.length === 0) return TestCaseStatus.PENDING;
     if (steps.some((step) => step.status === TestCaseStatus.IN_PROGRESS || step.status === TestCaseStatus.PENDING)) {
       return TestCaseStatus.IN_PROGRESS;
@@ -223,68 +244,67 @@ function SchemeCard({
     return steps.every((step) => step.status === TestCaseStatus.SUCCESS)
       ? TestCaseStatus.SUCCESS
       : TestCaseStatus.FAILURE;
-  }, [hasScheme, steps]);
+  }, [steps]);
 
   return (
-    <Card className='p-4'>
+    <Card className='group relative overflow-hidden p-4'>
       <div
         className='flex flex-wrap items-center justify-between gap-2 cursor-pointer'
         onClick={() => setIsExpanded((prev) => !prev)}
-        data-testid={`${type}-group-header`}
+        data-testid='scheme-group-header'
+        data-instance-id={item.instanceId}
       >
-        <div className='flex items-center gap-2'>
-          {isExpanded ? <ChevronDown className='h-4 w-4' /> : <ChevronRight className='h-4 w-4' />}
-          <div className='flex flex-col'>
-            <h3 className='font-semibold'>{schemeName(scheme) ?? SCHEME_DISPLAY_LABEL[type]}</h3>
-            {schemeName(scheme) && (
-              <span className='text-xs text-gray-500'>
-                {SCHEME_DISPLAY_LABEL[type]}
-                {schemeVersion(scheme) && ` (v${schemeVersion(scheme)})`}
-              </span>
-            )}
-            {!schemeName(scheme) && schemeVersion(scheme) && (
-              <span className='text-xs text-gray-500'>v{schemeVersion(scheme)}</span>
-            )}
+        <div className='flex min-w-0 items-center gap-2'>
+          {isExpanded ? <ChevronDown className='h-4 w-4 shrink-0' /> : <ChevronRight className='h-4 w-4 shrink-0' />}
+          <div className='flex min-w-0 flex-col'>
+            <h3 className='truncate font-semibold'>{title}</h3>
+            <span className='truncate text-xs text-gray-500'>{schemeSubtitle(scheme)}</span>
           </div>
         </div>
-        <StatusIcon status={overallStatus} testId={type} />
+        <StatusIcon status={overallStatus} testId={item.instanceId} />
       </div>
       {isExpanded && (
-        <div className='mt-4 pl-6 space-y-2'>
-          {scheme?.source && <SourceCaption source={scheme.source} />}
-          {steps.length > 0 ? (
-            steps.map((step) => (
-              <div key={step.id} className='py-2'>
-                <div className='flex items-center gap-2'>
-                  <StatusIcon status={step.status} testId={step.id} />
-                  <span>{step.name}</span>
-                </div>
-                {step.status === TestCaseStatus.FAILURE && stepErrors(step).length > 0 && (
-                  <ul className='mt-1 pl-6 list-disc text-sm text-red-600 space-y-1'>
-                    {stepErrors(step).map((error, idx) => (
-                      <li key={idx}>
-                        {error.message}
-                        {error.supportable && (
-                          <>
-                            {' '}
-                            If this keeps happening,{' '}
-                            <a href={SUPPORT_URL} target='_blank' rel='noopener noreferrer' className='underline'>
-                              report an issue
-                            </a>
-                            .
-                          </>
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                )}
+        <div className='mt-4 space-y-2 pl-6'>
+          {scheme.source && <SourceCaption source={scheme.source} />}
+          {steps.map((step) => (
+            <div key={step.id} className='py-2'>
+              <div className='flex items-center gap-2'>
+                <StatusIcon status={step.status} testId={step.id} />
+                <span>{step.name}</span>
               </div>
-            ))
-          ) : (
-            <p className='text-sm text-gray-500 italic'>Upload a conformity scheme to begin validation.</p>
-          )}
+              {step.status === TestCaseStatus.FAILURE && stepErrors(step).length > 0 && (
+                <ul className='mt-1 list-disc space-y-1 pl-6 text-sm text-red-600'>
+                  {stepErrors(step).map((error, idx) => (
+                    <li key={idx}>
+                      {error.message}
+                      {error.supportable && (
+                        <>
+                          {' '}
+                          If this keeps happening,{' '}
+                          <a href={SUPPORT_URL} target='_blank' rel='noopener noreferrer' className='underline'>
+                            report an issue
+                          </a>
+                          .
+                        </>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
         </div>
       )}
+      <button
+        type='button'
+        aria-label={`Remove ${title}`}
+        onClick={onRemove}
+        // Revealed only when the pointer is over the delete region itself (the right edge), or when
+        // the control is keyboard-focused, rather than on hover of the whole card.
+        className='absolute bottom-0 right-0 top-0 flex w-12 items-center justify-center bg-red-400 text-white opacity-0 transition-opacity hover:bg-red-500 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100'
+      >
+        <Trash2 className='h-4 w-4' />
+      </button>
     </Card>
   );
 }

--- a/packages/untp-playground/src/contexts/TestReportContext.tsx
+++ b/packages/untp-playground/src/contexts/TestReportContext.tsx
@@ -2,10 +2,10 @@
 
 import { generateReport } from '@/lib/reportService';
 import { downloadHtml, downloadJson } from '@/lib/utils';
-import { DownloadReportFormat, StoredCredential, StoredScheme, TestReport, TestStep } from '@/types';
+import { DownloadReportFormat, SchemeReportInput, StoredCredential, TestReport, TestStep } from '@/types';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { CredentialType, SchemeType, TestCaseStatus } from '../../constants';
+import { CredentialType, TestCaseStatus } from '../../constants';
 
 interface TestReportContextType {
   canGenerateReport: boolean;
@@ -17,62 +17,53 @@ interface TestReportContextType {
 
 const TestReportContext = createContext<TestReportContextType | undefined>(undefined);
 
+// A stable empty default so a consumer with no schemes does not churn the report-reset effect.
+const NO_SCHEME_INSTANCES: SchemeReportInput[] = [];
+
 interface TestReportProviderProps {
   children: React.ReactNode;
   testResults: Partial<Record<CredentialType, TestStep[]>>;
   credentials: Partial<Record<CredentialType, StoredCredential>>;
-  schemes?: Partial<Record<SchemeType, StoredScheme>>;
-  schemeTestResults?: Partial<Record<SchemeType, TestStep[]>>;
+  schemeInstances?: SchemeReportInput[];
 }
 
 export function TestReportProvider({
   children,
   testResults,
   credentials,
-  schemes,
-  schemeTestResults,
+  schemeInstances = NO_SCHEME_INSTANCES,
 }: TestReportProviderProps) {
   const [report, setReport] = useState<TestReport | null>(null);
 
   const allowedStatuses = [TestCaseStatus.SUCCESS, TestCaseStatus.FAILURE, TestCaseStatus.WARNING];
   const passStatuses = [TestCaseStatus.SUCCESS, TestCaseStatus.WARNING];
 
-  // Reset report when the uploaded artefacts change
+  // Invalidate any generated report whenever the loaded artefacts change, including when the last
+  // one is removed, so a stale report cannot be downloaded for artefacts no longer loaded.
   useEffect(() => {
-    const hasAnyCredential = Object.values(credentials).some((cred) => cred && cred.decoded);
-    const hasAnyScheme = Object.values(schemes ?? {}).some((scheme) => scheme && scheme.decoded);
-    if (hasAnyCredential || hasAnyScheme) {
-      setReport(null);
-    }
-  }, [credentials, schemes]);
+    setReport(null);
+  }, [credentials, schemeInstances]);
 
-  const credentialReportable =
-    Object.entries(testResults).every(([type, steps]) => {
-      if (!steps) return true;
-      const credential = credentials[type as CredentialType];
-      if (!credential || !credential.decoded) return true;
-      return steps.every((step) => allowedStatuses.includes(step.status));
-    }) &&
-    Object.entries(testResults).some(([type, steps]) => {
-      const credential = credentials[type as CredentialType];
-      return credential && credential.decoded && steps && steps.every((step) => allowedStatuses.includes(step.status));
-    });
+  // A report needs at least one loaded family, and every loaded family must be fully terminal (a
+  // non-empty result whose steps have all settled). A still-validating credential or scheme holds
+  // generation rather than being recorded as a spurious pass or failure (ADR-041).
+  const isTerminal = (steps: TestStep[] | undefined) =>
+    steps !== undefined && steps.length > 0 && steps.every((step) => allowedStatuses.includes(step.status));
 
-  const schemeReportable =
-    schemes !== undefined &&
-    schemeTestResults !== undefined &&
-    Object.entries(schemeTestResults).every(([type, steps]) => {
-      if (!steps) return true;
-      const scheme = schemes[type as SchemeType];
-      if (!scheme || !scheme.decoded) return true;
-      return steps.every((step) => allowedStatuses.includes(step.status));
-    }) &&
-    Object.entries(schemeTestResults).some(([type, steps]) => {
-      const scheme = schemes[type as SchemeType];
-      return scheme && scheme.decoded && steps && steps.every((step) => allowedStatuses.includes(step.status));
-    });
+  const hasCredentials = Object.values(credentials).some((cred) => cred && cred.decoded);
+  const hasSchemes = schemeInstances.length > 0;
 
-  const canGenerateReport = credentialReportable || schemeReportable;
+  const allCredentialsTerminal = (Object.keys(credentials) as CredentialType[]).every((type) => {
+    const credential = credentials[type];
+    if (!credential || !credential.decoded) return true;
+    return isTerminal(testResults[type]);
+  });
+  const allSchemesTerminal = schemeInstances.every(({ steps }) => isTerminal(steps));
+
+  const canGenerateReport =
+    (hasCredentials || hasSchemes) &&
+    (!hasCredentials || allCredentialsTerminal) &&
+    (!hasSchemes || allSchemesTerminal);
 
   const canDownloadReport = report !== null;
 
@@ -82,8 +73,7 @@ export function TestReportProvider({
         implementationName,
         credentials,
         testResults,
-        schemes,
-        schemeTestResults,
+        schemeInstances,
         passStatuses,
       });
 

--- a/packages/untp-playground/src/hooks/useArtefactCollection.ts
+++ b/packages/untp-playground/src/hooks/useArtefactCollection.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { emptyCollection } from '@/lib/artefactCollection';
+import type { CollectionState } from '@/types/artefact';
+
+/**
+ * React glue for the shared per-instance collection (ADR-041). It mirrors the state into a ref
+ * so a pure transition is applied against the latest value and its outcome is returned to the
+ * caller for a toast fired outside any state updater (avoiding the StrictMode double-fire). Every
+ * mutation goes through `dispatch`, so the ref and the state never diverge.
+ */
+export function useArtefactCollection<P, R>() {
+  const [state, setState] = useState<CollectionState<P, R>>(() => emptyCollection<P, R>());
+  const ref = useRef(state);
+
+  const dispatch = useCallback(
+    <Res extends { state: CollectionState<P, R> }>(transition: (current: CollectionState<P, R>) => Res): Res => {
+      const result = transition(ref.current);
+      ref.current = result.state;
+      setState(result.state);
+      return result;
+    },
+    [],
+  );
+
+  return { state, dispatch };
+}

--- a/packages/untp-playground/src/lib/artefactCollection.ts
+++ b/packages/untp-playground/src/lib/artefactCollection.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure operations for the shared per-instance artefact model (ADR-041).
+ *
+ * Framework-free and family-agnostic: `P` is the family payload, `R` the family result, both
+ * opaque here. Identity is the content hash: identical content is one instance, different content
+ * is a separate one. Id minting is injected so the operations stay pure and deterministic under
+ * test. The React layer supplies real minters.
+ */
+
+import type { ArtefactSlot, CollectionState, InstanceId, MatchResult, RunId, UpsertOutcome } from '@/types/artefact';
+
+export function emptyCollection<P, R>(): CollectionState<P, R> {
+  return { items: [] };
+}
+
+/** Find the instance whose content hash matches, if any. */
+export function matchTarget(
+  items: ReadonlyArray<{ instanceId: InstanceId; contentHash: string }>,
+  contentHash: string,
+): MatchResult {
+  const match = items.find((item) => item.contentHash === contentHash);
+  return match ? { kind: 'one', instanceId: match.instanceId } : { kind: 'none' };
+}
+
+/**
+ * Append a new instance in upload order, or, when its content hash matches a loaded instance,
+ * replace that instance at its existing index (keeping its instanceId, clearing its result and
+ * run token so a superseded run cannot write). Re-uploading identical content is therefore
+ * idempotent; different content always appends.
+ */
+export function upsert<P, R>(
+  state: CollectionState<P, R>,
+  input: { payload: P; contentHash: string; mintInstanceId: () => InstanceId },
+): { state: CollectionState<P, R>; outcome: UpsertOutcome } {
+  const index = state.items.findIndex((item) => item.contentHash === input.contentHash);
+
+  if (index !== -1) {
+    const instanceId = state.items[index].instanceId;
+    const items = state.items.slice();
+    items[index] = {
+      instanceId,
+      contentHash: input.contentHash,
+      payload: input.payload,
+      result: undefined,
+      runId: null,
+    };
+    return { state: { items }, outcome: { kind: 'replaced', instanceId, index } };
+  }
+
+  const instanceId = input.mintInstanceId();
+  const slot: ArtefactSlot<P, R> = {
+    instanceId,
+    contentHash: input.contentHash,
+    payload: input.payload,
+    result: undefined,
+    runId: null,
+  };
+  return { state: { items: [...state.items, slot] }, outcome: { kind: 'appended', instanceId } };
+}
+
+/** Remove an instance. Removing a missing instance is a no-op. */
+export function remove<P, R>(
+  state: CollectionState<P, R>,
+  instanceId: InstanceId,
+): { state: CollectionState<P, R>; removed: boolean } {
+  const index = state.items.findIndex((item) => item.instanceId === instanceId);
+  if (index === -1) return { state, removed: false };
+  const items = state.items.slice();
+  items.splice(index, 1);
+  return { state: { items }, removed: true };
+}
+
+/**
+ * Mint a fresh run token for an idle instance and set its pending result. Only an idle slot begins
+ * a run, so a repeated call for the same instance (for example React StrictMode's double effect)
+ * is a no-op returning a null run, rather than starting a duplicate pipeline.
+ */
+export function beginRun<P, R>(
+  state: CollectionState<P, R>,
+  instanceId: InstanceId,
+  emptyResult: R,
+  mintRunId: () => RunId,
+): { state: CollectionState<P, R>; runId: RunId | null } {
+  const index = state.items.findIndex((item) => item.instanceId === instanceId);
+  if (index === -1 || state.items[index].runId !== null) return { state, runId: null };
+
+  const runId = mintRunId();
+  const items = state.items.slice();
+  items[index] = { ...items[index], runId, result: emptyResult };
+  return { state: { items }, runId };
+}
+
+/**
+ * The only path that writes a result. Applies only when the instance still exists and still holds
+ * the given run token, so a superseded or removed run's late completion is dropped.
+ */
+export function commitResult<P, R>(
+  state: CollectionState<P, R>,
+  args: { instanceId: InstanceId; runId: RunId; result: R },
+): { state: CollectionState<P, R>; applied: boolean } {
+  const index = state.items.findIndex((item) => item.instanceId === args.instanceId);
+  if (index === -1 || state.items[index].runId !== args.runId) {
+    return { state, applied: false };
+  }
+  const items = state.items.slice();
+  items[index] = { ...items[index], result: args.result };
+  return { state: { items }, applied: true };
+}

--- a/packages/untp-playground/src/lib/hash.ts
+++ b/packages/untp-playground/src/lib/hash.ts
@@ -1,0 +1,22 @@
+/**
+ * A fast, non-cryptographic content hash (cyrb53) used to identify artefacts by content (ADR-041).
+ *
+ * Identity, not security: the playground uses this to dedupe identical uploads and to keep two
+ * documents with different content (even the same filename) as separate instances. Collision
+ * probability across a handful of loaded artefacts is negligible.
+ */
+export function hashContent(value: unknown): string {
+  const input = JSON.stringify(value) ?? '';
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
+}

--- a/packages/untp-playground/src/lib/hash.ts
+++ b/packages/untp-playground/src/lib/hash.ts
@@ -5,8 +5,29 @@
  * documents with different content (even the same filename) as separate instances. Collision
  * probability across a handful of loaded artefacts is negligible.
  */
+
+/**
+ * Deterministic JSON with recursively key-sorted objects, so the same document hashes identically
+ * regardless of the key order a parser or exporter happened to produce. `undefined` members are
+ * omitted, matching `JSON.stringify`.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? '';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const members = Object.keys(record)
+    .sort()
+    .map((key) => (record[key] === undefined ? '' : `${JSON.stringify(key)}:${stableStringify(record[key])}`))
+    .filter((member) => member.length > 0);
+  return `{${members.join(',')}}`;
+}
+
 export function hashContent(value: unknown): string {
-  const input = JSON.stringify(value) ?? '';
+  const input = stableStringify(value);
   let h1 = 0xdeadbeef;
   let h2 = 0x41c6ce57;
   for (let i = 0; i < input.length; i++) {

--- a/packages/untp-playground/src/lib/id.ts
+++ b/packages/untp-playground/src/lib/id.ts
@@ -1,0 +1,8 @@
+/** Mint an opaque unique id for instances, runs, and undo tokens (ADR-041). */
+export function newId(): string {
+  const webcrypto = globalThis.crypto;
+  if (webcrypto && typeof webcrypto.randomUUID === 'function') {
+    return webcrypto.randomUUID();
+  }
+  return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/packages/untp-playground/src/lib/reportService.ts
+++ b/packages/untp-playground/src/lib/reportService.ts
@@ -2,8 +2,8 @@ import { detectVersion } from '@/lib/credentialService';
 import { detectExtension } from '@/lib/schemaValidation';
 import { detectSchemeVersion } from '@/lib/schemeValidation';
 import {
+  SchemeReportInput,
   StoredCredential,
-  StoredScheme,
   TestReport,
   TestReportResult,
   TestReportSchemeResult,
@@ -17,8 +17,7 @@ interface GenerateReportParams {
   implementationName: string;
   credentials: Partial<Record<CredentialType, StoredCredential>>;
   testResults: Partial<Record<CredentialType, TestStep[]>>;
-  schemes?: Partial<Record<SchemeType, StoredScheme>>;
-  schemeTestResults?: Partial<Record<SchemeType, TestStep[]>>;
+  schemeInstances?: SchemeReportInput[];
   passStatuses: TestCaseStatus[];
 }
 
@@ -26,13 +25,30 @@ export const generateReport = async ({
   implementationName,
   credentials,
   testResults,
-  schemes,
-  schemeTestResults,
+  schemeInstances,
   passStatuses,
 }: GenerateReportParams): Promise<TestReport> => {
+  // Defence in depth for the ADR-041 report-readiness gate: every loaded artefact must be terminal
+  // (a non-empty result whose steps have all settled). Refuse rather than record a mid-pipeline
+  // artefact as a spurious pass or failure; the UI gate should already prevent reaching here.
+  const settledStatuses = [TestCaseStatus.SUCCESS, TestCaseStatus.FAILURE, TestCaseStatus.WARNING];
+  const isTerminal = (steps: TestStep[]) =>
+    steps.length > 0 && steps.every((step) => settledStatuses.includes(step.status));
+
   const validCredentials = Object.entries(credentials).map(
     ([type, cred]) => [type, cred] as [CredentialType, NonNullable<typeof cred>],
   );
+
+  for (const [type] of validCredentials) {
+    if (!isTerminal(testResults[type] ?? [])) {
+      throw new Error('Cannot generate a report while a credential is still validating.');
+    }
+  }
+  for (const { steps } of schemeInstances ?? []) {
+    if (!isTerminal(steps)) {
+      throw new Error('Cannot generate a report while a scheme is still validating.');
+    }
+  }
 
   const results: TestReportResult[] = validCredentials.map(([type, credential]) => {
     const steps = testResults[type] || [];
@@ -42,9 +58,10 @@ export const generateReport = async ({
     const coreSteps = steps.filter((step) => step.id !== TestCaseStepId.EXTENSION_SCHEMA_VALIDATION);
     const extensionStep = steps.find((step) => step.id === TestCaseStepId.EXTENSION_SCHEMA_VALIDATION);
 
-    const status = steps.every((step) => passStatuses.includes(step.status))
-      ? TestCaseStatus.SUCCESS
-      : TestCaseStatus.FAILURE;
+    const status =
+      steps.length > 0 && steps.every((step) => passStatuses.includes(step.status))
+        ? TestCaseStatus.SUCCESS
+        : TestCaseStatus.FAILURE;
     const result: TestReportResult = {
       status,
       overallStatus: status,
@@ -68,24 +85,21 @@ export const generateReport = async ({
     return result;
   });
 
-  const validSchemes = Object.entries(schemes ?? {}).map(
-    ([type, scheme]) => [type, scheme] as [SchemeType, NonNullable<typeof scheme>],
-  );
-
-  const conformitySchemeResults: TestReportSchemeResult[] = validSchemes.map(([type, scheme]) => {
-    const steps = schemeTestResults?.[type] ?? [];
+  const conformitySchemeResults: TestReportSchemeResult[] = (schemeInstances ?? []).map(({ scheme, steps }) => {
     const decoded = scheme.decoded;
     const version = detectSchemeVersion(decoded) ?? 'unknown';
     const name = typeof decoded?.name === 'string' ? decoded.name : undefined;
     const id = typeof decoded?.id === 'string' ? decoded.id : undefined;
 
-    const status = steps.every((step) => passStatuses.includes(step.status))
-      ? TestCaseStatus.SUCCESS
-      : TestCaseStatus.FAILURE;
+    // An instance with no steps is not a clean pass: require at least one settled step.
+    const status =
+      steps.length > 0 && steps.every((step) => passStatuses.includes(step.status))
+        ? TestCaseStatus.SUCCESS
+        : TestCaseStatus.FAILURE;
     return {
       status,
       overallStatus: status,
-      type,
+      type: SchemeType.CONFORMITY_SCHEME,
       version,
       ...(name && { name }),
       ...(id && { id }),

--- a/packages/untp-playground/src/lib/schemeCollection.ts
+++ b/packages/untp-playground/src/lib/schemeCollection.ts
@@ -1,0 +1,59 @@
+/**
+ * Conformity-scheme family layer over the shared per-instance model (ADR-041).
+ *
+ * The shared model in artefactCollection.ts owns the generic mechanics; this file owns the
+ * scheme-specific parts: the content hash that identifies a scheme, when its result is terminal,
+ * and its card title and subtitle copy.
+ */
+
+import { hashContent } from '@/lib/hash';
+import { detectSchemeVersion } from '@/lib/schemeValidation';
+import type { StoredScheme, TestStep } from '@/types';
+import { TestCaseStatus } from '../../constants';
+
+/** The spaced family label shown on every scheme card (final hi-fi and #677). */
+export const SCHEME_FAMILY_LABEL = 'Conformity Scheme';
+
+/** A scheme's identity is the content hash of its document, so identical content is one instance. */
+export function schemeContentHash(decoded: Record<string, unknown>): string {
+  return hashContent(decoded);
+}
+
+/** A scheme's pipeline is terminal once every step has settled to success or failure. */
+export function schemeIsTerminal(steps: TestStep[]): boolean {
+  return (
+    steps.length > 0 &&
+    steps.every((step) => step.status === TestCaseStatus.SUCCESS || step.status === TestCaseStatus.FAILURE)
+  );
+}
+
+/** Card title: the scheme name, else a URL's final path segment, else the filename, else the family label. Never the raw URL. */
+export function schemeTitle(scheme: StoredScheme): string {
+  const name = scheme.decoded?.name;
+  if (typeof name === 'string' && name.length > 0) return name;
+
+  const source = scheme.source;
+  if (source?.kind === 'url') {
+    const segment = finalPathSegment(source.url);
+    if (segment) return segment;
+  }
+  if (source?.kind === 'file' && source.filename.length > 0) return source.filename;
+
+  return SCHEME_FAMILY_LABEL;
+}
+
+/** Always-on subtitle: the family label with the detected UNTP context version when there is one. */
+export function schemeSubtitle(scheme: StoredScheme): string {
+  const version = detectSchemeVersion(scheme.decoded);
+  return version ? `${SCHEME_FAMILY_LABEL} (v${version})` : SCHEME_FAMILY_LABEL;
+}
+
+function finalPathSegment(rawUrl: string): string | undefined {
+  try {
+    const url = new URL(rawUrl);
+    const parts = url.pathname.split('/').filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : url.hostname;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/untp-playground/src/types/artefact.ts
+++ b/packages/untp-playground/src/types/artefact.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared per-instance artefact model (ADR-041).
+ *
+ * A family-agnostic ordered collection of validated artefact instances. It owns the instances,
+ * their opaque results, and the per-run write token that guards stale writes. Identity is the
+ * content hash of the artefact, so identical content is one instance and different content is a
+ * separate one, regardless of filename, URL, or any document id. `P` is the family payload and
+ * `R` the family result, both opaque here. Schemes (#677) are the first consumer; credentials
+ * (#810) and link sets (#811) reuse it.
+ *
+ * See docs/adrs/041-playground-shared-per-instance-artefact-model.md.
+ */
+
+/** Immutable synthetic id, minted per instance, stable across in-place replace. */
+export type InstanceId = string;
+/** Minted per pipeline run; the token a write must carry to be applied. */
+export type RunId = string;
+
+/** One instance: its content-hash identity, opaque payload, opaque result, and the live run token. */
+export interface ArtefactSlot<P, R> {
+  instanceId: InstanceId;
+  /** Content hash of the artefact; identical content shares one instance. */
+  contentHash: string;
+  payload: P;
+  /** `undefined` = no snapshot yet, or cleared for a fresh run. */
+  result: R | undefined;
+  /** `null` = idle (no live run). Set by `beginRun`, cleared by `upsert`. */
+  runId: RunId | null;
+}
+
+/** The whole collection: ordered instances in upload order. */
+export interface CollectionState<P, R> {
+  items: ArtefactSlot<P, R>[];
+}
+
+/** Result of matching an incoming content hash against the loaded instances. */
+export type MatchResult = { kind: 'none' } | { kind: 'one'; instanceId: InstanceId };
+
+/** Outcome of an upsert. */
+export type UpsertOutcome =
+  | { kind: 'appended'; instanceId: InstanceId }
+  | { kind: 'replaced'; instanceId: InstanceId; index: number };

--- a/packages/untp-playground/src/types/index.ts
+++ b/packages/untp-playground/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './artefact';
 export * from './credential';
 export * from './report';
 export * from './test';

--- a/packages/untp-playground/src/types/report.ts
+++ b/packages/untp-playground/src/types/report.ts
@@ -1,8 +1,14 @@
 import { SchemeType, TestCaseStatus } from '../../constants';
 import { EXTENSION_VERSIONS } from '../lib/schemaValidation';
-import { ArtefactSource, Credential } from './credential';
+import { ArtefactSource, Credential, StoredScheme } from './credential';
 import { TestStep } from './test';
 import { PermittedCredentialType } from './untp';
+
+/** One loaded scheme instance and its pipeline result, as the report consumes it (ADR-041). */
+export interface SchemeReportInput {
+  scheme: StoredScheme;
+  steps: TestStep[];
+}
 
 export interface TestReport {
   date: string;


### PR DESCRIPTION
This PR lets a user validate multiple conformity schemes in the UNTP Playground at once, each as its own card on the Conformity Schemes tab, so a scheme owner can check a whole vocabulary in one session instead of one scheme at a time.

It is built on a new shared per-instance artefact model (#819, ADR-041) that identifies each instance by the content hash of its document, so identical content is one instance and different content (even under the same filename) a separate one, and that guards each instance's asynchronous validation pipeline against stale writes with a per-run token. Credentials (#810) and link sets (#811) reuse the same model. Removing a scheme is a confirmation dialog rather than an undo, and a report cannot be generated until every loaded artefact has finished validating.

Part of #808
Closes #677
Closes #819

## Test plan
- [x] Two different schemes load as two cards; re-uploading identical content replaces in place; the tab shows the count.
- [x] A scheme with an unresolved @context fails Version Detection with the existing copy and shows two Skipped steps, independently per instance.
- [x] Removing a card opens a confirmation dialog; confirming removes it, cancelling leaves it; removing the last returns the empty state.
- [x] Generate Report is held until every loaded credential and scheme is terminal, and a generated report is invalidated when the last artefact is removed.
- [x] Full playground unit suite green (291 tests); the conformity-scheme E2E is re-keyed to the new card.
