### PR TITLE
feat(ri): validate and tighten facilities endpoint inputs and align their Swagger

### DIFF
--- a/documentation/docs/reference-implementation/api/facilities.md
+++ b/documentation/docs/reference-implementation/api/facilities.md
@@ -46,7 +46,9 @@ Facilities are scoped to the authenticated tenant. Each tenant manages its own s
 POST /api/v1/facilities
 ```
 
-Creates one or more facilities in bulk. The request body is an array of facility objects — each must include a `name`. Optional fields include `description`, `location`, `operatingOrganisationId`, `primaryIdentifierId`, and `secondaryIdentifierIds`.
+Creates one or more facilities in bulk. The request body must be a non-empty array of facility objects — each must include a non-empty `name`. Optional fields include `description` (non-empty if provided), `location`, `operatingOrganisationId`, `primaryIdentifierId`, and `secondaryIdentifierIds` (rejected with a 400 if provided but not an array). Unrecognised fields on each item are ignored.
+
+**Optional fields must be omitted to skip them — do not send them as a JSON `null`.** There is no clear-on-create semantics (nothing yet exists to clear), so an explicit `null` on any optional field is now rejected with a 400 for the whole request, the same as any other malformed value. This is a real behaviour change for `location`: it was previously accepted silently, with no different effect than omitting the field (the write skipped the column either way, leaving it unset) — that silent equivalence is gone, and `location: null` is now a 400.
 
 ```mermaid
 sequenceDiagram
@@ -81,7 +83,7 @@ Returns facilities for the authenticated tenant with optional filtering. Results
 |-----------|------|---------|-------------|
 | `search` | string | — | Search by facility name or identifier value |
 | `organisationId` | string | — | Filter by operating organisation ID |
-| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `limit` | integer | Defaults to 20, or the configured maximum when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---
@@ -102,16 +104,16 @@ Retrieves a specific facility by its database ID. The response includes the full
 PATCH /api/v1/facilities/{id}
 ```
 
-Updates one or more fields of an existing facility. At least one updatable field must be provided.
+Updates one or more fields of an existing facility. At least one recognised field is required — a body with none of the fields below (or only unrecognised keys) is rejected with a 400; unrecognised keys are otherwise ignored.
 
 | Updatable Field | Description |
 |-----------------|-------------|
-| `name` | Facility name (must be non-empty if provided) |
-| `description` | Free-text description |
-| `location` | UNTP location object (set to `null` to clear) |
-| `operatingOrganisationId` | ID of the operating organisation (set to `null` to clear) |
-| `primaryIdentifierId` | ID of the primary identifier (set to `null` to clear) |
-| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing) |
+| `name` | Facility name (non-empty if provided) |
+| `description` | Free-text description (non-empty if provided; set to `null` to clear) |
+| `location` | UNTP location object. Rejected with a 400 if provided as `null` — there is no clear mechanism for this field yet |
+| `operatingOrganisationId` | ID of the operating organisation (non-empty if provided; set to `null` to clear) |
+| `primaryIdentifierId` | ID of the primary identifier (non-empty if provided; set to `null` to clear) |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs, each non-empty — an empty array clears them, otherwise replaces the existing set. Rejected with a 400 if provided but not an array |
 
 ---
 
@@ -121,7 +123,7 @@ Updates one or more fields of an existing facility. At least one updatable field
 DELETE /api/v1/facilities/{id}
 ```
 
-Permanently deletes a facility. If the facility is referenced as the manufacturing facility for any products, those references are cleared (set to `null`) — the product records are not deleted.
+Permanently deletes a facility. If the facility is referenced as the manufacturing facility for any products, or as the facility on any credentials, those references are cleared (set to `null`) — the product and credential records are not deleted.
 
 ```mermaid
 sequenceDiagram

--- a/documentation/docs/reference-implementation/api/facilities.md
+++ b/documentation/docs/reference-implementation/api/facilities.md
@@ -46,7 +46,7 @@ Facilities are scoped to the authenticated tenant. Each tenant manages its own s
 POST /api/v1/facilities
 ```
 
-Creates one or more facilities in bulk. The request body must be a non-empty array of facility objects — each must include a non-empty `name`. Optional fields include `description` (non-empty if provided), `location`, `operatingOrganisationId`, `primaryIdentifierId`, and `secondaryIdentifierIds` (rejected with a 400 if provided but not an array). Unrecognised fields on each item are ignored.
+Creates one or more facilities in bulk. The request body must be a non-empty array of facility objects — each must include a non-empty `name`. Optional fields include `description` (non-empty if provided), `location`, `operatingOrganisationId`, `primaryIdentifierId`, and `secondaryIdentifierIds` (each ID unique within the array; rejected with a 400 if provided but not an array, or if it contains a duplicate). Unrecognised fields on each item are ignored.
 
 **Optional fields must be omitted to skip them — do not send them as a JSON `null`.** There is no clear-on-create semantics (nothing yet exists to clear), so an explicit `null` on any optional field is now rejected with a 400 for the whole request, the same as any other malformed value. This is a real behaviour change for `location`: it was previously accepted silently, with no different effect than omitting the field (the write skipped the column either way, leaving it unset) — that silent equivalence is gone, and `location: null` is now a 400.
 
@@ -113,7 +113,7 @@ Updates one or more fields of an existing facility. At least one recognised fiel
 | `location` | UNTP location object. Rejected with a 400 if provided as `null` — there is no clear mechanism for this field yet |
 | `operatingOrganisationId` | ID of the operating organisation (non-empty if provided; set to `null` to clear) |
 | `primaryIdentifierId` | ID of the primary identifier (non-empty if provided; set to `null` to clear) |
-| `secondaryIdentifierIds` | Array of secondary identifier IDs, each non-empty — an empty array clears them, otherwise replaces the existing set. Rejected with a 400 if provided but not an array |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs, each non-empty and unique within the array — an empty array clears them, otherwise replaces the existing set. Rejected with a 400 if provided but not an array, or if it contains a duplicate ID |
 
 ---
 

--- a/documentation/docs/reference-implementation/api/facilities.md
+++ b/documentation/docs/reference-implementation/api/facilities.md
@@ -48,7 +48,7 @@ POST /api/v1/facilities
 
 Creates one or more facilities in bulk. The request body must be a non-empty array of facility objects — each must include a non-empty `name`. Optional fields include `description` (non-empty if provided), `location`, `operatingOrganisationId`, `primaryIdentifierId`, and `secondaryIdentifierIds` (each ID unique within the array; rejected with a 400 if provided but not an array, or if it contains a duplicate). Unrecognised fields on each item are ignored.
 
-**Optional fields must be omitted to skip them — do not send them as a JSON `null`.** There is no clear-on-create semantics (nothing yet exists to clear), so an explicit `null` on any optional field is now rejected with a 400 for the whole request, the same as any other malformed value. This is a real behaviour change for `location`: it was previously accepted silently, with no different effect than omitting the field (the write skipped the column either way, leaving it unset) — that silent equivalence is gone, and `location: null` is now a 400.
+**Optional fields must be omitted to skip them — do not send them as a JSON `null`.** There is no clear-on-create semantics (nothing yet exists to clear), so an explicit `null` on any optional field is rejected with a 400 for the whole request, the same as any other malformed value. This is a real behaviour change for `location`: it was previously accepted silently, with no different effect than omitting the field (the write skipped the column either way, leaving it unset) — that silent equivalence is gone, and `location: null` is now a 400.
 
 ```mermaid
 sequenceDiagram

--- a/documentation/docs/reference-implementation/api/facilities.md
+++ b/documentation/docs/reference-implementation/api/facilities.md
@@ -83,7 +83,7 @@ Returns facilities for the authenticated tenant with optional filtering. Results
 |-----------|------|---------|-------------|
 | `search` | string | — | Search by facility name or identifier value |
 | `organisationId` | string | — | Filter by operating organisation ID |
-| `limit` | integer | Defaults to 20, or the configured maximum when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
+| `limit` | integer | Defaults to 20, or the [configured maximum](../operations/api-pagination#maximum-page-size) when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
@@ -262,6 +262,20 @@ describe('PATCH /api/v1/facilities/:id', () => {
     expect(mockUpdateFacility).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when secondaryIdentifierIds contains a duplicate and does not call the repository', async () => {
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: { secondaryIdentifierIds: ['ident-1', 'ident-1'] },
+    });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^secondaryIdentifierIds:/);
+    expect(json.error).toContain('must not contain duplicate identifiers');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when location is not an object and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: { location: 'somewhere' } });
     const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
@@ -222,6 +222,26 @@ describe('PATCH /api/v1/facilities/:id', () => {
     expect(mockUpdateFacility).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when name is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '   ' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('name: must not be only whitespace');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { description: '  ' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('description: must not be only whitespace');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when description is an empty string and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: { description: '' } });
     const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.test.ts
@@ -43,7 +43,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   deleteFacility: (id: string, tenantId: string) => mockDeleteFacility(id, tenantId),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { NotFoundError, ConflictError } from '@/lib/api/errors';
 import { GET, PATCH, DELETE } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -123,27 +123,168 @@ describe('PATCH /api/v1/facilities/:id', () => {
     expect(res.status).toBe(200);
     expect(json).toEqual(updated);
     expect(json).not.toHaveProperty('ok');
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', { name: 'Updated Warehouse' });
   });
 
-  it('returns 400 when no updatable fields are provided', async () => {
+  it('clears operatingOrganisationId and primaryIdentifierId with an explicit null', async () => {
+    mockUpdateFacility.mockResolvedValue({ id: 'fac-1' });
+
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: { operatingOrganisationId: null, primaryIdentifierId: null },
+    });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', {
+      operatingOrganisationId: null,
+      primaryIdentifierId: null,
+    });
+  });
+
+  it('clears description with an explicit null', async () => {
+    mockUpdateFacility.mockResolvedValue({ id: 'fac-1' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { description: null } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', { description: null });
+  });
+
+  it('clears secondaryIdentifierIds with an empty array', async () => {
+    mockUpdateFacility.mockResolvedValue({ id: 'fac-1' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: [] } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', { secondaryIdentifierIds: [] });
+  });
+
+  it('replaces secondaryIdentifierIds with a new set', async () => {
+    mockUpdateFacility.mockResolvedValue({ id: 'fac-1' });
+
+    const req = createFakeRequest({
+      method: 'PATCH',
+      body: { secondaryIdentifierIds: ['ident-1', 'ident-2'] },
+    });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', {
+      secondaryIdentifierIds: ['ident-1', 'ident-2'],
+    });
+  });
+
+  it('accepts an open location object and forwards it to the repository', async () => {
+    mockUpdateFacility.mockResolvedValue({ id: 'fac-1' });
+
+    const location = { address: { addressCountry: 'AU' } };
+    const req = createFakeRequest({ method: 'PATCH', body: { location } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateFacility).toHaveBeenCalledWith('fac-1', 'org-1', { location });
+  });
+
+  it('returns 400 when no updatable fields are provided and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: {} });
     const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('At least one updatable field is required');
+    // Exact match, including the `body: ` scope prefix parseRequestBody renders for a
+    // top-level (unpathed) issue, pinning the rendered message rather than a substring.
+    expect(json.error).toBe(
+      'body: At least one updatable field is required: name, description, location, operatingOrganisationId, primaryIdentifierId, secondaryIdentifierIds',
+    );
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when name is empty string', async () => {
+  it('returns 400 when the body only has an unrecognised (typo) field name', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { neme: 'Updated Warehouse' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one updatable field is required');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is an empty string and does not call the repository', async () => {
     const req = createFakeRequest({ method: 'PATCH', body: { name: '' } });
     const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toMatch(/^name:/);
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid JSON body', async () => {
+  it('returns 400 when description is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { description: '' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^description:/);
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when operatingOrganisationId is not a string or null and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { operatingOrganisationId: 123 } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^operatingOrganisationId:/);
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: '' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^primaryIdentifierId:/);
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: 'ident-1' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^secondaryIdentifierIds:/);
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when location is not an object and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { location: 'somewhere' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^location:/);
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when location is explicitly null and does not call the repository', async () => {
+    // Unlike description, location is a Json column: Prisma requires Prisma.JsonNull
+    // rather than a plain null, so there is no null-to-clear mechanism for it yet.
+    const req = createFakeRequest({ method: 'PATCH', body: { location: null } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^location:/);
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid JSON body and does not call the repository', async () => {
     const req = {
       method: 'PATCH',
       url: 'http://localhost/api/v1/facilities/fac-1',
@@ -157,6 +298,17 @@ describe('PATCH /api/v1/facilities/:id', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toBe('Invalid JSON body');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a literal null body and does not call the repository', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: null });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Expected object, received null');
+    expect(mockUpdateFacility).not.toHaveBeenCalled();
   });
 
   it('returns 404 when facility not found', async () => {
@@ -168,6 +320,19 @@ describe('PATCH /api/v1/facilities/:id', () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toContain('Facility not found');
+  });
+
+  it('returns 409 when repository reports a primary identifier conflict', async () => {
+    mockUpdateFacility.mockRejectedValue(
+      new ConflictError('The identifier is already the primary identifier of another facility'),
+    );
+
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: 'ident-1' } });
+    const res = await PATCH(req, createContext('fac-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toContain('already the primary identifier of another facility');
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -116,7 +116,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *                 items:
  *                   type: string
  *                   minLength: 1
- *                 description: IDs of secondary identifiers (an empty array clears them, replaces existing otherwise)
+ *                 description: IDs of secondary identifiers, each unique within the array (an empty array clears them, replaces existing otherwise)
  *             anyOf:
  *               - required: [name]
  *               - required: [description]
@@ -132,7 +132,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/Facility'
  *       400:
- *         description: Validation error (e.g. no updatable field provided, a non-array secondaryIdentifierIds, an overlapping primary/secondary identifier, a referenced record that no longer exists)
+ *         description: Validation error (e.g. no updatable field provided, a non-array or duplicated secondaryIdentifierIds, an overlapping primary/secondary identifier, a referenced record that no longer exists)
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -1,28 +1,19 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateFacilityRequestSchema } from '@/lib/api/request-schemas/facility';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { getFacilityById, updateFacility, deleteFacility, UpdateFacilityInput } from '@/lib/prisma/repositories';
+import { getFacilityById, updateFacility, deleteFacility } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/facilities/[id]' });
-
-/** Fields that may be updated on a facility. */
-const UPDATABLE_FIELDS = [
-  'name',
-  'description',
-  'location',
-  'operatingOrganisationId',
-  'primaryIdentifierId',
-  'secondaryIdentifierIds',
-] as const;
 
 /**
  * @swagger
  * /facilities/{id}:
  *   get:
  *     summary: Get a facility by ID
- *     description: Retrieves a specific facility by its database ID
+ *     description: Retrieves a specific facility by its database ID, including its primary identifier (with scheme and registrar), secondary identifiers, and operating organisation
  *     tags:
  *       - Facilities
  *     parameters:
@@ -41,6 +32,12 @@ const UPDATABLE_FIELDS = [
  *               $ref: '#/components/schemas/Facility'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -86,6 +83,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *         description: The database ID of the facility
  *     requestBody:
  *       required: true
+ *       description: At least one recognised field is required; unknown keys are ignored.
  *       content:
  *         application/json:
  *           schema:
@@ -93,27 +91,39 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             properties:
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: Updated facility name
  *               description:
  *                 type: string
- *                 description: Updated description
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: Updated description (set to null to clear)
  *               location:
  *                 type: object
- *                 description: Updated UNTP location object
+ *                 description: Updated UNTP location object. Rejected with a 400 if provided as null; there is no clear mechanism for this field yet
  *               operatingOrganisationId:
  *                 type: string
+ *                 minLength: 1
  *                 nullable: true
- *                 description: ID of the operating organisation (null to clear)
+ *                 description: ID of the operating organisation (set to null to clear)
  *               primaryIdentifierId:
  *                 type: string
+ *                 minLength: 1
  *                 nullable: true
- *                 description: ID of the primary identifier (null to clear)
+ *                 description: ID of the primary identifier (set to null to clear)
  *               secondaryIdentifierIds:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: IDs of secondary identifiers (replaces existing)
- *             minProperties: 1
+ *                   minLength: 1
+ *                 description: IDs of secondary identifiers (an empty array clears them, replaces existing otherwise)
+ *             anyOf:
+ *               - required: [name]
+ *               - required: [description]
+ *               - required: [location]
+ *               - required: [operatingOrganisationId]
+ *               - required: [primaryIdentifierId]
+ *               - required: [secondaryIdentifierIds]
  *     responses:
  *       200:
  *         description: Facility updated successfully
@@ -122,7 +132,7 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/Facility'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. no updatable field provided, a non-array secondaryIdentifierIds, an overlapping primary/secondary identifier, a referenced record that no longer exists)
  *         content:
  *           application/json:
  *             schema:
@@ -133,8 +143,14 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
- *         description: Facility not found
+ *         description: Facility not found, or a referenced organisation or identifier not found
  *         content:
  *           application/json:
  *             schema:
@@ -155,36 +171,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ facilityId: id }, 'Parsing request body');
-  let body: Record<string, unknown>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
   logger.info({ facilityId: id }, 'Validating update fields');
-  // Ensure at least one updatable field is present
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
-  if (!hasUpdatableField) {
-    throw new ValidationError(`At least one updatable field is required: ${UPDATABLE_FIELDS.join(', ')}`);
-  }
+  const body = await parseRequestBody(req, updateFacilityRequestSchema);
+  const fields = definedFields(body);
 
-  // Validate name if provided — must be a non-empty string
-  if ('name' in body && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-
-  const updateData: Record<string, unknown> = {};
-  for (const field of UPDATABLE_FIELDS) {
-    if (field in body) {
-      updateData[field] = body[field];
-    }
-  }
-
-  logger.info({ facilityId: id }, 'Updating facility');
-  const updated = await updateFacility(id, tenantId, updateData as UpdateFacilityInput);
+  logger.info({ facilityId: id, fields: Object.keys(fields) }, 'Updating facility');
+  const updated = await updateFacility(id, tenantId, fields);
 
   logger.info({ facilityId: id }, 'Facility updated');
   return NextResponse.json(updated);
@@ -210,6 +202,12 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *         description: Facility deleted successfully
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
@@ -155,6 +155,29 @@ describe('POST /api/v1/facilities', () => {
     expect(mockCreateFacilities).not.toHaveBeenCalled();
   });
 
+  // A separate branch from the empty-string case above: a minimum length
+  // counts characters, so a whitespace-only value satisfies it and would
+  // otherwise create a facility whose name renders as blank everywhere.
+  it('returns 400 when name is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: '   ' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('0.name: must not be only whitespace');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is only whitespace and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', description: '  ' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('0.description: must not be only whitespace');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when description is an empty string and does not call the repository', async () => {
     const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', description: '' }] });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
@@ -8,29 +8,17 @@ jest.mock('next/server', () => ({
   },
 }));
 
-// Mock withTenantAuth — skips auth but mirrors handleRouteError behaviour inline
+// Mock withTenantAuth — skips auth but preserves error handling via handleRouteError
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError } = jest.requireActual('@/lib/api/errors');
-  const { ValidationError } = jest.requireActual('@/lib/api/validation');
-
-  function jsonResponse(body: unknown, init?: { status?: number }) {
-    return { status: init?.status ?? 200, json: async () => body };
-  }
-
+  const { handleRouteError } = jest.requireActual('@/lib/api/handle-route-error');
   return {
     withTenantAuth:
       (handler: (...args: unknown[]) => unknown) =>
       async (...args: unknown[]) => {
         try {
           return await handler(...args);
-        } catch (e: unknown) {
-          if (e instanceof ValidationError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 400 });
-          }
-          if (e instanceof NotFoundError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 404 });
-          }
-          return jsonResponse({ error: (e as Error).message }, { status: 500 });
+        } catch (e) {
+          return handleRouteError(e);
         }
       },
   };
@@ -44,8 +32,8 @@ jest.mock('@/lib/prisma/repositories', () => ({
   listFacilities: (tenantId: string, opts: unknown) => mockListFacilities(tenantId, opts),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
-import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
+import { NotFoundError, ConflictError } from '@/lib/api/errors';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -110,40 +98,188 @@ describe('POST /api/v1/facilities', () => {
     expect(mockCreateFacilities).toHaveBeenCalledWith('org-1', input);
   });
 
-  it('returns 400 when body is not an array', async () => {
+  it('passes identifier and organisation fields to createFacilities', async () => {
+    mockCreateFacilities.mockResolvedValue([{ id: 'fac-1' }]);
+
+    const input = [
+      {
+        name: 'Warehouse Alpha',
+        operatingOrganisationId: 'org-42',
+        primaryIdentifierId: 'ident-1',
+        secondaryIdentifierIds: ['ident-2', 'ident-3'],
+      },
+    ];
+    const req = createFakeRequest({ body: input });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateFacilities).toHaveBeenCalledWith('org-1', input);
+  });
+
+  it('returns 400 when body is not an array and does not call the repository', async () => {
     const req = createFakeRequest({ body: { name: 'Not an array' } });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('Request body must be an array');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when body is an empty array', async () => {
+  it('returns 400 when body is an empty array and does not call the repository', async () => {
     const req = createFakeRequest({ body: [] });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(json.error).toContain('Request body must not be empty');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when name is missing from an item', async () => {
+  it('returns 400 when name is missing from an item and does not call the repository', async () => {
     const req = createFakeRequest({ body: [{ description: 'No name here' }] });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required');
+    expect(json.error).toMatch(/^0\.name:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for invalid JSON body', async () => {
+  it('returns 400 when name is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: '' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.name:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when description is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', description: '' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.description:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when operatingOrganisationId is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', operatingOrganisationId: '' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.operatingOrganisationId:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when primaryIdentifierId is not a string and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', primaryIdentifierId: 123 }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.primaryIdentifierId:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when secondaryIdentifierIds is not an array and does not call the repository', async () => {
+    const req = createFakeRequest({
+      body: [{ name: 'Warehouse Alpha', secondaryIdentifierIds: 'ident-1' }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.secondaryIdentifierIds:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when a secondaryIdentifierIds entry is an empty string and does not call the repository', async () => {
+    const req = createFakeRequest({
+      body: [{ name: 'Warehouse Alpha', secondaryIdentifierIds: [''] }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.secondaryIdentifierIds\.0:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when location is not an object and does not call the repository', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', location: 'somewhere' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.location:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when location is explicitly null and does not call the repository', async () => {
+    // location is a Json column: Prisma requires Prisma.JsonNull rather than a plain
+    // null, so a literal null is rejected the same as any other malformed value.
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', location: null }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.location:/);
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['description', { description: null }, /^0\.description:/],
+    ['operatingOrganisationId', { operatingOrganisationId: null }, /^0\.operatingOrganisationId:/],
+    ['primaryIdentifierId', { primaryIdentifierId: null }, /^0\.primaryIdentifierId:/],
+    ['secondaryIdentifierIds', { secondaryIdentifierIds: null }, /^0\.secondaryIdentifierIds:/],
+  ] as const)(
+    'returns 400 when %s is explicitly null and does not call the repository',
+    async (_field, overrides, pattern) => {
+      // None of these fields has clear-on-create semantics (nothing yet exists to
+      // clear): an explicit null is rejected the same as any other malformed value,
+      // never treated as equivalent to omitting the field.
+      const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', ...overrides }] });
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error).toMatch(pattern);
+      expect(mockCreateFacilities).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts an open location object and forwards it to the repository', async () => {
+    mockCreateFacilities.mockResolvedValue([{ id: 'fac-1' }]);
+
+    const location = { address: { addressCountry: 'AU' } };
+    const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', location }] });
+    await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(mockCreateFacilities).toHaveBeenCalledWith('org-1', [{ name: 'Warehouse Alpha', location }]);
+  });
+
+  it('returns 400 for invalid JSON body and does not call the repository', async () => {
     const req = createBadJsonRequest();
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(json.error).toBe('Invalid JSON body');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a literal null body and does not call the repository', async () => {
+    const req = createFakeRequest({ body: null });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('Expected object, received null');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
   });
 
   it('returns 404 when repository throws NotFoundError', async () => {
@@ -155,6 +291,19 @@ describe('POST /api/v1/facilities', () => {
 
     expect(res.status).toBe(404);
     expect(json.error).toContain('Organisation not found');
+  });
+
+  it('returns 409 when repository reports a primary identifier conflict', async () => {
+    mockCreateFacilities.mockRejectedValue(
+      new ConflictError('An identifier in this request is already the primary identifier of another facility'),
+    );
+
+    const req = createFakeRequest({ body: [{ name: 'Facility', primaryIdentifierId: 'ident-1' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toContain('already the primary identifier of another facility');
   });
 
   it('returns 500 on unexpected error', async () => {
@@ -205,6 +354,24 @@ describe('GET /api/v1/facilities', () => {
     });
   });
 
+  it('accepts an empty search filter unchanged', async () => {
+    mockListFacilities.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/facilities?search=',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockListFacilities).toHaveBeenCalledWith('org-1', {
+      search: '',
+      organisationId: undefined,
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
   it('passes pagination parameters', async () => {
     mockListFacilities.mockResolvedValue({ data: [], total: 0 });
 
@@ -236,7 +403,7 @@ describe('GET /api/v1/facilities', () => {
     });
   });
 
-  it('returns 400 for non-numeric limit', async () => {
+  it('returns 400 for non-numeric limit and does not call the repository', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/facilities?limit=abc',
@@ -245,10 +412,11 @@ describe('GET /api/v1/facilities', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('limit must be a positive integer');
+    expect(json.error).toContain('limit: must be a positive integer');
+    expect(mockListFacilities).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for negative offset', async () => {
+  it('returns 400 for negative offset and does not call the repository', async () => {
     const req = createFakeRequest({
       method: 'GET',
       url: 'http://localhost/api/v1/facilities?offset=-1',
@@ -257,7 +425,34 @@ describe('GET /api/v1/facilities', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('offset must be a non-negative integer');
+    expect(json.error).toContain('offset: must be a non-negative integer');
+    expect(mockListFacilities).not.toHaveBeenCalled();
+  });
+
+  it('rejects a limit above the maximum with a 400 and does not query', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: `http://localhost/api/v1/facilities?limit=${MAX_PAGE_LIMIT + 1}`,
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^limit:/);
+    expect(mockListFacilities).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a repeated query key and does not call the repository', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/facilities?limit=10&limit=20',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListFacilities).not.toHaveBeenCalled();
   });
 
   it('returns 500 when listFacilities throws', async () => {

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.test.ts
@@ -209,6 +209,22 @@ describe('POST /api/v1/facilities', () => {
     expect(mockCreateFacilities).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when secondaryIdentifierIds contains a duplicate and does not call the repository', async () => {
+    // Boundary self-consistency (shape-level): without this, the duplicate would
+    // reach facilitySecondaryIdentifier.createMany, hit the composite primary key,
+    // and surface as a misleading 409 "concurrently linked" conflict for a typo.
+    const req = createFakeRequest({
+      body: [{ name: 'Warehouse Alpha', secondaryIdentifierIds: ['ident-1', 'ident-1'] }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0\.secondaryIdentifierIds:/);
+    expect(json.error).toContain('must not contain duplicate identifiers');
+    expect(mockCreateFacilities).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when location is not an object and does not call the repository', async () => {
     const req = createFakeRequest({ body: [{ name: 'Warehouse Alpha', location: 'somewhere' }] });
     const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -53,7 +53,7 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *                   items:
  *                     type: string
  *                     minLength: 1
- *                   description: IDs of secondary identifiers. Omit to skip; null is rejected with a 400
+ *                   description: IDs of secondary identifiers, each unique within the array. Omit to skip; null is rejected with a 400
  *     responses:
  *       201:
  *         description: Facilities created successfully
@@ -64,7 +64,7 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *               items:
  *                 $ref: '#/components/schemas/Facility'
  *       400:
- *         description: Validation error (e.g. a body that is not a non-empty array, a missing or empty name, a non-array secondaryIdentifierIds, an overlapping primary/secondary identifier, a referenced record that no longer exists)
+ *         description: Validation error (e.g. a body that is not a non-empty array, a missing or empty name, a non-array or duplicated secondaryIdentifierIds, an overlapping primary/secondary identifier, a referenced record that no longer exists)
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { parseRequestBody, parseQueryParams } from '@/lib/api/validation';
+import { createFacilitiesRequestSchema, listFacilitiesQuerySchema } from '@/lib/api/request-schemas/facility';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { createFacilities, listFacilities } from '@/lib/prisma/repositories';
-import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/facilities' });
@@ -12,15 +13,17 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  * /facilities:
  *   post:
  *     summary: Create one or more facilities
- *     description: Creates one or more facilities from an array of inputs. Each item must include a name.
+ *     description: Creates one or more facilities from a non-empty array of inputs. Each item must include a name.
  *     tags:
  *       - Facilities
  *     requestBody:
  *       required: true
+ *       description: Unrecognised keys on each item are ignored. Every optional field below must be OMITTED to skip it; sending it as an explicit JSON null is rejected with a 400 for the whole request, including location (which previously accepted null as a silent no-op).
  *       content:
  *         application/json:
  *           schema:
  *             type: array
+ *             minItems: 1
  *             items:
  *               type: object
  *               required:
@@ -28,24 +31,29 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *               properties:
  *                 name:
  *                   type: string
+ *                   minLength: 1
  *                   description: Name of the facility
  *                 description:
  *                   type: string
- *                   description: Optional description
+ *                   minLength: 1
+ *                   description: Optional description. Omit to skip; null is rejected with a 400
  *                 location:
  *                   type: object
- *                   description: Optional UNTP location object
+ *                   description: Optional UNTP location object. Omit to skip; null is rejected with a 400
  *                 operatingOrganisationId:
  *                   type: string
- *                   description: ID of the operating organisation
+ *                   minLength: 1
+ *                   description: ID of the operating organisation. Omit to skip; null is rejected with a 400
  *                 primaryIdentifierId:
  *                   type: string
- *                   description: ID of the primary identifier
+ *                   minLength: 1
+ *                   description: ID of the primary identifier. Omit to skip; null is rejected with a 400
  *                 secondaryIdentifierIds:
  *                   type: array
  *                   items:
  *                     type: string
- *                   description: IDs of secondary identifiers
+ *                     minLength: 1
+ *                   description: IDs of secondary identifiers. Omit to skip; null is rejected with a 400
  *     responses:
  *       201:
  *         description: Facilities created successfully
@@ -56,7 +64,7 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *               items:
  *                 $ref: '#/components/schemas/Facility'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. a body that is not a non-empty array, a missing or empty name, a non-array secondaryIdentifierIds, an overlapping primary/secondary identifier, a referenced record that no longer exists)
  *         content:
  *           application/json:
  *             schema:
@@ -67,8 +75,14 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
- *         description: Referenced entity not found
+ *         description: Referenced organisation or identifier not found
  *         content:
  *           application/json:
  *             schema:
@@ -87,29 +101,8 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: unknown;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info('Validating input parameters');
-  if (!Array.isArray(body)) {
-    throw new ValidationError('Request body must be an array');
-  }
-
-  if (body.length === 0) {
-    throw new ValidationError('Request body must not be empty');
-  }
-
-  for (const item of body) {
-    if (!isNonEmptyString(item.name)) {
-      throw new ValidationError('name is required for each facility');
-    }
-  }
+  logger.info('Validating request body');
+  const body = await parseRequestBody(req, createFacilitiesRequestSchema);
 
   logger.info({ count: body.length }, 'Creating facilities');
   const facilities = await createFacilities(tenantId, body);
@@ -142,7 +135,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Maximum number of facilities to return
+ *         description: Number of facilities to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400.
  *       - in: query
  *         name: offset
  *         schema:
@@ -164,13 +157,19 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *                 pagination:
  *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. a non-integer limit/offset, a negative offset, a limit above the maximum, a repeated query parameter)
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
  *         description: Unauthorised - missing or invalid authentication
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       403:
+ *         description: Forbidden - authenticated principal has no resolvable tenant assignment
  *         content:
  *           application/json:
  *             schema:
@@ -183,13 +182,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing query filters');
-  const url = new URL(req.url);
-  const search = url.searchParams.get('search') ?? undefined;
-  const organisationId = url.searchParams.get('organisationId') ?? undefined;
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  logger.info('Parsing query parameters');
+  const query = parseQueryParams(new URL(req.url), listFacilitiesQuerySchema);
+  const { search, organisationId, limit, offset } = query;
 
   logger.info({ filters: { search, organisationId, limit, offset } }, 'Querying facilities');
   const { data, total } = await listFacilities(tenantId, { search, organisationId, limit, offset });

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -135,7 +135,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Number of facilities to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400.
+ *         description: Number of facilities to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:

--- a/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
-import { idSchema, locationSchema, nonEmptyArraySchema, paginationQuerySchema, requireAtLeastOneField } from './shared';
+import {
+  idSchema,
+  locationSchema,
+  nonBlankString,
+  nonEmptyArraySchema,
+  paginationQuerySchema,
+  requireAtLeastOneField,
+} from './shared';
 
 /**
  * A single item in the POST /facilities bulk-create request body.
@@ -19,8 +26,8 @@ import { idSchema, locationSchema, nonEmptyArraySchema, paginationQuerySchema, r
  * it, never send it as `null`.
  */
 const facilityItemSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().min(1).optional(),
+  name: nonBlankString,
+  description: nonBlankString.optional(),
   location: locationSchema.optional(),
   operatingOrganisationId: idSchema.optional(),
   primaryIdentifierId: idSchema.optional(),
@@ -50,8 +57,8 @@ export const createFacilitiesRequestSchema = nonEmptyArraySchema(facilityItemSch
  */
 export const updateFacilityRequestSchema = requireAtLeastOneField(
   z.object({
-    name: z.string().min(1).optional(),
-    description: z.string().min(1).nullable().optional(),
+    name: nonBlankString.optional(),
+    description: nonBlankString.nullable().optional(),
     location: locationSchema.optional(),
     operatingOrganisationId: idSchema.nullable().optional(),
     primaryIdentifierId: idSchema.nullable().optional(),

--- a/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import { idSchema, locationSchema, nonEmptyArraySchema, paginationQuerySchema, requireAtLeastOneField } from './shared';
+
+/**
+ * A single item in the POST /facilities bulk-create request body.
+ *
+ * `description` is validated as a non-empty string per ADR-037 decision
+ * point 5 (an open-vocabulary/free-text field stays a validated non-empty
+ * string rather than tightened further, with the reason recorded at the
+ * field: free text has no closed, checkable format to tighten to).
+ *
+ * None of this item's optional fields (`description`, `location`,
+ * `operatingOrganisationId`, `primaryIdentifierId`, `secondaryIdentifierIds`)
+ * has clear-to-default semantics on create (there is nothing yet to clear),
+ * so a literal `null` on any of them is REJECTED with a 400, the same as any
+ * other malformed value. This is not equivalent to omitting the field:
+ * omission succeeds (the field is simply unset), while an explicit `null`
+ * fails the whole bulk request. Clients must omit an optional field to skip
+ * it, never send it as `null`.
+ */
+const facilityItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1).optional(),
+  location: locationSchema.optional(),
+  operatingOrganisationId: idSchema.optional(),
+  primaryIdentifierId: idSchema.optional(),
+  secondaryIdentifierIds: z.array(idSchema).optional(),
+});
+
+/** Request body for POST /facilities: a non-empty array of facility items. */
+export const createFacilitiesRequestSchema = nonEmptyArraySchema(facilityItemSchema);
+
+/**
+ * Request body for PATCH /facilities/{id}. `description` is `.nullable()`:
+ * it is a nullable Prisma scalar column (`String?`), and the repository
+ * forwards an explicit `null` straight through as a clear (facility.repository.ts,
+ * `if (description !== undefined) data.description = description;`), unlike
+ * `location` (a Json column, where Prisma requires `Prisma.JsonNull` rather
+ * than a plain `null`, so `location` stays non-nullable here).
+ */
+export const updateFacilityRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: z.string().min(1).optional(),
+    description: z.string().min(1).nullable().optional(),
+    location: locationSchema.optional(),
+    operatingOrganisationId: idSchema.nullable().optional(),
+    primaryIdentifierId: idSchema.nullable().optional(),
+    secondaryIdentifierIds: z.array(idSchema).optional(),
+  }),
+  'At least one updatable field is required: name, description, location, operatingOrganisationId, primaryIdentifierId, secondaryIdentifierIds',
+);
+
+/**
+ * Query parameters for GET /facilities. `search` and `organisationId` are
+ * both left as unconstrained strings (ticket #794's accepted-unchanged AC),
+ * but for different reasons:
+ * - `search` matches with a "contains" filter, so an empty value matches
+ *   every row today; tightening it to non-empty would change that.
+ * - `organisationId` matches with an exact-equality filter, so an empty
+ *   value matches zero rows today (no facility has an empty FK); it is left
+ *   unconstrained per the ticket rather than tightened to idSchema.
+ */
+export const listFacilitiesQuerySchema = z
+  .object({
+    search: z.string().optional(),
+    organisationId: z.string().optional(),
+  })
+  .merge(paginationQuerySchema);

--- a/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/facility.ts
@@ -24,7 +24,17 @@ const facilityItemSchema = z.object({
   location: locationSchema.optional(),
   operatingOrganisationId: idSchema.optional(),
   primaryIdentifierId: idSchema.optional(),
-  secondaryIdentifierIds: z.array(idSchema).optional(),
+  // Rejects an in-array duplicate id as a well-formedness issue (boundary
+  // self-consistency, shape-level, no lookup required). Distinct from the
+  // primary/secondary overlap and cross-request checks, which need existing
+  // data and stay in the repository (ADR-036/037). Without this, a duplicate
+  // in the same request reaches facilitySecondaryIdentifier.createMany (no
+  // skipDuplicates), hits the composite primary key, and surfaces as a
+  // misleading 409 "concurrently linked" conflict for what is a client typo.
+  secondaryIdentifierIds: z
+    .array(idSchema)
+    .refine((val) => new Set(val).size === val.length, { message: 'must not contain duplicate identifiers' })
+    .optional(),
 });
 
 /** Request body for POST /facilities: a non-empty array of facility items. */
@@ -45,7 +55,13 @@ export const updateFacilityRequestSchema = requireAtLeastOneField(
     location: locationSchema.optional(),
     operatingOrganisationId: idSchema.nullable().optional(),
     primaryIdentifierId: idSchema.nullable().optional(),
-    secondaryIdentifierIds: z.array(idSchema).optional(),
+    // See facilityItemSchema's secondaryIdentifierIds comment: boundary
+    // self-consistency only, no lookup; the cross-field/existing-data checks
+    // stay in the repository.
+    secondaryIdentifierIds: z
+      .array(idSchema)
+      .refine((val) => new Set(val).size === val.length, { message: 'must not contain duplicate identifiers' })
+      .optional(),
   }),
   'At least one updatable field is required: name, description, location, operatingOrganisationId, primaryIdentifierId, secondaryIdentifierIds',
 );

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.test.ts
@@ -30,6 +30,7 @@ const mockTx = {
     delete: jest.fn(),
   },
   facilitySecondaryIdentifier: {
+    findMany: jest.fn(),
     deleteMany: jest.fn(),
     createMany: jest.fn(),
   },
@@ -444,6 +445,38 @@ describe('facility.repository', () => {
       );
     });
 
+    it('forwards an explicit description: null straight through to the update data', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.update.mockResolvedValue({ ...FACILITY_RECORD, description: null });
+
+      await updateFacility('facility-1', TENANT_ID, { description: null });
+
+      expect(mockTx.facility.update).toHaveBeenCalledWith(expect.objectContaining({ data: { description: null } }));
+    });
+
+    it('forwards operatingOrganisationId: null and primaryIdentifierId: null as disconnect payloads', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.update.mockResolvedValue({
+        ...FACILITY_RECORD,
+        operatingOrganisationId: null,
+        primaryIdentifierId: null,
+      });
+
+      await updateFacility('facility-1', TENANT_ID, {
+        operatingOrganisationId: null,
+        primaryIdentifierId: null,
+      });
+
+      expect(mockTx.facility.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            operatingOrganisation: { disconnect: true },
+            primaryIdentifier: { disconnect: true },
+          },
+        }),
+      );
+    });
+
     it('replaces secondary identifiers', async () => {
       mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
       mockTx.identifier.findFirst
@@ -532,6 +565,88 @@ describe('facility.repository', () => {
 
       await expect(result).rejects.toThrow(ValidationError);
       await expect(result).rejects.toThrow('Secondary identifiers must not contain duplicates');
+    });
+
+    it('rejects a primary-only update whose new primary matches an existing stored secondary identifier', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_A, tenantId: TENANT_ID });
+      mockTx.facilitySecondaryIdentifier.findMany.mockResolvedValue([{ identifierId: SECONDARY_ID_A }]);
+
+      const result = updateFacility('facility-1', TENANT_ID, { primaryIdentifierId: SECONDARY_ID_A });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('Primary identifier must not also appear in secondary identifiers');
+      expect(mockTx.facilitySecondaryIdentifier.findMany).toHaveBeenCalledWith({
+        where: { facilityId: 'facility-1' },
+        select: { identifierId: true },
+      });
+      expect(mockTx.facility.update).not.toHaveBeenCalled();
+    });
+
+    it('allows a primary-only-looking update when secondaryIdentifierIds in the same request no longer includes the new primary', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_A, tenantId: TENANT_ID });
+      mockTx.facilitySecondaryIdentifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.facilitySecondaryIdentifier.createMany.mockResolvedValue({ count: 1 });
+      mockTx.facility.update.mockResolvedValue(FACILITY_RECORD);
+
+      // SECONDARY_ID_A becomes the new primary, and the incoming secondaryIdentifierIds
+      // (SECONDARY_ID_B only) no longer lists it: the effective post-update state has no
+      // overlap, so this must succeed even though SECONDARY_ID_A is currently stored as
+      // a secondary identifier.
+      await updateFacility('facility-1', TENANT_ID, {
+        primaryIdentifierId: SECONDARY_ID_A,
+        secondaryIdentifierIds: [SECONDARY_ID_B],
+      });
+
+      expect(mockTx.facilitySecondaryIdentifier.findMany).not.toHaveBeenCalled();
+      // The join rows are actually rewritten to the new set (SECONDARY_ID_B only) --
+      // a regression that skipped the rewrite when both fields are supplied would
+      // otherwise leave SECONDARY_ID_A stored, silently reintroducing the overlap
+      // this test's success is supposed to depend on.
+      expect(mockTx.facilitySecondaryIdentifier.deleteMany).toHaveBeenCalledWith({
+        where: { facilityId: 'facility-1' },
+      });
+      expect(mockTx.facilitySecondaryIdentifier.createMany).toHaveBeenCalledWith({
+        data: [{ facilityId: 'facility-1', identifierId: SECONDARY_ID_B }],
+      });
+      expect(mockTx.facility.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ primaryIdentifier: { connect: { id: SECONDARY_ID_A } } }),
+        }),
+      );
+    });
+
+    it('allows a primary-only update whose new primary is not among the stored secondary identifiers', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.identifier.findFirst.mockResolvedValue({ id: SECONDARY_ID_B, tenantId: TENANT_ID });
+      mockTx.facilitySecondaryIdentifier.findMany.mockResolvedValue([{ identifierId: SECONDARY_ID_A }]);
+      mockTx.facility.update.mockResolvedValue(FACILITY_RECORD);
+
+      // Genuine non-overlapping case: SECONDARY_ID_B is neither the current primary nor
+      // a stored secondary, so the stored-secondaries lookup this fix introduced must
+      // still let a legitimately clean primary-only update through.
+      await updateFacility('facility-1', TENANT_ID, { primaryIdentifierId: SECONDARY_ID_B });
+
+      expect(mockTx.facilitySecondaryIdentifier.findMany).toHaveBeenCalledWith({
+        where: { facilityId: 'facility-1' },
+        select: { identifierId: true },
+      });
+      expect(mockTx.facility.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ primaryIdentifier: { connect: { id: SECONDARY_ID_B } } }),
+        }),
+      );
+    });
+
+    it('maps a foreign-key violation on the main update to ValidationError', async () => {
+      mockTx.facility.findFirst.mockResolvedValue(FACILITY_RECORD);
+      mockTx.facility.update.mockRejectedValue(prismaForeignKeyViolationError());
+
+      const result = updateFacility('facility-1', TENANT_ID, { name: 'Renamed Warehouse' });
+
+      await expect(result).rejects.toThrow(ValidationError);
+      await expect(result).rejects.toThrow('The referenced organisation or identifier no longer exists');
     });
 
     it('maps a unique-constraint violation to ConflictError with a clean message', async () => {

--- a/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/facility.repository.ts
@@ -4,7 +4,6 @@ import { NotFoundError } from '@/lib/api/errors';
 import { mapDatabaseError } from '@/lib/prisma/db-errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
-import { UntpLocation } from '@/lib/types';
 
 /**
  * Include shape for facility detail queries — eagerly loads primary and secondary
@@ -47,7 +46,9 @@ export type FacilityListItem = Omit<FacilityListRow, 'secondaryIdentifiers'> & {
 export type CreateFacilityInput = {
   name: string;
   description?: string;
-  location?: UntpLocation;
+  // An open object pending the UNTP-shaped location schema design (#804);
+  // tighten back to UntpLocation once that lands.
+  location?: Record<string, unknown>;
   operatingOrganisationId?: string;
   primaryIdentifierId?: string;
   secondaryIdentifierIds?: string[];
@@ -58,8 +59,12 @@ export type CreateFacilityInput = {
  */
 export type UpdateFacilityInput = {
   name?: string;
-  description?: string;
-  location?: UntpLocation;
+  // A nullable Prisma scalar column; explicit null clears it (see the
+  // `description !== undefined` forwarding below), unlike `location`.
+  description?: string | null;
+  // An open object pending the UNTP-shaped location schema design (#804);
+  // tighten back to UntpLocation once that lands.
+  location?: Record<string, unknown>;
   operatingOrganisationId?: string | null;
   primaryIdentifierId?: string | null;
   secondaryIdentifierIds?: string[];
@@ -292,6 +297,22 @@ export async function updateFacility(
     // Validate primary identifier ownership if provided and not clearing
     if (primaryIdentifierId !== undefined && primaryIdentifierId !== null) {
       await validateIdentifierOwnership(tx, primaryIdentifierId, tenantId, 'Primary identifier');
+
+      // A primary-only update (secondaryIdentifierIds not provided in this request)
+      // must still be checked against the facility's CURRENTLY STORED secondary
+      // identifiers: the overlap check below only runs when secondaryIdentifierIds
+      // is provided, which otherwise let a primary-only update silently persist the
+      // forbidden primary-also-secondary state (no database constraint catches it).
+      if (secondaryIdentifierIds === undefined) {
+        const storedSecondaries = await tx.facilitySecondaryIdentifier.findMany({
+          where: { facilityId: id },
+          select: { identifierId: true },
+        });
+        validateNoPrimarySecondaryOverlap(
+          primaryIdentifierId,
+          storedSecondaries.map((row: { identifierId: string }) => row.identifierId),
+        );
+      }
     }
 
     // Validate secondary identifiers and check for overlap with primary
@@ -353,6 +374,7 @@ export async function updateFacility(
       mapDatabaseError(e, {
         conflict: 'The identifier is already the primary identifier of another facility',
         notFound: 'Facility or a referenced resource not found',
+        invalidReference: 'The referenced organisation or identifier no longer exists',
       });
     }
   });

--- a/packages/reference-implementation/src/lib/swagger/schemas.test.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.test.ts
@@ -159,3 +159,94 @@ describe('generateOpenAPISchemas — Organisation component', () => {
     expect(scheme?.required).toContain('registrar');
   });
 });
+
+/**
+ * Structural coverage for the Facility response component. buildFacilitySchema
+ * (schemas.ts) is deliberately function-local rather than a module-level export
+ * (a top-level Zod chain off '@uncefact/untp-ri-services' imports crashes any
+ * suite that partially mocks that package), so the only way to assert its shape
+ * is against the generated JSON output, which is also the actual published
+ * contract consumers read.
+ *
+ * Scoped to the Facility component only; other domains' components are not this
+ * suite's concern.
+ */
+describe('generateOpenAPISchemas — Facility component', () => {
+  type JsonSchema = {
+    type?: string;
+    properties?: Record<string, JsonSchema>;
+    required?: string[];
+    items?: JsonSchema;
+    nullable?: boolean;
+  };
+
+  const facility = generateOpenAPISchemas().Facility as JsonSchema;
+
+  it('requires every field that every handler returns', () => {
+    expect(facility.required).toEqual(
+      expect.arrayContaining([
+        'id',
+        'tenantId',
+        'name',
+        'description',
+        'location',
+        'operatingOrganisationId',
+        'primaryIdentifierId',
+        'createdAt',
+        'updatedAt',
+      ]),
+    );
+  });
+
+  it('declares but does not require the list-versus-detail asymmetric fields', () => {
+    const asymmetricFields = [
+      'secondaryIdentifierIds',
+      'primaryIdentifier',
+      'secondaryIdentifiers',
+      'operatingOrganisation',
+    ];
+    for (const field of asymmetricFields) {
+      expect(facility.properties).toHaveProperty(field);
+      expect(facility.required).not.toContain(field);
+    }
+  });
+
+  it('marks primaryIdentifier and operatingOrganisation nullable (both are nullable FKs)', () => {
+    expect(facility.properties?.primaryIdentifier?.nullable).toBe(true);
+    expect(facility.properties?.operatingOrganisation?.nullable).toBe(true);
+  });
+
+  it("embeds the primary identifier's scheme without qualifiers, with registrar required", () => {
+    const primaryIdentifier = facility.properties?.primaryIdentifier;
+    expect(primaryIdentifier?.required).toContain('scheme');
+
+    const scheme = primaryIdentifier?.properties?.scheme;
+    expect(scheme?.properties).not.toHaveProperty('qualifiers');
+    expect(scheme?.properties).toHaveProperty('registrar');
+    expect(scheme?.required).toContain('registrar');
+  });
+
+  it('requires facilityId, identifierId, and identifier on each secondary identifier link', () => {
+    const link = facility.properties?.secondaryIdentifiers?.items;
+    expect(link?.required).toEqual(expect.arrayContaining(['facilityId', 'identifierId', 'identifier']));
+  });
+
+  it('embeds the same scheme shape (no qualifiers, required registrar) in secondary identifier links', () => {
+    const linkIdentifier = facility.properties?.secondaryIdentifiers?.items?.properties?.identifier;
+    expect(linkIdentifier?.required).toContain('scheme');
+
+    const linkScheme = linkIdentifier?.properties?.scheme;
+    expect(linkScheme?.properties).not.toHaveProperty('qualifiers');
+    expect(linkScheme?.properties).toHaveProperty('registrar');
+    expect(linkScheme?.required).toContain('registrar');
+  });
+
+  it('embeds the operating organisation as its own columns only, not its identifier relations', () => {
+    const operatingOrganisation = facility.properties?.operatingOrganisation;
+    expect(operatingOrganisation?.properties).not.toHaveProperty('primaryIdentifier');
+    expect(operatingOrganisation?.properties).not.toHaveProperty('secondaryIdentifierIds');
+    expect(operatingOrganisation?.required).toEqual(
+      expect.arrayContaining(['id', 'tenantId', 'name', 'description', 'location', 'primaryIdentifierId']),
+    );
+  });
+});

--- a/packages/reference-implementation/src/lib/swagger/schemas.test.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.test.ts
@@ -241,6 +241,24 @@ describe('generateOpenAPISchemas — Facility component', () => {
     expect(linkScheme?.required).toContain('registrar');
   });
 
+  // The nested registrar must stay the truncated shape. FACILITY_DETAIL_INCLUDE
+  // fetches the registrar's own columns only, so republishing the standalone
+  // Registrar resource's `schemes` array here would promise consumers a list of
+  // that registrar's other schemes which no facility response returns. Both
+  // nesting paths are checked, since they are built from the same projection
+  // but reached through different relations.
+  it.each([
+    ['primaryIdentifier', () => facility.properties?.primaryIdentifier?.properties?.scheme],
+    [
+      'secondaryIdentifiers',
+      () => facility.properties?.secondaryIdentifiers?.items?.properties?.identifier?.properties?.scheme,
+    ],
+  ])('gives the %s scheme a registrar with no schemes array', (_path, getScheme) => {
+    const registrar = getScheme()?.properties?.registrar;
+    expect(registrar?.properties).toBeDefined();
+    expect(registrar?.properties).not.toHaveProperty('schemes');
+  });
+
   it('embeds the operating organisation as its own columns only, not its identifier relations', () => {
     const operatingOrganisation = facility.properties?.operatingOrganisation;
     expect(operatingOrganisation?.properties).not.toHaveProperty('primaryIdentifier');

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -264,18 +264,98 @@ function buildOrganisationSchema() {
   });
 }
 
-export const facilitySchema = z.object({
-  id: z.string(),
-  tenantId: z.string(),
-  name: z.string(),
-  description: z.string().nullable(),
-  location: z.record(z.unknown()).nullable().describe('UNTP location object'),
-  operatingOrganisationId: z.string().nullable(),
-  primaryIdentifierId: z.string().nullable(),
-  secondaryIdentifierIds: z.array(z.string()).describe('IDs of secondary identifiers'),
-  createdAt: z.string().describe('ISO 8601 timestamp'),
-  updatedAt: z.string().describe('ISO 8601 timestamp'),
-});
+/**
+ * Builds the Facility response schema. This must stay lazy (called only from
+ * generateOpenAPISchemas, never derived at module top level): a test suite
+ * that partially mocks '@uncefact/untp-ri-services' (e.g. mocking only one
+ * export) leaves this module's other imports from that package undefined at
+ * module-evaluation time, and a top-level `.omit()`/`.extend()` chained off
+ * an undefined import throws before any test in that suite runs.
+ */
+function buildFacilitySchema() {
+  /**
+   * Identifier scheme as embedded in a facility's identifier relations.
+   * FACILITY_DETAIL_INCLUDE's `scheme` include fetches `registrar` but not
+   * `qualifiers`, unlike the identifier scheme endpoints; `qualifiers` is
+   * therefore omitted (never returned via this path) and `registrar` is
+   * required (always returned via this path), narrowing identifierSchemeSchema
+   * to match.
+   */
+  const facilityIdentifierSchemeSchema = identifierSchemeSchema.omit({ qualifiers: true }).extend({
+    registrar: registrarSchema,
+  });
+
+  /**
+   * Identifier as embedded in a facility's `primaryIdentifier` and secondary
+   * identifier relations, which eagerly load the owning scheme and its
+   * registrar (needed to construct ISO 18975 resolver URIs); mirrors
+   * FACILITY_DETAIL_INCLUDE in facility.repository.ts.
+   */
+  const facilityIdentifierWithSchemeSchema = identifierSchema.extend({
+    scheme: facilityIdentifierSchemeSchema,
+  });
+
+  /**
+   * A facility's secondary-identifier join record, as returned by the detail
+   * endpoints (GET /facilities/{id}, POST, PATCH); mirrors
+   * FACILITY_DETAIL_INCLUDE's `secondaryIdentifiers` include.
+   */
+  const facilitySecondaryIdentifierLinkSchema = z.object({
+    facilityId: z.string(),
+    identifierId: z.string(),
+    identifier: facilityIdentifierWithSchemeSchema,
+  });
+
+  /**
+   * A facility's operating organisation as embedded via `operatingOrganisation:
+   * true` in FACILITY_DETAIL_INCLUDE: the organisation's own columns only, not
+   * its identifier relations.
+   */
+  const facilityOperatingOrganisationSchema = z.object({
+    id: z.string(),
+    tenantId: z.string(),
+    name: z.string(),
+    description: z.string().nullable(),
+    location: z.record(z.unknown()).nullable().describe('UNTP location object'),
+    primaryIdentifierId: z.string().nullable(),
+    createdAt: z.string().describe('ISO 8601 timestamp'),
+    updatedAt: z.string().describe('ISO 8601 timestamp'),
+  });
+
+  // Facility record as returned by the REST API. GET /facilities/{id}, POST,
+  // and PATCH all include `primaryIdentifier`, `secondaryIdentifiers`, and
+  // `operatingOrganisation` (FACILITY_DETAIL_INCLUDE); GET /facilities (list)
+  // includes none of those but flattens secondary identifiers to
+  // `secondaryIdentifierIds` instead (FACILITY_LIST_INCLUDE). Both groups are
+  // marked optional here to match that list-versus-detail asymmetry.
+  return z.object({
+    id: z.string(),
+    tenantId: z.string(),
+    name: z.string(),
+    description: z.string().nullable(),
+    location: z.record(z.unknown()).nullable().describe('UNTP location object'),
+    operatingOrganisationId: z.string().nullable(),
+    primaryIdentifierId: z.string().nullable(),
+    createdAt: z.string().describe('ISO 8601 timestamp'),
+    updatedAt: z.string().describe('ISO 8601 timestamp'),
+    secondaryIdentifierIds: z
+      .array(z.string())
+      .optional()
+      .describe('IDs of secondary identifiers (list responses only)'),
+    primaryIdentifier: facilityIdentifierWithSchemeSchema
+      .nullable()
+      .optional()
+      .describe('Primary identifier with its scheme and registrar (detail responses only)'),
+    secondaryIdentifiers: z
+      .array(facilitySecondaryIdentifierLinkSchema)
+      .optional()
+      .describe('Secondary identifier links, each with its identifier, scheme, and registrar (detail responses only)'),
+    operatingOrganisation: facilityOperatingOrganisationSchema
+      .nullable()
+      .optional()
+      .describe('Operating organisation (detail responses only)'),
+  });
+}
 
 // ============================================================================
 // Re-export imported schemas so existing consumers continue to work
@@ -332,7 +412,7 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     RenderTemplate: renderTemplateSchema,
     Product: productSchema,
     Organisation: buildOrganisationSchema(),
-    Facility: facilitySchema,
+    Facility: buildFacilitySchema(),
   };
 
   const openAPISchemas: Record<string, OpenAPISchema> = {};

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -280,10 +280,18 @@ function buildFacilitySchema() {
    * therefore omitted (never returned via this path) and `registrar` is
    * required (always returned via this path), narrowing identifierSchemeSchema
    * to match.
+   *
+   * `registrar` is made required in place rather than reassigned to
+   * `registrarSchema`. The nested registrar is deliberately the truncated
+   * shape, without the `schemes` array the standalone Registrar resource
+   * carries, because this include fetches the registrar's own columns only.
+   * Substituting the top-level schema would republish that array here and
+   * promise consumers a list of the registrar's other schemes that no
+   * facility response ever returns.
    */
-  const facilityIdentifierSchemeSchema = identifierSchemeSchema.omit({ qualifiers: true }).extend({
-    registrar: registrarSchema,
-  });
+  const facilityIdentifierSchemeSchema = identifierSchemeSchema
+    .omit({ qualifiers: true })
+    .required({ registrar: true });
 
   /**
    * Identifier as embedded in a facility's `primaryIdentifier` and secondary


### PR DESCRIPTION
This PR migrates the facilities endpoints' request validation to per-resource Zod schemas at the route boundary and brings the routes' Swagger and docs into congruence with their real behaviour, so malformed input returns a 400 naming the offending field and the published contract matches what the routes do.

Validation: POST /facilities validates its bulk array body (non-empty array, per-item field checks with item-indexed error paths), PATCH /facilities/{id} requires at least one recognised field with null-to-clear preserved on description, operatingOrganisationId, and primaryIdentifierId (nullable columns whose null the repository already forwarded) and rejected elsewhere, and GET /facilities validates pagination while keeping the search and organisationId filters accepted unchanged. The location object stays an open record per the deferred UNTP location design, with an explicit null rejected at the boundary; the docs now state that optional create fields are omitted rather than sent as null.

Data integrity: the repository's primary/secondary identifier exclusivity check now validates the effective state whenever either field changes, closing a hole where a primary-only update could persist an identifier as both primary and secondary; a foreign-key race between the ownership check and the update write now maps to the documented actionable 400 instead of a sanitised 500. Both are pinned by repository regression tests, including proof the fix does not block a same-request primary/secondary swap.

Contract congruence: the Facility response component was rebuilt to document what the routes actually return (nested primaryIdentifier, secondaryIdentifiers, and operatingOrganisation on detail reads, flattened ids on list, embedded schemes carrying exactly the included relations), built lazily so partially-mocked test suites cannot crash at module load, and pinned by structural tests on the generated OpenAPI output. The shared 401/403 responses are documented on every route, and DELETE's docs note both product and credential references are cleared.

Tests: 270 across six suites, including the exclusivity regressions, explicit-null rejection tables, unknown-key stripping conveyance, and repository payload assertions for the null-to-clear and disconnect semantics.

Closes #794
