### PR TITLE
feat(ri): validate and tighten organisations endpoint inputs and align their Swagger

### DIFF
--- a/documentation/docs/reference-implementation/api/organisations.md
+++ b/documentation/docs/reference-implementation/api/organisations.md
@@ -76,7 +76,7 @@ Returns organisations for the authenticated tenant with optional filtering. Resu
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `search` | string | — | Search by organisation name or identifier value |
-| `limit` | integer | Defaults to 20, or the configured maximum when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
+| `limit` | integer | Defaults to 20, or the [configured maximum](../operations/api-pagination#maximum-page-size) when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---

--- a/documentation/docs/reference-implementation/api/organisations.md
+++ b/documentation/docs/reference-implementation/api/organisations.md
@@ -28,7 +28,7 @@ Identifiers are managed through the [Identifiers API](./identifiers) and linked 
 
 ### Location
 
-The optional `location` field stores a structured JSON object describing the geographical location of the organisation. See [Location](../master-data/#location) for the field structure.
+The optional `location` field accepts any JSON object; no shape validation is currently applied. The UNTP location field shapes are described in the [Location](../master-data/#location) section of the master data documentation, but the Reference Implementation does not yet validate submitted values against them.
 
 ### Tenant Scoping
 
@@ -42,7 +42,7 @@ Organisations are scoped to the authenticated tenant. Each tenant manages its ow
 POST /api/v1/organisations
 ```
 
-Creates one or more organisations in bulk. The request body is an array of organisation objects — each must include a `name`. Optional fields include `description`, `location`, `primaryIdentifierId`, and `secondaryIdentifierIds`.
+Creates one or more organisations in bulk. The request body must be a non-empty array of organisation objects — each must include a non-empty `name`. Optional fields include `description` (non-empty if provided), `location`, `primaryIdentifierId`, and `secondaryIdentifierIds` (each entry must be a non-empty identifier ID). Unknown keys on any item are ignored.
 
 ```mermaid
 sequenceDiagram
@@ -71,12 +71,12 @@ sequenceDiagram
 GET /api/v1/organisations
 ```
 
-Returns organisations for the authenticated tenant with optional filtering. Results are paginated.
+Returns organisations for the authenticated tenant with optional filtering. Results are paginated. Each list item includes `secondaryIdentifierIds` but omits the full `primaryIdentifier` and `secondaryIdentifiers` relations (unlike the single-record, create, and update responses, which include them).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `search` | string | — | Search by organisation name or identifier value |
-| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `limit` | integer | Defaults to 20, or the configured maximum when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---
@@ -97,15 +97,15 @@ Retrieves a specific organisation by its database ID. The response includes the 
 PATCH /api/v1/organisations/{id}
 ```
 
-Updates one or more fields of an existing organisation. At least one updatable field must be provided.
+Updates one or more fields of an existing organisation. At least one recognised field must be provided; unknown keys are ignored.
 
 | Updatable Field | Description |
 |-----------------|-------------|
 | `name` | Organisation name (must be non-empty if provided) |
-| `description` | Free-text description |
-| `location` | UNTP location object (set to `null` to clear) |
+| `description` | Free-text description (must be non-empty if provided; set to `null` to clear) |
+| `location` | Any JSON object is accepted; the UNTP location field shapes (see [Location](../master-data/#location)) are not currently validated |
 | `primaryIdentifierId` | ID of the primary identifier (set to `null` to clear) |
-| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing) |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing; an empty array clears all secondary identifiers) |
 
 ---
 
@@ -115,7 +115,7 @@ Updates one or more fields of an existing organisation. At least one updatable f
 DELETE /api/v1/organisations/{id}
 ```
 
-Permanently deletes an organisation. If the organisation is referenced by products or facilities, those references are cleared (set to `null`) — the related records are not deleted.
+Permanently deletes an organisation. If the organisation is referenced by products, facilities, or credentials, those references are cleared (set to `null`) — the related records are not deleted.
 
 ```mermaid
 sequenceDiagram

--- a/documentation/docs/reference-implementation/api/organisations.md
+++ b/documentation/docs/reference-implementation/api/organisations.md
@@ -42,7 +42,7 @@ Organisations are scoped to the authenticated tenant. Each tenant manages its ow
 POST /api/v1/organisations
 ```
 
-Creates one or more organisations in bulk. The request body must be a non-empty array of organisation objects — each must include a non-empty `name`. Optional fields include `description` (non-empty if provided), `location`, `primaryIdentifierId`, and `secondaryIdentifierIds` (each entry must be a non-empty identifier ID). Unknown keys on any item are ignored.
+Creates one or more organisations in bulk. The request body must be a non-empty array of organisation objects — each must include a non-empty `name`. Optional fields include `description` (non-empty if provided), `location`, `primaryIdentifierId`, and `secondaryIdentifierIds` (each entry must be a non-empty identifier ID, and the array must not contain duplicates). Unknown keys on any item are ignored.
 
 ```mermaid
 sequenceDiagram
@@ -105,7 +105,7 @@ Updates one or more fields of an existing organisation. At least one recognised 
 | `description` | Free-text description (must be non-empty if provided; set to `null` to clear) |
 | `location` | Any JSON object is accepted; the UNTP location field shapes (see [Location](../master-data/#location)) are not currently validated |
 | `primaryIdentifierId` | ID of the primary identifier (set to `null` to clear) |
-| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing; an empty array clears all secondary identifiers) |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing; an empty array clears all secondary identifiers; the array must not contain duplicates) |
 
 ---
 

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
@@ -281,6 +281,23 @@ describe('PATCH /api/v1/organisations/:id', () => {
     expect(mockUpdateOrganisation).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when secondaryIdentifierIds contains a duplicate in-request identifier and does not call the repository', async () => {
+    // Same boundary self-consistency check as the create route: an
+    // in-request duplicate would otherwise reach
+    // organisationSecondaryIdentifier.createMany (no skipDuplicates) and
+    // surface as the misleading concurrent-link 409 for a client typo.
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: { secondaryIdentifierIds: ['ident-1', 'ident-1'] },
+    });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('secondaryIdentifierIds: must not contain duplicate identifiers');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for a literal null body and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: null });
     const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
@@ -43,7 +43,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   deleteOrganisation: (id: string, tenantId: string) => mockDeleteOrganisation(id, tenantId),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { NotFoundError, ConflictError } from '@/lib/api/errors';
 import { GET, PATCH, DELETE } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -121,27 +121,177 @@ describe('PATCH /api/v1/organisations/:id', () => {
 
     expect(res.status).toBe(200);
     expect(json).toEqual(updated);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-a', 'org-1', { name: 'Updated Corp' });
   });
 
-  it('returns 400 when no updatable fields are provided', async () => {
+  it('strips an unrecognised key rather than rejecting the request or forwarding it', async () => {
+    // Distinct from the all-unrecognised-keys 400 case: this body has one
+    // recognised field (satisfying requireAtLeastOneField) alongside a
+    // typo'd key, so it must succeed with the typo silently stripped, not
+    // rejected and not passed through to the repository.
+    mockUpdateOrganisation.mockResolvedValue({ id: 'org-a' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Corp', typo: 'x' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-a', 'org-1', { name: 'Updated Corp' });
+  });
+
+  it('updates every recognised field and forwards them all to the repository', async () => {
+    mockUpdateOrganisation.mockResolvedValue({ id: 'org-a' });
+
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: {
+        name: 'Updated Corp',
+        description: 'New description',
+        location: { address: { streetAddress: '456 Other St' } },
+        primaryIdentifierId: 'ident-2',
+        secondaryIdentifierIds: ['ident-3'],
+      },
+    });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-a', 'org-1', {
+      name: 'Updated Corp',
+      description: 'New description',
+      location: { address: { streetAddress: '456 Other St' } },
+      primaryIdentifierId: 'ident-2',
+      secondaryIdentifierIds: ['ident-3'],
+    });
+  });
+
+  it('forwards an explicit null primaryIdentifierId to clear it', async () => {
+    mockUpdateOrganisation.mockResolvedValue({ id: 'org-a' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: null } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-a', 'org-1', { primaryIdentifierId: null });
+  });
+
+  it('forwards an explicit null description to clear it', async () => {
+    // description is a nullable scalar column (String?), unlike the Json
+    // location column: Prisma accepts a plain null here, and the
+    // pre-migration path already forwarded it as a working clear.
+    mockUpdateOrganisation.mockResolvedValue({ id: 'org-a' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { description: null } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-a', 'org-1', { description: null });
+  });
+
+  it('forwards an empty secondaryIdentifierIds array to clear all secondary identifiers', async () => {
+    mockUpdateOrganisation.mockResolvedValue({ id: 'org-a' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: [] } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOrganisation).toHaveBeenCalledWith('org-a', 'org-1', { secondaryIdentifierIds: [] });
+  });
+
+  it('returns 400 for an explicit null location and does not call the repository', async () => {
+    // A schema regression re-admitting null here would forward a value the
+    // Prisma client's input types exclude (Json null writes require the
+    // DbNull/JsonNull sentinels), and location's clear mechanism is
+    // deliberately deferred to #804. Unlike primaryIdentifierId, location has
+    // no null-to-clear contract.
+    const req = createFakeRequest({ method: 'PATCH', body: { location: null } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^location:/);
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when no updatable fields are provided and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: {} });
     const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('At least one updatable field must be provided');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when name is empty string', async () => {
+  it('returns 400 when the body contains only unrecognised keys and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { neme: 'Typo Corp' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one updatable field must be provided');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is an empty string and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
     const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toMatch(/^name:/);
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid JSON body', async () => {
+  it('returns 400 when description is mistyped and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { description: 42 } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^description:/);
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when location is not an object and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { location: 'not-an-object' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^location:/);
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is mistyped and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: 42 } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^primaryIdentifierId:/);
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: 'ident-1' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^secondaryIdentifierIds:/);
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a literal null body and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('body: Expected object, received null');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid JSON body and does not call the repository', async () => {
     const req = {
       method: 'PATCH',
       url: 'http://localhost/api/v1/organisations/org-a',
@@ -155,6 +305,7 @@ describe('PATCH /api/v1/organisations/:id', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toBe('Invalid JSON body');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
   });
 
   it('returns 404 when organisation not found', async () => {
@@ -166,6 +317,19 @@ describe('PATCH /api/v1/organisations/:id', () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toContain('Organisation not found');
+  });
+
+  it('returns 409 when repository reports a primary identifier conflict', async () => {
+    mockUpdateOrganisation.mockRejectedValue(
+      new ConflictError('The identifier is already the primary identifier of another organisation'),
+    );
+
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: 'ident-1' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toContain('The identifier is already the primary identifier of another organisation');
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.test.ts
@@ -241,6 +241,26 @@ describe('PATCH /api/v1/organisations/:id', () => {
     expect(mockUpdateOrganisation).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when name is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '   ' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('name: must not be only whitespace');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { description: '  ' } });
+    const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('description: must not be only whitespace');
+    expect(mockUpdateOrganisation).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when description is mistyped and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: { description: 42 } });
     const res = await PATCH(req, createContext('org-a') as unknown as Parameters<typeof PATCH>[1]);

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -1,18 +1,12 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateOrganisationRequestSchema } from '@/lib/api/request-schemas/organisation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import {
-  getOrganisationById,
-  updateOrganisation,
-  deleteOrganisation,
-  UpdateOrganisationInput,
-} from '@/lib/prisma/repositories';
+import { getOrganisationById, updateOrganisation, deleteOrganisation } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/organisations/[id]' });
-
-const UPDATABLE_FIELDS = ['name', 'description', 'location', 'primaryIdentifierId', 'secondaryIdentifierIds'] as const;
 
 /**
  * @swagger
@@ -38,6 +32,12 @@ const UPDATABLE_FIELDS = ['name', 'description', 'location', 'primaryIdentifierI
  *               $ref: '#/components/schemas/Organisation'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -83,6 +83,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         description: The database ID of the organisation
  *     requestBody:
  *       required: true
+ *       description: At least one recognised field is required; unknown keys are ignored.
  *       content:
  *         application/json:
  *           schema:
@@ -90,22 +91,33 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             properties:
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: Updated name of the organisation
  *               description:
  *                 type: string
- *                 description: Updated description
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: Updated description (set to null to clear)
  *               location:
  *                 type: object
- *                 description: Updated UNTP location object
+ *                 description: Updated location object. Any JSON object is accepted; the UNTP location field shapes described in the master data documentation are not currently validated.
  *               primaryIdentifierId:
  *                 type: string
- *                 description: ID of the primary identifier
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: ID of the primary identifier (set to null to clear)
  *               secondaryIdentifierIds:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: IDs of secondary identifiers
- *             minProperties: 1
+ *                   minLength: 1
+ *                 description: IDs of secondary identifiers (replaces the existing set; an empty array clears all secondary identifiers)
+ *             anyOf:
+ *               - required: [name]
+ *               - required: [description]
+ *               - required: [location]
+ *               - required: [primaryIdentifierId]
+ *               - required: [secondaryIdentifierIds]
  *     responses:
  *       200:
  *         description: Organisation updated successfully
@@ -114,7 +126,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/Organisation'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. no updatable field provided, a mistyped field, a non-array secondaryIdentifierIds, or a referenced primary identifier that no longer exists by the time the update is written)
  *         content:
  *           application/json:
  *             schema:
@@ -125,8 +137,14 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
- *         description: Organisation not found
+ *         description: Organisation not found, or a referenced primary or secondary identifier does not exist
  *         content:
  *           application/json:
  *             schema:
@@ -146,35 +164,13 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  */
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
-
-  logger.info({ organisationId: id }, 'Parsing request body');
-  let body: Record<string, unknown>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
   logger.info({ organisationId: id }, 'Validating update fields');
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
-  if (!hasUpdatableField) {
-    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
-  }
 
-  if (body.name !== undefined && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
+  const body = await parseRequestBody(req, updateOrganisationRequestSchema);
+  const fields = definedFields(body);
 
-  const updateData: Record<string, unknown> = {};
-  for (const field of UPDATABLE_FIELDS) {
-    if (field in body) {
-      updateData[field] = body[field];
-    }
-  }
-
-  logger.info({ organisationId: id }, 'Updating organisation');
-  const updated = await updateOrganisation(id, tenantId, updateData as UpdateOrganisationInput);
+  logger.info({ organisationId: id, fields: Object.keys(fields) }, 'Updating organisation');
+  const updated = await updateOrganisation(id, tenantId, fields);
 
   logger.info({ organisationId: id }, 'Organisation updated');
   return NextResponse.json(updated);
@@ -200,6 +196,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *         description: Organisation deleted successfully
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -111,7 +111,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                 items:
  *                   type: string
  *                   minLength: 1
- *                 description: IDs of secondary identifiers (replaces the existing set; an empty array clears all secondary identifiers)
+ *                 description: IDs of secondary identifiers (replaces the existing set; an empty array clears all secondary identifiers). Must not contain duplicates.
  *             anyOf:
  *               - required: [name]
  *               - required: [description]

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
@@ -193,6 +193,29 @@ describe('POST /api/v1/organisations', () => {
     expect(mockCreateOrganisations).not.toHaveBeenCalled();
   });
 
+  // A separate branch from the empty-string case above: a minimum length
+  // counts characters, so a whitespace-only value satisfies it and would
+  // otherwise create an organisation whose name renders as blank everywhere.
+  it('returns 400 when name is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: '   ' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('0.name: must not be only whitespace');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme', description: '  ' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('0.description: must not be only whitespace');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when name is mistyped and does not call the repository', async () => {
     const req = createFakeRequest({ body: [{ name: 42 }] });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
@@ -268,6 +268,23 @@ describe('POST /api/v1/organisations', () => {
     expect(mockCreateOrganisations).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when secondaryIdentifierIds contains a duplicate in-request identifier and does not call the repository', async () => {
+    // organisationSecondaryIdentifier.createMany runs without skipDuplicates,
+    // so an in-request duplicate hits the composite primary key and surfaces
+    // as the concurrent-link 409, a misleading response for what is a client
+    // typo; catching it here (shape-level, boundary self-consistency) keeps
+    // it a 400 naming the field instead.
+    const req = createFakeRequest({
+      body: [{ name: 'Acme Corp', secondaryIdentifierIds: ['ident-1', 'ident-1'] }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('0.secondaryIdentifierIds: must not contain duplicate identifiers');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for invalid JSON body and does not call the repository', async () => {
     const req = createBadJsonRequest();
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.test.ts
@@ -32,8 +32,8 @@ jest.mock('@/lib/prisma/repositories', () => ({
   listOrganisations: (tenantId: string, opts: unknown) => mockListOrganisations(tenantId, opts),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
-import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import { NotFoundError, ConflictError } from '@/lib/api/errors';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -87,40 +87,195 @@ describe('POST /api/v1/organisations', () => {
     expect(json).toEqual(organisations);
   });
 
-  it('returns 400 when body is not an array', async () => {
+  it('creates an organisation with optional fields and forwards them to the repository', async () => {
+    mockCreateOrganisations.mockResolvedValue([{ id: 'org-a' }]);
+
+    const req = createFakeRequest({
+      body: [
+        {
+          name: 'Acme Corp',
+          description: 'A test organisation',
+          location: { address: { streetAddress: '123 Main St' } },
+          primaryIdentifierId: 'ident-1',
+          secondaryIdentifierIds: ['ident-2', 'ident-3'],
+        },
+      ],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateOrganisations).toHaveBeenCalledWith('org-1', [
+      {
+        name: 'Acme Corp',
+        description: 'A test organisation',
+        location: { address: { streetAddress: '123 Main St' } },
+        primaryIdentifierId: 'ident-1',
+        secondaryIdentifierIds: ['ident-2', 'ident-3'],
+      },
+    ]);
+  });
+
+  it('strips an unrecognised key from an otherwise-valid item rather than rejecting or forwarding it', async () => {
+    mockCreateOrganisations.mockResolvedValue([{ id: 'org-a' }]);
+
+    const req = createFakeRequest({
+      body: [{ name: 'Acme Corp', typo: 'x' }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateOrganisations).toHaveBeenCalledWith('org-1', [{ name: 'Acme Corp' }]);
+  });
+
+  it('returns 400 for an explicit null location and does not call the repository', async () => {
+    // A schema regression re-admitting null here would forward a value the
+    // Prisma client's input types exclude (Json null writes require the
+    // DbNull/JsonNull sentinels), and location's clear mechanism is
+    // deliberately deferred to #804.
+    const req = createFakeRequest({
+      body: [{ name: 'Acme Corp', location: null }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.location:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when body is not an array and does not call the repository', async () => {
     const req = createFakeRequest({ body: { name: 'Acme Corp' } });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('Request body must be an array');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when body is an empty array', async () => {
+  it('returns 400 when body is an empty array and does not call the repository', async () => {
     const req = createFakeRequest({ body: [] });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('Request body must not be empty');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when name is missing on an item', async () => {
+  it('returns 400 for a literal null body and does not call the repository', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('body: Expected object, received null');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is missing on an item and does not call the repository', async () => {
     const req = createFakeRequest({ body: [{ description: 'No name here' }] });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required for each organisation');
+    expect(json.error).toMatch(/^0\.name:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid JSON body', async () => {
+  it('returns 400 when name is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: '' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.name:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is mistyped and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.name:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', description: '' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.description:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is an explicit null and does not call the repository', async () => {
+    // Create has no null-to-clear contract for any field (there is nothing
+    // to clear on a brand-new record); null is rejected the same as any
+    // other mistyped value, not silently accepted as omission.
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', description: null }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.description:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is mistyped and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', primaryIdentifierId: 42 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.primaryIdentifierId:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is an explicit null and does not call the repository', async () => {
+    // Create has nothing to clear, so unlike PATCH, null is not a supported
+    // way to say "no primary identifier"; omitting the field is.
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', primaryIdentifierId: null }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.primaryIdentifierId:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', secondaryIdentifierIds: 'ident-1' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.secondaryIdentifierIds:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when a secondaryIdentifierIds entry is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', secondaryIdentifierIds: [''] }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.secondaryIdentifierIds\.0:/);
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid JSON body and does not call the repository', async () => {
     const req = createBadJsonRequest();
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(json.error).toBe('Invalid JSON body');
+    expect(mockCreateOrganisations).not.toHaveBeenCalled();
   });
 
   it('returns 404 when repository throws NotFoundError', async () => {
@@ -132,6 +287,21 @@ describe('POST /api/v1/organisations', () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toContain('Tenant not found');
+  });
+
+  it('returns 409 when repository reports a primary identifier conflict', async () => {
+    mockCreateOrganisations.mockRejectedValue(
+      new ConflictError('An identifier in this request is already the primary identifier of another organisation'),
+    );
+
+    const req = createFakeRequest({ body: [{ name: 'Acme Corp', primaryIdentifierId: 'ident-1' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toContain(
+      'An identifier in this request is already the primary identifier of another organisation',
+    );
   });
 
   it('returns 500 on unexpected error', async () => {
@@ -185,6 +355,23 @@ describe('GET /api/v1/organisations', () => {
     });
   });
 
+  it('accepts an empty search filter unchanged', async () => {
+    mockListOrganisations.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/organisations?search=',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockListOrganisations).toHaveBeenCalledWith('org-1', {
+      search: '',
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
   it('handles no query parameters', async () => {
     mockListOrganisations.mockResolvedValue({ data: [], total: 0 });
 
@@ -198,7 +385,7 @@ describe('GET /api/v1/organisations', () => {
     });
   });
 
-  it('returns 400 for non-numeric limit', async () => {
+  it('returns 400 for non-numeric limit and does not query', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/organisations?limit=abc',
@@ -207,10 +394,11 @@ describe('GET /api/v1/organisations', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('limit must be a positive integer');
+    expect(json.error).toContain('limit: must be a positive integer');
+    expect(mockListOrganisations).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for negative offset', async () => {
+  it('returns 400 for negative offset and does not query', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/organisations?offset=-1',
@@ -219,7 +407,34 @@ describe('GET /api/v1/organisations', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('offset must be a non-negative integer');
+    expect(json.error).toContain('offset: must be a non-negative integer');
+    expect(mockListOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('rejects a limit above the maximum with a 400 and does not query', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: `http://localhost/api/v1/organisations?limit=${MAX_PAGE_LIMIT + 1}`,
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^limit:/);
+    expect(mockListOrganisations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a repeated query key and does not query', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/organisations?limit=10&limit=20',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListOrganisations).not.toHaveBeenCalled();
   });
 
   it('returns 500 when listOrganisations throws', async () => {

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parseQueryParams } from '@/lib/api/validation';
+import { createOrganisationsRequestSchema, listOrganisationsQuerySchema } from '@/lib/api/request-schemas/organisation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createOrganisations, listOrganisations } from '@/lib/prisma/repositories';
-import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/organisations' });
@@ -17,10 +18,12 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *       - Organisations
  *     requestBody:
  *       required: true
+ *       description: Unknown keys on any item are ignored.
  *       content:
  *         application/json:
  *           schema:
  *             type: array
+ *             minItems: 1
  *             items:
  *               type: object
  *               required:
@@ -28,20 +31,24 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *               properties:
  *                 name:
  *                   type: string
+ *                   minLength: 1
  *                   description: The name of the organisation
  *                 description:
  *                   type: string
+ *                   minLength: 1
  *                   description: Optional description
  *                 location:
  *                   type: object
- *                   description: Optional UNTP location object
+ *                   description: Optional location object. Any JSON object is accepted; the UNTP location field shapes described in the master data documentation are not currently validated.
  *                 primaryIdentifierId:
  *                   type: string
+ *                   minLength: 1
  *                   description: ID of the primary identifier
  *                 secondaryIdentifierIds:
  *                   type: array
  *                   items:
  *                     type: string
+ *                     minLength: 1
  *                   description: IDs of secondary identifiers
  *     responses:
  *       201:
@@ -53,13 +60,19 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *               items:
  *                 $ref: '#/components/schemas/Organisation'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. body not a non-empty array, a missing or mistyped name, a non-array secondaryIdentifierIds)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -84,29 +97,8 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: unknown;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info('Validating input parameters');
-  if (!Array.isArray(body)) {
-    throw new ValidationError('Request body must be an array');
-  }
-
-  if (body.length === 0) {
-    throw new ValidationError('Request body must not be empty');
-  }
-
-  for (const item of body) {
-    if (!isNonEmptyString(item.name)) {
-      throw new ValidationError('name is required for each organisation');
-    }
-  }
+  logger.info('Validating request body');
+  const body = await parseRequestBody(req, createOrganisationsRequestSchema);
 
   logger.info({ count: body.length }, 'Creating organisations');
   const organisations = await createOrganisations(tenantId, body);
@@ -134,7 +126,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Maximum number of organisations to return
+ *         description: Number of organisations to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400.
  *       - in: query
  *         name: offset
  *         schema:
@@ -156,13 +148,19 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *                 pagination:
  *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. a non-integer limit/offset, a negative offset, a limit above the maximum, a repeated query parameter)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -176,11 +174,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
   logger.info('Parsing query filters');
-  const url = new URL(req.url);
-  const search = url.searchParams.get('search') ?? undefined;
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  const { search, limit, offset } = parseQueryParams(new URL(req.url), listOrganisationsQuerySchema);
 
   logger.info({ filters: { search, limit, offset } }, 'Querying organisations');
   const { data, total } = await listOrganisations(tenantId, { search, limit, offset });

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -126,7 +126,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Number of organisations to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400.
+ *         description: Number of organisations to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -49,7 +49,7 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *                   items:
  *                     type: string
  *                     minLength: 1
- *                   description: IDs of secondary identifiers
+ *                   description: IDs of secondary identifiers. Must not contain duplicates.
  *     responses:
  *       201:
  *         description: Organisations created successfully

--- a/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { idSchema, locationSchema, nonEmptyArraySchema, paginationQuerySchema, requireAtLeastOneField } from './shared';
+
+/**
+ * A single organisation item within the POST /organisations bulk-create array.
+ *
+ * `description` rejects an explicit `null` on create (equivalent to omitting
+ * the field): there is nothing to clear yet on a brand-new record, so create
+ * has no null-to-clear contract for any field.
+ *
+ * `location` is an open JSON object (a UNTP-shaped location schema is a
+ * separate deferred design tracked in #804) but is not nullable: the
+ * generated Prisma client types every create/update `location` argument as
+ * `NullableJsonNullValueInput | InputJsonValue`, which excludes a plain
+ * `null` (clearing a Json column requires the `Prisma.DbNull`/`Prisma.JsonNull`
+ * sentinels), so a literal `null` here would reach Prisma's runtime argument
+ * validation and surface as a 500 rather than a 400.
+ */
+const organisationItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1).optional(),
+  location: locationSchema.optional(),
+  primaryIdentifierId: idSchema.optional(),
+  secondaryIdentifierIds: z.array(idSchema).optional(),
+});
+
+/** Request body for POST /organisations: a non-empty array of organisation items. */
+export const createOrganisationsRequestSchema = nonEmptyArraySchema(organisationItemSchema);
+
+/**
+ * Request body for PATCH /organisations/{id}. An empty `secondaryIdentifierIds`
+ * array clears all secondary identifiers. `description` is a nullable scalar
+ * column, and the pre-migration path forwarded an explicit `null` as a
+ * working clear, so `.nullable()` preserves that. `location` is not
+ * nullable; see organisationItemSchema for why a literal `null` is rejected
+ * here.
+ */
+export const updateOrganisationRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().min(1).nullable().optional(),
+    location: locationSchema.optional(),
+    primaryIdentifierId: idSchema.nullable().optional(),
+    secondaryIdentifierIds: z.array(idSchema).optional(),
+  }),
+  'At least one updatable field must be provided',
+);
+
+/** Query parameters for GET /organisations. Merges the `search` filter ahead of pagination (ADR-037). */
+export const listOrganisationsQuerySchema = z
+  .object({
+    search: z.string().optional(),
+  })
+  .merge(paginationQuerySchema);

--- a/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
@@ -10,18 +10,20 @@ import { idSchema, locationSchema, nonEmptyArraySchema, paginationQuerySchema, r
  *
  * `location` is an open JSON object (a UNTP-shaped location schema is a
  * separate deferred design tracked in #804) but is not nullable: the
- * generated Prisma client types every create/update `location` argument as
- * `NullableJsonNullValueInput | InputJsonValue`, which excludes a plain
- * `null` (clearing a Json column requires the `Prisma.DbNull`/`Prisma.JsonNull`
- * sentinels), so a literal `null` here would reach Prisma's runtime argument
- * validation and surface as a 500 rather than a 400.
+ * generated Prisma client's input types exclude a plain `null` for Json
+ * writes (the `Prisma.DbNull`/`Prisma.JsonNull` sentinels are the supported
+ * null writes), and location's clear mechanism is deliberately deferred to
+ * #804, so a literal `null` here is a 400.
  */
 const organisationItemSchema = z.object({
   name: z.string().min(1),
   description: z.string().min(1).optional(),
   location: locationSchema.optional(),
   primaryIdentifierId: idSchema.optional(),
-  secondaryIdentifierIds: z.array(idSchema).optional(),
+  secondaryIdentifierIds: z
+    .array(idSchema)
+    .refine((val) => new Set(val).size === val.length, { message: 'must not contain duplicate identifiers' })
+    .optional(),
 });
 
 /** Request body for POST /organisations: a non-empty array of organisation items. */
@@ -41,7 +43,10 @@ export const updateOrganisationRequestSchema = requireAtLeastOneField(
     description: z.string().min(1).nullable().optional(),
     location: locationSchema.optional(),
     primaryIdentifierId: idSchema.nullable().optional(),
-    secondaryIdentifierIds: z.array(idSchema).optional(),
+    secondaryIdentifierIds: z
+      .array(idSchema)
+      .refine((val) => new Set(val).size === val.length, { message: 'must not contain duplicate identifiers' })
+      .optional(),
   }),
   'At least one updatable field must be provided',
 );

--- a/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/organisation.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
-import { idSchema, locationSchema, nonEmptyArraySchema, paginationQuerySchema, requireAtLeastOneField } from './shared';
+import {
+  idSchema,
+  locationSchema,
+  nonBlankString,
+  nonEmptyArraySchema,
+  paginationQuerySchema,
+  requireAtLeastOneField,
+} from './shared';
 
 /**
  * A single organisation item within the POST /organisations bulk-create array.
@@ -16,8 +23,8 @@ import { idSchema, locationSchema, nonEmptyArraySchema, paginationQuerySchema, r
  * #804, so a literal `null` here is a 400.
  */
 const organisationItemSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().min(1).optional(),
+  name: nonBlankString,
+  description: nonBlankString.optional(),
   location: locationSchema.optional(),
   primaryIdentifierId: idSchema.optional(),
   secondaryIdentifierIds: z
@@ -39,8 +46,8 @@ export const createOrganisationsRequestSchema = nonEmptyArraySchema(organisation
  */
 export const updateOrganisationRequestSchema = requireAtLeastOneField(
   z.object({
-    name: z.string().min(1).optional(),
-    description: z.string().min(1).nullable().optional(),
+    name: nonBlankString.optional(),
+    description: nonBlankString.nullable().optional(),
     location: locationSchema.optional(),
     primaryIdentifierId: idSchema.nullable().optional(),
     secondaryIdentifierIds: z

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.test.ts
@@ -537,6 +537,7 @@ describe('organisation.repository', () => {
 
       expect(mockTx.organisationEntity.findFirst).toHaveBeenCalledWith({
         where: { id: 'org-1', tenantId: TENANT_ID },
+        include: { secondaryIdentifiers: { select: { identifierId: true } } },
       });
       expect(mockTx.organisationEntity.update).toHaveBeenCalledWith({
         where: { id: 'org-1' },
@@ -547,6 +548,35 @@ describe('organisation.repository', () => {
         },
       });
       expect(result.name).toBe('Acme Industries');
+    });
+
+    it('forwards an explicit null description into the update data', async () => {
+      // The data object is built with `input.description !== undefined && {...}`,
+      // not a truthiness check; a regression to a truthy check would silently
+      // drop `description: null` (indistinguishable from omitting the field)
+      // instead of forwarding the clear to Prisma. The route-level test mocks
+      // the repository, so it cannot see this; only a repository-level
+      // assertion on the actual transaction call does.
+      const updatedOrg = { ...ORG_RECORD, description: null };
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn().mockResolvedValue(updatedOrg),
+        },
+        identifier: { findFirst: jest.fn() },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      await updateOrganisation('org-1', TENANT_ID, { description: null });
+
+      expect(mockTx.organisationEntity.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ description: null }) }),
+      );
     });
 
     it('rejects duplicate secondary identifiers', async () => {
@@ -691,6 +721,74 @@ describe('organisation.repository', () => {
       expect(result.secondaryIdentifiers).toHaveLength(0);
     });
 
+    it('throws ValidationError when a primary-only update matches an existing stored secondary identifier', async () => {
+      // The overlap check must cover the request's *effective* state, not
+      // only fields the request happens to touch: a primary-only update
+      // that is never checked against the organisation's currently stored
+      // secondaries would silently persist the forbidden
+      // primary-also-secondary state (no database constraint enforces it).
+      const orgWithStoredSecondary = {
+        ...ORG_RECORD,
+        secondaryIdentifiers: [{ organisationId: 'org-1', identifierId: 'ident-2', identifier: IDENTIFIER_RECORD_2 }],
+      };
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(orgWithStoredSecondary),
+          update: jest.fn(),
+        },
+        identifier: { findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2) },
+        organisationSecondaryIdentifier: { deleteMany: jest.fn(), createMany: jest.fn() },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = updateOrganisation('org-1', TENANT_ID, { primaryIdentifierId: 'ident-2' });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Primary identifier cannot also be a secondary identifier');
+      expect(mockTx.organisationEntity.update).not.toHaveBeenCalled();
+    });
+
+    it('succeeds when a request reassigns an existing secondary to primary in the same call', async () => {
+      // The effective-state rule must not over-block: replacing the
+      // secondary set in the same request as the primary change resolves
+      // the overlap, so this combination is valid.
+      const orgWithStoredSecondary = {
+        ...ORG_RECORD,
+        secondaryIdentifiers: [{ organisationId: 'org-1', identifierId: 'ident-2', identifier: IDENTIFIER_RECORD_2 }],
+      };
+      const updatedOrg = {
+        ...ORG_RECORD,
+        primaryIdentifierId: 'ident-2',
+        primaryIdentifier: IDENTIFIER_RECORD_2,
+        secondaryIdentifiers: [],
+      };
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(orgWithStoredSecondary),
+          update: jest.fn().mockResolvedValue(updatedOrg),
+        },
+        identifier: { findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2) },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+          createMany: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = await updateOrganisation('org-1', TENANT_ID, {
+        primaryIdentifierId: 'ident-2',
+        secondaryIdentifierIds: [],
+      });
+
+      expect(mockTx.organisationSecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { organisationId: 'org-1' },
+      });
+      expect(mockTx.organisationEntity.update).toHaveBeenCalled();
+      expect(result.primaryIdentifierId).toBe('ident-2');
+    });
+
     it('throws NotFoundError if organisation does not belong to tenant', async () => {
       const mockTx = {
         organisationEntity: {
@@ -730,6 +828,32 @@ describe('organisation.repository', () => {
 
       await expect(result).rejects.toThrow(ConflictError);
       await expect(result).rejects.toThrow('The identifier is already the primary identifier of another organisation');
+    });
+
+    it('maps a foreign-key violation on the main update to ValidationError', async () => {
+      // Covers the ownership-check-to-write race: primaryIdentifierId passes
+      // validateIdentifierOwnership, then the referenced identifier is
+      // deleted before this update's connect executes, and Prisma raises
+      // P2003. Without this mapping, that race surfaced as a sanitised 500
+      // instead of the documented 400 "referenced record" response.
+      const mockTx = {
+        organisationEntity: {
+          findFirst: jest.fn().mockResolvedValue(ORG_RECORD),
+          update: jest.fn().mockRejectedValue(prismaForeignKeyViolationError()),
+        },
+        identifier: { findFirst: jest.fn().mockResolvedValue(IDENTIFIER_RECORD_2) },
+        organisationSecondaryIdentifier: {
+          deleteMany: jest.fn(),
+          createMany: jest.fn(),
+        },
+      };
+
+      mockTransaction.mockImplementation((cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx));
+
+      const result = updateOrganisation('org-1', TENANT_ID, { primaryIdentifierId: 'ident-2' });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced primary identifier no longer exists');
     });
 
     it('maps a record-not-found race to NotFoundError', async () => {

--- a/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/organisation.repository.ts
@@ -4,7 +4,6 @@ import { NotFoundError } from '@/lib/api/errors';
 import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
-import { UntpLocation } from '@/lib/types';
 
 /** Full relations for detail endpoints. */
 const ORGANISATION_DETAIL_INCLUDE = {
@@ -33,11 +32,20 @@ export type OrganisationListItem = Omit<OrganisationListRow, 'secondaryIdentifie
 
 /**
  * Input for creating a new organisation entity.
+ *
+ * `location` is an open JSON object (ADR-037): a UNTP-shaped location schema
+ * is a separate deferred design tracked in #804, so this type stays a plain
+ * record rather than the more specific UntpLocation shape. Not nullable: the
+ * generated Prisma client types `location` as
+ * `NullableJsonNullValueInput | InputJsonValue`, which excludes a plain
+ * `null` (clearing a Json column needs the `Prisma.DbNull`/`Prisma.JsonNull`
+ * sentinels), so the request schema rejects a literal `null` before it
+ * reaches here.
  */
 export type CreateOrganisationInput = {
   name: string;
   description?: string;
-  location?: UntpLocation;
+  location?: Record<string, unknown>;
   primaryIdentifierId?: string;
   secondaryIdentifierIds?: string[];
 };
@@ -45,13 +53,16 @@ export type CreateOrganisationInput = {
 /**
  * Input for updating an existing organisation entity.
  * Fields set to undefined are left unchanged.
+ * description set to null clears the description (a nullable scalar column).
  * primaryIdentifierId set to null clears the primary identifier.
  * secondaryIdentifierIds set to [] clears all secondary identifiers.
+ * location is an open JSON object (see CreateOrganisationInput for why this
+ * stays a plain record, ADR-037) and, like create, is not nullable.
  */
 export type UpdateOrganisationInput = {
   name?: string;
-  description?: string;
-  location?: UntpLocation;
+  description?: string | null;
+  location?: Record<string, unknown>;
   primaryIdentifierId?: string | null;
   secondaryIdentifierIds?: string[];
 };
@@ -243,9 +254,13 @@ export async function updateOrganisation(
   input: UpdateOrganisationInput,
 ): Promise<OrganisationEntityWithRelations> {
   return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
-    // Ownership check
+    // Ownership check. Also fetches the currently stored secondary
+    // identifier IDs: a primary-only update still needs them to validate
+    // against, since the overlap rule below covers the request's effective
+    // state, not only fields the request happens to touch.
     const existing = await tx.organisationEntity.findFirst({
       where: { id, tenantId },
+      include: { secondaryIdentifiers: { select: { identifierId: true } } },
     });
 
     if (!existing) {
@@ -257,12 +272,25 @@ export async function updateOrganisation(
       await validateIdentifierOwnership(tx, input.primaryIdentifierId, tenantId);
     }
 
-    // Validate secondary identifiers and check for overlap with primary
-    if (input.secondaryIdentifierIds !== undefined) {
+    // Validate no overlap between the effective primary and effective
+    // secondary sets: the incoming value when a field is part of this
+    // request, otherwise the organisation's current stored value. A
+    // primary-only update whose new primary matches an existing stored
+    // secondary identifier must be rejected exactly like the reverse
+    // (a secondary-only update matching the existing primary); no database
+    // constraint enforces this, so both directions are checked here.
+    if (input.primaryIdentifierId !== undefined || input.secondaryIdentifierIds !== undefined) {
       const effectivePrimaryId =
         input.primaryIdentifierId !== undefined ? input.primaryIdentifierId : existing.primaryIdentifierId;
-      validateNoPrimarySecondaryOverlap(effectivePrimaryId, input.secondaryIdentifierIds);
+      const effectiveSecondaryIds =
+        input.secondaryIdentifierIds !== undefined
+          ? input.secondaryIdentifierIds
+          : existing.secondaryIdentifiers.map((si) => si.identifierId);
+      validateNoPrimarySecondaryOverlap(effectivePrimaryId, effectiveSecondaryIds);
+    }
 
+    // Validate secondary identifiers belong to tenant, then replace them
+    if (input.secondaryIdentifierIds !== undefined) {
       for (const secId of input.secondaryIdentifierIds) {
         await validateIdentifierOwnership(tx, secId, tenantId);
       }
@@ -313,6 +341,7 @@ export async function updateOrganisation(
       mapDatabaseError(e, {
         conflict: 'The identifier is already the primary identifier of another organisation',
         notFound: 'Organisation or a referenced resource not found',
+        invalidReference: 'The referenced primary identifier no longer exists',
       });
     }
   });

--- a/packages/reference-implementation/src/lib/swagger/schemas.test.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.test.ts
@@ -1,6 +1,19 @@
 import { generateOpenAPISchemas } from './schemas';
 
 /**
+ * Minimal shape for navigating the generated OpenAPI JSON schema in these
+ * structural assertions. The real output carries far more (descriptions,
+ * formats, additionalProperties); only the fields these tests read are
+ * declared.
+ */
+type JsonSchemaObject = {
+  properties?: Record<string, JsonSchemaObject>;
+  required?: string[];
+  items?: JsonSchemaObject;
+  nullable?: boolean;
+};
+
+/**
  * Congruence checks for the registrar <-> scheme OpenAPI projection (#792
  * design-fork resolution). `registrarSchema` and `identifierSchemeSchema`
  * are composed from file-private cores in the services package specifically
@@ -78,5 +91,71 @@ describe('generateOpenAPISchemas — registrar/scheme projection congruence', ()
     };
 
     expect(identifierScheme.properties.registrar.properties.schemes).toBeUndefined();
+  });
+});
+
+describe('generateOpenAPISchemas — Organisation component', () => {
+  // buildOrganisationSchema (in schemas.ts) is function-local and only
+  // invoked from inside generateOpenAPISchemas, so the nested
+  // primaryIdentifier/secondaryIdentifiers/secondaryIdentifierIds asymmetry
+  // and the qualifiers-omission on the nested scheme have no other surface
+  // to assert against; the generated JSON is the public contract.
+  const schemas = generateOpenAPISchemas();
+  const organisation = schemas.Organisation as JsonSchemaObject;
+
+  it('requires every field present on both list and detail responses', () => {
+    expect(organisation.required).toEqual(
+      expect.arrayContaining([
+        'id',
+        'tenantId',
+        'name',
+        'description',
+        'location',
+        'primaryIdentifierId',
+        'createdAt',
+        'updatedAt',
+      ]),
+    );
+  });
+
+  it('lists primaryIdentifier, secondaryIdentifiers, and secondaryIdentifierIds as present but optional', () => {
+    // Detail responses (create, get-by-id, update) include primaryIdentifier
+    // and secondaryIdentifiers but omit secondaryIdentifierIds; list
+    // responses do the reverse (ORGANISATION_DETAIL_INCLUDE vs
+    // ORGANISATION_LIST_INCLUDE in organisation.repository.ts). None of the
+    // three is present on every response, so none is required.
+    expect(organisation.properties).toHaveProperty('primaryIdentifier');
+    expect(organisation.properties).toHaveProperty('secondaryIdentifiers');
+    expect(organisation.properties).toHaveProperty('secondaryIdentifierIds');
+    expect(organisation.required ?? []).not.toContain('primaryIdentifier');
+    expect(organisation.required ?? []).not.toContain('secondaryIdentifiers');
+    expect(organisation.required ?? []).not.toContain('secondaryIdentifierIds');
+  });
+
+  it('marks primaryIdentifier nullable, matching a detail response with no primary identifier set', () => {
+    // primaryIdentifierId (and so primaryIdentifier) can be null on an
+    // organisation that has none; the response schema must allow it rather
+    // than only allowing "present" or "absent".
+    expect(organisation.properties?.primaryIdentifier?.nullable).toBe(true);
+  });
+
+  it('omits qualifiers from and requires registrar on the primaryIdentifier scheme projection', () => {
+    // The repository's include (`scheme: { include: { registrar: true } }`)
+    // never requests qualifiers, so a scheme nested here never carries one;
+    // registrar is always requested, so it is always present.
+    const primaryIdentifier = organisation.properties?.primaryIdentifier;
+    const scheme = primaryIdentifier?.properties?.scheme;
+    expect(scheme?.properties).not.toHaveProperty('qualifiers');
+    expect(scheme?.required).toContain('registrar');
+  });
+
+  it('omits qualifiers from and requires registrar on the secondaryIdentifiers scheme projection', () => {
+    // secondaryIdentifiers is an array of join records, each carrying the
+    // same nested identifier/scheme/registrar shape as primaryIdentifier.
+    const secondaryIdentifiers = organisation.properties?.secondaryIdentifiers;
+    const identifier = secondaryIdentifiers?.items?.properties?.identifier;
+    const scheme = identifier?.properties?.scheme;
+    expect(scheme?.properties).not.toHaveProperty('qualifiers');
+    expect(scheme?.required).toContain('registrar');
   });
 });

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -171,17 +171,88 @@ export const productSchema = z.object({
   updatedAt: z.string().describe('ISO 8601 timestamp'),
 });
 
-export const organisationSchema = z.object({
-  id: z.string(),
-  tenantId: z.string(),
-  name: z.string(),
-  description: z.string().nullable(),
-  location: z.record(z.unknown()).nullable().describe('UNTP location object'),
-  primaryIdentifierId: z.string().nullable(),
-  secondaryIdentifierIds: z.array(z.string()).describe('IDs of secondary identifiers'),
-  createdAt: z.string().describe('ISO 8601 timestamp'),
-  updatedAt: z.string().describe('ISO 8601 timestamp'),
-});
+/**
+ * Builds the Organisation response schema, including its nested
+ * primary/secondary identifier sub-schemas.
+ *
+ * Built lazily (called only from generateOpenAPISchemas, never at
+ * module-evaluation time): every nested schema here derives from
+ * identifierSchemeSchema/identifierSchema via `.omit()`/`.required()`/
+ * `.extend()`, all imported from `@uncefact/untp-ri-services`. A consumer
+ * that imports anything else from this module under a partial mock of that
+ * package (e.g. credentials/route.test.ts, which mocks only
+ * `buildPublishLinks`) would see those two schemas as `undefined` and throw
+ * at import time if this derivation ran at the top level, before the test
+ * ever reaches the code it means to exercise.
+ */
+function buildOrganisationSchema() {
+  /**
+   * Identifier scheme nested under an organisation's identifier fields.
+   * Omits `qualifiers`: the repository's include
+   * (`scheme: { include: { registrar: true } }`) does not request the
+   * qualifiers relation, so it is never present on this nested view (unlike
+   * the standalone IdentifierScheme resource, which always includes it).
+   * `registrar` is made required here (it is optional on the standalone
+   * resource to match its own list-versus-detail asymmetry) because this
+   * nested view's include always requests it.
+   */
+  const organisationIdentifierSchemeSchema = identifierSchemeSchema.omit({ qualifiers: true }).required({
+    registrar: true,
+  });
+
+  /**
+   * Identifier record nested under an organisation's primary/secondary
+   * identifier fields, including its parent scheme (and that scheme's
+   * registrar), matching the repository's ORGANISATION_DETAIL_INCLUDE
+   * (`scheme: { include: { registrar: true } }`).
+   */
+  const organisationIdentifierSchema = identifierSchema.extend({
+    scheme: organisationIdentifierSchemeSchema.describe('Parent identifier scheme, including its registrar'),
+  });
+
+  /**
+   * Secondary identifier join record as returned nested under an
+   * organisation's detail response, matching
+   * ORGANISATION_DETAIL_INCLUDE.secondaryIdentifiers.
+   */
+  const organisationSecondaryIdentifierSchema = z.object({
+    organisationId: z.string(),
+    identifierId: z.string(),
+    identifier: organisationIdentifierSchema,
+  });
+
+  // The create, get-by-id, and update handlers all include the full
+  // `primaryIdentifier` and `secondaryIdentifiers` relations
+  // (ORGANISATION_DETAIL_INCLUDE); the list handler instead returns the
+  // lighter-weight `secondaryIdentifierIds` and omits both nested relations
+  // (ORGANISATION_LIST_INCLUDE), so the relation fields and
+  // `secondaryIdentifierIds` are each marked optional to match that
+  // asymmetry rather than overstating what every endpoint returns.
+  return z.object({
+    id: z.string(),
+    tenantId: z.string(),
+    name: z.string(),
+    description: z.string().nullable(),
+    location: z
+      .record(z.unknown())
+      .nullable()
+      .describe(
+        'Location object. Any JSON object is accepted; the UNTP location field shapes described in the master data documentation are not currently validated.',
+      ),
+    primaryIdentifierId: z.string().nullable(),
+    primaryIdentifier: organisationIdentifierSchema
+      .nullable()
+      .optional()
+      .describe('Full primary identifier record (omitted on list items)'),
+    secondaryIdentifierIds: z.array(z.string()).optional().describe('IDs of secondary identifiers (list items only)'),
+    secondaryIdentifiers: z
+      .array(organisationSecondaryIdentifierSchema)
+      .optional()
+      .describe('Full secondary identifier records (omitted on list items)'),
+    createdAt: z.string().describe('ISO 8601 timestamp'),
+    updatedAt: z.string().describe('ISO 8601 timestamp'),
+  });
+}
 
 export const facilitySchema = z.object({
   id: z.string(),
@@ -250,7 +321,7 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     DataModel: dataModelSchema,
     RenderTemplate: renderTemplateSchema,
     Product: productSchema,
-    Organisation: organisationSchema,
+    Organisation: buildOrganisationSchema(),
     Facility: facilitySchema,
   };
 


### PR DESCRIPTION
This PR migrates the organisations endpoints' request validation to per-resource Zod schemas at the route boundary and brings the routes' Swagger and docs into congruence with their real behaviour, so malformed input returns a 400 naming the offending field and the published contract matches what the routes do.

Validation: POST /organisations validates its bulk array body (non-empty array, per-item field checks with item-indexed error paths), PATCH /organisations/{id} requires at least one recognised field with null-to-clear preserved on description and primaryIdentifierId (nullable columns whose null the repository already forwarded) and rejected elsewhere, and GET /organisations validates its search filter and pagination through the shared query schema. The location object stays an open record per the deferred UNTP location design, with an explicit null rejected at the boundary (the Prisma client's input types exclude plain null for Json writes, and a clear mechanism for location is deferred to the UNTP location design).

Data integrity: the repository's primary/secondary identifier exclusivity check now validates the effective state whenever either field changes, closing a hole where a primary-only update could persist an identifier as both primary and secondary; a foreign-key race between the ownership check and the update write now maps to an actionable 400 instead of a sanitised 500. Both are pinned by repository regression tests.

Contract congruence: the Organisation response component now documents the nested primaryIdentifier/secondaryIdentifiers detail shapes (built lazily so partially-mocked test suites cannot crash at module load), the shared 401/403 responses are documented on every route, the previously untested documented 409s have route tests, and the location wording states plainly that any JSON object is accepted with UNTP shapes not yet validated.

Tests: 259 across six suites, including structural assertions on the generated OpenAPI component, unknown-key stripping proofs, explicit-null rejections, and the two exclusivity regressions.

Closes #793
