### PR TITLE
feat(ri): validate and tighten DIDs endpoint inputs and align their Swagger

### DIFF
--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -5,21 +5,21 @@ title: DIDs
 
 # DIDs API
 
-The DIDs API manages **[Decentralised Identifiers (DIDs)](https://www.w3.org/TR/did-core/)** — the cryptographic identities that the Reference Implementation uses to sign verifiable credentials. Every credential issued by the Reference Implementation is signed with a DID — either one the tenant has provisioned or the [system default DID](../system-architecture#system-tenant) available to all tenants.
+The DIDs API manages **[Decentralised Identifiers (DIDs)](https://www.w3.org/TR/did-core/)**, the cryptographic identities that the Reference Implementation uses to sign verifiable credentials. Every credential issued by the Reference Implementation is signed with a DID, either one the tenant has provisioned or the [system default DID](../system-architecture#system-tenant) available to all tenants.
 
 For background on how DIDs relate to the verifiable credential service, see [Verifiable Credential Service](../services/verifiable-credential-service).
 
 :::tip[Interactive API documentation]
-The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic. Refer to Swagger for exact payload shapes. All endpoints require authentication; see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
 :::
 
-Optional request fields across these endpoints (`name`, `description`, `isDefault`, `serviceInstanceId`) are left unset by omitting them, not by sending an explicit `null` — a `null` value is rejected with a 400.
+Optional request fields (`name`, `description`, `isDefault`, `serviceInstanceId`) are left unset by omitting them. Sending an explicit `null` for any of them is rejected with a 400.
 
 ## Concepts
 
 ### DID Types
 
-Every DID has a **type** that determines how it was created, who manages its key material, and who hosts its DID document. The types represent an [adoption ramp](../overview#incremental-adoption) — tenants can issue UNTP-compliant credentials from day one using the system default, and progressively take on more control as they become more technically sophisticated.
+Every DID has a **type** that determines how it was created, who manages its key material, and who hosts its DID document. The types represent an [adoption ramp](../overview#incremental-adoption): tenants can issue UNTP-compliant credentials from day one using the system default, and progressively take on more control as they become more technically sophisticated.
 
 #### `DEFAULT`
 
@@ -29,15 +29,15 @@ A system DID created during [startup](../operations/startup#step-2-database-seed
 
 The DID was created by the [verifiable credential service](../services/verifiable-credential-service) via `POST /api/v1/dids`. The VC service holds the cryptographic key material (public and private key), hosts the DID document, and performs all signing operations. The Reference Implementation stores a record of the DID, its status, and which service instance manages it. Initial status: `ACTIVE`.
 
-This is the simplest path for tenants that want their own DID — they create one and the VC service handles everything. The `alias` is a short identifier that the VC service prefixes with its own endpoint to form the full DID (e.g., alias `my-company` might produce `did:web:vckit.example.com:my-company`).
+This is the simplest path for tenants that want their own DID: they create one and the VC service handles everything. The `alias` is a short identifier that the VC service prefixes with its own endpoint to form the full DID (e.g., alias `my-company` might produce `did:web:vckit.example.com:my-company`).
 
 #### `SELF_MANAGED`
 
 A self-managed DID gives the tenant more control. There are two paths:
 
-1. **Create via the API** (`POST /api/v1/dids`) — The Reference Implementation calls the VC service to create the DID, so the VC service still holds the cryptographic key material and performs signing. However, the tenant is responsible for hosting the DID document at the location the DID identifier resolves to. The `alias` should be the full domain or path where the tenant will host the DID document (e.g., `example.com` for `did:web:example.com`). Initial status: `UNVERIFIED`.
+1. **Create via the API** (`POST /api/v1/dids`). The Reference Implementation calls the VC service to create the DID, so the VC service still holds the cryptographic key material and performs signing. However, the tenant is responsible for hosting the DID document at the location the DID identifier resolves to. The `alias` should be the full domain or path where the tenant will host the DID document (e.g., `example.com` for `did:web:example.com`). Initial status: `UNVERIFIED`.
 
-2. **Import an existing DID** (`POST /api/v1/dids/import`) — The tenant has provisioned their own verifiable credential service instance (registered via the [Services API](./services)), which already has a DID created in it. The tenant imports that DID into the Reference Implementation for tracking. The key material and DID document live entirely within the tenant's own infrastructure. The tenant must have added their VC service instance to their tenant before importing. When importing, the full DID identifier is provided via the `did` field (e.g., `did:web:example.com`). Initial status: `UNVERIFIED`.
+2. **Import an existing DID** (`POST /api/v1/dids/import`). The tenant has provisioned their own verifiable credential service instance (registered via the [Services API](./services)), which already has a DID created in it. The tenant imports that DID into the Reference Implementation for tracking. The key material and DID document live entirely within the tenant's own infrastructure. The tenant must have added their VC service instance to their tenant before importing. When importing, the full DID identifier is provided via the `did` field (e.g., `did:web:example.com`). Initial status: `UNVERIFIED`.
 
 In both cases, self-managed DIDs start as `UNVERIFIED` and should be confirmed via the [verify endpoint](#verify-a-did).
 
@@ -55,7 +55,7 @@ The rule follows the [did:web specification](https://w3c-ccg.github.io/did-metho
 
 The DID document must be served over HTTPS with a valid TLS certificate.
 
-When creating a self-managed DID via the API, the `alias` value determines the resulting DID identifier — set it to the domain (e.g., `example.com`) or domain with path (e.g., `example.com:department`) where you will host the document.
+When creating a self-managed DID via the API, the `alias` value determines the resulting DID identifier. Set it to the domain (e.g., `example.com`) or domain with path (e.g., `example.com:department`) where you will host the document.
 
 ### DID Methods
 
@@ -63,8 +63,8 @@ The `method` field identifies which [DID method](https://www.w3.org/TR/did-core/
 
 | Method | Status | Description |
 |--------|--------|-------------|
-| `DID_WEB` | Supported | [did:web](https://w3c-ccg.github.io/did-method-web/) — a DID method that uses web domains as the basis for the identifier |
-| `DID_WEB_VH` | Planned | A variant of did:web with version history support — not yet implemented |
+| `DID_WEB` | Supported | [did:web](https://w3c-ccg.github.io/did-method-web/), a DID method that uses web domains as the basis for the identifier |
+| `DID_WEB_VH` | Planned | A variant of did:web with version history support, not yet implemented |
 
 ### DID Statuses
 
@@ -73,8 +73,8 @@ The `method` field identifies which [DID method](https://www.w3.org/TR/did-core/
 | `ACTIVE` | The DID is ready to use for credential signing |
 | `UNVERIFIED` | The DID has been registered but it has not yet been confirmed that the DID document can be resolved |
 | `VERIFIED` | The DID document has been successfully resolved via the [verify endpoint](#verify-a-did) |
-| `VERIFICATION_FAILED` | The verification check failed — the DID document could not be resolved |
-| `INACTIVE` | Reserved for future use — deactivation of DIDs is not yet implemented |
+| `VERIFICATION_FAILED` | The verification check failed; the DID document could not be resolved |
+| `INACTIVE` | Reserved for future use; deactivation of DIDs is not yet implemented |
 
 ### Verification Checks
 
@@ -83,23 +83,23 @@ The [verify endpoint](#verify-a-did) runs the following checks in order. All che
 | Check | Description |
 |-------|-------------|
 | **Resolve** | Fetches the DID document from the URL the DID identifier resolves to (e.g., `https://example.com/.well-known/did.json` for `did:web:example.com`). Fails if the document cannot be retrieved or returns a non-success HTTP status. |
-| **HTTPS** | Confirms the DID document was served over HTTPS. Checks the final URL after any redirects — if a redirect lands on an insecure connection, this check fails. |
+| **HTTPS** | Confirms the DID document was served over HTTPS. Checks the final URL after any redirects; if a redirect lands on an insecure connection, this check fails. |
 | **Structure** | Validates the retrieved DID document against the [DID Document](https://www.w3.org/TR/did-core/) schema. Fails if required fields are missing or malformed. |
 | **Identity match** | Confirms that the `id` field in the DID document matches the DID identifier. Fails if they differ (e.g., the document was served from the wrong location). |
 | **Key material** | Fetches the key IDs from the VC service instance associated with the DID and confirms they correspond to the key IDs listed in the DID document's `verificationMethod` entries. This ensures the DID document points to the same keys that the VC service actually holds for signing. Fails if none of the VC service's keys appear in the document. |
-| **JSON-LD validity** | Validates that the DID document is valid JSON-LD. Currently skipped — disabled to avoid SSRF risks from untrusted `@context` URLs in DID documents. |
+| **JSON-LD validity** | Validates that the DID document is valid JSON-LD. Currently skipped; disabled to avoid SSRF risks from untrusted `@context` URLs in DID documents. |
 
 ### System DIDs vs Tenant DIDs
 
-DIDs exist at two levels — the **system default DID** (created during [startup](../operations/startup#step-2-database-seed), owned by the [system tenant](../system-architecture#system-tenant), read-only and visible to all tenants) and **tenant DIDs** (created or imported by a tenant through this API, scoped exclusively to that tenant). When listing DIDs, tenants see both their own DIDs and the system default.
+DIDs exist at two levels: the **system default DID** (created during [startup](../operations/startup#step-2-database-seed), owned by the [system tenant](../system-architecture#system-tenant), read-only and visible to all tenants) and **tenant DIDs** (created or imported by a tenant through this API, scoped exclusively to that tenant). When listing DIDs, tenants see both their own DIDs and the system default.
 
-**Credential signing is restricted to these two pools.** When [issuing a credential](./credentials#stage-4-issuer-did-ownership-validation), the `issuer.id` in the credential payload must be a DID that belongs to the authenticated tenant or a system default DID — available to all tenants as part of the [incremental adoption ramp](../overview#incremental-adoption). A tenant cannot issue credentials using a DID that belongs to another tenant.
+**Credential signing is restricted to these two pools.** When [issuing a credential](./credentials#stage-4-issuer-did-ownership-validation), the `issuer.id` in the credential payload must be a DID that belongs to the authenticated tenant or a system default DID, which is available to all tenants as part of the [incremental adoption ramp](../overview#incremental-adoption). A tenant cannot issue credentials using a DID that belongs to another tenant.
 
 ### Service Instance Association
 
-When creating a DID, you can specify which [verifiable credential service instance](./services) to use via `serviceInstanceId`. If omitted, the service instance is resolved using the same [resolution chain](../services/service-architecture#system-services-vs-tenant-services) as other operations — the tenant's [primary](./services#primary-instances) VC service instance if one is set, otherwise the system default.
+When creating a DID, you can specify which [verifiable credential service instance](./services) to use via `serviceInstanceId`. If omitted, the service instance is resolved using the same [resolution chain](../services/service-architecture#system-services-vs-tenant-services) as other operations: the tenant's [primary](./services#primary-instances) VC service instance if one is set, otherwise the system default.
 
-The service instance is the upstream provider that holds the cryptographic key material and performs signing operations.
+The service instance is the upstream provider that holds the cryptographic key material and performs signing operations. In most cases a DID is bound to the verifiable credential service instance that holds its key material, a binding fixed when the DID is created or imported. That binding can be lost if the service instance is later [force-deleted](./services#delete-a-service-instance), which leaves the DID without an associated service instance.
 
 ### Default DID
 
@@ -117,19 +117,19 @@ Calls the [verifiable credential service](../services/verifiable-credential-serv
 
 For **managed** DIDs, the VC service generates a new key pair, creates the DID, and hosts the DID document. The Reference Implementation stores a record linking the DID to the tenant and service instance. The DID is immediately `ACTIVE` and ready for credential signing.
 
-For **self-managed** DIDs created via this endpoint, the VC service still generates the key pair and creates the DID — the difference is that the tenant is responsible for hosting the DID document at the location the DID identifier resolves to (see [Self-Managed DID type](#self_managed) for details). The DID starts as `UNVERIFIED` and should be confirmed via the [verify endpoint](#verify-a-did) once the DID document is hosted.
+For **self-managed** DIDs created via this endpoint, the VC service still generates the key pair and creates the DID; the difference is that the tenant is responsible for hosting the DID document at the location the DID identifier resolves to (see [Self-Managed DID type](#self_managed) for details). The DID starts as `UNVERIFIED` and should be confirmed via the [verify endpoint](#verify-a-did) once the DID document is hosted.
 
 | Required Field | Description |
 |-----------------|-------------|
-| `type` | `MANAGED` or `SELF_MANAGED` (`DEFAULT` is system-managed and cannot be created via this endpoint) |
+| `type` | `MANAGED` or `SELF_MANAGED`. `DEFAULT` is [system-managed and created during seeding](../operations/startup#step-2-database-seed), and cannot be created via this endpoint |
 | `method` | `DID_WEB` (the supported method today; `DID_WEB_VH` is planned but not yet implemented and is rejected with a 400) |
-| `alias` | Alias for the DID (e.g. domain for did:web) |
+| `alias` | Alias for the DID. For `did:web`, this is the domain (or domain and path) that will host the DID document, for example `example.com` to produce `did:web:example.com` |
 
 | Optional Field | Description |
 |-----------------|-------------|
 | `name` | Human-readable name (must be non-empty if provided) |
 | `description` | Description of the DID's purpose (must be non-empty if provided) |
-| `isDefault` | Whether this DID should be the tenant's default |
+| `isDefault` | Whether this DID becomes the tenant's default signing identity, used when a credential is issued without naming an explicit issuer DID |
 | `serviceInstanceId` | Verifiable credential service instance to use for creation |
 
 ```mermaid
@@ -168,10 +168,10 @@ Returns DIDs for the authenticated tenant with optional filtering. Results are p
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `type` | string | — | Filter by DID type (the full set, including `DEFAULT`) |
-| `status` | string | — | Filter by DID status |
-| `serviceInstanceId` | string | — | Filter by service instance ID |
-| `limit` | integer | Defaults to 20, or the configured maximum when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
+| `type` | string | None | Filter by DID type (the full set, including `DEFAULT`) |
+| `status` | string | None | Filter by DID status |
+| `serviceInstanceId` | string | None | Filter by service instance ID |
+| `limit` | integer | Defaults to 20, or the [configured maximum](../operations/api-pagination#maximum-page-size) when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---
@@ -192,13 +192,13 @@ Retrieves a specific DID by its database ID.
 PATCH /api/v1/dids/{id}
 ```
 
-Updates the metadata of a DID. Only `name`, `description`, and `isDefault` can be changed — the DID identifier, type, method, and key material are immutable. At least one updatable field must be provided.
+Updates the metadata of a DID. Only `name`, `description`, and `isDefault` can be changed; the DID identifier, type, method, and key material are immutable. At least one updatable field must be provided.
 
 | Updatable Field | Description |
 |-----------------|-------------|
 | `name` | New name (must be non-empty if provided) |
 | `description` | New description (must be non-empty if provided) |
-| `isDefault` | Whether to set this DID as the tenant default. Cannot be changed on system default DIDs |
+| `isDefault` | Whether to set this DID as the tenant's default signing identity, used when a credential is issued without naming an explicit issuer DID. Cannot be changed on system default DIDs |
 
 ---
 
@@ -208,7 +208,7 @@ Updates the metadata of a DID. Only `name`, `description`, and `isDefault` can b
 DELETE /api/v1/dids/{id}
 ```
 
-Deletes a DID from the Reference Implementation database. If the DID still has an associated service instance (the association can be lost if the service instance was [force-deleted](./services#delete-a-service-instance)), the Reference Implementation also attempts to remove the DID from the upstream VC service on a best-effort basis — if the upstream deletion fails, the local record is still deleted and a warning is logged.
+Deletes a DID from the Reference Implementation database. If the DID still has an associated service instance (the association can be lost if the service instance was [force-deleted](./services#delete-a-service-instance)), the Reference Implementation also attempts to remove the DID from the upstream VC service on a best-effort basis; if the upstream deletion fails, the local record is still deleted and a warning is logged.
 
 DIDs marked as `isDefault` cannot be deleted. Remove the default flag first via the [update endpoint](#update-a-did), then delete.
 
@@ -246,7 +246,7 @@ sequenceDiagram
 GET /api/v1/dids/{id}/document
 ```
 
-Retrieves the [DID Document](https://www.w3.org/TR/did-core/) for a specific DID from the upstream verifiable credential service. The DID Document contains the public keys, authentication methods, and service endpoints associated with the DID — it is the publicly resolvable representation of the DID.
+Retrieves the [DID Document](https://www.w3.org/TR/did-core/) for a specific DID from the upstream verifiable credential service. The DID Document contains the public keys, authentication methods, and service endpoints associated with the DID; it is the publicly resolvable representation of the DID.
 
 ```mermaid
 sequenceDiagram
@@ -277,9 +277,9 @@ The VC service resolves the DID by fetching the DID document from wherever it is
 POST /api/v1/dids/{id}/verify
 ```
 
-Verifies that a DID can be resolved and that its DID document is valid. When verification runs to completion, the DID's status is updated based on the result — `VERIFIED` if all checks pass, `VERIFICATION_FAILED` otherwise. A pre-verification failure leaves the current status unchanged: the DEFAULT-type guard below, or a stored DID string that does not parse as `did:method:identifier` or names an unsupported method (reachable because [import](#import-a-did) accepts the `did` string without format validation) — both return a 400 without touching the record.
+Verifies that a DID can be resolved and that its DID document is valid. When verification runs to completion, the DID's status is updated based on the result: `VERIFIED` if all checks pass, `VERIFICATION_FAILED` otherwise. Some inputs fail before verification runs and return a 400 without changing the status: a system default DID (see below), a stored DID that does not parse as `did:method:identifier`, or a DID that uses an unsupported method.
 
-This endpoint is used for **self-managed** DIDs — both those [created via the API](#create-a-did) and those [imported](#import-a-did) — which start with status `UNVERIFIED`. It confirms that the DID document is publicly resolvable and structurally valid.
+This endpoint is used for **self-managed** DIDs, both those [created via the API](#create-a-did) and those [imported](#import-a-did), which start with status `UNVERIFIED`. It confirms that the DID document is publicly resolvable and structurally valid.
 
 System default DIDs (`type: DEFAULT`) cannot be verified through this endpoint. See [Verification Checks](#verification-checks) for the full list of checks performed.
 
@@ -324,7 +324,7 @@ Registers an existing, externally managed DID in the Reference Implementation wi
 
 Use this endpoint when you have a DID that was created outside the Reference Implementation (e.g., in a separate verifiable credential service instance) and you want to use it for credential signing within the Reference Implementation. After importing, use the [verify endpoint](#verify-a-did) to confirm that the DID document is resolvable.
 
-Before importing, the tenant must have registered the verifiable credential service instance that holds the DID via the [Services API](./services#create-a-service-instance). The `serviceInstanceId` is required — this is how the Reference Implementation knows which VC service to use when signing credentials with this DID. It is verified to belong to the authenticated tenant (or be a system default) before the record is saved; a nonexistent id, or one belonging to another tenant, is rejected with a 404.
+Before importing, the tenant must have registered the verifiable credential service instance that holds the DID via the [Services API](./services#create-a-service-instance). The `serviceInstanceId` is required; this is how the Reference Implementation knows which VC service to use when signing credentials with this DID. It is verified to belong to the authenticated tenant (or be a system default) before the record is saved; a nonexistent id, or one belonging to another tenant, is rejected with a 404.
 
 Note that unlike the [create endpoint](#create-a-did), the import endpoint does **not** call the upstream VC service. It only verifies the service instance and creates a local database record.
 

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -122,7 +122,7 @@ For **self-managed** DIDs created via this endpoint, the VC service still genera
 | Required Field | Description |
 |-----------------|-------------|
 | `type` | `MANAGED` or `SELF_MANAGED` (`DEFAULT` is system-managed and cannot be created via this endpoint) |
-| `method` | DID method. Rejected with a 400 if the resolved DID service does not support it |
+| `method` | `DID_WEB` (the supported method today; `DID_WEB_VH` is planned but not yet implemented and is rejected with a 400) |
 | `alias` | Alias for the DID (e.g. domain for did:web) |
 
 | Optional Field | Description |
@@ -324,16 +324,18 @@ Registers an existing, externally managed DID in the Reference Implementation wi
 
 Use this endpoint when you have a DID that was created outside the Reference Implementation (e.g., in a separate verifiable credential service instance) and you want to use it for credential signing within the Reference Implementation. After importing, use the [verify endpoint](#verify-a-did) to confirm that the DID document is resolvable.
 
-Before importing, the tenant must have registered the verifiable credential service instance that holds the DID via the [Services API](./services#create-a-service-instance). The `serviceInstanceId` is required — this is how the Reference Implementation knows which VC service to use when signing credentials with this DID.
+Before importing, the tenant must have registered the verifiable credential service instance that holds the DID via the [Services API](./services#create-a-service-instance). The `serviceInstanceId` is required — this is how the Reference Implementation knows which VC service to use when signing credentials with this DID. It is verified to belong to the authenticated tenant (or be a system default) before the record is saved; a nonexistent id, or one belonging to another tenant, is rejected with a 404.
 
-Note that unlike the [create endpoint](#create-a-did), the import endpoint does **not** call the upstream VC service. It only creates a local database record.
+Note that unlike the [create endpoint](#create-a-did), the import endpoint does **not** call the upstream VC service. It only verifies the service instance and creates a local database record.
+
+Importing a `did:webvh` identifier is rejected: `method` is restricted to `DID_WEB` until did:webvh support lands, so a webvh DID cannot be imported ahead of that even though the `did` string itself is otherwise accepted without format validation.
 
 | Required Field | Description |
 |-----------------|-------------|
 | `did` | The DID identifier to import (e.g. `did:web:example.com`) |
-| `method` | DID method |
+| `method` | `DID_WEB` (the supported method today; `DID_WEB_VH` is planned but not yet implemented and is rejected with a 400) |
 | `keyId` | Key identifier associated with the DID |
-| `serviceInstanceId` | Verifiable credential service instance that holds the key material for this DID |
+| `serviceInstanceId` | Verifiable credential service instance that holds the key material for this DID. Must belong to the authenticated tenant or be a system default; otherwise rejected with a 404 |
 
 | Optional Field | Description |
 |-----------------|-------------|
@@ -348,6 +350,10 @@ sequenceDiagram
 
     Client->>RI: POST /api/v1/dids/import { did, method, keyId, serviceInstanceId }
     RI->>RI: Validate did, method, keyId, serviceInstanceId
+    RI->>DB: Verify serviceInstanceId belongs to this tenant (or is a system default)
+    alt not found or belongs to another tenant
+        RI-->>Client: 404 Not Found
+    end
     RI->>DB: Save DID record (type: SELF_MANAGED, status: UNVERIFIED)
     DB-->>RI: Created record
     RI-->>Client: 201 Created (DID)

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -123,7 +123,7 @@ For **self-managed** DIDs created via this endpoint, the VC service still genera
 |-----------------|-------------|
 | `type` | `MANAGED` or `SELF_MANAGED`. `DEFAULT` is [system-managed and created during seeding](../operations/startup#step-2-database-seed), and cannot be created via this endpoint |
 | `method` | `DID_WEB` (the supported method today; `DID_WEB_VH` is planned but not yet implemented and is rejected with a 400) |
-| `alias` | Alias for the DID. For `did:web`, this is the domain (or domain and path) that will host the DID document, for example `example.com` to produce `did:web:example.com` |
+| `alias` | Identifier for the DID, read differently depending on `type`. For a [`MANAGED`](#managed) DID, a short name that the verifiable credential service prefixes with its own host, so `acme-corp` produces `did:web:vckit.example.com:acme-corp`; everything outside letters, digits, and hyphens is stripped, so a domain passed here loses its dots. For a [`SELF_MANAGED`](#self_managed) DID, the full domain (or domain and path) where you will host the DID document, so `example.com` produces `did:web:example.com`; dots and colons are preserved |
 
 | Optional Field | Description |
 |-----------------|-------------|
@@ -146,7 +146,7 @@ sequenceDiagram
     RI->>DB: Resolve VC service instance (specified or primary)
     DB-->>RI: Service instance config (encrypted)
     RI->>RI: Decrypt service config
-    RI->>RI: Normalise alias for DID method
+    RI->>RI: Normalise alias for DID type and method
     alt self-managed did:web claiming the system VC service host
         RI-->>Client: 403 Forbidden
     end

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -86,7 +86,7 @@ The [verify endpoint](#verify-a-did) runs the following checks in order. All che
 | **HTTPS** | Confirms the DID document was served over HTTPS. Checks the final URL after any redirects; if a redirect lands on an insecure connection, this check fails. |
 | **Structure** | Validates the retrieved DID document against the [DID Document](https://www.w3.org/TR/did-core/) schema. Fails if required fields are missing or malformed. |
 | **Identity match** | Confirms that the `id` field in the DID document matches the DID identifier. Fails if they differ (e.g., the document was served from the wrong location). |
-| **Key material** | Fetches the key IDs from the VC service instance associated with the DID and confirms they correspond to the key IDs listed in the DID document's `verificationMethod` entries. This ensures the DID document points to the same keys that the VC service actually holds for signing. Fails if none of the VC service's keys appear in the document. |
+| **Key material** | Fetches the key IDs from the VC service instance associated with the DID and confirms they correspond to the key IDs listed in the DID document's `verificationMethod` entries. This ensures the DID document points to the same keys that the VC service actually holds for signing. Fails if the VC service holds keys for this DID and none of them appear in the document. When the VC service reports no keys at all, there is nothing to compare and the check passes with the message "No provider keys to compare". |
 | **JSON-LD validity** | Validates that the DID document is valid JSON-LD. Currently skipped; disabled to avoid SSRF risks from untrusted `@context` URLs in DID documents. |
 
 ### System DIDs vs Tenant DIDs
@@ -132,6 +132,8 @@ For **self-managed** DIDs created via this endpoint, the VC service still genera
 | `isDefault` | Whether this DID becomes the tenant's default signing identity, used when a credential is issued without naming an explicit issuer DID |
 | `serviceInstanceId` | Verifiable credential service instance to use for creation |
 
+A tenant cannot claim the instance's own root DID. A self-managed `did:web` whose alias is exactly the hostname of the system VC service (with or without its port, so both `vckit.example.com` and `vckit.example.com:3332`) is rejected with a 403, because that DID identifies the VC service instance itself rather than anything the tenant owns. Only the alias on its own is reserved: a DID with a path under that host, such as `did:web:vckit.example.com:tenant-a`, is allowed.
+
 ```mermaid
 sequenceDiagram
     participant Client
@@ -145,6 +147,9 @@ sequenceDiagram
     DB-->>RI: Service instance config (encrypted)
     RI->>RI: Decrypt service config
     RI->>RI: Normalise alias for DID method
+    alt self-managed did:web claiming the system VC service host
+        RI-->>Client: 403 Forbidden
+    end
     RI->>DB: Check for duplicate alias on service instance
     alt duplicate exists
         RI-->>Client: 409 Conflict

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -13,6 +13,8 @@ For background on how DIDs relate to the verifiable credential service, see [Ver
 The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
 :::
 
+Optional request fields across these endpoints (`name`, `description`, `isDefault`, `serviceInstanceId`) are left unset by omitting them, not by sending an explicit `null` — a `null` value is rejected with a 400.
+
 ## Concepts
 
 ### DID Types
@@ -117,6 +119,19 @@ For **managed** DIDs, the VC service generates a new key pair, creates the DID, 
 
 For **self-managed** DIDs created via this endpoint, the VC service still generates the key pair and creates the DID — the difference is that the tenant is responsible for hosting the DID document at the location the DID identifier resolves to (see [Self-Managed DID type](#self_managed) for details). The DID starts as `UNVERIFIED` and should be confirmed via the [verify endpoint](#verify-a-did) once the DID document is hosted.
 
+| Required Field | Description |
+|-----------------|-------------|
+| `type` | `MANAGED` or `SELF_MANAGED` (`DEFAULT` is system-managed and cannot be created via this endpoint) |
+| `method` | DID method. Rejected with a 400 if the resolved DID service does not support it |
+| `alias` | Alias for the DID (e.g. domain for did:web) |
+
+| Optional Field | Description |
+|-----------------|-------------|
+| `name` | Human-readable name (must be non-empty if provided) |
+| `description` | Description of the DID's purpose (must be non-empty if provided) |
+| `isDefault` | Whether this DID should be the tenant's default |
+| `serviceInstanceId` | Verifiable credential service instance to use for creation |
+
 ```mermaid
 sequenceDiagram
     participant Client
@@ -151,6 +166,14 @@ GET /api/v1/dids
 
 Returns DIDs for the authenticated tenant with optional filtering. Results are paginated.
 
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `type` | string | — | Filter by DID type (the full set, including `DEFAULT`) |
+| `status` | string | — | Filter by DID status |
+| `serviceInstanceId` | string | — | Filter by service instance ID |
+| `limit` | integer | Defaults to 20, or the configured maximum when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
+| `offset` | integer | `0` | Number of results to skip |
+
 ---
 
 ### Get a DID
@@ -169,7 +192,13 @@ Retrieves a specific DID by its database ID.
 PATCH /api/v1/dids/{id}
 ```
 
-Updates the metadata of a DID. Only `name`, `description`, and `isDefault` can be changed — the DID identifier, type, method, and key material are immutable.
+Updates the metadata of a DID. Only `name`, `description`, and `isDefault` can be changed — the DID identifier, type, method, and key material are immutable. At least one updatable field must be provided.
+
+| Updatable Field | Description |
+|-----------------|-------------|
+| `name` | New name (must be non-empty if provided) |
+| `description` | New description (must be non-empty if provided) |
+| `isDefault` | Whether to set this DID as the tenant default. Cannot be changed on system default DIDs |
 
 ---
 
@@ -248,7 +277,7 @@ The VC service resolves the DID by fetching the DID document from wherever it is
 POST /api/v1/dids/{id}/verify
 ```
 
-Verifies that a DID can be resolved and that its DID document is valid. The DID's status is updated based on the result — `VERIFIED` if all checks pass, `VERIFICATION_FAILED` otherwise.
+Verifies that a DID can be resolved and that its DID document is valid. When verification runs to completion, the DID's status is updated based on the result — `VERIFIED` if all checks pass, `VERIFICATION_FAILED` otherwise. A pre-verification failure leaves the current status unchanged: the DEFAULT-type guard below, or a stored DID string that does not parse as `did:method:identifier` or names an unsupported method (reachable because [import](#import-a-did) accepts the `did` string without format validation) — both return a 400 without touching the record.
 
 This endpoint is used for **self-managed** DIDs — both those [created via the API](#create-a-did) and those [imported](#import-a-did) — which start with status `UNVERIFIED`. It confirms that the DID document is publicly resolvable and structurally valid.
 
@@ -298,6 +327,18 @@ Use this endpoint when you have a DID that was created outside the Reference Imp
 Before importing, the tenant must have registered the verifiable credential service instance that holds the DID via the [Services API](./services#create-a-service-instance). The `serviceInstanceId` is required — this is how the Reference Implementation knows which VC service to use when signing credentials with this DID.
 
 Note that unlike the [create endpoint](#create-a-did), the import endpoint does **not** call the upstream VC service. It only creates a local database record.
+
+| Required Field | Description |
+|-----------------|-------------|
+| `did` | The DID identifier to import (e.g. `did:web:example.com`) |
+| `method` | DID method |
+| `keyId` | Key identifier associated with the DID |
+| `serviceInstanceId` | Verifiable credential service instance that holds the key material for this DID |
+
+| Optional Field | Description |
+|-----------------|-------------|
+| `name` | Human-readable name (must be non-empty if provided) |
+| `description` | Description of the DID's purpose (must be non-empty if provided) |
 
 ```mermaid
 sequenceDiagram

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -19,7 +19,7 @@ Optional request fields (`name`, `description`, `isDefault`, `serviceInstanceId`
 
 ### DID Types
 
-Every DID has a **type** that determines how it was created, who manages its key material, and who hosts its DID document. The types represent an [adoption ramp](../overview#incremental-adoption): tenants can issue UNTP-compliant credentials from day one using the system default, and progressively take on more control as they become more technically sophisticated.
+Every DID has a **type** that determines how it was created, who manages its key material, and who hosts its DID document. The types represent an [adoption ramp](../overview#incremental-adoption): tenants can issue UNTP-compliant credentials from day one using the system default DID, and progressively take on more control as they become more technically sophisticated.
 
 #### `DEFAULT`
 
@@ -97,7 +97,7 @@ DIDs exist at two levels: the **system default DID** (created during [startup](.
 
 ### Service Instance Association
 
-When creating a DID, you can specify which [verifiable credential service instance](./services) to use via `serviceInstanceId`. If omitted, the service instance is resolved using the same [resolution chain](../services/service-architecture#system-services-vs-tenant-services) as other operations: the tenant's [primary](./services#primary-instances) VC service instance if one is set, otherwise the system default.
+When creating a DID, you can specify which [verifiable credential service instance](./services) to use via `serviceInstanceId`. If omitted, the service instance is resolved using the same [resolution chain](../services/service-architecture#system-services-vs-tenant-services) as other operations: the tenant's [primary](./services#primary-instances) VC service instance if one is set, otherwise the system default verifiable credential service.
 
 The service instance is the upstream provider that holds the cryptographic key material and performs signing operations. In most cases a DID is bound to the verifiable credential service instance that holds its key material, a binding fixed when the DID is created or imported. That binding can be lost if the service instance is later [force-deleted](./services#delete-a-service-instance), which leaves the DID without an associated service instance.
 
@@ -324,7 +324,7 @@ Registers an existing, externally managed DID in the Reference Implementation wi
 
 Use this endpoint when you have a DID that was created outside the Reference Implementation (e.g., in a separate verifiable credential service instance) and you want to use it for credential signing within the Reference Implementation. After importing, use the [verify endpoint](#verify-a-did) to confirm that the DID document is resolvable.
 
-Before importing, the tenant must have registered the verifiable credential service instance that holds the DID via the [Services API](./services#create-a-service-instance). The `serviceInstanceId` is required; this is how the Reference Implementation knows which VC service to use when signing credentials with this DID. It is verified to belong to the authenticated tenant (or be a system default) before the record is saved; a nonexistent id, or one belonging to another tenant, is rejected with a 404.
+Before importing, the tenant must have registered the verifiable credential service instance that holds the DID via the [Services API](./services#create-a-service-instance). The `serviceInstanceId` is required; this is how the Reference Implementation knows which VC service to use when signing credentials with this DID. It is verified to belong to the authenticated tenant (or be the system default verifiable credential service) before the record is saved; a nonexistent id, or one belonging to another tenant, is rejected with a 404.
 
 Note that unlike the [create endpoint](#create-a-did), the import endpoint does **not** call the upstream VC service. It only verifies the service instance and creates a local database record.
 
@@ -334,8 +334,8 @@ Importing a `did:webvh` identifier is rejected because `method` is restricted to
 |-----------------|-------------|
 | `did` | The DID identifier to import (e.g. `did:web:example.com`) |
 | `method` | `DID_WEB` (the supported method today; `DID_WEB_VH` is planned but not yet implemented and is rejected with a 400) |
-| `keyId` | Key identifier associated with the DID |
-| `serviceInstanceId` | Verifiable credential service instance that holds the key material for this DID. Must belong to the authenticated tenant or be a system default; otherwise rejected with a 404 |
+| `keyId` | The identifier of the specific key to use for signing with this DID. A DID can control more than one key, so the key is named explicitly rather than inferred |
+| `serviceInstanceId` | Verifiable credential service instance that holds the key material for this DID. Must belong to the authenticated tenant or be the system default verifiable credential service; otherwise rejected with a 404 |
 
 | Optional Field | Description |
 |-----------------|-------------|
@@ -350,7 +350,7 @@ sequenceDiagram
 
     Client->>RI: POST /api/v1/dids/import { did, method, keyId, serviceInstanceId }
     RI->>RI: Validate did, method, keyId, serviceInstanceId
-    RI->>DB: Verify serviceInstanceId belongs to this tenant (or is a system default)
+    RI->>DB: Verify serviceInstanceId belongs to this tenant (or is the system default verifiable credential service)
     alt not found or belongs to another tenant
         RI-->>Client: 404 Not Found
     end

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -332,7 +332,7 @@ Importing a `did:webvh` identifier is rejected because `method` is restricted to
 
 | Required Field | Description |
 |-----------------|-------------|
-| `did` | The DID identifier to import (e.g. `did:web:example.com`) |
+| `did` | The DID identifier to import (e.g. `did:web:example.com`). Must be a well-formed DID of the form `did:<method>:<identifier>` with a recognised method; a malformed DID is rejected with a 400 |
 | `method` | `DID_WEB` (the supported method today; `DID_WEB_VH` is planned but not yet implemented and is rejected with a 400) |
 | `keyId` | The identifier of the specific key to use for signing with this DID. A DID can control more than one key, so the key is named explicitly rather than inferred |
 | `serviceInstanceId` | Verifiable credential service instance that holds the key material for this DID. Must belong to the authenticated tenant or be the system default verifiable credential service; otherwise rejected with a 404 |

--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -328,7 +328,7 @@ Before importing, the tenant must have registered the verifiable credential serv
 
 Note that unlike the [create endpoint](#create-a-did), the import endpoint does **not** call the upstream VC service. It only verifies the service instance and creates a local database record.
 
-Importing a `did:webvh` identifier is rejected: `method` is restricted to `DID_WEB` until did:webvh support lands, so a webvh DID cannot be imported ahead of that even though the `did` string itself is otherwise accepted without format validation.
+Importing a `did:webvh` identifier is rejected because `method` is restricted to `DID_WEB` until did:webvh support lands.
 
 | Required Field | Description |
 |-----------------|-------------|

--- a/packages/reference-implementation/e2e/cypress/e2e/api/did_api/did-management.cy.ts
+++ b/packages/reference-implementation/e2e/cypress/e2e/api/did_api/did-management.cy.ts
@@ -547,7 +547,7 @@ describe('DID API', { testIsolation: false }, () => {
         failOnStatusCode: false,
       }).then((response) => {
         expect(response.status).to.eq(400);
-        expect(response.body.error).to.include('default');
+        expect(response.body.error).to.include('isDefault');
       });
     });
 

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.test.ts
@@ -8,7 +8,7 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// Mock withTenantAuth to skip auth while delegating error mapping to the real
 // handleRouteError, so this suite is checked against production's actual
 // status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.test.ts
@@ -8,39 +8,18 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth to mirror handleRouteError behaviour
+// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// handleRouteError, so this suite is checked against production's actual
+// status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
       (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
         try {
           return await handler(req, ctx);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 500 });
-          }
-          if (e instanceof ServiceError) {
-            const serviceErr = e as Error & { code?: string; statusCode?: number };
-            return jsonResponse(
-              { error: serviceErr.message, code: serviceErr.code },
-              { status: serviceErr.statusCode },
-            );
-          }
-          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };
@@ -58,6 +37,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 }));
 
 import { ServiceResolutionError } from '@/lib/api/errors';
+import { DidDocumentFetchError } from '@uncefact/untp-ri-services';
 import { GET } from './route';
 
 function createContext(id: string) {
@@ -111,6 +91,17 @@ describe('GET /api/v1/dids/:id/document', () => {
     const res = await GET(createFakeRequest(), createContext('did-1') as unknown as Parameters<typeof GET>[1]);
 
     expect(res.status).toBe(500);
+  });
+
+  it('returns 502 with code DID_DOCUMENT_FETCH_FAILED when the upstream document fetch fails', async () => {
+    mockGetDidById.mockResolvedValue({ id: 'did-1', did: 'did:web:example.com' });
+    mockDidService.getDocument.mockRejectedValue(new DidDocumentFetchError('did:web:example.com', 'HTTP 500'));
+
+    const res = await GET(createFakeRequest(), createContext('did-1') as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(json.code).toBe('DID_DOCUMENT_FETCH_FAILED');
   });
 
   it('returns 500 when service resolution fails', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
@@ -35,6 +35,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/document' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
  *         description: DID or service instance not found
  *         content:
@@ -43,6 +49,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/document' });
  *               $ref: '#/components/schemas/ErrorResponse'
  *       500:
  *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       502:
+ *         description: Upstream DID document fetch failed (DID_DOCUMENT_FETCH_FAILED) - the resolved VC service could not resolve the DID document
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
@@ -54,7 +54,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/document' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       502:
- *         description: Upstream DID document fetch failed (DID_DOCUMENT_FETCH_FAILED) - the resolved VC service could not resolve the DID document
+ *         description: Upstream DID document fetch failed (DID_DOCUMENT_FETCH_FAILED). The verifiable credential service resolves the DID but could not retrieve its document from where the DID is hosted, which for a self-managed DID is the tenant's own hosting location.
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
@@ -8,7 +8,7 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// Mock withTenantAuth to skip auth while delegating error mapping to the real
 // handleRouteError, so this suite is checked against production's actual
 // status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
@@ -8,39 +8,18 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth to mirror handleRouteError behaviour
+// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// handleRouteError, so this suite is checked against production's actual
+// status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
       (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
         try {
           return await handler(req, ctx);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 500 });
-          }
-          if (e instanceof ServiceError) {
-            const serviceErr = e as Error & { code?: string; statusCode?: number };
-            return jsonResponse(
-              { error: serviceErr.message, code: serviceErr.code },
-              { status: serviceErr.statusCode },
-            );
-          }
-          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };
@@ -127,13 +106,77 @@ describe('PATCH /api/v1/dids/:id', () => {
 
     expect(res.status).toBe(200);
     expect(json.name).toBe('New Name');
+    expect(mockUpdateDid).toHaveBeenCalledWith('did-1', 'org-1', { name: 'New Name', description: 'New desc' });
   });
 
-  it('returns 400 when no fields provided', async () => {
+  it('returns 400 when no fields provided, and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: {} });
     const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
 
     expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one of name, description, or isDefault is required');
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body only has an unrecognised (typo) field name', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { neme: 'New Name' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one of name, description, or isDefault is required');
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a literal null body, and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^body:/);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is an empty string, and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^name:/);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is an empty string, and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { description: '' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^description:/);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isDefault is not a boolean (mistyped optional field), and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { isDefault: 'yes' } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^isDefault:/);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isDefault is an explicit null (omission, not null, leaves it unchanged)', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { isDefault: null } });
+    const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^isDefault:/);
+    expect(mockUpdateDid).not.toHaveBeenCalled();
   });
 
   it('returns 404 when DID not found or access denied', async () => {
@@ -159,14 +202,14 @@ describe('PATCH /api/v1/dids/:id', () => {
   });
 
   it('returns 400 when setting isDefault on a DEFAULT type DID', async () => {
-    mockUpdateDid.mockRejectedValue(new ValidationError('Cannot modify default status of system DIDs'));
+    mockUpdateDid.mockRejectedValue(new ValidationError('isDefault: Cannot modify default status of system DIDs'));
 
     const req = createFakeRequest({ method: 'PATCH', body: { isDefault: true } });
     const res = await PATCH(req, createContext('did-1') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('Cannot modify default status of system DIDs');
+    expect(json.error).toBe('isDefault: Cannot modify default status of system DIDs');
   });
 
   it('accepts isDefault with name together', async () => {
@@ -249,7 +292,7 @@ describe('DELETE /api/v1/dids/:id', () => {
     expect(mockDeleteDid).toHaveBeenCalledWith('did-1', 'org-1');
   });
 
-  it('returns 400 when trying to delete a default DID', async () => {
+  it('returns 400 when trying to delete a DID flagged isDefault', async () => {
     mockGetDidById.mockResolvedValue({
       id: 'did-1',
       did: 'did:web:example.com',
@@ -262,7 +305,9 @@ describe('DELETE /api/v1/dids/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toBe('Cannot delete system default DID');
+    expect(json.error).toBe(
+      'Cannot delete a DID currently flagged isDefault - clear the flag via the update endpoint first',
+    );
     expect(mockDeleteDid).not.toHaveBeenCalled();
     expect(mockDidService.delete).not.toHaveBeenCalled();
   });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.test.ts
@@ -346,4 +346,23 @@ describe('DELETE /api/v1/dids/:id', () => {
     expect(mockResolveDidService).toHaveBeenCalledWith('org-1', 'inst-1');
     expect(mockDidService.delete).not.toHaveBeenCalled();
   });
+
+  // The two tests above prove failures AFTER the record is deleted are
+  // swallowed. This one holds the opposite line: the record deletion itself is
+  // not best-effort, so its failure must surface rather than return 204, and
+  // the upstream removal must not run for a record that is still there.
+  it('surfaces the error and skips upstream removal when deleteDid throws', async () => {
+    mockGetDidById.mockResolvedValue({
+      id: 'did-1',
+      did: 'did:web:example.com',
+      serviceInstanceId: 'inst-1',
+    });
+    mockDeleteDid.mockRejectedValue(new Error('Database unavailable'));
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('did-1') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(500);
+    expect(mockDidService.delete).not.toHaveBeenCalled();
+  });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { ValidationError, parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateDidRequestSchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { getDidById, updateDid, deleteDid } from '@/lib/prisma/repositories';
 import { resolveDidService } from '@/lib/services/resolve-did-service';
@@ -32,6 +33,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]' });
  *               $ref: '#/components/schemas/Did'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -79,6 +86,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         description: The database ID of the DID
  *     requestBody:
  *       required: true
+ *       description: At least one recognised field is required; unknown keys are ignored.
  *       content:
  *         application/json:
  *           schema:
@@ -86,14 +94,19 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             properties:
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: New name for the DID
  *               description:
  *                 type: string
+ *                 minLength: 1
  *                 description: New description for the DID
  *               isDefault:
  *                 type: boolean
  *                 description: Whether to set this DID as the tenant default
- *             minProperties: 1
+ *             anyOf:
+ *               - required: [name]
+ *               - required: [description]
+ *               - required: [isDefault]
  *     responses:
  *       200:
  *         description: DID updated successfully
@@ -102,13 +115,19 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/Did'
  *       400:
- *         description: Validation error - at least one field required
+ *         description: Validation error (e.g. no fields provided, a field of the wrong type, or the system tenant changing isDefault on its own DEFAULT-type DID - any other tenant PATCHing that DID gets a 404 instead, since it is not scoped to their tenant)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -129,29 +148,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ didId: id }, 'Parsing request body');
-  let body: { name?: string; description?: string; isDefault?: boolean };
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
   logger.info({ didId: id }, 'Validating update fields');
-  const hasName = isNonEmptyString(body.name);
-  const hasDescription = isNonEmptyString(body.description);
-  const hasIsDefault = typeof body.isDefault === 'boolean';
+  const body = await parseRequestBody(req, updateDidRequestSchema);
+  const fields = definedFields(body);
 
-  if (!hasName && !hasDescription && !hasIsDefault) {
-    throw new ValidationError('At least one of name, description, or isDefault is required');
-  }
-
-  logger.info({ didId: id, fields: { hasName, hasDescription, hasIsDefault } }, 'Updating DID record');
-  const updated = await updateDid(id, tenantId, {
-    ...(hasName && { name: body.name }),
-    ...(hasDescription && { description: body.description }),
-    ...(hasIsDefault && { isDefault: body.isDefault }),
-  });
+  logger.info({ didId: id, fields: Object.keys(fields) }, 'Updating DID record');
+  const updated = await updateDid(id, tenantId, fields);
 
   logger.info({ didId: id }, 'DID updated');
   return NextResponse.json(updated);
@@ -176,13 +178,19 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: DID deleted successfully
  *       400:
- *         description: Cannot delete the system default DID
+ *         description: Cannot delete a DID currently flagged isDefault - clear the flag via the update endpoint first
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -210,7 +218,9 @@ export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
   }
 
   if (did.isDefault) {
-    throw new ValidationError('Cannot delete system default DID');
+    throw new ValidationError(
+      'Cannot delete a DID currently flagged isDefault - clear the flag via the update endpoint first',
+    );
   }
 
   logger.info({ didId: id }, 'Deleting DID from database');

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -164,7 +164,11 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  * /dids/{id}:
  *   delete:
  *     summary: Delete a DID
- *     description: Deletes a DID. If the DID is managed (has a serviceInstanceId), it is also removed from the upstream provider.
+ *     description: |
+ *       Deletes a DID record. If the DID is managed (has a serviceInstanceId), removal from the upstream
+ *       provider is also attempted, on a best-effort basis: the record is already deleted by that point, so
+ *       a provider that is unreachable or rejects the removal leaves an orphaned upstream DID and the
+ *       request still returns 204.
  *     tags:
  *       - DIDs
  *     parameters:
@@ -235,9 +239,9 @@ export const DELETE = withTenantAuth(async (_req, { tenantId, params }) => {
       const { service: didService } = await resolveDidService(tenantId, did.serviceInstanceId);
       await didService.delete(did.did);
     } catch (err) {
-      logger.error(
-        { didId: id, did: did.did, error: err },
-        'Best-effort upstream DID deletion failed; orphaned upstream DID is harmless',
+      logger.warn(
+        { didId: id, did: did.did, serviceInstanceId: did.serviceInstanceId, error: err },
+        'Failed to delete DID from upstream provider; upstream DID may be orphaned',
       );
     }
   }

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -8,7 +8,7 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// Mock withTenantAuth to skip auth while delegating error mapping to the real
 // handleRouteError, so this suite is checked against production's actual
 // status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -176,8 +176,9 @@ describe('POST /api/v1/dids/:id/verify', () => {
   });
 
   it('returns 400 with code DID_PARSE_FAILED when the stored DID string does not parse', async () => {
-    // Reachable because import (POST /dids/import) accepts the did string without format
-    // validation, so a malformed DID can reach parseDidMethod on its first verify attempt.
+    // Defensive: import validates the DID string with parseDidMethod, so a malformed DID
+    // should not normally be stored. The verify path still guards against one slipping
+    // through (e.g. legacy data predating that validation) rather than crashing.
     mockGetDidById.mockResolvedValue({ id: 'did-1', did: 'not-a-did' });
     mockDidService.verify.mockRejectedValue(new DidParseError('not-a-did', 'invalid format'));
 

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.test.ts
@@ -8,39 +8,18 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth to mirror handleRouteError behaviour
+// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// handleRouteError, so this suite is checked against production's actual
+// status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
       (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
         try {
           return await handler(req, ctx);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 500 });
-          }
-          if (e instanceof ServiceError) {
-            const serviceErr = e as Error & { code?: string; statusCode?: number };
-            return jsonResponse(
-              { error: serviceErr.message, code: serviceErr.code },
-              { status: serviceErr.statusCode },
-            );
-          }
-          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };
@@ -71,6 +50,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 }));
 
 import { ServiceResolutionError } from '@/lib/api/errors';
+import { DidParseError, DidMethodNotSupportedError } from '@uncefact/untp-ri-services';
 import { POST } from './route';
 
 function createContext(id: string) {
@@ -193,5 +173,31 @@ describe('POST /api/v1/dids/:id/verify', () => {
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toContain('No service instance available');
+  });
+
+  it('returns 400 with code DID_PARSE_FAILED when the stored DID string does not parse', async () => {
+    // Reachable because import (POST /dids/import) accepts the did string without format
+    // validation, so a malformed DID can reach parseDidMethod on its first verify attempt.
+    mockGetDidById.mockResolvedValue({ id: 'did-1', did: 'not-a-did' });
+    mockDidService.verify.mockRejectedValue(new DidParseError('not-a-did', 'invalid format'));
+
+    const res = await POST(createFakeRequest(), createContext('did-1') as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.code).toBe('DID_PARSE_FAILED');
+    expect(mockUpdateDidStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with code DID_METHOD_NOT_SUPPORTED when the stored DID names an unsupported method', async () => {
+    mockGetDidById.mockResolvedValue({ id: 'did-1', did: 'did:example:123' });
+    mockDidService.verify.mockRejectedValue(new DidMethodNotSupportedError('example'));
+
+    const res = await POST(createFakeRequest(), createContext('did-1') as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.code).toBe('DID_METHOD_NOT_SUPPORTED');
+    expect(mockUpdateDidStatus).not.toHaveBeenCalled();
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
@@ -18,6 +18,9 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
  *       Verifies that a DID can be resolved and updates its status accordingly.
  *       If verification succeeds, the DID status is set to VERIFIED.
  *       If verification fails, the DID status is set to VERIFICATION_FAILED.
+ *       Status changes only when verification runs to completion and returns a result; a pre-verification
+ *       failure (the DEFAULT-type guard, or a DID whose format or method cannot be parsed) leaves the DID's
+ *       current status unchanged.
  *     tags:
  *       - DIDs
  *     parameters:
@@ -39,8 +42,23 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
  *                   $ref: '#/components/schemas/VerificationResult'
  *                 did:
  *                   $ref: '#/components/schemas/Did'
+ *       400:
+ *         description: |
+ *           Either of:
+ *           - System default DIDs cannot be verified through this endpoint.
+ *           - DID_PARSE_FAILED or DID_METHOD_NOT_SUPPORTED: the stored DID string does not parse as `did:method:identifier`, or names a method this deployment does not support. Reachable because import (POST /dids/import) accepts the did string as-is without format validation, so a malformed or unsupported-method DID can reach this check on its first verification attempt.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
@@ -46,7 +46,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
  *         description: |
  *           Either of:
  *           - System default DIDs cannot be verified through this endpoint.
- *           - DID_PARSE_FAILED or DID_METHOD_NOT_SUPPORTED: the stored DID string does not parse as `did:method:identifier`, or names a method this deployment does not support. Reachable because import (POST /dids/import) accepts the did string as-is without format validation, so a malformed or unsupported-method DID can reach this check on its first verification attempt.
+ *           - DID_PARSE_FAILED or DID_METHOD_NOT_SUPPORTED: the stored DID string does not parse as `did:method:identifier`, or names a method this deployment does not support. Import (POST /dids/import) now rejects both at the boundary, so this check catches records stored before that validation was in place, and any record whose method stopped being supported after it was stored.
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -7,33 +7,18 @@ jest.mock('next/server', () => ({
   },
 }));
 
+// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// handleRouteError, so this suite is checked against production's actual
+// status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { ConflictError, NotFoundError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
       (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
         try {
           return await handler(req, ctx);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          if (e instanceof ConflictError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 409 });
-          }
-          if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 500 });
-          }
-          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };
@@ -44,10 +29,11 @@ jest.mock('@/lib/prisma/repositories', () => ({
   createDid: (...args: unknown[]) => mockCreateDid(...args),
 }));
 
-jest.mock('@uncefact/untp-ri-services', () => ({
-  DidMethod: { DID_WEB: 'DID_WEB', DID_WEB_VH: 'DID_WEB_VH' },
-}));
-
+// The request schema (request-schemas/did.ts) imports the full set of DID
+// enums from '@uncefact/untp-ri-services' (CREATABLE_DID_TYPES, DidMethod,
+// DidStatus, DidType), so this module must not be mocked with a partial
+// factory (ADR-037): a factory providing only DidMethod would leave the
+// schema's z.nativeEnum/z.enum calls undefined at import time.
 import { POST } from './route';
 
 // -- Helpers ------------------------------------------------------------------
@@ -135,7 +121,7 @@ describe('POST /api/v1/dids/import', () => {
     );
   });
 
-  it('returns 400 when serviceInstanceId is missing', async () => {
+  it('returns 400 when serviceInstanceId is missing, and does not call the repository', async () => {
     const req = createFakeRequest({
       did: 'did:web:example.com',
       method: 'DID_WEB',
@@ -146,10 +132,11 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('serviceInstanceId is required');
+    expect(body.error).toMatch(/^serviceInstanceId:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when serviceInstanceId is an empty string', async () => {
+  it('returns 400 when serviceInstanceId is an empty string, and does not call the repository', async () => {
     const req = createFakeRequest({
       did: 'did:web:example.com',
       method: 'DID_WEB',
@@ -161,7 +148,88 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('serviceInstanceId is required');
+    expect(body.error).toMatch(/^serviceInstanceId:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when serviceInstanceId is an explicit null (omission, not null, is required), and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: null,
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^serviceInstanceId:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when did is a number, and does not call the repository', async () => {
+    const req = createFakeRequest({ did: 1, method: 'DID_WEB', keyId: 'key-1', serviceInstanceId: 'inst-1' });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^did:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when keyId is a boolean, and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: true,
+      serviceInstanceId: 'inst-1',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^keyId:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when serviceInstanceId is a number, and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: 5,
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^serviceInstanceId:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when serviceInstanceId does not reference an existing service instance (P2003 mapping)', async () => {
+    // Import has no upfront resolveDidService step, so an invalid FK surfaces via the
+    // repository's P2003 mapping (ValidationError, 400) rather than the 404 that POST
+    // /dids would raise for the same condition (documented asymmetry, ADR-037).
+    const { ValidationError } = jest.requireActual('@/lib/api/validation');
+    mockCreateDid.mockRejectedValueOnce(new ValidationError('serviceInstanceId: Service instance not found'));
+
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: 'nonexistent',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('serviceInstanceId: Service instance not found');
   });
 
   it('sets status to UNVERIFIED', async () => {
@@ -198,37 +266,40 @@ describe('POST /api/v1/dids/import', () => {
     );
   });
 
-  it('returns 400 when did is missing', async () => {
-    const req = createFakeRequest({ method: 'DID_WEB', keyId: 'key-1' });
+  it('returns 400 when did is missing, and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'DID_WEB', keyId: 'key-1', serviceInstanceId: 'inst-1' });
 
     const res = await POST(req, createContext());
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('did is required');
+    expect(body.error).toMatch(/^did:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when keyId is missing', async () => {
-    const req = createFakeRequest({ did: 'did:web:example.com', method: 'DID_WEB' });
+  it('returns 400 when keyId is missing, and does not call the repository', async () => {
+    const req = createFakeRequest({ did: 'did:web:example.com', method: 'DID_WEB', serviceInstanceId: 'inst-1' });
 
     const res = await POST(req, createContext());
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('keyId is required');
+    expect(body.error).toMatch(/^keyId:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when method is missing', async () => {
+  it('returns 400 when method is missing, and does not call the repository', async () => {
     const req = createFakeRequest({ did: 'did:web:example.com', keyId: 'key-1', serviceInstanceId: 'inst-1' });
 
     const res = await POST(req, createContext());
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('method is required');
+    expect(body.error).toMatch(/^method:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid method', async () => {
+  it('returns 400 for invalid method, and does not call the repository', async () => {
     const req = createFakeRequest({
       did: 'did:web:example.com',
       keyId: 'key-1',
@@ -240,10 +311,11 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('method must be one of');
+    expect(body.error).toMatch(/^method:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid JSON body', async () => {
+  it('returns 400 for invalid JSON body, and does not call the repository', async () => {
     const req = {
       json: async () => {
         throw new Error('bad json');
@@ -255,6 +327,18 @@ describe('POST /api/v1/dids/import', () => {
 
     expect(res.status).toBe(400);
     expect(body.error).toBe('Invalid JSON body');
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a literal null body, and does not call the repository', async () => {
+    const req = createFakeRequest(null);
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^body:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('does NOT call any DID service adapter', async () => {
@@ -306,27 +390,34 @@ describe('POST /api/v1/dids/import', () => {
     expect(body.error).toBeDefined();
   });
 
-  it('returns 400 when did is an empty string', async () => {
-    const req = createFakeRequest({ did: '', method: 'DID_WEB', keyId: 'key-1' });
+  it('returns 400 when did is an empty string, and does not call the repository', async () => {
+    const req = createFakeRequest({ did: '', method: 'DID_WEB', keyId: 'key-1', serviceInstanceId: 'inst-1' });
 
     const res = await POST(req, createContext());
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('did is required');
+    expect(body.error).toMatch(/^did:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when keyId is an empty string', async () => {
-    const req = createFakeRequest({ did: 'did:web:example.com', method: 'DID_WEB', keyId: '' });
+  it('returns 400 when keyId is an empty string, and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: '',
+      serviceInstanceId: 'inst-1',
+    });
 
     const res = await POST(req, createContext());
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('keyId is required');
+    expect(body.error).toMatch(/^keyId:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when method is an empty string', async () => {
+  it('returns 400 when method is an empty string, and does not call the repository', async () => {
     const req = createFakeRequest({
       did: 'did:web:example.com',
       keyId: 'key-1',
@@ -338,7 +429,42 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toContain('method');
+    expect(body.error).toMatch(/^method:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is an empty string (mistyped optional field), and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      keyId: 'key-1',
+      method: 'DID_WEB',
+      serviceInstanceId: 'inst-1',
+      name: '',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^name:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is an empty string (mistyped optional field), and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      keyId: 'key-1',
+      method: 'DID_WEB',
+      serviceInstanceId: 'inst-1',
+      description: '',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^description:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('succeeds when description is omitted', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -7,7 +7,7 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// Mock withTenantAuth to skip auth while delegating error mapping to the real
 // handleRouteError, so this suite is checked against production's actual
 // status/code mapping rather than a hand-rolled duplicate that can drift.
 jest.mock('@/lib/api/with-tenant-auth', () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -185,6 +185,35 @@ describe('POST /api/v1/dids/import', () => {
     expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
+  it('returns 400 with code DID_PARSE_FAILED when did is not a well-formed DID, and does not call the repository', async () => {
+    const req = createFakeRequest({ did: 'not-a-did', method: 'DID_WEB', keyId: 'key-1', serviceInstanceId: 'inst-1' });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('DID_PARSE_FAILED');
+    expect(mockGetInstanceByResolution).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with code DID_METHOD_NOT_SUPPORTED when the did names an unrecognised method, and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:key:z6Mk',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: 'inst-1',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('DID_METHOD_NOT_SUPPORTED');
+    expect(mockGetInstanceByResolution).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when keyId is a boolean, and does not call the repository', async () => {
     const req = createFakeRequest({
       did: 'did:web:example.com',

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -25,8 +25,10 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
 });
 
 const mockCreateDid = jest.fn();
+const mockGetInstanceByResolution = jest.fn();
 jest.mock('@/lib/prisma/repositories', () => ({
   createDid: (...args: unknown[]) => mockCreateDid(...args),
+  getInstanceByResolution: (...args: unknown[]) => mockGetInstanceByResolution(...args),
 }));
 
 // The request schema (request-schemas/did.ts) imports the full set of DID
@@ -72,6 +74,7 @@ describe('POST /api/v1/dids/import', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCreateDid.mockResolvedValue(MOCK_DID_RECORD);
+    mockGetInstanceByResolution.mockResolvedValue({ id: 'inst-1', tenantId: 'tenant-1' });
   });
 
   it('imports a DID and returns 201', async () => {
@@ -89,6 +92,9 @@ describe('POST /api/v1/dids/import', () => {
 
     expect(res.status).toBe(201);
     expect(body).toEqual(MOCK_DID_RECORD);
+
+    // Verifies the tenant-scoped existence check runs before the write
+    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('tenant-1', 'VC', 'inst-1');
 
     // Verify createDid was called with correct params -- NOT calling adapter
     expect(mockCreateDid).toHaveBeenCalledWith({
@@ -211,10 +217,52 @@ describe('POST /api/v1/dids/import', () => {
     expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when serviceInstanceId does not reference an existing service instance (P2003 mapping)', async () => {
-    // Import has no upfront resolveDidService step, so an invalid FK surfaces via the
-    // repository's P2003 mapping (ValidationError, 400) rather than the 404 that POST
-    // /dids would raise for the same condition (documented asymmetry, ADR-037).
+  it('returns 404 when serviceInstanceId does not resolve for this tenant, and does not call the repository', async () => {
+    mockGetInstanceByResolution.mockResolvedValue(null);
+
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: 'nonexistent',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toContain('nonexistent');
+    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('tenant-1', 'VC', 'nonexistent');
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when serviceInstanceId belongs to a different tenant, checked against the authenticated tenant not a caller-supplied one', async () => {
+    // getInstanceByResolution itself scopes the lookup to the tenantId it is called with (see
+    // service-instance.repository.test.ts's "returns null for explicit ID not accessible"), so
+    // resolving null here for tenant-2 stands in for "the instance exists but belongs to
+    // tenant-1". This asserts the route passes the AUTHENTICATED tenantId from context, since a
+    // route that read a tenantId from the request body instead would defeat the check entirely.
+    mockGetInstanceByResolution.mockResolvedValue(null);
+
+    const req = createFakeRequest({
+      did: 'did:web:example.com',
+      method: 'DID_WEB',
+      keyId: 'key-1',
+      serviceInstanceId: 'inst-owned-by-tenant-1',
+    });
+
+    const res = await POST(req, createContext({ tenantId: 'tenant-2' }));
+
+    expect(res.status).toBe(404);
+    expect(mockGetInstanceByResolution).toHaveBeenCalledWith('tenant-2', 'VC', 'inst-owned-by-tenant-1');
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when serviceInstanceId is deleted in the race window between resolution and the write (P2003 backstop)', async () => {
+    // getInstanceByResolution finds the instance (it existed at check time), but createDid
+    // still rejects via the repository's P2003 mapping, simulating deletion in the narrow
+    // window between the check and the write. The 404 path above covers the common case;
+    // this is the rare backstop the repository mapping exists for.
     const { ValidationError } = jest.requireActual('@/lib/api/validation');
     mockCreateDid.mockRejectedValueOnce(new ValidationError('serviceInstanceId: Service instance not found'));
 
@@ -222,7 +270,7 @@ describe('POST /api/v1/dids/import', () => {
       did: 'did:web:example.com',
       method: 'DID_WEB',
       keyId: 'key-1',
-      serviceInstanceId: 'nonexistent',
+      serviceInstanceId: 'inst-1',
     });
 
     const res = await POST(req, createContext());
@@ -304,6 +352,22 @@ describe('POST /api/v1/dids/import', () => {
       did: 'did:web:example.com',
       keyId: 'key-1',
       method: 'INVALID',
+      serviceInstanceId: 'inst-1',
+    });
+
+    const res = await POST(req, createContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/^method:/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for method DID_WEB_VH (planned but not yet implemented), and does not call the repository', async () => {
+    const req = createFakeRequest({
+      did: 'did:webvh:example.com',
+      keyId: 'key-1',
+      method: 'DID_WEB_VH',
       serviceInstanceId: 'inst-1',
     });
 

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.test.ts
@@ -480,7 +480,10 @@ describe('POST /api/v1/dids/import', () => {
     const body = await res.json();
 
     expect(res.status).toBe(500);
-    expect(body.error).toBeDefined();
+    // Pins handleRouteError's final fallthrough, which echoes a non-database
+    // error's own message. A toBeDefined() check here would pass just as
+    // happily if the response carried the wrong error entirely.
+    expect(body.error).toBe('Database connection lost');
   });
 
   it('returns 400 when did is an empty string, and does not call the repository', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, validateEnum } from '@/lib/api/validation';
+import { parseRequestBody } from '@/lib/api/validation';
+import { importDidRequestSchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createDid } from '@/lib/prisma/repositories';
-import { DidMethod } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/dids/import' });
@@ -28,22 +28,27 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *             properties:
  *               did:
  *                 type: string
+ *                 minLength: 1
  *                 description: The DID identifier to import (e.g., did:web:example.com)
  *               method:
  *                 type: string
- *                 enum: [DID_WEB]
+ *                 enum: [DID_WEB, DID_WEB_VH]
  *                 description: DID method
  *               keyId:
  *                 type: string
+ *                 minLength: 1
  *                 description: Key identifier associated with the DID
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: Human-readable name for the DID
  *               description:
  *                 type: string
+ *                 minLength: 1
  *                 description: Description of the DID's purpose
  *               serviceInstanceId:
  *                 type: string
+ *                 minLength: 1
  *                 description: Service instance ID — the verifiable credential service that holds the key material for this DID
  *     responses:
  *       201:
@@ -53,13 +58,19 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *             schema:
  *               $ref: '#/components/schemas/Did'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. a missing or non-string did/keyId/serviceInstanceId, an invalid method, or a serviceInstanceId that does not reference an existing service instance - unlike POST /dids, this endpoint does not resolve the service instance up front, so a nonexistent one surfaces here as a 400 rather than a 404)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -78,44 +89,15 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  let body: {
-    did?: string;
-    method?: string;
-    keyId?: string;
-    name?: string;
-    description?: string;
-    serviceInstanceId?: string;
-  };
+  logger.info('Validating request body');
+  const body = await parseRequestBody(req, importDidRequestSchema);
 
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ did: body.did, method: body.method }, 'Validating import parameters');
-  if (!isNonEmptyString(body.did)) {
-    throw new ValidationError('did is required');
-  }
-  if (!isNonEmptyString(body.keyId)) {
-    throw new ValidationError('keyId is required');
-  }
-  if (!isNonEmptyString(body.serviceInstanceId)) {
-    throw new ValidationError('serviceInstanceId is required');
-  }
-
-  const method = validateEnum(body.method, Object.values(DidMethod), 'method');
-  if (!method) {
-    throw new ValidationError('method is required');
-  }
-
-  logger.info({ did: body.did, method }, 'Saving imported DID record');
+  logger.info({ did: body.did, method: body.method }, 'Saving imported DID record');
   const record = await createDid({
     tenantId,
     did: body.did,
     type: 'SELF_MANAGED',
-    method,
+    method: body.method,
     keyId: body.keyId,
     name: body.name ?? body.did,
     description: body.description,

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -51,7 +51,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *               serviceInstanceId:
  *                 type: string
  *                 minLength: 1
- *                 description: Service instance ID — the verifiable credential service that holds the key material for this DID
+ *                 description: Service instance ID (the verifiable credential service that holds the key material for this DID)
  *     responses:
  *       201:
  *         description: DID imported successfully

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from 'next/server';
 import { parseRequestBody } from '@/lib/api/validation';
 import { importDidRequestSchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { createDid } from '@/lib/prisma/repositories';
+import { createDid, getInstanceByResolution } from '@/lib/prisma/repositories';
+import { ServiceInstanceNotFoundError } from '@/lib/api/errors';
+import { ServiceType } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/dids/import' });
@@ -32,8 +34,8 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *                 description: The DID identifier to import (e.g., did:web:example.com)
  *               method:
  *                 type: string
- *                 enum: [DID_WEB, DID_WEB_VH]
- *                 description: DID method
+ *                 enum: [DID_WEB]
+ *                 description: DID method. did:web is the supported method today; did:webvh is planned but not yet implemented and is rejected.
  *               keyId:
  *                 type: string
  *                 minLength: 1
@@ -58,7 +60,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *             schema:
  *               $ref: '#/components/schemas/Did'
  *       400:
- *         description: Validation error (e.g. a missing or non-string did/keyId/serviceInstanceId, an invalid method, or a serviceInstanceId that does not reference an existing service instance - unlike POST /dids, this endpoint does not resolve the service instance up front, so a nonexistent one surfaces here as a 400 rather than a 404)
+ *         description: Validation error (e.g. a missing or non-string did/keyId/serviceInstanceId, an invalid method). A serviceInstanceId deleted in the rare window between resolution and the write can also surface here as a generic validation error.
  *         content:
  *           application/json:
  *             schema:
@@ -71,6 +73,12 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *               $ref: '#/components/schemas/ErrorResponse'
  *       403:
  *         description: Forbidden - authenticated principal has no resolvable tenant assignment
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Service instance not found, or belongs to a different tenant
  *         content:
  *           application/json:
  *             schema:
@@ -91,6 +99,19 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
 export const POST = withTenantAuth(async (req, { tenantId }) => {
   logger.info('Validating request body');
   const body = await parseRequestBody(req, importDidRequestSchema);
+
+  // Import never resolves a working adapter (it stores the reference without calling the
+  // upstream VC service), so it uses the tenant-scoped existence lookup resolveDidService
+  // wraps rather than resolveDidService itself: resolving the full adapter would introduce
+  // failure modes (decryption, adapter registry, config validation) this route has no need
+  // to depend on. Without this check, an existing service instance belonging to a different
+  // tenant would pass the repository's plain FK check and be stored, since the FK is only
+  // ServiceInstance.id with no tenancy constraint.
+  logger.info({ serviceInstanceId: body.serviceInstanceId }, 'Verifying service instance belongs to this tenant');
+  const instance = await getInstanceByResolution(tenantId, ServiceType.VC, body.serviceInstanceId);
+  if (!instance) {
+    throw new ServiceInstanceNotFoundError(body.serviceInstanceId);
+  }
 
   logger.info({ did: body.did, method: body.method }, 'Saving imported DID record');
   const record = await createDid({

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -4,7 +4,7 @@ import { importDidRequestSchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createDid, getInstanceByResolution } from '@/lib/prisma/repositories';
 import { ServiceInstanceNotFoundError } from '@/lib/api/errors';
-import { ServiceType } from '@uncefact/untp-ri-services';
+import { ServiceType, parseDidMethod } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/dids/import' });
@@ -60,7 +60,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *             schema:
  *               $ref: '#/components/schemas/Did'
  *       400:
- *         description: Validation error (e.g. a missing or non-string did/keyId/serviceInstanceId, an invalid method). A serviceInstanceId deleted in the rare window between resolution and the write can also surface here as a generic validation error.
+ *         description: Validation error. Causes include a missing or non-string did/keyId/serviceInstanceId, an invalid method, a did that is not a well-formed DID (code DID_PARSE_FAILED) or whose method is not recognised (code DID_METHOD_NOT_SUPPORTED), and a serviceInstanceId deleted in the rare window between resolution and the write.
  *         content:
  *           application/json:
  *             schema:
@@ -99,6 +99,11 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
 export const POST = withTenantAuth(async (req, { tenantId }) => {
   logger.info('Validating request body');
   const body = await parseRequestBody(req, importDidRequestSchema);
+
+  // Validate the DID string with the same parser the verify path uses, so a malformed DID
+  // (or one whose method is not recognised) is rejected here with the same DID_PARSE_FAILED /
+  // DID_METHOD_NOT_SUPPORTED 400 rather than being stored and only failing on its first verify.
+  parseDidMethod(body.did);
 
   // Import never resolves a working adapter (it stores the reference without calling the
   // upstream VC service), so it uses the tenant-scoped existence lookup resolveDidService

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -514,7 +514,12 @@ describe('POST /api/v1/dids', () => {
     const json = await res.json();
 
     expect(res.status).toBe(409);
-    expect(json.error).toBeDefined();
+    // Pins the local duplicate-alias message specifically. This route has three
+    // distinct 409 causes, and the other two (the unique-constraint violation
+    // in createDid, and the upstream provider reporting the alias as taken)
+    // would satisfy a bare "an error is present" check just as well, so only
+    // the exact message shows the pre-check is what rejected this request.
+    expect(json.error).toBe('A DID with alias "existing-alias" already exists on this service instance');
     expect(mockFindDidByAliasAndService).toHaveBeenCalledWith('existing-alias', 'inst-1');
     expect(mockDidService.create).not.toHaveBeenCalled();
     expect(mockCreateDid).not.toHaveBeenCalled();

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -27,6 +27,15 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
   };
 });
 
+// The route's logger is bound once at module scope, so `warn` is held in a
+// hoisted mock rather than created fresh per child() call: the root-DID guard's
+// disabled-by-bad-config path has no response-visible effect, and this warning
+// is the only place that behaviour surfaces.
+const mockLoggerWarn = jest.fn();
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: { child: () => ({ info: jest.fn(), warn: mockLoggerWarn, error: jest.fn() }) },
+}));
+
 const mockResolveDidService = jest.fn();
 const mockCreateDid = jest.fn();
 const mockListDids = jest.fn();
@@ -80,13 +89,21 @@ const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
 describe('POST /api/v1/dids', () => {
   const mockDidService = {
     create: jest.fn(),
-    normaliseAlias: jest.fn().mockImplementation((alias: string) => alias),
-    getSupportedTypes: jest.fn().mockReturnValue(['MANAGED', 'SELF_MANAGED']),
-    getSupportedMethods: jest.fn().mockReturnValue(['DID_WEB']),
+    normaliseAlias: jest.fn(),
+    getSupportedTypes: jest.fn(),
+    getSupportedMethods: jest.fn(),
   };
 
+  // The service-capability defaults are re-applied per test rather than set once
+  // where mockDidService is declared: jest.clearAllMocks() clears recorded calls
+  // but leaves implementations in place, so a test that narrows one (the
+  // unsupported-type test) or makes one throw (the alias-normalisation test)
+  // would otherwise keep that behaviour for every test declared after it.
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDidService.normaliseAlias.mockImplementation((alias: string) => alias);
+    mockDidService.getSupportedTypes.mockReturnValue(['MANAGED', 'SELF_MANAGED']);
+    mockDidService.getSupportedMethods.mockReturnValue(['DID_WEB']);
     mockResolveDidService.mockResolvedValue({ service: mockDidService, instanceId: 'inst-1' });
     mockFindDidByAliasAndService.mockResolvedValue(false);
   });
@@ -112,6 +129,9 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(201);
     expect(json.did).toBe('did:web:example.com:org:123');
+    // Pins the MANAGED side of the status ternary. Its SELF_MANAGED side is
+    // covered by the next test, so flipping either branch fails a test.
+    expect(mockCreateDid).toHaveBeenCalledWith(expect.objectContaining({ status: DidStatus.ACTIVE }));
   });
 
   it('creates a self-managed DID with UNVERIFIED status and serviceInstanceId', async () => {
@@ -640,6 +660,27 @@ describe('POST /api/v1/dids', () => {
       });
       const res = await POST(req, TENANT_CONTEXT as unknown as Parameters<typeof POST>[1]);
       expect(res.status).toBe(201);
+    });
+
+    // An unparseable SYSTEM_VC_BASE_URL disables the guard entirely, so the
+    // alias that the two 403 tests above prove is reserved becomes creatable.
+    // Asserted here so the disabling is a deliberate, visible behaviour rather
+    // than a silent consequence of the catch that also catches ForbiddenError.
+    it('creates the DID and warns the operator when SYSTEM_VC_BASE_URL cannot be parsed', async () => {
+      process.env.SYSTEM_VC_BASE_URL = 'not-a-url';
+      mockDidService.create.mockResolvedValue({ did: 'did:web:vckit.example.com', keyId: 'key-5' });
+      mockCreateDid.mockResolvedValue({ id: 'record-5' });
+
+      const req = createFakeRequest({
+        body: { type: DidType.SELF_MANAGED, method: DidMethod.DID_WEB, alias: 'vckit.example.com' },
+      });
+      const res = await POST(req, TENANT_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(res.status).toBe(201);
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ vcBaseUrl: 'not-a-url' }),
+        expect.stringContaining('root DID domain guard is disabled'),
+      );
     });
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -514,17 +514,34 @@ describe('POST /api/v1/dids', () => {
     expect(json.error).toContain('already exists');
   });
 
-  it('returns 400 when service does not support the requested method', async () => {
-    mockDidService.getSupportedMethods.mockReturnValue(['DID_WEB']);
+  it('returns 400 when the resolved service does not support the requested method', async () => {
+    // DID_WEB is the only Zod-valid method (supportedDidMethodSchema), so this exercises the
+    // route's own capability check (assertSupported) against a service whose capabilities
+    // narrow further than the schema-level set, not the Zod boundary itself.
+    mockDidService.getSupportedMethods.mockReturnValue([]);
 
     const req = createFakeRequest({
-      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB_VH, alias: 'test' },
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test' },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toBe('method: must be one of DID_WEB');
+    expect(json.error).toMatch(/^method: must be one of/);
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for method DID_WEB_VH (planned but not yet implemented)', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: 'DID_WEB_VH', alias: 'test' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^method:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('resolves the DID service with the organisation ID', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -8,7 +8,7 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// Mock withTenantAuth to skip auth while delegating error mapping to the real
 // handleRouteError, so this suite is checked against production's actual
 // status/code mapping (e.g. ServiceInstanceNotFoundError -> 404, other
 // ServiceRegistryError subtypes -> 500) rather than a hand-rolled duplicate

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -8,46 +8,20 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth to mirror handleRouteError behaviour
+// Mock withTenantAuth — skips auth but delegates error mapping to the real
+// handleRouteError, so this suite is checked against production's actual
+// status/code mapping (e.g. ServiceInstanceNotFoundError -> 404, other
+// ServiceRegistryError subtypes -> 500) rather than a hand-rolled duplicate
+// that can drift from it.
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, ForbiddenError, ConflictError, errorMessage, ServiceRegistryError } =
-    jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-  const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
       (handler: (req: unknown, ctx: unknown) => Promise<unknown>) => async (req: unknown, ctx: unknown) => {
         try {
           return await handler(req, ctx);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof ForbiddenError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 403 });
-          }
-          if (e instanceof ConflictError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 409 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 500 });
-          }
-          if (e instanceof ServiceError) {
-            const serviceErr = e as Error & { code?: string; statusCode?: number };
-            return jsonResponse(
-              { error: serviceErr.message, code: serviceErr.code },
-              { status: serviceErr.statusCode },
-            );
-          }
-          return jsonResponse({ error: errorMessage(e) }, { status: 500 });
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };
@@ -69,9 +43,9 @@ jest.mock('@/lib/prisma/repositories', () => ({
     mockFindDidByAliasAndService(alias, serviceInstanceId),
 }));
 
-import { ServiceResolutionError } from '@/lib/api/errors';
-import { DidType, DidMethod, DidStatus } from '@uncefact/untp-ri-services';
-import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import { ServiceResolutionError, ServiceInstanceNotFoundError } from '@/lib/api/errors';
+import { DidType, DidMethod, DidStatus, DidCreateError, DidDocumentFetchError } from '@uncefact/untp-ri-services';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string; rawBody?: string }): Request {
@@ -187,51 +161,177 @@ describe('POST /api/v1/dids', () => {
     expect(json.isDefault).toBe(true);
   });
 
-  it('returns 400 for invalid type', async () => {
+  it('returns 400 for invalid type and does not resolve a service or call the repository', async () => {
     const req = createFakeRequest({
-      body: { type: 'INVALID', method: DidMethod.DID_WEB },
+      body: { type: 'INVALID', method: DidMethod.DID_WEB, alias: 'test' },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('type must be');
+    expect(json.error).toMatch(/^type:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockFindDidByAliasAndService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for missing type', async () => {
-    const req = createFakeRequest({ body: { method: DidMethod.DID_WEB } });
-    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
-
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 400 for invalid method', async () => {
+  it('returns 400 for the DEFAULT type (system-managed, not creatable via this endpoint)', async () => {
     const req = createFakeRequest({
-      body: { type: DidType.MANAGED, method: 'INVALID' },
+      body: { type: DidType.DEFAULT, method: DidMethod.DID_WEB, alias: 'test' },
     });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('method must be');
+    expect(json.error).toMatch(/^type:/);
+    // Asserts the Zod boundary itself rejects DEFAULT, not a later capability check: if
+    // creatableDidTypeSchema were ever widened to include DEFAULT, the request would reach
+    // resolveDidService before failing, which this assertion would catch.
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for missing method', async () => {
-    const req = createFakeRequest({ body: { type: DidType.MANAGED } });
+  it('returns 400 for missing type and does not resolve a service or call the repository', async () => {
+    const req = createFakeRequest({ body: { method: DidMethod.DID_WEB, alias: 'test' } });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('method is required');
+    expect(json.error).toMatch(/^type:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid JSON body', async () => {
+  it('returns 400 for invalid method and does not resolve a service or call the repository', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: 'INVALID', alias: 'test' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^method:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for missing method and does not resolve a service or call the repository', async () => {
+    const req = createFakeRequest({ body: { type: DidType.MANAGED, alias: 'test' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^method:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for missing alias and does not resolve a service or call the repository', async () => {
+    const req = createFakeRequest({ body: { type: DidType.MANAGED, method: DidMethod.DID_WEB } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^alias:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty alias string', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: '' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^alias:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when isDefault is not a boolean (mistyped optional field)', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test', isDefault: 'yes' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^isDefault:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is an empty string (mistyped optional field)', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test', name: '' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^name:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is an explicit null (omission, not null, leaves it unset)', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test', name: null },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^name:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is an empty string (mistyped optional field)', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test', description: '' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^description:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when serviceInstanceId is an empty string (mistyped optional field)', async () => {
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test', serviceInstanceId: '' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^serviceInstanceId:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid JSON body and does not resolve a service or call the repository', async () => {
     const req = createBadJsonRequest();
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
     expect(res.status).toBe(400);
     const json = await res.json();
     expect(json.error).toBe('Invalid JSON body');
+    expect(mockResolveDidService).not.toHaveBeenCalled();
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a literal null body', async () => {
+    const req = createFakeRequest({ rawBody: 'null' });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^body:/);
+    expect(mockResolveDidService).not.toHaveBeenCalled();
   });
 
   it('returns 500 when DID service fails', async () => {
@@ -245,6 +345,51 @@ describe('POST /api/v1/dids', () => {
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toContain('VCKit error');
+  });
+
+  it('returns 502 with code DID_CREATE_FAILED when the upstream create call fails', async () => {
+    mockDidService.create.mockRejectedValue(new DidCreateError('HTTP 500: Internal Server Error'));
+
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(json.code).toBe('DID_CREATE_FAILED');
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 502 with code DID_DOCUMENT_FETCH_FAILED when the post-create document fetch fails', async () => {
+    // create() calls getDocument() internally after a successful upstream create; a failure there
+    // propagates as DidDocumentFetchError, not DidCreateError, and the RI never saves a record
+    // (mockCreateDid must stay uncalled) since the route never receives a providerResult.
+    mockDidService.create.mockRejectedValue(new DidDocumentFetchError('did:web:example.com', 'HTTP 500'));
+
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(json.code).toBe('DID_DOCUMENT_FETCH_FAILED');
+    expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the specified service instance does not exist', async () => {
+    mockResolveDidService.mockRejectedValue(new ServiceInstanceNotFoundError('inst-missing'));
+
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test', serviceInstanceId: 'inst-missing' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('inst-missing');
+    expect(mockCreateDid).not.toHaveBeenCalled();
   });
 
   it('passes correct options to didService.create', async () => {
@@ -298,7 +443,7 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('type must be one of');
+    expect(json.error).toBe('type: must be one of MANAGED');
   });
 
   it('returns 400 when alias normalisation fails', async () => {
@@ -313,7 +458,7 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('Invalid DID alias');
+    expect(json.error).toBe('alias: Invalid DID alias: "!!!" produces an empty identifier after normalisation');
   });
 
   it('passes the normalised alias to didService.create', async () => {
@@ -379,7 +524,7 @@ describe('POST /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('method must be one of');
+    expect(json.error).toBe('method: must be one of DID_WEB');
   });
 
   it('resolves the DID service with the organisation ID', async () => {
@@ -557,7 +702,7 @@ describe('GET /api/v1/dids', () => {
     });
   });
 
-  it('returns 400 for invalid type query parameter', async () => {
+  it('returns 400 for invalid type query parameter, and does not query the repository', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/dids?type=GARBAGE',
@@ -566,10 +711,24 @@ describe('GET /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('type must be');
+    expect(json.error).toMatch(/^type:/);
+    expect(mockListDids).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid status query parameter', async () => {
+  it('accepts the DEFAULT type in the query filter (the full enum, unlike the creatable POST subset)', async () => {
+    mockListDids.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/dids?type=DEFAULT',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockListDids).toHaveBeenCalledWith('org-1', expect.objectContaining({ type: 'DEFAULT' }));
+  });
+
+  it('returns 400 for invalid status query parameter, and does not query the repository', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/dids?status=GARBAGE',
@@ -578,10 +737,24 @@ describe('GET /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('status must be');
+    expect(json.error).toMatch(/^status:/);
+    expect(mockListDids).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for non-numeric limit', async () => {
+  it('returns 400 for an empty serviceInstanceId filter, and does not query the repository', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/dids?serviceInstanceId=',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^serviceInstanceId:/);
+    expect(mockListDids).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for non-numeric limit, and does not query the repository', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/dids?limit=abc',
@@ -590,10 +763,11 @@ describe('GET /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('limit must be a positive integer');
+    expect(json.error).toContain('limit: must be a positive integer');
+    expect(mockListDids).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for negative offset', async () => {
+  it('returns 400 for negative offset, and does not query the repository', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/dids?offset=-1',
@@ -602,7 +776,34 @@ describe('GET /api/v1/dids', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain('offset must be a non-negative integer');
+    expect(json.error).toContain('offset: must be a non-negative integer');
+    expect(mockListDids).not.toHaveBeenCalled();
+  });
+
+  it('rejects a limit above the maximum with a 400, and does not query the repository', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: `http://localhost/api/v1/dids?limit=${MAX_PAGE_LIMIT + 1}`,
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/^limit:/);
+    expect(mockListDids).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a repeated query key, and does not query the repository', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/dids?limit=10&limit=20',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListDids).not.toHaveBeenCalled();
   });
 
   it('returns 500 when listDids throws', async () => {

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -1,15 +1,31 @@
 import { NextResponse } from 'next/server';
 import { resolveDidService } from '@/lib/services/resolve-did-service';
 import { errorMessage, ConflictError, ForbiddenError } from '@/lib/api/errors';
-import { ValidationError, validateEnum, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { ValidationError, parseRequestBody, parseQueryParams } from '@/lib/api/validation';
+import { createDidRequestSchema, listDidsQuerySchema } from '@/lib/api/request-schemas/did';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createDid, listDids, findDidByAliasAndService } from '@/lib/prisma/repositories';
-import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
-import { CREATABLE_DID_TYPES, DidType, DidMethod, DidStatus, DidConflictError } from '@uncefact/untp-ri-services';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
+import { DidType, DidMethod, DidStatus, DidConflictError } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 
 const logger = apiLogger.child({ route: '/api/v1/dids' });
+
+/**
+ * Asserts that the resolved DID service's actual capabilities (queried at
+ * request time, since they vary by adapter) include the given value,
+ * rendering a `field: message` 400 to match the Zod-boundary shape. A local
+ * check rather than the shared `validateEnum` helper: that helper renders
+ * `field must be one of ...`, a different shape to the boundary's
+ * `field: message` convention, and the shared helper is not to be edited for
+ * one route's message format.
+ */
+function assertSupported<T extends string>(field: string, value: T, supported: readonly T[]): void {
+  if (!supported.includes(value)) {
+    throw new ValidationError(`${field}: must be one of ${supported.join(', ')}`);
+  }
+}
 
 /**
  * @swagger
@@ -33,25 +49,29 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *               type:
  *                 type: string
  *                 enum: [MANAGED, SELF_MANAGED]
- *                 description: Type of DID to create
+ *                 description: Type of DID to create (DEFAULT is system-managed and cannot be created via this endpoint)
  *               method:
  *                 type: string
- *                 enum: [DID_WEB]
+ *                 enum: [DID_WEB, DID_WEB_VH]
  *                 description: DID method to use
  *               alias:
  *                 type: string
+ *                 minLength: 1
  *                 description: Alias for the DID (e.g., domain for did:web)
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: Human-readable name for the DID
  *               description:
  *                 type: string
+ *                 minLength: 1
  *                 description: Description of the DID's purpose
  *               isDefault:
  *                 type: boolean
  *                 description: Whether this DID should be the tenant's default
  *               serviceInstanceId:
  *                 type: string
+ *                 minLength: 1
  *                 description: Optional service instance ID to use for DID creation
  *     responses:
  *       201:
@@ -61,7 +81,7 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *             schema:
  *               $ref: '#/components/schemas/Did'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. missing or invalid type/method/alias, a type or method the resolved DID service does not support, an alias that fails normalisation)
  *         content:
  *           application/json:
  *             schema:
@@ -73,7 +93,10 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       403:
- *         description: Forbidden - cannot create a root DID for the system VC service domain
+ *         description: |
+ *           Forbidden. Either of:
+ *           - Cannot create a root DID for the system VC service domain
+ *           - Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -96,52 +119,37 @@ const logger = apiLogger.child({ route: '/api/v1/dids' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       502:
+ *         description: |
+ *           Upstream failure, one of:
+ *           - DID_CREATE_FAILED: the resolved VC service rejected or could not complete the create call.
+ *           - DID_DOCUMENT_FETCH_FAILED: the create call succeeded upstream but the immediate document fetch that follows it failed. The DID exists on the upstream provider but no Reference Implementation record was saved; retrying the request may then hit an upstream duplicate. Reconcile by fetching the DID by alias from the VC service before retrying, or importing it via POST /dids/import once its details are known.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  let body: {
-    type?: string;
-    method?: string;
-    alias?: string;
-    name?: string;
-    description?: string;
-    isDefault?: boolean;
-    serviceInstanceId?: string;
-  };
+  logger.info('Validating request body');
+  const body = await parseRequestBody(req, createDidRequestSchema);
+  const { type, method, alias } = body;
 
-  logger.info('Parsing request body');
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info({ type: body.type, method: body.method, alias: body.alias }, 'Validating input parameters');
-  const type = validateEnum(body.type, CREATABLE_DID_TYPES, 'type');
-  if (!type) throw new ValidationError('type is required');
-
-  const method = validateEnum(body.method, Object.values(DidMethod), 'method');
-  if (!method) throw new ValidationError('method is required');
-
-  if (!body.alias || typeof body.alias !== 'string') {
-    throw new ValidationError('alias is required');
-  }
-
-  logger.info({ type, method, alias: body.alias }, 'Resolving DID service');
+  logger.info({ type, method, alias }, 'Resolving DID service');
   const { service: didService, instanceId: serviceInstanceId } = await resolveDidService(
     tenantId,
     body.serviceInstanceId,
   );
 
   logger.info({ serviceInstanceId }, 'Validating parameters against service capabilities');
-  validateEnum(type, didService.getSupportedTypes(), 'type');
-  validateEnum(method, didService.getSupportedMethods(), 'method');
+  assertSupported('type', type, didService.getSupportedTypes());
+  assertSupported('method', method, didService.getSupportedMethods());
 
-  logger.info({ alias: body.alias, method }, 'Normalising alias');
+  logger.info({ alias, method }, 'Normalising alias');
   let normalisedAlias: string;
   try {
-    normalisedAlias = didService.normaliseAlias(body.alias, method, type);
+    normalisedAlias = didService.normaliseAlias(alias, method, type);
   } catch (aliasErr) {
-    throw new ValidationError(errorMessage(aliasErr, 'Invalid alias'));
+    throw new ValidationError(`alias: ${errorMessage(aliasErr, 'invalid alias')}`);
   }
 
   // Prevent non-system tenants from creating self-managed root DIDs that match
@@ -245,13 +253,14 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         name: serviceInstanceId
  *         schema:
  *           type: string
+ *           minLength: 1
  *         description: Filter by service instance ID
  *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Maximum number of DIDs to return
+ *         description: Number of DIDs to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400.
  *       - in: query
  *         name: offset
  *         schema:
@@ -273,13 +282,19 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *                 pagination:
  *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. an invalid type or status, a limit above the deployment maximum, a negative offset, a repeated query parameter)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorized - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -292,15 +307,8 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  const url = new URL(req.url);
-
   logger.info('Parsing query filters');
-  const type = validateEnum(url.searchParams.get('type') ?? undefined, Object.values(DidType), 'type');
-  const status = validateEnum(url.searchParams.get('status') ?? undefined, Object.values(DidStatus), 'status');
-  const serviceInstanceId = url.searchParams.get('serviceInstanceId') ?? undefined;
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  const { type, status, serviceInstanceId, limit, offset } = parseQueryParams(new URL(req.url), listDidsQuerySchema);
 
   logger.info({ filters: { type, status, serviceInstanceId, limit, offset } }, 'Querying DIDs from database');
   const { data, total } = await listDids(tenantId, {

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -57,7 +57,13 @@ function assertSupported<T extends string>(field: string, value: T, supported: r
  *               alias:
  *                 type: string
  *                 minLength: 1
- *                 description: Alias for the DID (e.g., domain for did:web)
+ *                 description: |
+ *                   Identifier for the DID, read differently depending on `type`. For MANAGED, a short
+ *                   name that the verifiable credential service prefixes with its own host, so `acme-corp`
+ *                   becomes `did:web:vckit.example.com:acme-corp`; characters outside letters, digits, and
+ *                   hyphens are stripped, so a domain passed here loses its dots. For SELF_MANAGED, the
+ *                   full domain (or domain and path) that will host the DID document, so `example.com`
+ *                   becomes `did:web:example.com`; dots and colons are preserved.
  *               name:
  *                 type: string
  *                 minLength: 1

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -153,7 +153,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   }
 
   // Prevent non-system tenants from creating self-managed root DIDs that match
-  // the system VCKit domain. A root did:web is one with no path segments — just
+  // the system VCKit domain. A root did:web is one with no path segments, just
   // the domain (e.g. did:web:vckit.example.com). This stops tenants from
   // hijacking the VCKit instance's root DID.
   if (type === DidType.SELF_MANAGED && method === DidMethod.DID_WEB && tenantId !== SYSTEM_TENANT_ID) {
@@ -178,7 +178,10 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
         }
       } catch (e) {
         if (e instanceof ForbiddenError) throw e;
-        logger.warn({ vcBaseUrl, err: e }, 'SYSTEM_VC_BASE_URL is not a valid URL — root DID domain guard is disabled');
+        logger.warn(
+          { vcBaseUrl, err: e },
+          'SYSTEM_VC_BASE_URL is not a valid URL, so the root DID domain guard is disabled',
+        );
       }
     }
   }
@@ -201,7 +204,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     });
   } catch (err) {
     // The upstream provider may report "already exists" even when the RI database has no record
-    // — e.g. after a DB reset without resetting the provider.
+    // for example after a DB reset without resetting the provider.
     if (err instanceof DidConflictError) {
       throw new ConflictError(err.message);
     }

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -102,7 +102,11 @@ function assertSupported<T extends string>(field: string, value: T, supported: r
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
- *         description: A DID with this alias already exists on the service instance, or a DID record with this DID already exists
+ *         description: |
+ *           Conflict. Any of:
+ *           - A DID with this alias already exists on the service instance
+ *           - A DID record with this DID already exists
+ *           - The upstream provider reports the alias as already in use, which happens when the provider holds a DID this deployment's database has no record of
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -52,8 +52,8 @@ function assertSupported<T extends string>(field: string, value: T, supported: r
  *                 description: Type of DID to create (DEFAULT is system-managed and cannot be created via this endpoint)
  *               method:
  *                 type: string
- *                 enum: [DID_WEB, DID_WEB_VH]
- *                 description: DID method to use
+ *                 enum: [DID_WEB]
+ *                 description: DID method to use. did:web is the supported method today; did:webvh is planned but not yet implemented and is rejected.
  *               alias:
  *                 type: string
  *                 minLength: 1

--- a/packages/reference-implementation/src/lib/api/request-schemas/did.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/did.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CREATABLE_DID_TYPES, DidMethod, DidStatus, DidType } from '@uncefact/untp-ri-services';
+import { CREATABLE_DID_TYPES, SUPPORTED_DID_METHODS, DidStatus, DidType } from '@uncefact/untp-ri-services';
 import { idSchema, paginationQuerySchema, requireAtLeastOneField } from './shared';
 
 /**
@@ -10,6 +10,17 @@ import { idSchema, paginationQuerySchema, requireAtLeastOneField } from './share
  * filter by any type including DEFAULT.
  */
 const creatableDidTypeSchema = z.enum(CREATABLE_DID_TYPES);
+
+/**
+ * DID methods this boundary accepts, both for creating a new DID and for
+ * importing an existing one. The full DidMethod enum includes DID_WEB_VH, a
+ * planned member the platform does not implement yet (see SUPPORTED_DID_METHODS'
+ * own doc comment); accepting it here would let an unimplemented method be
+ * stored via import (which has no capability-check call site) even though the
+ * create route's capability check would reject it. Mirrors SUPPORTED_DID_METHODS
+ * from the did-manager service so the code list stays single-source.
+ */
+const supportedDidMethodSchema = z.enum(SUPPORTED_DID_METHODS);
 
 /**
  * Request body for POST /dids. Domain-membership checks against the
@@ -26,7 +37,7 @@ const creatableDidTypeSchema = z.enum(CREATABLE_DID_TYPES);
  */
 export const createDidRequestSchema = z.object({
   type: creatableDidTypeSchema,
-  method: z.nativeEnum(DidMethod),
+  method: supportedDidMethodSchema,
   alias: z.string().min(1),
   name: z.string().min(1).optional(),
   description: z.string().min(1).optional(),
@@ -44,7 +55,7 @@ export const createDidRequestSchema = z.object({
  */
 export const importDidRequestSchema = z.object({
   did: z.string().min(1),
-  method: z.nativeEnum(DidMethod),
+  method: supportedDidMethodSchema,
   keyId: z.string().min(1),
   name: z.string().min(1).optional(),
   description: z.string().min(1).optional(),

--- a/packages/reference-implementation/src/lib/api/request-schemas/did.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/did.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { CREATABLE_DID_TYPES, DidMethod, DidStatus, DidType } from '@uncefact/untp-ri-services';
+import { idSchema, paginationQuerySchema, requireAtLeastOneField } from './shared';
+
+/**
+ * DID types creatable via POST /dids, a subset of DidType that excludes
+ * DEFAULT (system-managed). Mirrors CREATABLE_DID_TYPES from the did-manager
+ * service so the code list stays single-source; the GET /dids query `type`
+ * filter validates against the full DidType enum instead, since a client can
+ * filter by any type including DEFAULT.
+ */
+const creatableDidTypeSchema = z.enum(CREATABLE_DID_TYPES);
+
+/**
+ * Request body for POST /dids. Domain-membership checks against the
+ * resolved DID service's actual capabilities (getSupportedTypes,
+ * getSupportedMethods) stay in the route handler (ADR-037): this schema
+ * only checks that `type` and `method` are members of their respective
+ * code lists.
+ *
+ * `name`/`description` reject an empty string with a 400; previously these
+ * fields had no runtime check and an empty string was silently accepted and
+ * stored. An explicit JSON `null` is also rejected (400): omission is the
+ * only way to leave an optional field unset, since neither field has
+ * clearing semantics on create.
+ */
+export const createDidRequestSchema = z.object({
+  type: creatableDidTypeSchema,
+  method: z.nativeEnum(DidMethod),
+  alias: z.string().min(1),
+  name: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+  isDefault: z.boolean().optional(),
+  serviceInstanceId: idSchema.optional(),
+});
+
+/**
+ * Request body for POST /dids/import.
+ *
+ * `name`/`description` reject an empty string with a 400 (previously
+ * unvalidated and silently accepted) and reject an explicit JSON `null` the
+ * same way as {@link createDidRequestSchema}, for the same reason: omission,
+ * not null, is how an optional field is left unset here.
+ */
+export const importDidRequestSchema = z.object({
+  did: z.string().min(1),
+  method: z.nativeEnum(DidMethod),
+  keyId: z.string().min(1),
+  name: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+  serviceInstanceId: idSchema,
+});
+
+/**
+ * Request body for PATCH /dids/{id}.
+ *
+ * `name`/`description` reject an empty string with a 400; the previous
+ * handler treated an empty string as "not provided" and silently dropped it
+ * from the update instead of failing. An explicit JSON `null` is also
+ * rejected (400): neither field is a nullable FK with clear-via-null
+ * semantics, so omission is the only way to leave a field unchanged.
+ */
+export const updateDidRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+    isDefault: z.boolean().optional(),
+  }),
+  'At least one of name, description, or isDefault is required',
+);
+
+/** Query parameters for GET /dids. */
+export const listDidsQuerySchema = z
+  .object({
+    type: z.nativeEnum(DidType).optional(),
+    status: z.nativeEnum(DidStatus).optional(),
+    serviceInstanceId: idSchema.optional(),
+  })
+  .merge(paginationQuerySchema);

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.test.ts
@@ -244,7 +244,7 @@ describe('did.repository', () => {
       });
 
       await expect(result).rejects.toThrow(ValidationError);
-      await expect(result).rejects.toThrow('Service instance not found');
+      await expect(result).rejects.toThrow('serviceInstanceId: Service instance not found');
     });
 
     it('maps a foreign-key violation to ValidationError on the isDefault transaction path', async () => {
@@ -261,7 +261,7 @@ describe('did.repository', () => {
       });
 
       await expect(result).rejects.toThrow(ValidationError);
-      await expect(result).rejects.toThrow('Service instance not found');
+      await expect(result).rejects.toThrow('serviceInstanceId: Service instance not found');
     });
 
     it('rethrows a non-database error unchanged', async () => {
@@ -528,7 +528,7 @@ describe('did.repository', () => {
       mockTx.did.findFirst.mockResolvedValue({ ...DID_RECORD, type: 'DEFAULT' });
 
       await expect(updateDid('did-record-1', ORG_ID, { isDefault: true })).rejects.toThrow(
-        'Cannot modify default status of system DIDs',
+        'isDefault: Cannot modify default status of system DIDs',
       );
       expect(mockTx.did.updateMany).not.toHaveBeenCalled();
       expect(mockTx.did.update).not.toHaveBeenCalled();

--- a/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/did.repository.ts
@@ -79,7 +79,7 @@ export async function createDid(input: CreateDidInput): Promise<Did> {
   } catch (e) {
     mapDatabaseError(e, {
       conflict: 'A DID record with this DID already exists',
-      invalidReference: 'Service instance not found',
+      invalidReference: 'serviceInstanceId: Service instance not found',
     });
   }
 }
@@ -195,7 +195,7 @@ export async function updateDid(id: string, tenantId: string, input: UpdateDidIn
     }
 
     if (input.isDefault !== undefined && existing.type === 'DEFAULT') {
-      throw new ValidationError('Cannot modify default status of system DIDs');
+      throw new ValidationError('isDefault: Cannot modify default status of system DIDs');
     }
 
     if (input.isDefault) {

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -1,5 +1,5 @@
 import type { IDidService, CreateDidOptions, DidRecord, DidDocument, DidVerificationResult } from '../../types.js';
-import { DidMethod, DidType, DidVerificationCheckName } from '../../types.js';
+import { DidMethod, DidType, DidVerificationCheckName, SUPPORTED_DID_METHODS } from '../../types.js';
 import { verifyDid } from '../../common/verify.js';
 import { normaliseDidWebAlias, normaliseSelfManagedAlias } from '../../common/utils.js';
 import type { AdapterRegistryEntry } from '../../../registry/types.js';
@@ -258,7 +258,7 @@ export class VCKitDidAdapter implements IDidService {
   }
 
   getSupportedMethods(): DidMethod[] {
-    return [DidMethod.DID_WEB];
+    return [...SUPPORTED_DID_METHODS];
   }
 
   getSupportedKeyTypes(): string[] {

--- a/packages/services/src/did-manager/schemas.ts
+++ b/packages/services/src/did-manager/schemas.ts
@@ -14,23 +14,32 @@
 
 import { z } from 'zod';
 
+import { DidMethod, DidStatus, DidType } from './types.js';
+
 // ============================================================================
 // API response schemas (Swagger / OpenAPI)
 // ============================================================================
 
 /**
  * DID record as returned by the REST API.
+ *
+ * The enum-valued fields derive from the DidType / DidMethod / DidStatus
+ * enums rather than restating their members as string literals, so a member
+ * added to one of those enums cannot leave this published contract behind.
+ *
+ * `method` is deliberately the full DidMethod enum and not the narrower
+ * SUPPORTED_DID_METHODS the write boundary accepts: the stored column is the
+ * database's own DidMethod enum, so a record written before a method left the
+ * supported set still reads back, and the response contract has to admit it.
  */
 export const didResponseSchema = z.object({
   id: z.string().describe('Database ID of the DID record'),
   did: z.string().describe('The DID identifier (e.g., did:web:example.com)'),
-  type: z.enum(['DEFAULT', 'MANAGED', 'SELF_MANAGED']).describe('Type of DID'),
-  method: z.enum(['DID_WEB', 'DID_WEB_VH']).describe('DID method'),
+  type: z.nativeEnum(DidType).describe('Type of DID'),
+  method: z.nativeEnum(DidMethod).describe('DID method'),
   name: z.string().describe('Human-readable name'),
   description: z.string().nullable().describe('Description of the DID'),
-  status: z
-    .enum(['ACTIVE', 'INACTIVE', 'VERIFIED', 'UNVERIFIED', 'VERIFICATION_FAILED'])
-    .describe('Current status of the DID'),
+  status: z.nativeEnum(DidStatus).describe('Current status of the DID'),
   keyId: z.string().describe('Key identifier associated with the DID'),
   tenantId: z.string().describe('ID of the owning tenant'),
   serviceInstanceId: z.string().nullable().describe('ID of the service instance used to manage this DID'),

--- a/packages/services/src/did-manager/types.ts
+++ b/packages/services/src/did-manager/types.ts
@@ -47,6 +47,14 @@ export enum DidStatus {
 /** DID types that can be created via the API (excludes DEFAULT, which is system-managed). */
 export const CREATABLE_DID_TYPES = [DidType.MANAGED, DidType.SELF_MANAGED] as const;
 
+/**
+ * DID methods this platform actually implements today. DID_WEB_VH is a planned
+ * member of DidMethod (see the enum's own doc comment) and joins this list once
+ * did:webvh support lands; until then it must stay excluded here so it is never
+ * accepted or advertised as a supported method.
+ */
+export const SUPPORTED_DID_METHODS = [DidMethod.DID_WEB] as const;
+
 /** DID statuses that are eligible for credential issuance. */
 export const ISSUABLE_DID_STATUSES = [DidStatus.ACTIVE, DidStatus.VERIFIED] as const;
 


### PR DESCRIPTION
This PR migrates the DIDs endpoints' request validation to per-resource Zod schemas at the route boundary and brings every DIDs route's Swagger documentation into congruence with its real behaviour, so malformed input returns a 400 naming the offending field and the published contract matches what the routes actually do.

Validation: POST /dids validates the creatable type subset and the supported method set, POST /dids/import validates its required fields, PATCH /dids/{id} requires at least one recognised field, and GET /dids validates its type/status/serviceInstanceId filters and pagination through the shared query schema. Empty-string and explicit-null optional fields are rejected with the decision recorded at each schema, replacing the prior silent-drop and silent-accept paths.

Boundary tightening: the accepted method set is single-sourced to the methods the platform actually implements (did:web today; did:webvh is planned and rejected until it lands), so an unimplemented method can no longer be advertised or, on the import route which has no capability check, stored. The import route now verifies that a supplied serviceInstanceId belongs to the authenticated tenant before writing, returning 404 for a nonexistent or foreign-tenant id, closing a path that previously stored a cross-tenant reference.

Contract congruence: every route documents the shared 401/403 responses; POST /dids and GET /dids/{id}/document document their reachable 502s (including the dual DID_CREATE_FAILED / DID_DOCUMENT_FETCH_FAILED codes on create, with the partial-success condition where the upstream DID exists but no local record was saved); POST /dids/{id}/verify documents its three reachable 400 paths and the docs no longer claim a status update when verification throws before completing; DELETE's runtime message now matches its description (any DID flagged isDefault). Handler-level 400s whose cause is a request field carry the same field-prefixed message shape as schema failures.

Tests: the five route suites delegate error mapping to the production handleRouteError (the hand-rolled mocks mapped ServiceInstanceNotFoundError to the wrong status), and cover both 502 codes, the POST 404, the verify parse/method 400s, the import FK 400, the unsupported-method and cross-tenant service-instance rejections, explicit-null and non-string field cases, and repository-argument assertions.

Closes #796
