### PR TITLE
feat(playground): show multiple credentials per type as instance groups

### DIFF
--- a/packages/untp-playground/__tests__/app/page.test.tsx
+++ b/packages/untp-playground/__tests__/app/page.test.tsx
@@ -18,6 +18,7 @@ import { ArtefactKind, permittedCredentialTypes } from '../../constants';
 jest.mock('sonner', () => ({
   toast: {
     error: jest.fn(),
+    success: jest.fn(),
   },
 }));
 
@@ -343,6 +344,124 @@ describe('Tabbed artefact surface (#809)', () => {
     fireEvent.click(uploader);
 
     expect(await screen.findByRole('tab', { name: /Conformity Schemes\s*1/ })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('Replaced'));
+    });
+    expect(toast.error).not.toHaveBeenCalledWith('Failed to process artefact');
+  });
+
+  it('loads two distinct credentials as separate instances instead of overwriting (#810)', async () => {
+    // detectArtefact is left unset here (undefined => not a scheme), but earlier tests in this
+    // block set it to the SCHEME kind and jest.clearAllMocks() does not reset a mockReturnValue,
+    // so it is reset explicitly to route this upload to the credential branch.
+    (detectArtefact as jest.Mock).mockReturnValue(undefined);
+    (isEnvelopedProof as jest.Mock).mockReturnValue(false);
+    (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+    (detectExtension as jest.Mock).mockReturnValue(undefined);
+    (detectVersion as jest.Mock).mockReturnValue('0.6.0');
+    (validateCredentialSchema as jest.Mock).mockReturnValue({ valid: true });
+
+    // Identity is the content hash, so each upload must carry distinct content to be a new instance.
+    let marker = 0;
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() =>
+            onArtefactUpload({
+              verifiableCredential: { type: ['VerifiableCredential', 'DigitalProductPassport'], marker: marker++ },
+            })
+          }
+        >
+          Upload
+        </button>
+      ),
+    );
+    render(<Home />);
+
+    const uploader = screen.getByTestId('mock-uploader');
+    fireEvent.click(uploader);
+    fireEvent.click(uploader);
+
+    // The Credentials tab count reflects the number of loaded instances, matching the Conformity
+    // Schemes tab (#845).
+    expect(await screen.findByRole('tab', { name: /Credentials\s*2/ })).toBeInTheDocument();
+  });
+
+  it('replaces in place when the same credential content is uploaded twice (#810)', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue(undefined);
+    (isEnvelopedProof as jest.Mock).mockReturnValue(false);
+    (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+    (detectExtension as jest.Mock).mockReturnValue(undefined);
+    (detectVersion as jest.Mock).mockReturnValue('0.6.0');
+    (validateCredentialSchema as jest.Mock).mockReturnValue({ valid: true });
+
+    // Identical content each click -> same content hash -> the second upload replaces the first.
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() =>
+            onArtefactUpload({
+              verifiableCredential: { type: ['VerifiableCredential', 'DigitalProductPassport'] },
+            })
+          }
+        >
+          Upload
+        </button>
+      ),
+    );
+    render(<Home />);
+
+    const uploader = screen.getByTestId('mock-uploader');
+    fireEvent.click(uploader);
+    fireEvent.click(uploader);
+
+    expect(await screen.findByRole('tab', { name: /Credentials\s*1/ })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('Replaced'));
+    });
+    expect(toast.error).not.toHaveBeenCalledWith('Failed to process artefact');
+  });
+
+  it('collapses two differently-enveloped credentials into one instance when their decoded content is identical (#810)', async () => {
+    // Identity keys on `credentialContentHash(stored.decoded)`, the decoded document, never the
+    // enveloping JWT (ADR-041). The mocked decoder always resolves to the same document below, so
+    // two uploads with distinct envelopes must still collapse to one instance.
+    const decodedCredential = { type: ['VerifiableCredential', 'DigitalProductPassport'], id: 'shared-content' };
+
+    (detectArtefact as jest.Mock).mockReturnValue(undefined);
+    (isEnvelopedProof as jest.Mock).mockReturnValue(true);
+    (decodeEnvelopedCredential as jest.Mock).mockReturnValue(decodedCredential);
+    (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+    (detectExtension as jest.Mock).mockReturnValue(undefined);
+    (detectVersion as jest.Mock).mockReturnValue('0.6.0');
+    (validateCredentialSchema as jest.Mock).mockReturnValue({ valid: true });
+
+    // Two distinct envelope shapes, so the pre-decode raw artefact differs on each upload; only the
+    // decoded document (mocked to be identical every time) should determine identity.
+    let envelopeMarker = 0;
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() => onArtefactUpload({ verifiableCredential: { envelope: `jwt-${envelopeMarker++}` } })}
+        >
+          Upload
+        </button>
+      ),
+    );
+    render(<Home />);
+
+    const uploader = screen.getByTestId('mock-uploader');
+    fireEvent.click(uploader);
+    fireEvent.click(uploader);
+
+    // One instance, and the second upload was a replace rather than an append.
+    expect(await screen.findByRole('tab', { name: /Credentials\s*1/ })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('Replaced'));
+    });
   });
 
   it('shows the credentials empty state when no credential is loaded', () => {

--- a/packages/untp-playground/__tests__/components/TestResults.test.tsx
+++ b/packages/untp-playground/__tests__/components/TestResults.test.tsx
@@ -263,6 +263,30 @@ describe('Credential verification throw regression (#810)', () => {
       description: 'Could not reach the verification service. Please try again.',
     });
   });
+
+  it('fails the context step, settles every other step, and allows removal when validateContext throws', async () => {
+    (validateContext as jest.Mock).mockRejectedValue(new Error('jsonld expansion failed'));
+    const { toast } = require('sonner');
+
+    render(
+      <Harness credentials={[makeStored({ id: 'context-throw' }, { kind: 'file', filename: 'dpp-context.json' })]} />,
+    );
+    await expandInstance();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context-status-icon-failure')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId(/status-icon-(pending|in-progress)/)).toHaveLength(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Remove dpp-context.json' })).toBeInTheDocument();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Validation of the JSON-LD context failed. Please try again.');
+  });
 });
 
 describe('Credential replace-in-place through the collection (#810)', () => {

--- a/packages/untp-playground/__tests__/components/TestResults.test.tsx
+++ b/packages/untp-playground/__tests__/components/TestResults.test.tsx
@@ -1,19 +1,24 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect, useRef } from 'react';
 import { TestResults, confettiConfig } from '@/components/TestResults';
+import { useArtefactCollection } from '@/hooks/useArtefactCollection';
+import { upsert } from '@/lib/artefactCollection';
+import { credentialContentHash } from '@/lib/credentialCollection';
+import { newId } from '@/lib/id';
 import { validateContext } from '@/lib/contextValidation';
 import { detectExtension, validateCredentialSchema, validateExtension } from '@/lib/schemaValidation';
 import { detectVcdmVersion } from '@/lib/utils';
 import { validateVcdmRules } from '@/lib/vcdm-validation';
 import { verifyCredential } from '@/lib/verificationService';
-import { Credential } from '@/types/credential';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { StoredCredential, TestStep } from '@/types';
 import confetti from 'canvas-confetti';
-import { CredentialType, TestCaseStatus, TestCaseStepId, VCDMVersion, VCDM_CONTEXT_URLS } from '../../constants';
+import { VCDM_CONTEXT_URLS, VCDMVersion } from '../../constants';
 
 jest.mock('@/lib/verificationService');
 jest.mock('@/lib/schemaValidation');
 jest.mock('@/lib/vcdm-validation');
 jest.mock('@/lib/utils');
-jest.mock('@/lib/credentialService');
 jest.mock('@/lib/contextValidation');
 jest.mock('canvas-confetti');
 jest.mock('jsonld', () => ({
@@ -26,271 +31,458 @@ jest.mock('sonner', () => ({
   },
 }));
 
-// Mock sample credentials
-const mockBasicCredential = {
-  DigitalProductPassport: {
-    original: {
-      proof: { type: 'Ed25519Signature2020' },
-    },
+// Real detectCredentialType/detectVersion/isEnvelopedProof from '@/lib/credentialService' are left
+// unmocked, so grouping by detected type (#810) exercises the real detection over realistic fixtures.
+
+const untpContext = (version: string) => `https://vocabulary.uncefact.org/untp/dpp/${version}/context.jsonld`;
+
+function makeStored(
+  overrides: { id?: string; type?: string[]; version?: string; issuer?: any } = {},
+  source?: StoredCredential['source'],
+): StoredCredential {
+  const version = overrides.version ?? '0.6.0';
+  return {
+    original: { proof: { type: 'Ed25519Signature2020' } },
     decoded: {
-      '@context': [VCDM_CONTEXT_URLS.v2, 'https://vocabulary.uncefact.org/2.0.0/context.jsonld'],
-      type: ['VerifiableCredential', 'DigitalProductPassport'],
-    } as Credential,
-  },
-};
+      '@context': [VCDM_CONTEXT_URLS.v2, untpContext(version)],
+      type: overrides.type ?? ['VerifiableCredential', 'DigitalProductPassport'],
+      issuer: overrides.issuer ?? { id: 'did:web:acme.example' },
+      ...(overrides.id !== undefined && { id: overrides.id }),
+    },
+    source,
+  };
+}
 
-const mockSetTestResults = jest.fn();
-const mockTestResults = {};
+// Harness: drives the real collection hook so the pipeline runs and the cards re-render on commit.
+function Harness({ credentials }: { credentials: StoredCredential[] }) {
+  const collection = useArtefactCollection<StoredCredential, TestStep[]>();
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current) return;
+    seeded.current = true;
+    for (const c of credentials) {
+      collection.dispatch((state) =>
+        upsert(state, { payload: c, contentHash: credentialContentHash(c.decoded), mintInstanceId: newId }),
+      );
+    }
+  }, [credentials, collection]);
+  return <TestResults collection={collection.state} dispatch={collection.dispatch} />;
+}
 
-describe('TestResults Component', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.resetAllMocks();
-    // Setup default mock implementations
-    (verifyCredential as jest.Mock).mockResolvedValue({ verified: true });
-    (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: true });
-    (validateExtension as jest.Mock).mockResolvedValue({ valid: true });
-    (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: true });
-    (validateContext as jest.Mock).mockResolvedValue({ valid: true, data: {} });
-    (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.V1);
+const expandInstance = () => userEvent.click(screen.getByTestId('credential-instance-header'));
+
+// The group rollup icon is shown only while the group is collapsed (expanded groups show each
+// instance's own status), so a test that asserts the rollup collapses the group first.
+const collapseGroup = async (type = 'DigitalProductPassport') =>
+  userEvent.click(await screen.findByTestId(`${type}-group-header`));
+
+// Harness for a replace-in-place sequence: seeds one credential on mount, then upserts a second
+// credential (identical or distinct content, chosen by the caller) on a button click, exactly the
+// way page.tsx's handleArtefactUpload dispatches each upload through the same collection.
+function ReplaceHarness({ first, second }: { first: StoredCredential; second: StoredCredential }) {
+  const collection = useArtefactCollection<StoredCredential, TestStep[]>();
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current) return;
+    seeded.current = true;
+    collection.dispatch((state) =>
+      upsert(state, { payload: first, contentHash: credentialContentHash(first.decoded), mintInstanceId: newId }),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const uploadSecond = () => {
+    collection.dispatch((state) =>
+      upsert(state, { payload: second, contentHash: credentialContentHash(second.decoded), mintInstanceId: newId }),
+    );
+  };
+
+  return (
+    <>
+      <button onClick={uploadSecond}>Upload second</button>
+      <TestResults collection={collection.state} dispatch={collection.dispatch} />
+    </>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (verifyCredential as jest.Mock).mockResolvedValue({ verified: true });
+  (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: true });
+  (validateExtension as jest.Mock).mockResolvedValue({ valid: true });
+  (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: true });
+  (validateContext as jest.Mock).mockResolvedValue({ valid: true, data: {} });
+  (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.V2);
+  (detectExtension as jest.Mock).mockReturnValue(undefined);
+});
+
+describe('TestResults grouping (#810, #845)', () => {
+  it('renders a group only for a credential type that has an uploaded instance', async () => {
+    render(<Harness credentials={[makeStored({ id: 'a' })]} />);
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'Digital Product Passport' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 3, name: 'Digital Conformity Credential' })).not.toBeInTheDocument();
   });
 
-  it('renders empty state correctly', () => {
-    render(<TestResults credentials={{}} testResults={mockTestResults} setTestResults={mockSetTestResults} />);
-    expect(screen.getByText('DigitalProductPassport')).toBeInTheDocument();
-    expect(screen.getByText('DigitalConformityCredential')).toBeInTheDocument();
-    expect(screen.getByText('DigitalFacilityRecord')).toBeInTheDocument();
-    expect(screen.getByText('DigitalIdentityAnchor')).toBeInTheDocument();
-    expect(screen.getByText('DigitalTraceabilityEvent')).toBeInTheDocument();
-  });
-
-  it('renders credential section with correct type, version and VCDM version', async () => {
-    (detectExtension as jest.Mock).mockReturnValue({
-      core: { type: 'DigitalProductPassport', version: '2.0.0' },
-      extension: { type: 'DigitalProductPassport', version: '2.0.0' },
-    });
-    (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.V1);
-
+  it('groups multiple instances of the same type under one header with an instance count', async () => {
     render(
-      <TestResults
-        credentials={mockBasicCredential}
-        testResults={mockTestResults}
-        setTestResults={mockSetTestResults}
+      <Harness
+        credentials={[
+          makeStored({ id: 'a' }, { kind: 'file', filename: 'dpp-a.json' }),
+          makeStored({ id: 'b' }, { kind: 'file', filename: 'dpp-b.json' }),
+        ]}
       />,
     );
 
-    // Check for the credential type heading and version
-    const credentialSection = screen.getByRole('heading', {
-      level: 3,
-      name: /DigitalProductPassport.*v2\.0\.0/,
-    });
-    expect(credentialSection).toBeInTheDocument();
-
-    // Check for VCDM version badge
-    expect(screen.getByText('VCDM v1')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 3, name: 'Digital Product Passports' })).toBeInTheDocument();
+    expect(screen.getByTestId('DigitalProductPassport-group-header')).toHaveTextContent('2');
+    expect(await screen.findByText('dpp-a.json')).toBeInTheDocument();
+    expect(await screen.findByText('dpp-b.json')).toBeInTheDocument();
   });
 
-  it('shows unsupported VCDM version badge when version is unknown', async () => {
+  it('rolls the group status up to the worst instance: any failing instance fails the whole group', async () => {
+    (validateCredentialSchema as jest.Mock).mockImplementation(async (decoded: any) => ({
+      valid: decoded.id !== 'fail',
+    }));
+
+    render(
+      <Harness
+        credentials={[
+          makeStored({ id: 'pass' }, { kind: 'file', filename: 'dpp-pass.json' }),
+          makeStored({ id: 'fail' }, { kind: 'file', filename: 'dpp-fail.json' }),
+        ]}
+      />,
+    );
+
+    await screen.findByText('dpp-pass.json');
+    await collapseGroup();
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-status-icon-failure')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a success rollup once every instance in the group has passed', async () => {
+    render(
+      <Harness
+        credentials={[
+          makeStored({ id: 'a' }, { kind: 'file', filename: 'dpp-a.json' }),
+          makeStored({ id: 'b' }, { kind: 'file', filename: 'dpp-b.json' }),
+        ]}
+      />,
+    );
+
+    await collapseGroup();
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-status-icon-success')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('TestResults removal (#810)', () => {
+  it('removes an instance only after the confirmation dialog is confirmed, and the group disappears once its last instance is removed', async () => {
+    render(<Harness credentials={[makeStored({ id: 'only' }, { kind: 'file', filename: 'dpp-only.json' })]} />);
+
+    await screen.findByText('dpp-only.json');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Remove dpp-only.json' })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove dpp-only.json' }));
+    expect(await screen.findByText('Remove dpp-only.json?')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { level: 3, name: 'Digital Product Passport' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the instance when the removal is cancelled', async () => {
+    render(<Harness credentials={[makeStored({ id: 'keep' }, { kind: 'file', filename: 'dpp-keep.json' })]} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Remove dpp-keep.json' })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove dpp-keep.json' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText('dpp-keep.json')).toBeInTheDocument();
+  });
+
+  it('does not offer a remove control while an instance is mid-pipeline', async () => {
+    let resolveVerify: (value: { verified: boolean }) => void = () => {};
+    (verifyCredential as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveVerify = resolve;
+        }),
+    );
+
+    render(<Harness credentials={[makeStored({ id: 'pending' }, { kind: 'file', filename: 'dpp-pending.json' })]} />);
+
+    await screen.findByText('dpp-pending.json');
+    expect(screen.queryByRole('button', { name: 'Remove dpp-pending.json' })).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveVerify({ verified: true });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Remove dpp-pending.json' })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Credential verification throw regression (#810)', () => {
+  it('fails the verification step, settles every other step, and allows removal when verifyCredential throws', async () => {
+    (verifyCredential as jest.Mock).mockRejectedValue(new Error('Service unavailable'));
+    const { toast } = require('sonner');
+
+    render(
+      <Harness credentials={[makeStored({ id: 'verify-throw' }, { kind: 'file', filename: 'dpp-throw.json' })]} />,
+    );
+    await expandInstance();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('verification-status-icon-failure')).toBeInTheDocument();
+    });
+
+    // No step is left pending or in progress: a thrown verification error settles the whole
+    // pipeline rather than leaving the instance stuck mid-run.
+    await waitFor(() => {
+      expect(screen.queryAllByTestId(/status-icon-(pending|in-progress)/)).toHaveLength(0);
+    });
+
+    // A settled pipeline (success or failure on every step) makes the instance removable.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Remove dpp-throw.json' })).toBeInTheDocument();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('Credential verification failed', {
+      description: 'Could not reach the verification service. Please try again.',
+    });
+  });
+});
+
+describe('Credential replace-in-place through the collection (#810)', () => {
+  it('replaces the same content in place and reruns its pipeline for the replacement', async () => {
+    const first = makeStored({ id: 'replace-me' }, { kind: 'file', filename: 'dpp-replace.json' });
+    // Same decoded content as `first` (same id, type, issuer, context), so its content hash matches
+    // and the upsert replaces the existing instance rather than appending a second one.
+    const second = makeStored({ id: 'replace-me' }, { kind: 'file', filename: 'dpp-replace.json' });
+
+    render(<ReplaceHarness first={first} second={second} />);
+
+    await screen.findByText('dpp-replace.json');
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-group-header')).toHaveTextContent('1');
+    });
+    await waitFor(() => {
+      expect(validateVcdmRules).toHaveBeenCalledTimes(1);
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Upload second' }));
+
+    // Still exactly one instance row for the group: the upload replaced rather than appended.
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-group-header')).toHaveTextContent('1');
+    });
+    expect(screen.getAllByTestId('credential-instance-header')).toHaveLength(1);
+
+    // The pipeline reran for the replacement: the validators were invoked a second time and the
+    // row reaches a settled status again rather than keeping the pre-replacement result.
+    await waitFor(() => {
+      expect(validateVcdmRules).toHaveBeenCalledTimes(2);
+    });
+    await collapseGroup();
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-status-icon-success')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Credential validation pipeline (preserved verbatim from pre-#810)', () => {
+  it('shows unsupported VCDM version as a failed step', async () => {
     (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.UNKNOWN);
 
-    render(
-      <TestResults
-        credentials={mockBasicCredential}
-        testResults={mockTestResults}
-        setTestResults={mockSetTestResults}
-      />,
-    );
-    expect(screen.getByText('Unsupported VCDM version')).toBeInTheDocument();
-  });
+    render(<Harness credentials={[makeStored({ id: 'unknown-vcdm' })]} />);
+    await expandInstance();
 
-  describe('VCDM Validation', () => {
-    it('shows success for valid VCDM schema validation', async () => {
-      (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: true });
-      (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.V1);
-
-      const mockTestSteps = {
-        [CredentialType.DIGITAL_PRODUCT_PASSPORT]: [
-          {
-            id: TestCaseStepId.VCDM_SCHEMA_VALIDATION,
-            status: TestCaseStatus.SUCCESS,
-            name: 'VCDM Schema Validation',
-            details: 'Valid VCDM schema',
-          },
-        ],
-      };
-
-      await act(async () => {
-        render(
-          <TestResults
-            credentials={mockBasicCredential}
-            testResults={mockTestSteps}
-            setTestResults={mockSetTestResults}
-          />,
-        );
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId('DigitalProductPassport-status-icon-success')).toBeInTheDocument();
-      });
-
-      await act(async () => {
-        const groupHeader = screen.getByTestId('DigitalProductPassport-group-header');
-        expect(groupHeader).toBeInTheDocument();
-        fireEvent.click(groupHeader!);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText(/vcdm schema validation/i)).toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(validateVcdmRules).toHaveBeenCalledWith(mockBasicCredential.DigitalProductPassport.decoded);
-      });
-    });
-
-    it('shows failure for invalid VCDM schema validation', async () => {
-      const mockTestSteps = {
-        [CredentialType.DIGITAL_PRODUCT_PASSPORT]: [
-          {
-            id: TestCaseStepId.VCDM_SCHEMA_VALIDATION,
-            name: 'VCDM Schema Validation',
-            status: TestCaseStatus.FAILURE,
-            details: 'Invalid VCDM schema',
-          },
-        ],
-      };
-
-      render(
-        <TestResults
-          credentials={mockBasicCredential}
-          testResults={mockTestSteps}
-          setTestResults={mockSetTestResults}
-        />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('DigitalProductPassport-status-icon-failure')).toBeInTheDocument();
-      });
-    });
-
-    it('handles VCDM schema fetch errors', async () => {
-      const mockToast = jest.spyOn(require('sonner').toast, 'error');
-      (validateVcdmRules as jest.Mock).mockRejectedValue(new Error('Failed to fetch schema'));
-
-      await act(async () => {
-        render(
-          <TestResults
-            credentials={mockBasicCredential}
-            testResults={mockTestResults}
-            setTestResults={mockSetTestResults}
-          />,
-        );
-      });
-
-      await waitFor(() => {
-        expect(mockToast).toHaveBeenCalledWith('Failed to fetch the VCDM schema. Please contact support.');
-      });
+    await waitFor(() => {
+      expect(screen.getByTestId('vcdm-version-status-icon-failure')).toBeInTheDocument();
     });
   });
 
-  describe('Confetti Behavior', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
+  it('shows success for valid VCDM schema validation', async () => {
+    render(<Harness credentials={[makeStored({ id: 'vcdm-ok' })]} />);
+    await expandInstance();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('vcdm-schema-validation-status-icon-success')).toBeInTheDocument();
+    });
+    expect(validateVcdmRules).toHaveBeenCalledWith(expect.objectContaining({ id: 'vcdm-ok' }));
+  });
+
+  it('shows failure for invalid VCDM schema validation', async () => {
+    (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: false, errors: [{ message: 'bad vcdm' }] });
+
+    render(<Harness credentials={[makeStored({ id: 'vcdm-bad' })]} />);
+    await expandInstance();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('vcdm-schema-validation-status-icon-failure')).toBeInTheDocument();
+    });
+  });
+
+  it('handles VCDM schema fetch errors', async () => {
+    (validateVcdmRules as jest.Mock).mockRejectedValue(new Error('network down'));
+    const { toast } = require('sonner');
+
+    render(<Harness credentials={[makeStored({ id: 'vcdm-fetch-error' })]} />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to fetch the VCDM schema. Please contact support.');
+    });
+    await expandInstance();
+    await waitFor(() => {
+      expect(screen.getByTestId('vcdm-schema-validation-status-icon-failure')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the UNTP schema fetch error with the exact preserved copy and params', async () => {
+    (validateCredentialSchema as jest.Mock).mockRejectedValue(new Error('fetch failed'));
+    const { toast } = require('sonner');
+
+    render(<Harness credentials={[makeStored({ id: 'untp-fetch-error' })]} />);
+    await expandInstance();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to fetch schema. Please try again.');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('untp-schema-validation-status-icon-failure')).toBeInTheDocument();
     });
 
-    it('shows confetti when all validations pass', async () => {
-      (verifyCredential as jest.Mock).mockResolvedValue({ verified: true });
-      (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: true });
-      (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: true });
-      (detectExtension as jest.Mock).mockReturnValue(undefined);
-      (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.V1);
+    await userEvent.click(screen.getByRole('button', { name: 'View Details' }));
+    await userEvent.click(await screen.findByText('Fix validation error'));
+    expect(
+      await screen.findByText("Ensure the credential includes the required UNTP context IRIs in the '@context' field."),
+    ).toBeInTheDocument();
+  });
 
-      render(
-        <TestResults
-          credentials={mockBasicCredential}
-          testResults={mockTestResults}
-          setTestResults={mockSetTestResults}
-        />,
+  it('validates against context and reports failure with the preserved toast copy', async () => {
+    (validateContext as jest.Mock).mockResolvedValue({
+      valid: false,
+      error: { keyword: 'unknown', message: 'bad context', instancePath: '' },
+    });
+    const { toast } = require('sonner');
+
+    render(<Harness credentials={[makeStored({ id: 'context-fail' })]} />);
+    await expandInstance();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Validation of the JSON-LD context failed. Please check the View Details for more information.',
       );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('context-status-icon-failure')).toBeInTheDocument();
+    });
+  });
 
-      await waitFor(() => {
-        expect(confetti).toHaveBeenCalledTimes(1);
-        expect(confetti).toHaveBeenCalledWith(expect.objectContaining(confettiConfig));
+  it('shows a verification failure toast with the underlying error description', async () => {
+    (verifyCredential as jest.Mock).mockResolvedValue({ verified: false, error: 'signature mismatch' });
+    const { toast } = require('sonner');
+
+    render(<Harness credentials={[makeStored({ id: 'verify-fail' })]} />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Credential verification failed', {
+        description: 'signature mismatch',
       });
     });
+  });
 
-    it('does not show confetti when VCDM validation fails', async () => {
-      (verifyCredential as jest.Mock).mockResolvedValue({ verified: true });
-      (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: true });
-      (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: false });
-      (detectVcdmVersion as jest.Mock).mockReturnValue(VCDMVersion.V1);
-
-      await act(async () => {
-        render(
-          <TestResults
-            credentials={mockBasicCredential}
-            testResults={mockTestResults}
-            setTestResults={mockSetTestResults}
-          />,
-        );
-      });
-
-      expect(confetti).not.toHaveBeenCalled();
+  it('runs the extension schema validation step only when an extension is detected', async () => {
+    (detectExtension as jest.Mock).mockReturnValue({
+      core: { type: 'DigitalProductPassport', version: '0.5.0' },
+      extension: { type: 'DigitalLivestockPassport', version: '0.4.0' },
     });
 
-    it('does not show confetti when schema validation fails', async () => {
-      (verifyCredential as jest.Mock).mockResolvedValue({ verified: true });
-      (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: false });
-      (detectExtension as jest.Mock).mockReturnValue(undefined);
+    render(<Harness credentials={[makeStored({ id: 'extension' })]} />);
+    await expandInstance();
 
-      await act(async () => {
-        render(
-          <TestResults
-            credentials={mockBasicCredential}
-            testResults={mockTestResults}
-            setTestResults={mockSetTestResults}
-          />,
-        );
-      });
-
-      expect(confetti).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId('extension-schema-validation-status-icon-success')).toBeInTheDocument();
     });
+  });
 
-    it('does not show confetti when extension validation fails', async () => {
-      (verifyCredential as jest.Mock).mockResolvedValue({ verified: true });
-      (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: true });
-      (detectExtension as jest.Mock).mockReturnValue('someExtension');
-      (validateExtension as jest.Mock).mockResolvedValue({ valid: false });
-
-      await act(async () => {
-        render(
-          <TestResults
-            credentials={mockBasicCredential}
-            testResults={mockTestResults}
-            setTestResults={mockSetTestResults}
-          />,
-        );
-      });
-
-      expect(confetti).not.toHaveBeenCalled();
+  it('handles extension schema fetch errors with the preserved copy and params', async () => {
+    (detectExtension as jest.Mock).mockReturnValue({
+      core: { type: 'DigitalProductPassport', version: '0.5.0' },
+      extension: { type: 'DigitalLivestockPassport', version: '0.4.0' },
     });
+    (validateExtension as jest.Mock).mockRejectedValue(new Error('fetch failed'));
+    const { toast } = require('sonner');
 
-    it('does not show confetti when verification fails', async () => {
-      (verifyCredential as jest.Mock).mockResolvedValue({ verified: false });
-      (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: true });
-      (detectExtension as jest.Mock).mockReturnValue(undefined);
+    render(<Harness credentials={[makeStored({ id: 'extension-fetch-error' })]} />);
+    await expandInstance();
 
-      await act(async () => {
-        render(
-          <TestResults
-            credentials={mockBasicCredential}
-            testResults={mockTestResults}
-            setTestResults={mockSetTestResults}
-          />,
-        );
-      });
-
-      expect(confetti).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to fetch extension schema. Please try again.');
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('extension-schema-validation-status-icon-failure')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Confetti behaviour, gated per (instanceId, runId)', () => {
+  it('shows confetti when all validations pass', async () => {
+    render(<Harness credentials={[makeStored({ id: 'confetti-pass' })]} />);
+
+    await waitFor(() => {
+      expect(confetti).toHaveBeenCalledTimes(1);
+      expect(confetti).toHaveBeenCalledWith(expect.objectContaining(confettiConfig));
+    });
+  });
+
+  it('does not show confetti when VCDM validation fails', async () => {
+    (validateVcdmRules as jest.Mock).mockResolvedValue({ valid: false });
+
+    render(<Harness credentials={[makeStored({ id: 'confetti-vcdm-fail' })]} />);
+
+    // Collapse the group so its rollup icon (a known testid) reflects the single instance's settled
+    // worst status; the rollup shows only while collapsed.
+    await collapseGroup();
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-status-icon-failure')).toBeInTheDocument();
+    });
+    expect(confetti).not.toHaveBeenCalled();
+  });
+
+  it('does not show confetti when schema validation fails', async () => {
+    (validateCredentialSchema as jest.Mock).mockResolvedValue({ valid: false });
+
+    render(<Harness credentials={[makeStored({ id: 'confetti-schema-fail' })]} />);
+
+    await collapseGroup();
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-status-icon-failure')).toBeInTheDocument();
+    });
+    expect(confetti).not.toHaveBeenCalled();
+  });
+
+  it('does not show confetti when verification fails', async () => {
+    (verifyCredential as jest.Mock).mockResolvedValue({ verified: false });
+
+    render(<Harness credentials={[makeStored({ id: 'confetti-verify-fail' })]} />);
+
+    await collapseGroup();
+    await waitFor(() => {
+      expect(screen.getByTestId('DigitalProductPassport-status-icon-failure')).toBeInTheDocument();
+    });
+    expect(confetti).not.toHaveBeenCalled();
   });
 });

--- a/packages/untp-playground/__tests__/contexts/TestReportContext.test.tsx
+++ b/packages/untp-playground/__tests__/contexts/TestReportContext.test.tsx
@@ -1,30 +1,30 @@
 import { TestReportProvider, useTestReport } from '@/contexts/TestReportContext';
 import { generateReport } from '@/lib/reportService';
 import { downloadJson, downloadHtml } from '@/lib/utils';
-import { Credential, DownloadReportFormat, StoredCredential, TestReport, TestStep } from '@/types';
+import { CredentialReportInput, DownloadReportFormat, TestReport } from '@/types';
 import { act, renderHook } from '@testing-library/react';
 import { toast } from 'sonner';
-import { CredentialType, TestCaseStatus, TestCaseStepId, VCDM_CONTEXT_URLS } from '../../constants';
+import { TestCaseStatus, TestCaseStepId, VCDM_CONTEXT_URLS } from '../../constants';
 
 jest.mock('@/lib/reportService');
 jest.mock('@/lib/utils');
 jest.mock('sonner');
 
-const mockCredentials: Partial<Record<CredentialType, StoredCredential>> = {
-  DigitalProductPassport: {
-    original: {},
-    decoded: {
-      '@context': [VCDM_CONTEXT_URLS.v2],
-      type: ['VerifiableCredential'],
-    } as Credential,
-  },
+const credentialDoc = {
+  '@context': [VCDM_CONTEXT_URLS.v2],
+  type: ['VerifiableCredential', 'DigitalProductPassport'],
 };
 
-const mockTestResults: Partial<Record<CredentialType, TestStep[]>> = {
-  DigitalProductPassport: [
+const terminalCredentialInstance: CredentialReportInput = {
+  credential: { original: credentialDoc, decoded: credentialDoc },
+  steps: [
     { id: TestCaseStepId.PROOF_TYPE, status: TestCaseStatus.SUCCESS, name: 'Test 1' },
     { id: TestCaseStepId.VERIFICATION, status: TestCaseStatus.SUCCESS, name: 'Test 2' },
   ],
+};
+const pendingCredentialInstance: CredentialReportInput = {
+  credential: { original: credentialDoc, decoded: credentialDoc },
+  steps: [{ id: TestCaseStepId.PROOF_TYPE, status: TestCaseStatus.PENDING, name: 'Test 1' }],
 };
 
 const schemeDoc = {
@@ -45,7 +45,7 @@ const pendingSchemeInstance = {
 const mockReport: TestReport = {
   implementation: { name: 'Test Implementation' },
   reportName: 'UNTP',
-  results: [],
+  verifiableCredentials: [],
   date: new Date().toISOString(),
   testSuite: {
     runner: 'UNTP Playground',
@@ -68,9 +68,7 @@ describe('TestReportContext', () => {
   });
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <TestReportProvider testResults={mockTestResults} credentials={mockCredentials}>
-      {children}
-    </TestReportProvider>
+    <TestReportProvider credentialInstances={[terminalCredentialInstance]}>{children}</TestReportProvider>
   );
 
   it('provides initial context values', () => {
@@ -82,21 +80,15 @@ describe('TestReportContext', () => {
     expect(typeof result.current.downloadReport).toBe('function');
   });
 
-  it('allows report generation when all test results are valid', () => {
+  it('allows report generation when every credential instance is terminal', () => {
     const { result } = renderHook(() => useTestReport(), { wrapper });
     expect(result.current.canGenerateReport).toBeTruthy();
   });
 
-  it('prevents report generation when tests are pending', () => {
-    const pendingResults: Partial<Record<CredentialType, TestStep[]>> = {
-      DigitalProductPassport: [{ id: TestCaseStepId.PROOF_TYPE, status: TestCaseStatus.PENDING, name: 'Test 1' }],
-    };
-
+  it('prevents report generation when a credential instance is still pending', () => {
     const { result } = renderHook(() => useTestReport(), {
       wrapper: ({ children }) => (
-        <TestReportProvider testResults={pendingResults} credentials={mockCredentials}>
-          {children}
-        </TestReportProvider>
+        <TestReportProvider credentialInstances={[pendingCredentialInstance]}>{children}</TestReportProvider>
       ),
     });
 
@@ -106,9 +98,7 @@ describe('TestReportContext', () => {
   it('does not allow generation while a scheme instance is still validating', () => {
     const { result } = renderHook(() => useTestReport(), {
       wrapper: ({ children }) => (
-        <TestReportProvider testResults={{}} credentials={{}} schemeInstances={[pendingSchemeInstance]}>
-          {children}
-        </TestReportProvider>
+        <TestReportProvider schemeInstances={[pendingSchemeInstance]}>{children}</TestReportProvider>
       ),
     });
     expect(result.current.canGenerateReport).toBeFalsy();
@@ -117,9 +107,7 @@ describe('TestReportContext', () => {
   it('allows generation when every loaded scheme instance is terminal', () => {
     const { result } = renderHook(() => useTestReport(), {
       wrapper: ({ children }) => (
-        <TestReportProvider testResults={{}} credentials={{}} schemeInstances={[terminalSchemeInstance]}>
-          {children}
-        </TestReportProvider>
+        <TestReportProvider schemeInstances={[terminalSchemeInstance]}>{children}</TestReportProvider>
       ),
     });
     expect(result.current.canGenerateReport).toBeTruthy();
@@ -129,8 +117,7 @@ describe('TestReportContext', () => {
     const { result } = renderHook(() => useTestReport(), {
       wrapper: ({ children }) => (
         <TestReportProvider
-          testResults={mockTestResults}
-          credentials={mockCredentials}
+          credentialInstances={[terminalCredentialInstance]}
           schemeInstances={[pendingSchemeInstance]}
         >
           {children}
@@ -140,14 +127,17 @@ describe('TestReportContext', () => {
     expect(result.current.canGenerateReport).toBeFalsy();
   });
 
+  it('prevents report generation when there are no loaded credentials or schemes', () => {
+    const { result } = renderHook(() => useTestReport(), {
+      wrapper: ({ children }) => <TestReportProvider>{children}</TestReportProvider>,
+    });
+    expect(result.current.canGenerateReport).toBeFalsy();
+  });
+
   it('invalidates a generated report when the last artefact is removed', async () => {
     let schemes = [terminalSchemeInstance];
     const { result, rerender } = renderHook(() => useTestReport(), {
-      wrapper: ({ children }) => (
-        <TestReportProvider testResults={{}} credentials={{}} schemeInstances={schemes}>
-          {children}
-        </TestReportProvider>
-      ),
+      wrapper: ({ children }) => <TestReportProvider schemeInstances={schemes}>{children}</TestReportProvider>,
     });
 
     await act(async () => {
@@ -173,8 +163,7 @@ describe('TestReportContext', () => {
 
     expect(generateReport).toHaveBeenCalledWith({
       implementationName: 'Test Implementation',
-      credentials: mockCredentials,
-      testResults: mockTestResults,
+      credentialInstances: [terminalCredentialInstance],
       schemeInstances: [],
       passStatuses: [TestCaseStatus.SUCCESS, TestCaseStatus.WARNING],
     });
@@ -268,38 +257,43 @@ describe('TestReportContext', () => {
     expect(downloadJson).not.toHaveBeenCalled();
   });
 
-  it('resets report when credentials change', async () => {
-    const { result, unmount } = renderHook(() => useTestReport(), { wrapper });
+  it('resets report when the loaded credential instances change', async () => {
+    // Rerenders the SAME provider instance with a changed `credentialInstances` prop (mirroring
+    // the scheme-removal test above), so this exercises the reset effect's dependency array
+    // directly: mounting a fresh provider with different instances would pass regardless of
+    // whether `credentialInstances` is actually a dependency of the effect.
+    let credentials = [terminalCredentialInstance];
+    const { result, rerender } = renderHook(() => useTestReport(), {
+      wrapper: ({ children }) => <TestReportProvider credentialInstances={credentials}>{children}</TestReportProvider>,
+    });
 
     await act(async () => {
       await result.current.generateReport('Test Implementation');
     });
-
     expect(result.current.report).toEqual(mockReport);
 
-    // Unmount to cleanup
-    unmount();
-
-    const newCredentials: Partial<Record<CredentialType, StoredCredential>> = {
-      DigitalProductPassport: {
-        original: { new: true },
-        decoded: {
-          '@context': [VCDM_CONTEXT_URLS.v2],
-          type: ['VerifiableCredential'],
-        } as Credential,
-      },
+    const newCredentialInstance: CredentialReportInput = {
+      credential: { original: { ...credentialDoc, new: true }, decoded: { ...credentialDoc, new: true } },
+      steps: terminalCredentialInstance.steps,
     };
+    credentials = [newCredentialInstance];
+    rerender();
 
-    // Render with new credentials
-    const { result: newResult } = renderHook(() => useTestReport(), {
+    expect(result.current.report).toBeNull();
+  });
+
+  it('prevents report generation for a credential instance with no steps at all', () => {
+    const emptyStepsInstance: CredentialReportInput = {
+      credential: { original: credentialDoc, decoded: credentialDoc },
+      steps: [],
+    };
+    const { result } = renderHook(() => useTestReport(), {
       wrapper: ({ children }) => (
-        <TestReportProvider testResults={mockTestResults} credentials={newCredentials}>
-          {children}
-        </TestReportProvider>
+        <TestReportProvider credentialInstances={[emptyStepsInstance]}>{children}</TestReportProvider>
       ),
     });
 
-    expect(newResult.current.report).toBeNull();
+    expect(result.current.canGenerateReport).toBeFalsy();
   });
 
   it('shows error toast when unsupported report format is selected', async () => {

--- a/packages/untp-playground/__tests__/lib/credentialCollection.test.ts
+++ b/packages/untp-playground/__tests__/lib/credentialCollection.test.ts
@@ -1,0 +1,198 @@
+import {
+  credentialContentHash,
+  credentialGroupLabel,
+  credentialGroupType,
+  credentialIsTerminal,
+  credentialSubtitle,
+  credentialTitle,
+  credentialTypeLabel,
+  instanceStatus,
+  worstStatus,
+} from '@/lib/credentialCollection';
+import type { Credential, StoredCredential, TestStep } from '@/types';
+import { TestCaseStatus, TestCaseStepId, VCDM_CONTEXT_URLS } from '../../constants';
+
+const step = (status: TestCaseStatus): TestStep => ({
+  id: TestCaseStepId.VCDM_VERSION,
+  name: 'x',
+  status,
+});
+
+const credential = (decoded: Credential, source?: StoredCredential['source']): StoredCredential => ({
+  original: decoded,
+  decoded,
+  source,
+});
+
+const dppDoc = (extra: Record<string, unknown> = {}) => ({
+  '@context': [VCDM_CONTEXT_URLS.v2, 'https://vocabulary.uncefact.org/untp/dpp/0.6.0/context.jsonld'],
+  type: ['VerifiableCredential', 'DigitalProductPassport'],
+  ...extra,
+});
+
+describe('credentialContentHash', () => {
+  it('is stable for identical content', () => {
+    const doc = dppDoc({ id: 'x' });
+    expect(credentialContentHash(doc)).toBe(credentialContentHash({ ...doc }));
+  });
+
+  it('is invariant to key order, so a re-serialised document is still one instance', () => {
+    expect(credentialContentHash({ id: 'x', type: ['a'], meta: { a: 1, b: 2 } })).toBe(
+      credentialContentHash({ meta: { b: 2, a: 1 }, type: ['a'], id: 'x' }),
+    );
+  });
+
+  it('differs for different content', () => {
+    expect(credentialContentHash(dppDoc({ id: 'a' }))).not.toBe(credentialContentHash(dppDoc({ id: 'b' })));
+  });
+});
+
+describe('credentialIsTerminal', () => {
+  it('is false for an empty step list', () => {
+    expect(credentialIsTerminal([])).toBe(false);
+  });
+
+  it('is false while any step is pending or in progress', () => {
+    expect(credentialIsTerminal([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.IN_PROGRESS)])).toBe(false);
+    expect(credentialIsTerminal([step(TestCaseStatus.PENDING)])).toBe(false);
+  });
+
+  it('is true when every step has settled to success or failure', () => {
+    expect(credentialIsTerminal([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.SUCCESS)])).toBe(true);
+    expect(credentialIsTerminal([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.FAILURE)])).toBe(true);
+    expect(credentialIsTerminal([step(TestCaseStatus.FAILURE)])).toBe(true);
+  });
+
+  it('is true when a step has settled to warning, matching the report-readiness gate (TERMINAL_STATUSES)', () => {
+    expect(credentialIsTerminal([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.WARNING)])).toBe(true);
+  });
+});
+
+describe('credentialGroupType', () => {
+  it('detects the core UNTP type for a plain credential', () => {
+    expect(credentialGroupType(dppDoc())).toBe('DigitalProductPassport');
+  });
+
+  it('resolves to the extension core type when the document is a known extension', () => {
+    // DigitalLivestockPassport v0.4.0 resolves to a DigitalProductPassport v0.5.0 core (schemaValidation.ts).
+    const doc = {
+      '@context': [VCDM_CONTEXT_URLS.v2, 'https://aatp.foodagility.com/0.4.0/context.jsonld'],
+      type: ['VerifiableCredential', 'DigitalLivestockPassport'],
+    };
+    expect(credentialGroupType(doc)).toBe('DigitalProductPassport');
+  });
+
+  it('returns Unknown for a document with no recognised UNTP type', () => {
+    expect(credentialGroupType({ '@context': [VCDM_CONTEXT_URLS.v2], type: ['VerifiableCredential'] })).toBe('Unknown');
+  });
+});
+
+describe('credentialTypeLabel', () => {
+  it('splits a PascalCase type into spaced words', () => {
+    expect(credentialTypeLabel('DigitalProductPassport')).toBe('Digital Product Passport');
+    expect(credentialTypeLabel('DigitalConformityCredential')).toBe('Digital Conformity Credential');
+  });
+});
+
+describe('credentialGroupLabel', () => {
+  it('uses the singular label for a single instance', () => {
+    expect(credentialGroupLabel('DigitalProductPassport', 1)).toBe('Digital Product Passport');
+  });
+
+  it('pluralises the label for more than one instance', () => {
+    expect(credentialGroupLabel('DigitalProductPassport', 2)).toBe('Digital Product Passports');
+    expect(credentialGroupLabel('DigitalConformityCredential', 3)).toBe('Digital Conformity Credentials');
+  });
+});
+
+describe('credentialTitle', () => {
+  it('uses the final path segment of a url source, never the raw url', () => {
+    const title = credentialTitle(credential(dppDoc(), { kind: 'url', url: 'https://c.example/credentials/dpp.json' }));
+    expect(title).toBe('dpp.json');
+    expect(title).not.toContain('https://');
+  });
+
+  it('uses the filename for a file source', () => {
+    expect(credentialTitle(credential(dppDoc(), { kind: 'file', filename: 'my-dpp.json' }))).toBe('my-dpp.json');
+  });
+
+  it('falls back to the spaced detected type when there is no source', () => {
+    expect(credentialTitle(credential(dppDoc()))).toBe('Digital Product Passport');
+  });
+});
+
+describe('credentialSubtitle', () => {
+  it('shows the detected version and issuer for a file-sourced instance', () => {
+    const doc = dppDoc({ issuer: { id: 'did:web:acme.example' } });
+    expect(credentialSubtitle(credential(doc, { kind: 'file', filename: 'dpp.json' }))).toBe(
+      'v0.6.0 · did:web:acme.example',
+    );
+  });
+
+  it('supports a plain string issuer', () => {
+    const doc = dppDoc({ issuer: 'did:web:acme.example' });
+    expect(credentialSubtitle(credential(doc))).toBe('v0.6.0 · did:web:acme.example');
+  });
+
+  it('puts the source host first for a url-sourced instance', () => {
+    const doc = dppDoc({ issuer: { id: 'did:web:volt.example' } });
+    const subtitle = credentialSubtitle(
+      credential(doc, { kind: 'url', url: 'https://credentials.example.org/dpp-battery.json' }),
+    );
+    expect(subtitle).toBe('credentials.example.org · v0.6.0 · did:web:volt.example');
+  });
+
+  it('shows "unknown version" when no UNTP version is detected, and omits a missing issuer', () => {
+    const doc = { '@context': [VCDM_CONTEXT_URLS.v2], type: ['VerifiableCredential', 'DigitalProductPassport'] };
+    expect(credentialSubtitle(credential(doc))).toBe('unknown version');
+  });
+
+  it('names the detected extension (type and version) rather than only the core version', () => {
+    // DigitalLivestockPassport v0.4.0 groups under DigitalProductPassport, but the row names the
+    // extension so the user can see which extension was validated (schemaValidation.ts).
+    const doc = {
+      '@context': [VCDM_CONTEXT_URLS.v2, 'https://aatp.foodagility.com/0.4.0/context.jsonld'],
+      type: ['VerifiableCredential', 'DigitalLivestockPassport'],
+      issuer: { id: 'did:web:farm.example' },
+    };
+    expect(credentialSubtitle(credential(doc, { kind: 'file', filename: 'dlp.json' }))).toBe(
+      'DigitalLivestockPassport v0.4.0 · did:web:farm.example',
+    );
+  });
+});
+
+describe('worstStatus', () => {
+  it('is pending for an empty list', () => {
+    expect(worstStatus([])).toBe(TestCaseStatus.PENDING);
+  });
+
+  it('is success when every status is success', () => {
+    expect(worstStatus([TestCaseStatus.SUCCESS, TestCaseStatus.SUCCESS])).toBe(TestCaseStatus.SUCCESS);
+  });
+
+  it('is in progress when any status is pending or in progress and none has failed', () => {
+    expect(worstStatus([TestCaseStatus.SUCCESS, TestCaseStatus.IN_PROGRESS])).toBe(TestCaseStatus.IN_PROGRESS);
+    expect(worstStatus([TestCaseStatus.SUCCESS, TestCaseStatus.PENDING])).toBe(TestCaseStatus.IN_PROGRESS);
+  });
+
+  it('is failure when any status has failed, regardless of other statuses', () => {
+    expect(worstStatus([TestCaseStatus.SUCCESS, TestCaseStatus.IN_PROGRESS, TestCaseStatus.FAILURE])).toBe(
+      TestCaseStatus.FAILURE,
+    );
+  });
+});
+
+describe('instanceStatus', () => {
+  it('is pending before a run has produced any steps', () => {
+    expect(instanceStatus(undefined)).toBe(TestCaseStatus.PENDING);
+    expect(instanceStatus([])).toBe(TestCaseStatus.PENDING);
+  });
+
+  it('reduces a step list to the worst status', () => {
+    expect(instanceStatus([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.FAILURE)])).toBe(TestCaseStatus.FAILURE);
+    expect(instanceStatus([step(TestCaseStatus.SUCCESS), step(TestCaseStatus.IN_PROGRESS)])).toBe(
+      TestCaseStatus.IN_PROGRESS,
+    );
+    expect(instanceStatus([step(TestCaseStatus.SUCCESS)])).toBe(TestCaseStatus.SUCCESS);
+  });
+});

--- a/packages/untp-playground/__tests__/lib/reportService.test.ts
+++ b/packages/untp-playground/__tests__/lib/reportService.test.ts
@@ -1,9 +1,9 @@
-import { detectVersion } from '@/lib/credentialService';
+import { detectCredentialType, detectVersion } from '@/lib/credentialService';
 import { detectExtension } from '@/lib/schemaValidation';
-import { StoredCredential, TestStep } from '@/types';
+import { CredentialReportInput } from '@/types';
 import { reportName } from '../../config';
 import { generateReport } from '@/lib/reportService';
-import { CredentialType, TestCaseStatus, TestCaseStepId } from '../../constants';
+import { TestCaseStatus } from '../../constants';
 
 jest.mock('@/lib/credentialService');
 jest.mock('@/lib/schemaValidation');
@@ -14,65 +14,51 @@ jest.mock('../../config', () => ({
 
 describe('generateReport', () => {
   const mockImplementationName = 'Test Implementation';
-  const mockCredentials = {
-    DigitalProductPassport: {
-      original: {
-        '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
-        type: 'EnvelopedVerifiableCredential',
-        id: 'data:application/vc+jwt,eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIkRpZ2l0YWxQcm9kdWN0UGFzc3BvcnQiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibXlTdWJqZWN0UHJvcGVydHkiOiJteVN1YmplY3RWYWx1ZSJ9fQ',
-      },
-      decoded: {
-        '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
-        type: ['VerifiableCredential', 'DigitalProductPassport'],
-        credentialSubject: {
-          mySubjectProperty: 'mySubjectValue',
-        },
-      },
+
+  const envelopedCredential = {
+    '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
+    type: 'EnvelopedVerifiableCredential',
+    id: 'data:application/vc+jwt,eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIkRpZ2l0YWxQcm9kdWN0UGFzc3BvcnQiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibXlTdWJqZWN0UHJvcGVydHkiOiJteVN1YmplY3RWYWx1ZSJ9fQ',
+  };
+  const decodedCredential = {
+    '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
+    type: ['VerifiableCredential', 'DigitalProductPassport'],
+    credentialSubject: {
+      mySubjectProperty: 'mySubjectValue',
     },
   };
-  const mockTestResults: any = {
-    DigitalProductPassport: [
+  const mockCredentialInstance: CredentialReportInput = {
+    credential: { original: envelopedCredential, decoded: decodedCredential },
+    steps: [
       {
-        id: 'proof-type',
+        id: 'proof-type' as any,
         name: 'Proof Type Detection',
-        status: 'success',
-        details: {
-          type: 'enveloping',
-        },
+        status: TestCaseStatus.SUCCESS,
+        details: { type: 'enveloping' },
       },
       {
-        id: 'vcdm-version',
+        id: 'vcdm-version' as any,
         name: 'VCDM Version Detection',
-        status: 'success',
-        details: {
-          version: 'v2',
-        },
+        status: TestCaseStatus.SUCCESS,
+        details: { version: 'v2' },
       },
       {
-        id: 'vcdm-schema-validation',
+        id: 'vcdm-schema-validation' as any,
         name: 'VCDM Schema Validation',
-        status: 'success',
-        details: {
-          valid: true,
-          errors: [],
-        },
+        status: TestCaseStatus.SUCCESS,
+        details: { valid: true, errors: [] },
       },
       {
-        id: 'verification',
+        id: 'verification' as any,
         name: 'Credential Verification',
-        status: 'success',
-        details: {
-          verified: true,
-        },
+        status: TestCaseStatus.SUCCESS,
+        details: { verified: true },
       },
       {
-        id: 'untp-schema-validation',
+        id: 'untp-schema-validation' as any,
         name: 'UNTP Schema Validation',
-        status: 'success',
-        details: {
-          valid: true,
-          errors: [],
-        },
+        status: TestCaseStatus.SUCCESS,
+        details: { valid: true, errors: [] },
       },
     ],
   };
@@ -80,21 +66,20 @@ describe('generateReport', () => {
 
   beforeEach(() => {
     (detectVersion as jest.Mock).mockReturnValue('1.0.0');
-    (detectExtension as jest.Mock).mockReturnValue({
-      core: { version: '1.0.0' },
-      extension: { type: 'extensionType', version: '1.0.0' },
-    });
+    (detectExtension as jest.Mock).mockReturnValue(undefined);
+    // credentialGroupType (used by generateReport to derive the report's core.type) falls back to
+    // detectCredentialType when there is no extension; credentialService is wholesale-mocked here.
+    (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should generate a report with valid credentials and test results', async () => {
+  it('should generate a report with valid credential instances', async () => {
     const report = await generateReport({
       implementationName: mockImplementationName,
-      credentials: mockCredentials,
-      testResults: mockTestResults,
+      credentialInstances: [mockCredentialInstance],
       passStatuses: mockPassStatuses,
     });
 
@@ -114,70 +99,22 @@ describe('generateReport', () => {
         {
           status: 'success',
           overallStatus: 'success',
-          credential: {
-            '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
-            type: 'EnvelopedVerifiableCredential',
-            id: 'data:application/vc+jwt,eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIkRpZ2l0YWxQcm9kdWN0UGFzc3BvcnQiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibXlTdWJqZWN0UHJvcGVydHkiOiJteVN1YmplY3RWYWx1ZSJ9fQ',
-          },
+          credential: envelopedCredential,
           core: {
             type: 'DigitalProductPassport',
             version: '1.0.0',
-            steps: [
-              {
-                id: 'proof-type',
-                name: 'Proof Type Detection',
-                status: 'success',
-                details: {
-                  type: 'enveloping',
-                },
-              },
-              {
-                id: 'vcdm-version',
-                name: 'VCDM Version Detection',
-                status: 'success',
-                details: {
-                  version: 'v2',
-                },
-              },
-              {
-                id: 'vcdm-schema-validation',
-                name: 'VCDM Schema Validation',
-                status: 'success',
-                details: {
-                  valid: true,
-                  errors: [],
-                },
-              },
-              {
-                id: 'verification',
-                name: 'Credential Verification',
-                status: 'success',
-                details: {
-                  verified: true,
-                },
-              },
-              {
-                id: 'untp-schema-validation',
-                name: 'UNTP Schema Validation',
-                status: 'success',
-                details: {
-                  valid: true,
-                  errors: [],
-                },
-              },
-            ],
+            steps: mockCredentialInstance.steps,
           },
         },
       ],
     });
   });
 
-  it('should throw an error if no valid credentials are provided', async () => {
+  it('should throw an error if no valid credential or scheme instances are provided', async () => {
     await expect(
       generateReport({
         implementationName: mockImplementationName,
-        credentials: {},
-        testResults: {},
+        credentialInstances: [],
         passStatuses: mockPassStatuses,
       }),
     ).rejects.toThrow('No valid credentials or schemes to generate report');
@@ -185,36 +122,32 @@ describe('generateReport', () => {
 
   it('should generate a report with the extension', async () => {
     (detectExtension as jest.Mock).mockReturnValue({
-      core: { version: '1.0.0' },
+      core: { type: 'DigitalProductPassport', version: '1.0.0' },
       extension: { type: 'extensionType', version: '1.0.0' },
     });
 
     const mockConfig = require('../../config');
     mockConfig.reportName = 'AATP';
 
-    const testResults: any = {
-      DigitalProductPassport: [
+    const instance: CredentialReportInput = {
+      credential: { original: envelopedCredential, decoded: decodedCredential },
+      steps: [
         {
-          id: 'extension-schema-validation',
+          id: 'extension-schema-validation' as any,
           name: 'Extension Schema Validation',
-          status: 'success',
-          details: {
-            valid: true,
-            errors: [],
-          },
+          status: TestCaseStatus.SUCCESS,
+          details: { valid: true, errors: [] },
         },
         {
-          id: 'context',
+          id: 'context' as any,
           name: 'JSON-LD Document Expansion and Context Validation',
-          status: 'failure',
+          status: TestCaseStatus.FAILURE,
           details: {
             errors: [
               {
                 keyword: 'const',
-                message:
-                  'Properties "credentialSubject/productImage/linkURL, credentialSubject/productImage/linkName, credentialSubject/producedByParty, credentialSubject/dimensions/weight, credentialSubject/dimensions/length, credentialSubject/dimensions/width, credentialSubject/dimensions/height, credentialSubject/dimensions/volume, credentialSubject/characteristic, credentialSubject/dueDiligenceDeclaration/linkURL, credentialSubject/dueDiligenceDeclaration/linkName, credentialSubject/circularityScorecard/recyclableContent, credentialSubject/circularityScorecard/recycledContent, credentialSubject/circularityScorecard/utilityFactor, credentialSubject/circularityScorecard/materialCircularityIndicator, credentialSubject/circularityScorecard/recyclingInformation, credentialSubject/circularityScorecard/repairInformation, credentialSubject/emissionsScorecard/carbonFootprint, credentialSubject/emissionsScorecard/declaredUnit, credentialSubject/emissionsScorecard/operationalScope, credentialSubject/emissionsScorecard/primarySourcedRatio, credentialSubject/emissionsScorecard/reportingStandard, render" are defined in the credential but missing from the context.',
-                instancePath:
-                  'credentialSubject/productImage/linkURL, credentialSubject/productImage/linkName, credentialSubject/producedByParty, credentialSubject/dimensions/weight, credentialSubject/dimensions/length, credentialSubject/dimensions/width, credentialSubject/dimensions/height, credentialSubject/dimensions/volume, credentialSubject/characteristic, credentialSubject/dueDiligenceDeclaration/linkURL, credentialSubject/dueDiligenceDeclaration/linkName, credentialSubject/circularityScorecard/recyclableContent, credentialSubject/circularityScorecard/recycledContent, credentialSubject/circularityScorecard/utilityFactor, credentialSubject/circularityScorecard/materialCircularityIndicator, credentialSubject/circularityScorecard/recyclingInformation, credentialSubject/circularityScorecard/repairInformation, credentialSubject/emissionsScorecard/carbonFootprint, credentialSubject/emissionsScorecard/declaredUnit, credentialSubject/emissionsScorecard/operationalScope, credentialSubject/emissionsScorecard/primarySourcedRatio, credentialSubject/emissionsScorecard/reportingStandard, render',
+                message: 'Properties are defined in the credential but missing from the context.',
+                instancePath: 'credentialSubject',
               },
             ],
           },
@@ -224,12 +157,16 @@ describe('generateReport', () => {
 
     const report = await generateReport({
       implementationName: mockImplementationName,
-      credentials: mockCredentials,
-      testResults: testResults,
+      credentialInstances: [instance],
       passStatuses: mockPassStatuses,
     });
 
     expect(report.reportName).toBe('AATP');
+    expect(report.verifiableCredentials[0].core.type).toBe('DigitalProductPassport');
+    // The context step failed, so the credential's overall status (and report-level pass flag via
+    // it) must be failure, matching the equivalent assertion on the scheme path below.
+    expect(report.verifiableCredentials[0].status).toBe(TestCaseStatus.FAILURE);
+    expect(report.verifiableCredentials[0].overallStatus).toBe(TestCaseStatus.FAILURE);
     expect(report.verifiableCredentials[0].extension).toEqual({
       type: 'extensionType',
       version: '1.0.0',
@@ -261,17 +198,16 @@ describe('generateReport', () => {
           source: { kind: 'url' as const, url: 'https://example.com/scheme/1.json' },
         },
         steps: [
-          { id: 'scheme-version-detection', name: 'Version Detection', status: TestCaseStatus.SUCCESS },
-          { id: 'scheme-schema-validation', name: 'Schema Validation', status: TestCaseStatus.SUCCESS },
-          { id: 'context', name: 'Context Validation', status: TestCaseStatus.SUCCESS },
+          { id: 'scheme-version-detection' as any, name: 'Version Detection', status: TestCaseStatus.SUCCESS },
+          { id: 'scheme-schema-validation' as any, name: 'Schema Validation', status: TestCaseStatus.SUCCESS },
+          { id: 'context' as any, name: 'Context Validation', status: TestCaseStatus.SUCCESS },
         ],
       },
     ];
 
     const report = await generateReport({
       implementationName: mockImplementationName,
-      credentials: {},
-      testResults: {},
+      credentialInstances: [],
       schemeInstances,
       passStatuses: mockPassStatuses,
     });
@@ -300,17 +236,16 @@ describe('generateReport', () => {
           },
         },
         steps: [
-          { id: 'scheme-version-detection', name: 'Version Detection', status: TestCaseStatus.SUCCESS },
-          { id: 'scheme-schema-validation', name: 'Schema Validation', status: TestCaseStatus.FAILURE },
-          { id: 'context', name: 'Context Validation', status: TestCaseStatus.SUCCESS },
+          { id: 'scheme-version-detection' as any, name: 'Version Detection', status: TestCaseStatus.SUCCESS },
+          { id: 'scheme-schema-validation' as any, name: 'Schema Validation', status: TestCaseStatus.FAILURE },
+          { id: 'context' as any, name: 'Context Validation', status: TestCaseStatus.SUCCESS },
         ],
       },
     ];
 
     const report = await generateReport({
       implementationName: mockImplementationName,
-      credentials: {},
-      testResults: {},
+      credentialInstances: [],
       schemeInstances,
       passStatuses: mockPassStatuses,
     });
@@ -323,8 +258,7 @@ describe('generateReport', () => {
     await expect(
       generateReport({
         implementationName: mockImplementationName,
-        credentials: {},
-        testResults: {},
+        credentialInstances: [],
         schemeInstances: [
           {
             scheme: {
@@ -342,20 +276,47 @@ describe('generateReport', () => {
     ).rejects.toThrow('Cannot generate a report while a scheme is still validating.');
   });
 
-  it('refuses to generate a report while a credential is still validating', async () => {
+  it('refuses to generate a report while a credential instance is still validating', async () => {
     await expect(
       generateReport({
         implementationName: mockImplementationName,
-        credentials: {
-          DigitalProductPassport: {
-            original: {},
-            decoded: { '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'] },
+        credentialInstances: [
+          {
+            credential: {
+              original: {},
+              decoded: { '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'] },
+            },
+            steps: [], // credential loaded but no results yet
           },
-        },
-        testResults: {}, // credential loaded but no results yet
+        ],
         schemeInstances: [],
         passStatuses: mockPassStatuses,
       }),
     ).rejects.toThrow('Cannot generate a report while a credential is still validating.');
+  });
+
+  it('keeps two terminal instances of the same core type as two separate report entries', async () => {
+    const instanceA: CredentialReportInput = {
+      credential: { original: { ...envelopedCredential, id: 'a' }, decoded: { ...decodedCredential, id: 'a' } },
+      steps: mockCredentialInstance.steps,
+    };
+    const instanceB: CredentialReportInput = {
+      credential: { original: { ...envelopedCredential, id: 'b' }, decoded: { ...decodedCredential, id: 'b' } },
+      steps: mockCredentialInstance.steps,
+    };
+
+    const report = await generateReport({
+      implementationName: mockImplementationName,
+      credentialInstances: [instanceA, instanceB],
+      passStatuses: mockPassStatuses,
+    });
+
+    // Multi-instance cardinality: two loaded instances of the same core type must produce two
+    // report entries. A regression to a type-keyed structure would collapse them to one.
+    expect(report.verifiableCredentials).toHaveLength(2);
+    expect(report.verifiableCredentials[0].core.type).toBe('DigitalProductPassport');
+    expect(report.verifiableCredentials[1].core.type).toBe('DigitalProductPassport');
+    expect(report.verifiableCredentials[0].credential).toEqual({ ...envelopedCredential, id: 'a' });
+    expect(report.verifiableCredentials[1].credential).toEqual({ ...envelopedCredential, id: 'b' });
   });
 });

--- a/packages/untp-playground/constants.ts
+++ b/packages/untp-playground/constants.ts
@@ -84,6 +84,13 @@ export enum TestCaseStatus {
   FAILURE = 'failure',
 }
 
+/**
+ * The statuses that count as settled: a step (and so an instance) has finished running. Removal
+ * availability and report readiness both key off this, so they must agree on whether WARNING is
+ * terminal; keeping the set in one place stops those checks from drifting apart.
+ */
+export const TERMINAL_STATUSES = [TestCaseStatus.SUCCESS, TestCaseStatus.WARNING, TestCaseStatus.FAILURE];
+
 export enum TestCaseStepId {
   PROOF_TYPE = 'proof-type',
   VCDM_VERSION = 'vcdm-version',

--- a/packages/untp-playground/e2e/cypress/e2e/vcdm-validation.cy.ts
+++ b/packages/untp-playground/e2e/cypress/e2e/vcdm-validation.cy.ts
@@ -35,11 +35,12 @@ describe('VCDM Schema Validation', () => {
     issuer: 'did:example:123',
   };
 
+  // The coloured VCDM-version pill is gone (#810): VCDM v2 is the only supported version, and the
+  // VCDM Version Detection checklist step already carries this signal, so every case below asserts
+  // it directly instead of the removed pill text/colour.
+
   it('should validate a VCDM v2` credential successfully', () => {
     cy.uploadCredential(validCredential);
-
-    cy.contains('VCDM v2').should('be.visible');
-    cy.checkVCDMVersionColor('DigitalProductPassport', 'green');
 
     cy.expandGroup();
     cy.checkValidationStatus('VCDM Version Detection', 'success');
@@ -49,9 +50,6 @@ describe('VCDM Schema Validation', () => {
   it('should show error for v1 VCDM version', () => {
     cy.uploadCredential(v1VcdmCredential);
 
-    cy.contains('VCDM v1').should('be.visible');
-    cy.checkVCDMVersionColor('DigitalProductPassport', 'red');
-
     cy.expandGroup();
     cy.checkValidationStatus('VCDM Version Detection', 'success');
     cy.checkValidationStatus('VCDM Schema Validation', 'failure');
@@ -60,9 +58,6 @@ describe('VCDM Schema Validation', () => {
   it('should show error for unsupported VCDM version', () => {
     cy.uploadCredential(invalidVcdmVersionCredential);
 
-    cy.contains('Unsupported VCDM version').should('be.visible');
-    cy.checkVCDMVersionColor('DigitalProductPassport', 'red');
-
     cy.expandGroup();
     cy.checkValidationStatus('VCDM Version Detection', 'failure');
   });
@@ -70,10 +65,8 @@ describe('VCDM Schema Validation', () => {
   it('should show validation errors for missing @context', () => {
     cy.uploadCredential(missingContextCredential);
 
-    cy.contains('Unsupported VCDM version').should('be.visible');
-    cy.checkVCDMVersionColor('DigitalProductPassport', 'red');
-
     cy.expandGroup();
+    cy.checkValidationStatus('VCDM Version Detection', 'failure');
     cy.checkValidationStatus('VCDM Schema Validation', 'failure');
 
     cy.openErrorDetails();
@@ -90,10 +83,8 @@ describe('VCDM Schema Validation', () => {
 
     cy.uploadCredential(invalidCredential);
 
-    cy.contains('VCDM v2').should('be.visible');
-    cy.checkVCDMVersionColor('DigitalProductPassport', 'green');
-
     cy.expandGroup();
+    cy.checkValidationStatus('VCDM Version Detection', 'success');
     cy.checkValidationStatus('VCDM Schema Validation', 'failure');
 
     cy.openErrorDetails();
@@ -110,8 +101,8 @@ describe('VCDM Schema Validation', () => {
 
     cy.uploadCredential(validCredential);
 
-    cy.contains('VCDM v2').should('be.visible');
-    cy.checkVCDMVersionColor('DigitalProductPassport', 'green');
+    cy.expandGroup();
+    cy.checkValidationStatus('VCDM Version Detection', 'success');
 
     cy.wait('@schemaFetch');
     cy.get('[data-sonner-toast]').contains('Failed to fetch the VCDM schema').should('exist');
@@ -120,10 +111,8 @@ describe('VCDM Schema Validation', () => {
   it('should show confetti for fully valid credential', () => {
     cy.uploadCredential('cypress/fixtures/credentials-e2e/valid-v2-enveloped-dpp.json');
 
-    cy.contains('VCDM v2').should('be.visible');
-    cy.checkVCDMVersionColor('DigitalProductPassport', 'green');
-
     cy.expandGroup();
+    cy.checkValidationStatus('VCDM Version Detection', 'success');
     cy.checkValidationStatus('VCDM Schema Validation', 'success');
     cy.validateConfetti();
   });

--- a/packages/untp-playground/e2e/cypress/support/commands/untp-playground.ts
+++ b/packages/untp-playground/e2e/cypress/support/commands/untp-playground.ts
@@ -34,9 +34,13 @@ Cypress.Commands.add('uploadCredential', (credential: object | string) => {
   }
 });
 
-// Command to expand a validation group (defaults to 'DigitalProductPassport-group-header')
-Cypress.Commands.add('expandGroup', (groupTestId: string = 'DigitalProductPassport-group-header') => {
-  cy.get(`[data-testid="${groupTestId}"]`).click();
+// Command to reveal a credential's pipeline steps. Since #810, a credential type group
+// (CredentialTypeGroup) is expanded by default once a credential is uploaded, so its instance row
+// (CredentialInstanceRow) is already visible; the click needed to reveal that instance's own
+// pipeline steps is on the instance row itself. This targets the single instance row rendered for
+// an E2E spec's single-credential-per-type upload.
+Cypress.Commands.add('expandGroup', () => {
+  cy.get('[data-testid="credential-instance-header"]').click();
 });
 
 // Command to validate that a specific step shows the expected status icon
@@ -69,18 +73,6 @@ Cypress.Commands.add('validateConfetti', () => {
     .and('include', 'position: fixed')
     .and('include', 'pointer-events: none')
     .and('include', 'z-index: 100');
-});
-
-// Command to check VCDM version badge color
-Cypress.Commands.add('checkVCDMVersionColor', (credentialType: string, expectedColor: 'green' | 'red') => {
-  const colorClasses = {
-    green: ['bg-green-100', 'text-green-800'],
-    red: ['bg-red-100', 'text-red-800'],
-  };
-
-  cy.get(`[data-testid="${credentialType}-vcdm-version"]`)
-    .should('have.class', colorClasses[expectedColor][0])
-    .and('have.class', colorClasses[expectedColor][1]);
 });
 
 // Command to open validation details

--- a/packages/untp-playground/e2e/cypress/support/index.d.ts
+++ b/packages/untp-playground/e2e/cypress/support/index.d.ts
@@ -6,9 +6,10 @@ interface PlaygroundChainable {
   uploadCredential(credential: object | string): Cypress.Chainable<void>;
 
   /**
-   * Expands a validation group. Defaults to the DigitalProductPassport group.
+   * Reveals a credential's pipeline steps by expanding its (single) instance row. The type group
+   * itself is expanded by default once a credential is uploaded (#810).
    */
-  expandGroup(groupTestId?: string): Cypress.Chainable<void>;
+  expandGroup(): Cypress.Chainable<void>;
 
   /**
    * Checks that the validation status icon for a given step is visible.
@@ -33,11 +34,6 @@ interface PlaygroundChainable {
    * Validates that the confetti is visible.
    */
   validateConfetti(): Cypress.Chainable<void>;
-
-  /**
-   * Checks the color of the VCDM version badge.
-   */
-  checkVCDMVersionColor(credentialType: string, expectedColor: 'green' | 'red'): Cypress.Chainable<void>;
 
   /**
    * Opens the validation details.

--- a/packages/untp-playground/src/app/page.tsx
+++ b/packages/untp-playground/src/app/page.tsx
@@ -15,15 +15,10 @@ import { TestResults } from '@/components/TestResults';
 import { TestReportProvider } from '@/contexts/TestReportContext';
 import { useArtefactCollection } from '@/hooks/useArtefactCollection';
 import { upsert } from '@/lib/artefactCollection';
+import { credentialContentHash, credentialGroupType, credentialTitle } from '@/lib/credentialCollection';
 import { newId } from '@/lib/id';
 import { schemeContentHash, schemeTitle } from '@/lib/schemeCollection';
-import {
-  decodeEnvelopedCredential,
-  detectArtefact,
-  detectCredentialType,
-  isEnvelopedProof,
-} from '@/lib/credentialService';
-import { detectExtension } from '@/lib/schemaValidation';
+import { decodeEnvelopedCredential, detectArtefact, isEnvelopedProof } from '@/lib/credentialService';
 import { isPermittedCredentialType, validateNormalizedCredential } from '@/lib/utils';
 import type { PermittedCredentialType, StoredCredential, StoredScheme, TestStep } from '@/types';
 import { useError } from '@/contexts/ErrorContext';
@@ -33,28 +28,26 @@ import { FileText, Link2, Server } from 'lucide-react';
 import { ArtefactKind, permittedCredentialTypes } from '../../constants';
 
 export default function Home() {
-  const [credentials, setCredentials] = useState<{
-    [key in PermittedCredentialType]?: StoredCredential;
-  }>({});
-  const [testResults, setTestResults] = useState<{
-    [key in PermittedCredentialType]?: TestStep[];
-  }>({});
+  const credential = useArtefactCollection<StoredCredential, TestStep[]>();
   const scheme = useArtefactCollection<StoredScheme, TestStep[]>();
   const [fileCount, setFileCount] = useState(0);
   const { dispatchError, errors, setIsDetailsOpen } = useError();
 
   const shouldDisplayUploadDetailBtn = errors && errors.length > 0;
 
-  // Whether each family has instances loaded. schemesCount drives both the Conformity Schemes
-  // empty state and its tab count. credentialsCount drives only the Credentials empty state (that
-  // tab has no count). linkSetsCount drives only the Link Sets tab count; its empty state stays
-  // unconditional until #811 adds real data.
-  const credentialsCount = Object.keys(credentials).length;
+  // Whether each family has instances loaded. Both credentialsCount and schemesCount drive their
+  // family's empty state and tab count, consistently (#845). linkSetsCount drives only the Link
+  // Sets tab count; its empty state stays unconditional until #811 adds real data.
+  const credentialsCount = credential.state.items.length;
   const schemesCount = scheme.state.items.length;
   const linkSetsCount = 0; // Link Sets family lands in #811.
 
-  // Recomputed only when the scheme instances change (add, replace, remove, or a result commit), so
-  // an unrelated re-render does not create a fresh array and re-run the report-reset effect.
+  // Recomputed only when the instances change (add, replace, remove, or a result commit), so an
+  // unrelated re-render does not create a fresh array and re-run the report-reset effect.
+  const credentialInstances = useMemo(
+    () => credential.state.items.map((item) => ({ credential: item.payload, steps: item.result ?? [] })),
+    [credential.state.items],
+  );
   const schemeInstances = useMemo(
     () => scheme.state.items.map((item) => ({ scheme: item.payload, steps: item.result ?? [] })),
     [scheme.state.items],
@@ -86,8 +79,7 @@ export default function Home() {
       const isEnveloped = isEnvelopedProof(normalizedCredential);
       const decodedCredential = isEnveloped ? decodeEnvelopedCredential(normalizedCredential) : normalizedCredential;
 
-      const extension = detectExtension(decodedCredential);
-      let credentialType = extension ? extension.core.type : detectCredentialType(decodedCredential);
+      const credentialType = credentialGroupType(decodedCredential);
 
       if (!credentialType || !isPermittedCredentialType(credentialType as PermittedCredentialType)) {
         dispatchError([
@@ -106,14 +98,13 @@ export default function Home() {
         return;
       }
 
-      setCredentials((prev) => ({
-        ...prev,
-        [credentialType]: {
-          original: normalizedCredential,
-          decoded: decodedCredential,
-          source,
-        },
-      }));
+      const stored: StoredCredential = { original: normalizedCredential, decoded: decodedCredential, source };
+      const { outcome } = credential.dispatch((state) =>
+        upsert(state, { payload: stored, contentHash: credentialContentHash(stored.decoded), mintInstanceId: newId }),
+      );
+      if (outcome.kind === 'replaced') {
+        toast.success(`Replaced ${credentialTitle(stored)}`);
+      }
     } catch (error) {
       console.error(error);
       toast.error('Failed to process artefact');
@@ -144,14 +135,19 @@ export default function Home() {
     <div className='min-h-screen flex flex-col'>
       <Header />
       <main className='container mx-auto p-8 max-w-7xl flex-1'>
-        <TestReportProvider testResults={testResults} credentials={credentials} schemeInstances={schemeInstances}>
+        <TestReportProvider credentialInstances={credentialInstances} schemeInstances={schemeInstances}>
           <SectionHeader title='Test artefacts'>
             <ReportActions />
           </SectionHeader>
 
           <Tabs defaultValue='credentials'>
             <TabsList>
-              <TabsTrigger value='credentials'>Credentials</TabsTrigger>
+              <TabsTrigger value='credentials'>
+                Credentials
+                {credentialsCount > 0 && (
+                  <span className='text-xs tabular-nums text-muted-foreground'>{credentialsCount}</span>
+                )}
+              </TabsTrigger>
               <TabsTrigger value='schemes'>
                 Conformity Schemes
                 {schemesCount > 0 && <span className='text-xs tabular-nums text-muted-foreground'>{schemesCount}</span>}
@@ -176,7 +172,7 @@ export default function Home() {
                       guidance='Add a credential from the panel on the right. Drop a JSON / JWT file or paste a URL. Each credential you add appears here and in the generated report.'
                     />
                   ) : (
-                    <TestResults credentials={credentials} testResults={testResults} setTestResults={setTestResults} />
+                    <TestResults collection={credential.state} dispatch={credential.dispatch} />
                   )}
                 </TabsContent>
 

--- a/packages/untp-playground/src/components/TestResults.tsx
+++ b/packages/untp-playground/src/components/TestResults.tsx
@@ -1,24 +1,43 @@
 'use client';
 
+import { SourceCaption } from '@/components/SourceCaption';
 import { StatusIcon } from '@/components/StatusIcon';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { beginRun, commitResult, remove } from '@/lib/artefactCollection';
 import { validateContext } from '@/lib/contextValidation';
-import { detectVersion, isEnvelopedProof } from '@/lib/credentialService';
+import {
+  credentialGroupLabel,
+  credentialGroupType,
+  credentialIsTerminal,
+  credentialSubtitle,
+  credentialTitle,
+  instanceStatus,
+  worstStatus,
+} from '@/lib/credentialCollection';
+import { isEnvelopedProof } from '@/lib/credentialService';
+import { newId } from '@/lib/id';
 import { detectExtension, validateCredentialSchema, validateExtension } from '@/lib/schemaValidation';
 import { detectVcdmVersion } from '@/lib/utils';
 import { validateVcdmRules } from '@/lib/vcdm-validation';
 import { verifyCredential } from '@/lib/verificationService';
-import { ArtefactSource, Credential, PermittedCredentialType, StoredCredential, TestStep } from '@/types';
-import { SourceCaption } from '@/components/SourceCaption';
+import type { ArtefactSlot, CollectionState, InstanceId, RunId } from '@/types/artefact';
+import type { StoredCredential, TestStep } from '@/types';
 import confetti from 'canvas-confetti';
-import { AlertCircle, Check, ChevronDown, ChevronRight, Loader2, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import {
   allowedContextValue,
   allowedExtensionValue,
-  CredentialType,
   permittedCredentialTypes,
   TestCaseStatus,
   TestCaseStepId,
@@ -27,30 +46,15 @@ import {
 } from '../../constants';
 import ValidationDetailsSheet from './ValidationDetailsSheet';
 
-// Add this type to help with tracking previous credentials
-type CredentialCache = Record<
-  PermittedCredentialType,
-  {
-    credential: {
-      original: any;
-      decoded: Credential;
-    };
-    validated: boolean;
-    confettiShown?: boolean;
-  }
->;
+type CredentialCollection = CollectionState<StoredCredential, TestStep[]>;
+type CredentialDispatch = <Res extends { state: CredentialCollection }>(
+  transition: (current: CredentialCollection) => Res,
+) => Res;
+type CredentialSlot = ArtefactSlot<StoredCredential, TestStep[]>;
 
-interface TestGroupProps {
-  credentialType: string;
-  version: string;
-  steps: TestStep[];
-  vcdmVersion: VCDMVersion | undefined;
-  hasCredential: boolean;
-  extensionCredentialType?: string;
-  extensionVersion?: string;
-  isExpanded: boolean;
-  onToggle: () => void;
-  source?: ArtefactSource;
+interface TestResultsProps {
+  collection: CredentialCollection;
+  dispatch: CredentialDispatch;
 }
 
 export const confettiConfig = {
@@ -59,75 +63,425 @@ export const confettiConfig = {
   origin: { y: 0.7 },
 };
 
-const TestGroup = ({
-  credentialType,
-  version,
-  extensionCredentialType,
-  extensionVersion,
-  steps,
-  isExpanded,
-  onToggle,
-  hasCredential,
-  vcdmVersion,
-  source,
-}: TestGroupProps) => {
-  const isLoading = steps.some((step) => step.status === 'in-progress');
+/**
+ * The credential pipeline's starting step list. Proof type and VCDM version are detected
+ * synchronously from the stored document, so they carry their final status immediately; every
+ * other step (and the extension step, only when an extension is detected) starts pending and is
+ * settled by `runCredentialPipeline`.
+ */
+function initialSteps(stored: StoredCredential): TestStep[] {
+  const vcdmVersion = detectVcdmVersion(stored.decoded);
+  const isUnsupportedVCDMVersion = vcdmVersion === VCDMVersion.UNKNOWN;
 
-  const overallStatus = useMemo(() => {
-    if (!hasCredential) return TestCaseStatus.PENDING;
-    if (version === VCDMVersion.UNKNOWN) return TestCaseStatus.FAILURE;
-    if (isLoading || steps.some((step) => step.status === TestCaseStatus.PENDING)) return TestCaseStatus.IN_PROGRESS;
-    return steps.every((step) => step.status === TestCaseStatus.SUCCESS)
-      ? TestCaseStatus.SUCCESS
-      : TestCaseStatus.FAILURE;
-  }, [steps, isLoading, hasCredential, version]);
+  const steps: TestStep[] = [
+    {
+      id: TestCaseStepId.PROOF_TYPE,
+      name: 'Proof Type Detection',
+      status: TestCaseStatus.SUCCESS,
+      details: { type: isEnvelopedProof(stored.original) ? VCProofType.ENVELOPING : VCProofType.EMBEDDED },
+    },
+    {
+      id: TestCaseStepId.VCDM_VERSION,
+      name: 'VCDM Version Detection',
+      status: isUnsupportedVCDMVersion ? TestCaseStatus.FAILURE : TestCaseStatus.SUCCESS,
+      details: { version: vcdmVersion },
+    },
+    { id: TestCaseStepId.VCDM_SCHEMA_VALIDATION, name: 'VCDM Schema Validation', status: TestCaseStatus.PENDING },
+    { id: TestCaseStepId.VERIFICATION, name: 'Credential Verification', status: TestCaseStatus.PENDING },
+    { id: TestCaseStepId.UNTP_SCHEMA_VALIDATION, name: 'UNTP Schema Validation', status: TestCaseStatus.PENDING },
+    {
+      id: TestCaseStepId.CONTEXT_VALIDATION,
+      name: 'JSON-LD Document Expansion and Context Validation',
+      status: TestCaseStatus.PENDING,
+    },
+  ];
+
+  if (detectExtension(stored.decoded)) {
+    steps.push({
+      id: TestCaseStepId.EXTENSION_SCHEMA_VALIDATION,
+      name: 'Extension Schema Validation',
+      status: TestCaseStatus.PENDING,
+    });
+  }
+
+  return steps;
+}
+
+export function TestResults({ collection, dispatch }: TestResultsProps) {
+  // Confetti fires once per (instance, run) so it does not re-fire on unrelated re-renders.
+  const confettiShownRef = useRef<Set<string>>(new Set());
+  const [pendingRemoval, setPendingRemoval] = useState<CredentialSlot | null>(null);
+
+  // Start the pipeline for any instance that has no live run and no result yet (freshly added or
+  // replaced). beginRun no-ops on an already-running slot, so a repeated effect cannot double-start.
+  useEffect(() => {
+    for (const item of collection.items) {
+      if (item.runId === null && item.result === undefined) {
+        const { runId } = dispatch((state) => beginRun(state, item.instanceId, initialSteps(item.payload), newId));
+        if (runId) void runCredentialPipeline(item.instanceId, runId, item.payload, dispatch);
+      }
+    }
+  }, [collection.items, dispatch]);
+
+  useEffect(() => {
+    for (const item of collection.items) {
+      const steps = item.result;
+      if (!steps || item.runId === null) continue;
+      const key = `${item.instanceId}:${item.runId}`;
+      if (confettiShownRef.current.has(key)) continue;
+      if (steps.length > 0 && steps.every((step) => step.status === TestCaseStatus.SUCCESS)) {
+        confettiShownRef.current.add(key);
+        confetti(confettiConfig);
+      }
+    }
+  }, [collection.items]);
+
+  const confirmRemoval = () => {
+    if (!pendingRemoval) return;
+    dispatch((state) => remove(state, pendingRemoval.instanceId));
+    setPendingRemoval(null);
+  };
+
+  // Group instances by detected credential type, in the fixed checklist order, and keep a group
+  // only for a type that has at least one instance (#845): no empty type cards, no n / 5
+  // denominator.
+  const groups = useMemo(
+    () =>
+      permittedCredentialTypes
+        .map((type) => ({
+          type,
+          instances: collection.items.filter((item) => credentialGroupType(item.payload.decoded) === type),
+        }))
+        .filter((group) => group.instances.length > 0),
+    [collection.items],
+  );
+
+  return (
+    <section className='space-y-4' data-testid='credential-results'>
+      {groups.map((group) => (
+        <CredentialTypeGroup
+          key={group.type}
+          type={group.type}
+          instances={group.instances}
+          onRemove={(item) => setPendingRemoval(item)}
+        />
+      ))}
+
+      <Dialog open={pendingRemoval !== null} onOpenChange={(open) => !open && setPendingRemoval(null)}>
+        <DialogContent className='sm:max-w-[425px]'>
+          <DialogHeader>
+            <DialogTitle>Remove {pendingRemoval ? credentialTitle(pendingRemoval.payload) : 'credential'}?</DialogTitle>
+            <DialogDescription>
+              This removes the credential and its validation results from this session. You can add it again by
+              uploading it.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant='outline' onClick={() => setPendingRemoval(null)}>
+              Cancel
+            </Button>
+            <Button variant='destructive' onClick={confirmRemoval}>
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}
+
+/**
+ * Runs the credential validation pipeline (proof type and VCDM version are pre-computed in
+ * `initialSteps`; this settles VCDM schema, verification, UNTP schema, JSON-LD context and, when
+ * detected, the extension schema) and commits the whole step list through the run-guarded
+ * `commitResult` after each stage, like `runSchemePipeline`. Step statuses and detail shapes follow
+ * the pre-#810 implementation; the write path moved onto the shared per-instance model (ADR-041),
+ * and each async step (verification included) fails its own step and honours the run guard before
+ * toasting, so a service error settles the instance rather than leaving it stuck.
+ */
+async function runCredentialPipeline(
+  instanceId: InstanceId,
+  runId: RunId,
+  stored: StoredCredential,
+  dispatch: CredentialDispatch,
+): Promise<void> {
+  const steps = initialSteps(stored);
+
+  // The only write path: commit the whole step list through the run guard. Returns false once the
+  // run has been superseded (replaced or removed), so a stale run stops writing.
+  const setSteps = (patches: Array<[TestCaseStepId, Partial<TestStep>]>): boolean => {
+    for (const [stepId, patch] of patches) {
+      const index = steps.findIndex((step) => step.id === stepId);
+      if (index !== -1) steps[index] = { ...steps[index], ...patch };
+    }
+    const { applied } = dispatch((state) =>
+      commitResult(state, { instanceId, runId, result: steps.map((step) => ({ ...step })) }),
+    );
+    return applied;
+  };
+  const setStep = (stepId: TestCaseStepId, patch: Partial<TestStep>): boolean => setSteps([[stepId, patch]]);
+
+  try {
+    // Mark the four asynchronous steps in progress together, mirroring the original single-pass
+    // update rather than one commit per step.
+    if (
+      !setSteps([
+        [TestCaseStepId.VERIFICATION, { status: TestCaseStatus.IN_PROGRESS }],
+        [TestCaseStepId.UNTP_SCHEMA_VALIDATION, { status: TestCaseStatus.IN_PROGRESS }],
+        [TestCaseStepId.VCDM_SCHEMA_VALIDATION, { status: TestCaseStatus.IN_PROGRESS }],
+        [TestCaseStepId.CONTEXT_VALIDATION, { status: TestCaseStatus.IN_PROGRESS }],
+      ])
+    ) {
+      return;
+    }
+
+    // A verification-service error (unconfigured service, downstream 5xx, network) must fail the
+    // verification step visibly and let the remaining steps settle. Without this catch the throw
+    // reaches the outer handler and leaves the instance stuck IN_PROGRESS: non-terminal, so
+    // non-removable and blocking report generation for the whole session.
+    try {
+      const verificationResult = await verifyCredential(stored.original);
+      if (
+        !setStep(TestCaseStepId.VERIFICATION, {
+          status: verificationResult.verified ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
+          details: {
+            verified: verificationResult.verified,
+            ...(verificationResult.error && { error: verificationResult.error }),
+          },
+        })
+      ) {
+        return;
+      }
+
+      if (!verificationResult.verified) {
+        const errorMessage =
+          typeof verificationResult.error === 'object'
+            ? verificationResult.error.message || 'The credential could not be verified'
+            : verificationResult.error || 'The credential could not be verified';
+
+        toast.error('Credential verification failed', { description: errorMessage });
+      }
+    } catch {
+      const description = 'Could not reach the verification service. Please try again.';
+      // Commit the failure through the run guard first; a superseded run stops here and stays silent.
+      if (
+        !setStep(TestCaseStepId.VERIFICATION, {
+          status: TestCaseStatus.FAILURE,
+          details: { verified: false, error: description },
+        })
+      ) {
+        return;
+      }
+      toast.error('Credential verification failed', { description });
+    }
+
+    const extension = detectExtension(stored.decoded);
+
+    try {
+      const vcdmValidationResult = await validateVcdmRules(stored.decoded);
+      if (
+        !setStep(TestCaseStepId.VCDM_SCHEMA_VALIDATION, {
+          status: vcdmValidationResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
+          details: vcdmValidationResult,
+        })
+      ) {
+        return;
+      }
+    } catch {
+      if (!setStep(TestCaseStepId.VCDM_SCHEMA_VALIDATION, { status: TestCaseStatus.FAILURE })) return;
+      toast.error('Failed to fetch the VCDM schema. Please contact support.');
+    }
+
+    try {
+      const validationResult = await validateCredentialSchema(stored.decoded);
+      if (
+        !setStep(TestCaseStepId.UNTP_SCHEMA_VALIDATION, {
+          status: validationResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
+          details: validationResult,
+        })
+      ) {
+        return;
+      }
+    } catch (error) {
+      console.log('Schema validation error:', error);
+      if (
+        !setStep(TestCaseStepId.UNTP_SCHEMA_VALIDATION, {
+          status: TestCaseStatus.FAILURE,
+          details: {
+            errors: [
+              {
+                keyword: 'schema',
+                message: 'Failed to fetch schema',
+                instancePath: '',
+                params: {
+                  missingValue: 'The schema could not be loaded due to missing UNTP context IRIs.',
+                  solution: "Ensure the credential includes the required UNTP context IRIs in the '@context' field.",
+                  allowedValue: allowedContextValue,
+                  receivedValue: stored,
+                },
+              },
+            ],
+          },
+        })
+      ) {
+        return;
+      }
+      toast.error('Failed to fetch schema. Please try again.');
+    }
+
+    const validateContextResult = await validateContext(stored.decoded);
+    if (
+      !setStep(TestCaseStepId.CONTEXT_VALIDATION, {
+        status: validateContextResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
+        details: validateContextResult.valid
+          ? validateContextResult.data
+          : { errors: validateContextResult.error ? [validateContextResult.error] : [] },
+      })
+    ) {
+      return;
+    }
+    if (!validateContextResult.valid) {
+      toast.error('Validation of the JSON-LD context failed. Please check the View Details for more information.');
+    }
+
+    if (extension) {
+      try {
+        const extensionValidationResult = await validateExtension(stored.decoded);
+        if (
+          !setStep(TestCaseStepId.EXTENSION_SCHEMA_VALIDATION, {
+            status: extensionValidationResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
+            details: extensionValidationResult,
+          })
+        ) {
+          return;
+        }
+      } catch (error) {
+        console.log('Extension schema validation error:', error);
+        if (
+          !setStep(TestCaseStepId.EXTENSION_SCHEMA_VALIDATION, {
+            status: TestCaseStatus.FAILURE,
+            details: {
+              errors: [
+                {
+                  keyword: 'schema',
+                  message: 'Failed to fetch extension schema',
+                  instancePath: '',
+                  params: {
+                    missingValue: 'The schema could not be loaded due to missing extension context IRIs.',
+                    solution:
+                      "Ensure the credential includes the required extension context IRIs in the '@context' field.",
+                    allowedValue: allowedExtensionValue,
+                    receivedValue: stored,
+                  },
+                },
+              ],
+            },
+          })
+        ) {
+          return;
+        }
+        toast.error('Failed to fetch extension schema. Please try again.');
+      }
+    }
+  } catch (error) {
+    console.log('Error processing credential:', error);
+  }
+}
+
+function CredentialTypeGroup({
+  type,
+  instances,
+  onRemove,
+}: {
+  type: string;
+  instances: CredentialSlot[];
+  onRemove: (item: CredentialSlot) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const rollup = useMemo(() => worstStatus(instances.map((item) => instanceStatus(item.result))), [instances]);
 
   return (
     <Card className='p-4'>
       <div
         className='flex flex-wrap items-center justify-between gap-2 cursor-pointer'
-        onClick={onToggle}
-        data-testid={`${credentialType}-group-header`}
+        onClick={() => setIsExpanded((prev) => !prev)}
+        data-testid={`${type}-group-header`}
       >
         <div className='flex items-center gap-2'>
           {isExpanded ? <ChevronDown className='h-4 w-4' /> : <ChevronRight className='h-4 w-4' />}
-          <h3 className='font-semibold'>
-            {credentialType}
-            {hasCredential && ` (${version === VCDMVersion.UNKNOWN ? version + ' version' : 'v' + version})`}
-          </h3>
-          {extensionCredentialType && (
-            <h4 className='text-sm text-gray-500'>
-              {extensionCredentialType}
-              {extensionVersion === VCDMVersion.UNKNOWN ? 'unknown' : ` (v${extensionVersion})`}
-            </h4>
-          )}
+          <h3 className='font-semibold'>{credentialGroupLabel(type, instances.length)}</h3>
+          <span className='text-xs tabular-nums text-muted-foreground'>{instances.length}</span>
         </div>
-        <div className='flex items-center gap-4'>
-          {hasCredential && vcdmVersion && (
-            <span
-              className={`text-xs px-2 py-1 rounded-full ${
-                vcdmVersion === VCDMVersion.V2 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-              }`}
-              data-testid={`${credentialType}-vcdm-version`}
-            >
-              {vcdmVersion === VCDMVersion.UNKNOWN ? 'Unsupported VCDM version' : `VCDM ${vcdmVersion}`}
-            </span>
-          )}
-          <StatusIcon status={overallStatus} testId={`${credentialType}`} />
-        </div>
+        {/* The rollup summarises the group only while it is collapsed; once expanded, each instance
+            row shows its own status, so the group-level icon would be redundant. */}
+        {!isExpanded && <StatusIcon status={rollup} testId={type} />}
       </div>
       {isExpanded && (
-        <div className='mt-4 pl-6 space-y-2'>
-          {source && <SourceCaption source={source} />}
-          {steps.map((step) => (
-            <TestStepItem key={step.id} step={step} />
+        <div className='mt-4 space-y-2 pl-6'>
+          {instances.map((item) => (
+            <CredentialInstanceRow key={item.instanceId} item={item} onRemove={() => onRemove(item)} />
           ))}
-          {!hasCredential && <p className='text-sm text-gray-500 italic'>Upload a credential to begin validation</p>}
         </div>
       )}
     </Card>
   );
-};
+}
+
+function CredentialInstanceRow({ item, onRemove }: { item: CredentialSlot; onRemove: () => void }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const stored = item.payload;
+  const steps = item.result ?? [];
+  const title = credentialTitle(stored);
+  const status = instanceStatus(item.result);
+  // A queued or mid-pipeline instance offers no remove control until its pipeline settles (#810 AC).
+  // Removability tracks a terminal result, not the run token, so a freshly queued slot is not
+  // briefly removable in the render before its run begins.
+  const removable = credentialIsTerminal(steps);
+
+  return (
+    <div className='group relative overflow-hidden rounded-md border'>
+      <div
+        className='flex flex-wrap items-center justify-between gap-2 p-3 cursor-pointer'
+        onClick={() => setIsExpanded((prev) => !prev)}
+        data-testid='credential-instance-header'
+        data-instance-id={item.instanceId}
+      >
+        <div className='flex min-w-0 items-center gap-2'>
+          {isExpanded ? <ChevronDown className='h-4 w-4 shrink-0' /> : <ChevronRight className='h-4 w-4 shrink-0' />}
+          <div className='flex min-w-0 flex-col'>
+            <h4 className='truncate font-medium'>{title}</h4>
+            <span className='truncate text-xs text-gray-500'>{credentialSubtitle(stored)}</span>
+          </div>
+        </div>
+        <StatusIcon status={status} testId={item.instanceId} />
+      </div>
+      {isExpanded && (
+        <div className='space-y-2 px-3 pb-3 pl-9'>
+          {stored.source && <SourceCaption source={stored.source} />}
+          {steps.map((step) => (
+            <TestStepItem key={step.id} step={step} />
+          ))}
+        </div>
+      )}
+      {removable && (
+        <button
+          type='button'
+          aria-label={`Remove ${title}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          // Revealed only when the pointer is over the delete region itself (the right edge), or when
+          // the control is keyboard-focused, rather than on hover of the whole row.
+          className='absolute bottom-0 right-0 top-0 flex w-12 items-center justify-center bg-red-400 text-white opacity-0 transition-opacity hover:bg-red-500 hover:opacity-100 focus:opacity-100 focus-visible:opacity-100'
+        >
+          <Trash2 className='h-4 w-4' />
+        </button>
+      )}
+    </div>
+  );
+}
 
 const TestStepItem = ({ step }: { step: TestStep }) => {
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
@@ -170,415 +524,3 @@ const TestStepItem = ({ step }: { step: TestStep }) => {
     </div>
   );
 };
-
-interface TestResultsProps {
-  credentials: Partial<Record<PermittedCredentialType, StoredCredential>>;
-  testResults: Partial<Record<PermittedCredentialType, TestStep[]>>;
-  setTestResults: React.Dispatch<React.SetStateAction<Partial<Record<PermittedCredentialType, TestStep[]>>>>;
-}
-
-export function TestResults({ credentials, testResults, setTestResults }: TestResultsProps) {
-  const [expandedGroups, setExpandedGroups] = useState<string[]>([]);
-  const validatedCredentialsRef = useRef<CredentialCache | Record<string, never>>({});
-  const previousCredentialsRef = useRef<
-    Partial<Record<PermittedCredentialType, { original: any; decoded: Credential }>>
-  >({});
-
-  const initializeTestSteps = (credential?: { original: any; decoded: Credential }) => {
-    if (!credential) {
-      return [
-        {
-          id: TestCaseStepId.PROOF_TYPE,
-          name: 'Proof Type Detection',
-          status: TestCaseStatus.PENDING,
-        },
-        {
-          id: TestCaseStepId.VCDM_VERSION,
-          name: 'VCDM Version Detection',
-          status: TestCaseStatus.PENDING,
-        },
-        {
-          id: TestCaseStepId.VCDM_SCHEMA_VALIDATION,
-          name: 'VCDM Schema Validation',
-          status: TestCaseStatus.PENDING,
-        },
-        {
-          id: TestCaseStepId.VERIFICATION,
-          name: 'Credential Verification',
-          status: TestCaseStatus.PENDING,
-        },
-        {
-          id: TestCaseStepId.UNTP_SCHEMA_VALIDATION,
-          name: 'UNTP Schema Validation',
-          status: TestCaseStatus.PENDING,
-        },
-        {
-          id: TestCaseStepId.CONTEXT_VALIDATION,
-          name: 'JSON-LD Document Expansion and Context Validation',
-          status: TestCaseStatus.PENDING,
-        },
-      ];
-    }
-
-    const vcdmVersion = detectVcdmVersion(credential.decoded);
-    const isUnsupportedVCDMVersion = vcdmVersion === VCDMVersion.UNKNOWN;
-
-    const steps = [
-      {
-        id: TestCaseStepId.PROOF_TYPE,
-        name: 'Proof Type Detection',
-        status: 'success',
-        details: {
-          type: isEnvelopedProof(credential.original) ? VCProofType.ENVELOPING : VCProofType.EMBEDDED,
-        },
-      },
-      {
-        id: TestCaseStepId.VCDM_VERSION,
-        name: 'VCDM Version Detection',
-        status: isUnsupportedVCDMVersion ? TestCaseStatus.FAILURE : TestCaseStatus.SUCCESS,
-        details: {
-          version: vcdmVersion,
-        },
-      },
-      {
-        id: TestCaseStepId.VCDM_SCHEMA_VALIDATION,
-        name: 'VCDM Schema Validation',
-        status: TestCaseStatus.PENDING,
-      },
-      {
-        id: TestCaseStepId.VERIFICATION,
-        name: 'Credential Verification',
-        status: TestCaseStatus.PENDING,
-      },
-      {
-        id: TestCaseStepId.UNTP_SCHEMA_VALIDATION,
-        name: 'UNTP Schema Validation',
-        status: TestCaseStatus.PENDING,
-      },
-      {
-        id: TestCaseStepId.CONTEXT_VALIDATION,
-        name: 'JSON-LD Document Expansion and Context Validation',
-        status: TestCaseStatus.PENDING,
-      },
-    ];
-
-    const extension = detectExtension(credential.decoded);
-
-    if (extension) {
-      steps.push({
-        id: TestCaseStepId.EXTENSION_SCHEMA_VALIDATION,
-        name: 'Extension Schema Validation',
-        status: TestCaseStatus.PENDING,
-      });
-    }
-    return steps;
-  };
-
-  // First useEffect for initializing test steps
-  useEffect(() => {
-    permittedCredentialTypes.forEach((type) => {
-      const credential = credentials[type];
-      const previousCredential = previousCredentialsRef.current[type];
-
-      // Only initialize or update if the credential has changed
-      if (credential !== previousCredential) {
-        setTestResults((prev) => ({
-          ...prev,
-          [type]: initializeTestSteps(credential),
-        }));
-      }
-    });
-
-    previousCredentialsRef.current = credentials;
-  }, [credentials, setTestResults]);
-
-  // Validation useEffect
-  useEffect(() => {
-    Object.entries(credentials).forEach(([type, credential]) => {
-      const credentialType = type as PermittedCredentialType;
-      const cached = validatedCredentialsRef.current[credentialType];
-
-      // Skip if this credential has already been validated
-      if (cached?.credential.original === credential.original) {
-        return;
-      }
-
-      const verifyAndValidate = async () => {
-        try {
-          // Set in-progress state
-          setTestResults((prev) => ({
-            ...prev,
-            [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-              step.id === TestCaseStepId.VERIFICATION ||
-              step.id === TestCaseStepId.UNTP_SCHEMA_VALIDATION ||
-              step.id === TestCaseStepId.VCDM_SCHEMA_VALIDATION ||
-              step.id === TestCaseStepId.CONTEXT_VALIDATION
-                ? { ...step, status: TestCaseStatus.IN_PROGRESS }
-                : step,
-            ),
-          }));
-
-          // Verification
-          const verificationResult = await verifyCredential(credential.original);
-          setTestResults((prev) => ({
-            ...prev,
-            [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-              step.id === TestCaseStepId.VERIFICATION
-                ? {
-                    ...step,
-                    status: verificationResult.verified ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
-                    details: {
-                      verified: verificationResult.verified,
-                      ...(verificationResult.error && { error: verificationResult.error }),
-                    },
-                  }
-                : step,
-            ),
-          }));
-
-          if (!verificationResult.verified) {
-            const errorMessage =
-              typeof verificationResult.error === 'object'
-                ? verificationResult.error.message || 'The credential could not be verified'
-                : verificationResult.error || 'The credential could not be verified';
-
-            toast.error('Credential verification failed', {
-              description: errorMessage,
-            });
-          }
-
-          // Store reference to validated credential
-          validatedCredentialsRef.current[credentialType] = {
-            credential: {
-              original: credential.original,
-              decoded: credential.decoded,
-            },
-            validated: true,
-          };
-
-          let allChecksPass = verificationResult.verified;
-          const extension = detectExtension(credential.decoded);
-
-          // VCDM schema validation
-          try {
-            const vcdmValidationResult = await validateVcdmRules(credential.decoded);
-
-            allChecksPass = allChecksPass && vcdmValidationResult.valid;
-
-            setTestResults((prev) => ({
-              ...prev,
-              [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-                step.id === TestCaseStepId.VCDM_SCHEMA_VALIDATION
-                  ? {
-                      ...step,
-                      status: vcdmValidationResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
-                      details: vcdmValidationResult,
-                    }
-                  : step,
-              ),
-            }));
-          } catch (error) {
-            toast.error('Failed to fetch the VCDM schema. Please contact support.');
-
-            allChecksPass = false;
-
-            setTestResults((prev) => ({
-              ...prev,
-              [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-                step.id === TestCaseStepId.VCDM_SCHEMA_VALIDATION
-                  ? {
-                      ...step,
-                      status: TestCaseStatus.FAILURE,
-                    }
-                  : step,
-              ),
-            }));
-          }
-
-          // Schema validation
-          try {
-            const validationResult = await validateCredentialSchema(credential.decoded);
-            allChecksPass = allChecksPass && validationResult.valid;
-
-            setTestResults((prev) => ({
-              ...prev,
-              [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-                step.id === TestCaseStepId.UNTP_SCHEMA_VALIDATION
-                  ? {
-                      ...step,
-                      status: validationResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
-                      details: validationResult,
-                    }
-                  : step,
-              ),
-            }));
-          } catch (error) {
-            allChecksPass = false;
-            console.log('Schema validation error:', error);
-            toast.error('Failed to fetch schema. Please try again.');
-
-            // Only update the schema validation step
-            setTestResults((prev) => ({
-              ...prev,
-              [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-                step.id === TestCaseStepId.UNTP_SCHEMA_VALIDATION
-                  ? {
-                      ...step,
-                      status: TestCaseStatus.FAILURE,
-                      details: {
-                        errors: [
-                          {
-                            keyword: 'schema',
-                            message: 'Failed to fetch schema',
-                            instancePath: '',
-                            params: {
-                              missingValue: 'The schema could not be loaded due to missing UNTP context IRIs.',
-                              solution:
-                                "Ensure the credential includes the required UNTP context IRIs in the '@context' field.",
-                              allowedValue: allowedContextValue,
-                              receivedValue: credential,
-                            },
-                          },
-                        ],
-                      },
-                    }
-                  : step,
-              ),
-            }));
-          }
-
-          // JSON-LD Document Expansion and Context Validation
-          const validateContextResult = await validateContext(credential.decoded);
-          const contextTestResult = { status: TestCaseStatus.SUCCESS, details: validateContextResult.data };
-
-          if (!validateContextResult.valid) {
-            allChecksPass = false;
-            toast.error(
-              'Validation of the JSON-LD context failed. Please check the View Details for more information.',
-            );
-            contextTestResult.status = TestCaseStatus.FAILURE;
-            contextTestResult.details = { errors: [validateContextResult.error] };
-          }
-
-          setTestResults((prev) => ({
-            ...prev,
-            [type as CredentialType]: prev[type as CredentialType]?.map((step) =>
-              step.id === TestCaseStepId.CONTEXT_VALIDATION
-                ? {
-                    ...step,
-                    status: contextTestResult.status,
-                    details: contextTestResult.details,
-                  }
-                : step,
-            ),
-          }));
-
-          // Extension schema validation
-          if (extension) {
-            try {
-              const extensionValidationResult = await validateExtension(credential.decoded);
-              allChecksPass = allChecksPass && extensionValidationResult.valid;
-
-              setTestResults((prev) => ({
-                ...prev,
-                [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-                  step.id === TestCaseStepId.EXTENSION_SCHEMA_VALIDATION
-                    ? {
-                        ...step,
-                        status: extensionValidationResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
-                        details: extensionValidationResult,
-                      }
-                    : step,
-                ),
-              }));
-            } catch (error) {
-              allChecksPass = false;
-              console.log('Extension schema validation error:', error);
-              toast.error('Failed to fetch extension schema. Please try again.');
-
-              // Only update the schema validation step
-              setTestResults((prev) => ({
-                ...prev,
-                [type as PermittedCredentialType]: prev[type as PermittedCredentialType]?.map((step) =>
-                  step.id === TestCaseStepId.EXTENSION_SCHEMA_VALIDATION
-                    ? {
-                        ...step,
-                        status: TestCaseStatus.FAILURE,
-                        details: {
-                          errors: [
-                            {
-                              keyword: 'schema',
-                              message: 'Failed to fetch extension schema',
-                              instancePath: '',
-                              params: {
-                                missingValue: 'The schema could not be loaded due to missing extension context IRIs.',
-                                solution:
-                                  "Ensure the credential includes the required extension context IRIs in the '@context' field.",
-                                allowedValue: allowedExtensionValue,
-                                receivedValue: credential,
-                              },
-                            },
-                          ],
-                        },
-                      }
-                    : step,
-                ),
-              }));
-            }
-          }
-
-          // Trigger confetti only if all checks pass
-          if (allChecksPass && !validatedCredentialsRef.current[credentialType]?.confettiShown) {
-            confetti(confettiConfig);
-
-            validatedCredentialsRef.current[credentialType] = {
-              ...validatedCredentialsRef.current[credentialType]!,
-              confettiShown: true,
-            };
-          }
-        } catch (error) {
-          console.log('Error processing credential:', error);
-        }
-      };
-
-      verifyAndValidate();
-    });
-  }, [credentials, setTestResults]);
-
-  const toggleGroup = (groupId: string) => {
-    setExpandedGroups((prev) => (prev.includes(groupId) ? prev.filter((id) => id !== groupId) : [...prev, groupId]));
-  };
-
-  return (
-    <div className='space-y-4'>
-      {permittedCredentialTypes.map((type) => {
-        const credential = credentials[type];
-        const steps = testResults[type] || [];
-        const hasCredential = !!credential;
-        const extension = hasCredential ? detectExtension(credential.decoded) : null;
-        const version = hasCredential
-          ? extension?.core?.version || detectVersion(credential.decoded)
-          : VCDMVersion.UNKNOWN;
-        const extensionCredentialType = extension?.extension?.type;
-        const extensionVersion = extension?.extension?.version;
-        const vcdmVersion = hasCredential ? detectVcdmVersion(credential.decoded) : undefined;
-
-        return (
-          <TestGroup
-            key={type}
-            credentialType={type}
-            version={version}
-            vcdmVersion={vcdmVersion}
-            extensionCredentialType={extensionCredentialType}
-            extensionVersion={extensionVersion}
-            steps={steps}
-            isExpanded={expandedGroups.includes(type)}
-            onToggle={() => toggleGroup(type)}
-            hasCredential={hasCredential}
-            source={credential?.source}
-          />
-        );
-      })}
-    </div>
-  );
-}

--- a/packages/untp-playground/src/components/TestResults.tsx
+++ b/packages/untp-playground/src/components/TestResults.tsx
@@ -329,19 +329,40 @@ async function runCredentialPipeline(
       toast.error('Failed to fetch schema. Please try again.');
     }
 
-    const validateContextResult = await validateContext(stored.decoded);
-    if (
-      !setStep(TestCaseStepId.CONTEXT_VALIDATION, {
-        status: validateContextResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
-        details: validateContextResult.valid
-          ? validateContextResult.data
-          : { errors: validateContextResult.error ? [validateContextResult.error] : [] },
-      })
-    ) {
-      return;
-    }
-    if (!validateContextResult.valid) {
-      toast.error('Validation of the JSON-LD context failed. Please check the View Details for more information.');
+    try {
+      const validateContextResult = await validateContext(stored.decoded);
+      if (
+        !setStep(TestCaseStepId.CONTEXT_VALIDATION, {
+          status: validateContextResult.valid ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
+          details: validateContextResult.valid
+            ? validateContextResult.data
+            : { errors: validateContextResult.error ? [validateContextResult.error] : [] },
+        })
+      ) {
+        return;
+      }
+      if (!validateContextResult.valid) {
+        toast.error('Validation of the JSON-LD context failed. Please check the View Details for more information.');
+      }
+    } catch (error) {
+      console.log('Context validation error:', error);
+      if (
+        !setStep(TestCaseStepId.CONTEXT_VALIDATION, {
+          status: TestCaseStatus.FAILURE,
+          details: {
+            errors: [
+              {
+                keyword: 'context',
+                message: error instanceof Error ? error.message : 'Failed to validate the JSON-LD context',
+                instancePath: '',
+              },
+            ],
+          },
+        })
+      ) {
+        return;
+      }
+      toast.error('Validation of the JSON-LD context failed. Please try again.');
     }
 
     if (extension) {

--- a/packages/untp-playground/src/contexts/TestReportContext.tsx
+++ b/packages/untp-playground/src/contexts/TestReportContext.tsx
@@ -2,10 +2,10 @@
 
 import { generateReport } from '@/lib/reportService';
 import { downloadHtml, downloadJson } from '@/lib/utils';
-import { DownloadReportFormat, SchemeReportInput, StoredCredential, TestReport, TestStep } from '@/types';
+import { CredentialReportInput, DownloadReportFormat, SchemeReportInput, TestReport, TestStep } from '@/types';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { CredentialType, TestCaseStatus } from '../../constants';
+import { TERMINAL_STATUSES, TestCaseStatus } from '../../constants';
 
 interface TestReportContextType {
   canGenerateReport: boolean;
@@ -17,47 +17,42 @@ interface TestReportContextType {
 
 const TestReportContext = createContext<TestReportContextType | undefined>(undefined);
 
-// A stable empty default so a consumer with no schemes does not churn the report-reset effect.
+// Stable empty defaults so a consumer with no credentials or schemes does not churn the
+// report-reset effect.
+const NO_CREDENTIAL_INSTANCES: CredentialReportInput[] = [];
 const NO_SCHEME_INSTANCES: SchemeReportInput[] = [];
 
 interface TestReportProviderProps {
   children: React.ReactNode;
-  testResults: Partial<Record<CredentialType, TestStep[]>>;
-  credentials: Partial<Record<CredentialType, StoredCredential>>;
+  credentialInstances?: CredentialReportInput[];
   schemeInstances?: SchemeReportInput[];
 }
 
 export function TestReportProvider({
   children,
-  testResults,
-  credentials,
+  credentialInstances = NO_CREDENTIAL_INSTANCES,
   schemeInstances = NO_SCHEME_INSTANCES,
 }: TestReportProviderProps) {
   const [report, setReport] = useState<TestReport | null>(null);
 
-  const allowedStatuses = [TestCaseStatus.SUCCESS, TestCaseStatus.FAILURE, TestCaseStatus.WARNING];
   const passStatuses = [TestCaseStatus.SUCCESS, TestCaseStatus.WARNING];
 
   // Invalidate any generated report whenever the loaded artefacts change, including when the last
   // one is removed, so a stale report cannot be downloaded for artefacts no longer loaded.
   useEffect(() => {
     setReport(null);
-  }, [credentials, schemeInstances]);
+  }, [credentialInstances, schemeInstances]);
 
   // A report needs at least one loaded family, and every loaded family must be fully terminal (a
   // non-empty result whose steps have all settled). A still-validating credential or scheme holds
   // generation rather than being recorded as a spurious pass or failure (ADR-041).
   const isTerminal = (steps: TestStep[] | undefined) =>
-    steps !== undefined && steps.length > 0 && steps.every((step) => allowedStatuses.includes(step.status));
+    steps !== undefined && steps.length > 0 && steps.every((step) => TERMINAL_STATUSES.includes(step.status));
 
-  const hasCredentials = Object.values(credentials).some((cred) => cred && cred.decoded);
+  const hasCredentials = credentialInstances.length > 0;
   const hasSchemes = schemeInstances.length > 0;
 
-  const allCredentialsTerminal = (Object.keys(credentials) as CredentialType[]).every((type) => {
-    const credential = credentials[type];
-    if (!credential || !credential.decoded) return true;
-    return isTerminal(testResults[type]);
-  });
+  const allCredentialsTerminal = credentialInstances.every(({ steps }) => isTerminal(steps));
   const allSchemesTerminal = schemeInstances.every(({ steps }) => isTerminal(steps));
 
   const canGenerateReport =
@@ -71,8 +66,7 @@ export function TestReportProvider({
     try {
       const newReport = await generateReport({
         implementationName,
-        credentials,
-        testResults,
+        credentialInstances,
         schemeInstances,
         passStatuses,
       });

--- a/packages/untp-playground/src/lib/credentialCollection.ts
+++ b/packages/untp-playground/src/lib/credentialCollection.ts
@@ -1,0 +1,157 @@
+/**
+ * Credential family layer over the shared per-instance model (ADR-041).
+ *
+ * The shared model in artefactCollection.ts owns the generic mechanics; this file owns the
+ * credential-specific parts: the content hash that identifies a credential instance, when its
+ * result is terminal, its card title and subtitle copy, the detected type used to group instances
+ * (#810), and the worst-of rollup shown on a type group's header and reused for a single
+ * instance's own overall status.
+ */
+
+import { hashContent } from '@/lib/hash';
+import { detectCredentialType, detectVersion } from '@/lib/credentialService';
+import { detectExtension } from '@/lib/schemaValidation';
+import type { Credential, StoredCredential, TestStep } from '@/types';
+import { TERMINAL_STATUSES, TestCaseStatus } from '../../constants';
+
+/**
+ * A credential instance's identity is the content hash of its decoded document, never the
+ * enveloping JWT, so an enveloped credential keys on its document rather than the envelope
+ * string.
+ */
+export function credentialContentHash(decoded: Record<string, unknown>): string {
+  return hashContent(decoded);
+}
+
+/**
+ * A credential's pipeline is terminal once every step has settled. Uses the shared
+ * `TERMINAL_STATUSES` so the remove gate agrees with report readiness on whether WARNING counts as
+ * settled (they must, or a finished instance could be readable in the report yet non-removable).
+ */
+export function credentialIsTerminal(steps: TestStep[]): boolean {
+  return steps.length > 0 && steps.every((step) => TERMINAL_STATUSES.includes(step.status));
+}
+
+/**
+ * The detected type used to group instances: an extension's resolved core type takes precedence
+ * over the raw detected type, matching the ingest check in `page.tsx`, so a re-ingest whose
+ * detected type changed moves the same instance between groups rather than splitting identity.
+ */
+export function credentialGroupType(decoded: Record<string, unknown>): string {
+  const extension = detectExtension(decoded);
+  if (extension) return extension.core.type;
+  return detectCredentialType(decoded as Credential);
+}
+
+/** Splits a PascalCase credential type into spaced words, e.g. "Digital Product Passport". */
+export function credentialTypeLabel(type: string): string {
+  return type.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+}
+
+/**
+ * The group header label: the spaced type, pluralised when the group holds more than one instance.
+ * Every UNTP credential type ends in a word that pluralises with a trailing "s" (Passport, Credential,
+ * Record, Anchor, Event), so a simple suffix is correct for the grouped types.
+ */
+export function credentialGroupLabel(type: string, count: number): string {
+  const label = credentialTypeLabel(type);
+  return count === 1 ? label : `${label}s`;
+}
+
+/** Instance row title: the filename, or a URL's final path segment, else the detected type. Never the raw URL. */
+export function credentialTitle(stored: StoredCredential): string {
+  const source = stored.source;
+  if (source?.kind === 'url') {
+    const segment = finalPathSegment(source.url);
+    if (segment) return segment;
+  }
+  if (source?.kind === 'file' && source.filename.length > 0) return source.filename;
+
+  return credentialTypeLabel(credentialGroupType(stored.decoded));
+}
+
+/**
+ * Instance row subtitle: the detected version and issuer, with the source host first for a
+ * URL-sourced instance. When the credential is a known extension, the version slot names the
+ * extension itself (type and version, e.g. "DigitalLivestockPassport v0.4.0") so the row shows the
+ * specific extension that was validated, not just the core UNTP version of the group it sits under.
+ */
+export function credentialSubtitle(stored: StoredCredential): string {
+  const decoded = stored.decoded;
+  const extension = detectExtension(decoded);
+  const versionLabel = extension ? extensionLabel(extension.extension) : coreVersionLabel(detectVersion(decoded));
+  const issuer = credentialIssuerId(decoded);
+
+  const parts: string[] = [];
+  const source = stored.source;
+  if (source?.kind === 'url') {
+    const host = hostOf(source.url);
+    if (host) parts.push(host);
+  }
+  parts.push(versionLabel);
+  if (issuer) parts.push(issuer);
+
+  return parts.join(' · ');
+}
+
+function coreVersionLabel(version: string): string {
+  return version && version !== 'unknown' ? `v${version}` : 'unknown version';
+}
+
+function extensionLabel(extension: { type: string; version: string }): string {
+  const suffix = extension.version && extension.version !== 'unknown' ? ` v${extension.version}` : '';
+  return `${extension.type}${suffix}`;
+}
+
+/**
+ * Extensible worst-of rollup, ordered worst first. Reduces either a single instance's own step
+ * statuses to its overall status, or a type group's per-instance statuses to the group rollup, so
+ * a future bucket (#813 adds an amber "blocked" state) is added as one more entry here rather than
+ * by rewriting a cascade of if/else across both call sites.
+ */
+const ROLLUP_BUCKETS: { matches: TestCaseStatus[]; canonical: TestCaseStatus }[] = [
+  { matches: [TestCaseStatus.FAILURE], canonical: TestCaseStatus.FAILURE },
+  { matches: [TestCaseStatus.PENDING, TestCaseStatus.IN_PROGRESS], canonical: TestCaseStatus.IN_PROGRESS },
+  { matches: [TestCaseStatus.SUCCESS, TestCaseStatus.WARNING], canonical: TestCaseStatus.SUCCESS },
+];
+
+export function worstStatus(statuses: TestCaseStatus[]): TestCaseStatus {
+  if (statuses.length === 0) return TestCaseStatus.PENDING;
+  for (const bucket of ROLLUP_BUCKETS) {
+    if (statuses.some((status) => bucket.matches.includes(status))) return bucket.canonical;
+  }
+  return TestCaseStatus.FAILURE;
+}
+
+/** A single instance's own overall status, from its own steps (`undefined` before its run starts). */
+export function instanceStatus(steps: TestStep[] | undefined): TestCaseStatus {
+  if (!steps || steps.length === 0) return TestCaseStatus.PENDING;
+  return worstStatus(steps.map((step) => step.status));
+}
+
+function credentialIssuerId(decoded: Record<string, unknown>): string | undefined {
+  const issuer = (decoded as { issuer?: unknown }).issuer;
+  if (typeof issuer === 'string' && issuer.length > 0) return issuer;
+  if (issuer && typeof issuer === 'object' && typeof (issuer as { id?: unknown }).id === 'string') {
+    return (issuer as { id: string }).id;
+  }
+  return undefined;
+}
+
+function hostOf(rawUrl: string): string | undefined {
+  try {
+    return new URL(rawUrl).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+function finalPathSegment(rawUrl: string): string | undefined {
+  try {
+    const url = new URL(rawUrl);
+    const parts = url.pathname.split('/').filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : url.hostname;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/untp-playground/src/lib/reportService.ts
+++ b/packages/untp-playground/src/lib/reportService.ts
@@ -1,9 +1,11 @@
 import { detectVersion } from '@/lib/credentialService';
+import { credentialGroupType } from '@/lib/credentialCollection';
 import { detectExtension } from '@/lib/schemaValidation';
 import { detectSchemeVersion } from '@/lib/schemeValidation';
 import {
+  CredentialReportInput,
+  PermittedCredentialType,
   SchemeReportInput,
-  StoredCredential,
   TestReport,
   TestReportResult,
   TestReportSchemeResult,
@@ -11,36 +13,29 @@ import {
   TestStep,
 } from '@/types';
 import { reportName, testSuiteRunner, testSuiteUrl, testSuiteVersion } from '../../config';
-import { CredentialType, SchemeType, TestCaseStatus, TestCaseStepId } from '../../constants';
+import { SchemeType, TERMINAL_STATUSES, TestCaseStatus, TestCaseStepId } from '../../constants';
 
 interface GenerateReportParams {
   implementationName: string;
-  credentials: Partial<Record<CredentialType, StoredCredential>>;
-  testResults: Partial<Record<CredentialType, TestStep[]>>;
+  credentialInstances?: CredentialReportInput[];
   schemeInstances?: SchemeReportInput[];
   passStatuses: TestCaseStatus[];
 }
 
 export const generateReport = async ({
   implementationName,
-  credentials,
-  testResults,
+  credentialInstances,
   schemeInstances,
   passStatuses,
 }: GenerateReportParams): Promise<TestReport> => {
   // Defence in depth for the ADR-041 report-readiness gate: every loaded artefact must be terminal
   // (a non-empty result whose steps have all settled). Refuse rather than record a mid-pipeline
   // artefact as a spurious pass or failure; the UI gate should already prevent reaching here.
-  const settledStatuses = [TestCaseStatus.SUCCESS, TestCaseStatus.FAILURE, TestCaseStatus.WARNING];
   const isTerminal = (steps: TestStep[]) =>
-    steps.length > 0 && steps.every((step) => settledStatuses.includes(step.status));
+    steps.length > 0 && steps.every((step) => TERMINAL_STATUSES.includes(step.status));
 
-  const validCredentials = Object.entries(credentials).map(
-    ([type, cred]) => [type, cred] as [CredentialType, NonNullable<typeof cred>],
-  );
-
-  for (const [type] of validCredentials) {
-    if (!isTerminal(testResults[type] ?? [])) {
+  for (const { steps } of credentialInstances ?? []) {
+    if (!isTerminal(steps)) {
       throw new Error('Cannot generate a report while a credential is still validating.');
     }
   }
@@ -50,8 +45,8 @@ export const generateReport = async ({
     }
   }
 
-  const results: TestReportResult[] = validCredentials.map(([type, credential]) => {
-    const steps = testResults[type] || [];
+  const results: TestReportResult[] = (credentialInstances ?? []).map(({ credential, steps }) => {
+    const type = credentialGroupType(credential.decoded) as PermittedCredentialType;
     const extension = detectExtension(credential.decoded);
     const version = extension ? extension.core.version : detectVersion(credential.decoded);
 

--- a/packages/untp-playground/src/types/report.ts
+++ b/packages/untp-playground/src/types/report.ts
@@ -1,8 +1,14 @@
 import { SchemeType, TestCaseStatus } from '../../constants';
 import { EXTENSION_VERSIONS } from '../lib/schemaValidation';
-import { ArtefactSource, Credential, StoredScheme } from './credential';
+import { ArtefactSource, Credential, StoredCredential, StoredScheme } from './credential';
 import { TestStep } from './test';
 import { PermittedCredentialType } from './untp';
+
+/** One loaded credential instance and its pipeline result, as the report consumes it (ADR-041). */
+export interface CredentialReportInput {
+  credential: StoredCredential;
+  steps: TestStep[];
+}
 
 /** One loaded scheme instance and its pipeline result, as the report consumes it (ADR-041). */
 export interface SchemeReportInput {


### PR DESCRIPTION
This PR makes the UNTP Playground keep every credential a user validates instead of overwriting the previous one of the same type, so validating several credentials of a type in one session now shows each as its own result.
Each credential type appears as a group only once it has an instance, with a count and a rollup status while collapsed, and every instance is an independently validated child row identified by the content hash of its decoded document, replaced in place when identical content is re-uploaded and removed via a confirmation dialog.
This is the credentials-family consumer of the shared per-instance model recorded in ADR-041, following the conformity-schemes consumer landed by #677.

Closes #810
Part of #808

## Test plan
- [x] A second credential of a type appears as a new instance row rather than overwriting the first
- [x] Re-uploading identical content replaces the instance in place with a Replaced toast and no duplicate row
- [x] Removing the last instance of a type makes the group disappear
- [x] An enveloped credential keys on its decoded document, so two envelopes of the same document are one instance
- [x] A verification-service error fails the verification step visibly and leaves the instance removable rather than stuck
