### PR TITLE
fix(services): harden the public-URL SSRF guard against IPv6 classification bypasses

### DIFF
--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -22,7 +22,13 @@ const jestConfig = {
     '^@uncefact/untp-utils/validation$': '<rootDir>/../untp-utils/build/validation/index.js',
     '^@uncefact/untp-utils/conformity-vocabulary$': '<rootDir>/../untp-utils/build/conformity-vocabulary/index.js',
     '^@uncefact/untp-utils$': '<rootDir>/../untp-utils/build/index.js',
-    '(.+)\\.js': '$1',
+    // Strips the `.js` extension this package's ESM-style relative imports
+    // use (e.g. `./utils/validate-public-url.js`) so Jest's CJS resolver
+    // finds the `.ts` source. Anchored to relative-path specifiers only: an
+    // unanchored pattern also matches bare package specifiers that happen to
+    // end in `.js` (e.g. the `ipaddr.js` npm package), mangling them into an
+    // unresolvable module name.
+    '^(\\.{1,2}/.+)\\.js$': '$1',
   },
   extensionsToTreatAsEsm: ['.ts'],
 };

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -75,6 +75,7 @@
   "dependencies": {
     "@uncefact/untp-utils": "workspace:*",
     "@vckit/core-types": "1.0.0-beta.7",
+    "ipaddr.js": "^2.4.0",
     "jose": "^5.9.3",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/packages/services/src/utils/validate-public-url.test.ts
+++ b/packages/services/src/utils/validate-public-url.test.ts
@@ -5,6 +5,20 @@ jest.mock('node:dns', () => ({
   },
 }));
 
+// Defaults to the real `ipaddr.js` behaviour so every test other than the
+// fail-closed ones below exercises the genuine range/parse logic; only the
+// tests that need to force a parser failure or a defensive branch override
+// the implementation for a single call via `mockImplementationOnce`.
+const actualIpaddrParse: (typeof import('ipaddr.js'))['parse'] = jest.requireActual('ipaddr.js').parse;
+const mockIpaddrParse = jest.fn((...args: Parameters<typeof actualIpaddrParse>) => actualIpaddrParse(...args));
+jest.mock('ipaddr.js', () => {
+  const actual = jest.requireActual('ipaddr.js');
+  return {
+    ...actual,
+    parse: (...args: Parameters<typeof actualIpaddrParse>) => mockIpaddrParse(...args),
+  };
+});
+
 import { isPrivateIpv4, isPrivateIpv6, validatePublicUrl } from './validate-public-url';
 
 describe('isPrivateIpv4', () => {
@@ -21,11 +35,24 @@ describe('isPrivateIpv4', () => {
     ['169.254.0.1', true],
     ['0.0.0.0', true],
     ['0.255.255.255', true],
+    // Documentation (RFC 5737 / TEST-NET-1)
+    ['192.0.2.1', true],
+    // Benchmarking (RFC 2544)
+    ['198.18.0.1', true],
+    ['198.19.255.255', true],
+    // Multicast (RFC 3171)
+    ['224.0.0.1', true],
+    ['239.255.255.255', true],
+    // Reserved (RFC 1700 and friends)
+    ['240.0.0.1', true],
+    ['255.255.255.254', true],
+    // Carrier-grade NAT (RFC 6598)
+    ['100.64.0.1', true],
     ['93.184.216.34', false],
     ['8.8.8.8', false],
     ['172.32.0.1', false],
     ['1.1.1.1', false],
-  ])('returns %s for %s', (address, expected) => {
+  ])('isPrivateIpv4(%s) returns %s', (address, expected) => {
     expect(isPrivateIpv4(address)).toBe(expected);
   });
 
@@ -34,49 +61,116 @@ describe('isPrivateIpv4', () => {
     expect(isPrivateIpv4('256.0.0.1')).toBe(false);
     expect(isPrivateIpv4('1.2.3')).toBe(false);
   });
+
+  it('fails closed when ipaddr.js cannot parse a value node:net accepted', () => {
+    mockIpaddrParse.mockImplementationOnce(() => {
+      throw new Error('parser/version skew');
+    });
+    expect(isPrivateIpv4('93.184.216.34')).toBe(true);
+  });
 });
 
 describe('isPrivateIpv6', () => {
   it.each([
+    ['::', true],
     ['::1', true],
     ['fe80::1', true],
     ['fe80:0000::1', true],
+    // Unique-local (RFC 4193)
+    ['fd00::1', true],
+    ['fc00::1', true],
     ['::ffff:127.0.0.1', true],
     ['::ffff:10.0.0.1', true],
     ['::ffff:192.168.1.1', true],
     ['::ffff:93.184.216.34', false],
-    ['2001:db8::1', false],
-  ])('returns %s for %s', (address, expected) => {
+    // IPv4-mapped form in hex-group notation (equivalent to ::ffff:127.0.0.1
+    // above); `URL.hostname` normalises bracketed literals to this shape, so
+    // the dotted-quad form above alone would never actually be exercised by
+    // validatePublicUrl.
+    ['::ffff:7f00:1', true],
+    // Deprecated IPv4-compatible form (RFC 4291 section 2.5.5.1): the same
+    // embedded-address structure as IPv4-mapped but without the 0xffff
+    // marker. `::7f00:1` is `::127.0.0.1` and `::a9fe:a9fe` is
+    // `::169.254.169.254` (cloud metadata) in hex-group notation, the exact
+    // shape `URL.hostname` produces for a bracketed literal.
+    ['::7f00:1', true],
+    ['::a9fe:a9fe', true],
+    // Same embedded-form structure but wrapping a genuine public address
+    // (`::5db8:d822` is `::93.184.216.34`): the IPv4-compatible form is
+    // rejected unconditionally regardless of the embedded address, because
+    // the form itself (RFC 4291 section 2.5.5.1) is deprecated, IANA-reserved
+    // space that does not route, not merely a wrapper around a real address.
+    ['::5db8:d822', true],
+    // Documentation (RFC 3849 / RFC 2928): reserved, not routable, and must
+    // not be treated as public even though it looks like an ordinary
+    // globally-scoped (2000::/3) address.
+    ['2001:db8::1', true],
+    // Unallocated / IANA-reserved space above the Global Unicast block.
+    // `ipaddr.js` has no named special range for any of these, so its
+    // `range()` reports the 'unicast' fallback default for all of them; the
+    // Global Unicast (2000::/3) gate is what correctly denies them.
+    ['4000::1', true],
+    ['fe00::1', true],
+    ['101::1', true],
+    ['100:0:0:1::1', true],
+    // Decommissioned 6bone experimental block (3ffe::/16): sits inside
+    // 2000::/3 (so the Global Unicast gate alone would let it through) and
+    // `ipaddr.js` 2.4.0 has no named range for it (reports the 'unicast'
+    // fallback), so it needs the explicit reject.
+    ['3ffe::1', true],
+    // Public IPv6 literal (bracket-stripped by the caller before reaching here)
+    ['2606:4700:4700::1111', false],
+    ['2001:4860:4860::8888', false],
+  ])('isPrivateIpv6(%s) returns %s', (address, expected) => {
     expect(isPrivateIpv6(address)).toBe(expected);
+  });
+
+  it('returns false for invalid addresses', () => {
+    expect(isPrivateIpv6('not-an-ip')).toBe(false);
+    expect(isPrivateIpv6('93.184.216.34')).toBe(false);
+  });
+
+  it('fails closed when ipaddr.js cannot parse a value node:net accepted', () => {
+    mockIpaddrParse.mockImplementationOnce(() => {
+      throw new Error('parser/version skew');
+    });
+    expect(isPrivateIpv6('2606:4700:4700::1111')).toBe(true);
+  });
+
+  it('fails closed when ipaddr.js reports a non-ipv6 kind for an IPv6-shaped input', () => {
+    // Defensive branch: a parser/version mismatch that returns the wrong
+    // address family for input node:net already classified as IPv6.
+    mockIpaddrParse.mockImplementationOnce(() => ({ kind: () => 'ipv4' }) as ReturnType<typeof actualIpaddrParse>);
+    expect(isPrivateIpv6('2606:4700:4700::1111')).toBe(true);
   });
 });
 
 describe('validatePublicUrl', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    mockDnsLookup.mockReset();
   });
 
   it('allows public IP addresses', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
     await expect(validatePublicUrl(new URL('https://example.com/cred'))).resolves.toBeUndefined();
   });
 
   it('rejects hostname resolving to localhost', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+    mockDnsLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
     await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
       'uri must not point to a private or reserved network address',
     );
   });
 
   it('rejects hostname resolving to private network', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+    mockDnsLookup.mockResolvedValue([{ address: '10.0.0.1', family: 4 }]);
     await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
       'uri must not point to a private or reserved network address',
     );
   });
 
   it('rejects hostname resolving to cloud metadata IP', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '169.254.169.254', family: 4 });
+    mockDnsLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
     await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
       'uri must not point to a private or reserved network address',
     );
@@ -89,10 +183,89 @@ describe('validatePublicUrl', () => {
     expect(mockDnsLookup).not.toHaveBeenCalled();
   });
 
-  it('rejects IPv6 loopback literal', async () => {
+  it('rejects bracketed IPv6 loopback literal as private, without a DNS call', async () => {
     await expect(validatePublicUrl(new URL('http://[::1]/cred'))).rejects.toThrow(
       'uri must not point to a private or reserved network address',
     );
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it('rejects bracketed IPv6 unique-local literal as private, without a DNS call', async () => {
+    await expect(validatePublicUrl(new URL('http://[fd00::1]/cred'))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['loopback (::127.0.0.1)', '[::127.0.0.1]'],
+    ['cloud metadata (::169.254.169.254)', '[::169.254.169.254]'],
+  ])('rejects a bracketed IPv4-compatible IPv6 literal wrapping a %s address', async (_label, hostLiteral) => {
+    await expect(validatePublicUrl(new URL(`http://${hostLiteral}/cred`))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it('accepts a bracketed public IPv6 literal without a DNS call', async () => {
+    await expect(validatePublicUrl(new URL('http://[2606:4700:4700::1111]/cred'))).resolves.toBeUndefined();
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['4000::/3', '[4000::1]'],
+    ['fe00::/9', '[fe00::1]'],
+    ['100::/8', '[101::1]'],
+    ['3ffe::/16 (decommissioned 6bone)', '[3ffe::1]'],
+  ])(
+    'rejects a bracketed IPv6 literal in unallocated/reserved space (%s), without a DNS call',
+    async (_label, hostLiteral) => {
+      await expect(validatePublicUrl(new URL(`http://${hostLiteral}/cred`))).rejects.toThrow(
+        'uri must not point to a private or reserved network address',
+      );
+      expect(mockDnsLookup).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a bracketed IPv4-mapped IPv6 literal wrapping a private address, without a DNS call', async () => {
+    await expect(validatePublicUrl(new URL('http://[::ffff:127.0.0.1]/cred'))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it('accepts a bracketed IPv4-mapped IPv6 literal wrapping a public address, without a DNS call', async () => {
+    await expect(validatePublicUrl(new URL('http://[::ffff:93.184.216.34]/cred'))).resolves.toBeUndefined();
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['documentation (TEST-NET-1)', '192.0.2.1'],
+    ['benchmarking', '198.18.0.1'],
+    ['multicast', '224.0.0.1'],
+    ['reserved', '240.0.0.1'],
+  ])('rejects an IPv4 literal in the %s range', async (_label, address) => {
+    await expect(validatePublicUrl(new URL(`http://${address}/cred`))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it('accepts a plain public IPv4 literal without a DNS call', async () => {
+    await expect(validatePublicUrl(new URL('http://93.184.216.34/cred'))).resolves.toBeUndefined();
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['RFC1918 (10/8)', '10.0.0.1'],
+    ['RFC1918 (172.16/12)', '172.16.0.1'],
+    ['RFC1918 (192.168/16)', '192.168.0.1'],
+    ['link-local / cloud metadata', '169.254.169.254'],
+  ])('rejects an IPv4 literal in the %s range', async (_label, address) => {
+    await expect(validatePublicUrl(new URL(`http://${address}/cred`))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+    expect(mockDnsLookup).not.toHaveBeenCalled();
   });
 
   it('rejects when DNS resolution fails', async () => {
@@ -102,10 +275,95 @@ describe('validatePublicUrl', () => {
     );
   });
 
+  it('preserves the underlying DNS error as the cause', async () => {
+    const dnsError = new Error('ENOTFOUND');
+    mockDnsLookup.mockRejectedValue(dnsError);
+    let caught: unknown;
+    try {
+      await validatePublicUrl(new URL('https://nonexistent.invalid'));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe('uri hostname could not be resolved');
+    expect((caught as Error).cause).toBe(dnsError);
+  });
+
+  it('rejects when DNS resolution returns no records', async () => {
+    mockDnsLookup.mockResolvedValue([]);
+    await expect(validatePublicUrl(new URL('https://empty.example.com'))).rejects.toThrow(
+      'uri hostname could not be resolved',
+    );
+  });
+
   it('rejects IPv6 private resolved address', async () => {
-    mockDnsLookup.mockResolvedValue({ address: '::1', family: 6 });
+    mockDnsLookup.mockResolvedValue([{ address: '::1', family: 6 }]);
     await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
       'uri must not point to a private or reserved network address',
     );
+  });
+
+  it('rejects a hostname resolving to a mix of public and private addresses (public first)', async () => {
+    mockDnsLookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.1', family: 4 },
+    ]);
+    await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+  });
+
+  it('rejects a hostname resolving to a mix of private and public addresses (private first)', async () => {
+    mockDnsLookup.mockResolvedValue([
+      { address: '10.0.0.1', family: 4 },
+      { address: '93.184.216.34', family: 4 },
+    ]);
+    await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+  });
+
+  it('rejects a resolved record whose claimed family disagrees with its address shape', async () => {
+    // A private IPv4 address mislabelled with family: 6 must not slip
+    // through by running the wrong (IPv6) predicate against a string that
+    // isn't a parseable IPv6 address, which would otherwise return false.
+    mockDnsLookup.mockResolvedValue([{ address: '10.0.0.1', family: 6 }]);
+    await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+  });
+
+  it('rejects a resolved record whose address is neither valid IPv4 nor valid IPv6', async () => {
+    mockDnsLookup.mockResolvedValue([{ address: 'not-an-ip-address', family: 4 }]);
+    await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+  });
+
+  it('rejects a resolved record with family: 0, even when the address itself is public', async () => {
+    // `record.family` is typed as a bare `number`; family 0 is a documented
+    // possible (resolver-bug) value. Using a PUBLIC address here means this
+    // test would pass under a weaker "classify by shape only, ignore
+    // record.family" implementation, which is not what is required: the
+    // derived family must also AGREE with the claimed family, and 0 can
+    // never agree with a real derived family of 4 or 6.
+    mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 0 }]);
+    await expect(validatePublicUrl(new URL('https://evil.example.com'))).rejects.toThrow(
+      'uri must not point to a private or reserved network address',
+    );
+  });
+
+  it('accepts a hostname whose every resolved address is public', async () => {
+    mockDnsLookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '1.1.1.1', family: 4 },
+    ]);
+    await expect(validatePublicUrl(new URL('https://example.com/cred'))).resolves.toBeUndefined();
+  });
+
+  it('calls dns.lookup with { all: true } so every advertised address is checked', async () => {
+    mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    await validatePublicUrl(new URL('https://example.com/cred'));
+    expect(mockDnsLookup).toHaveBeenCalledWith('example.com', { all: true });
   });
 });

--- a/packages/services/src/utils/validate-public-url.ts
+++ b/packages/services/src/utils/validate-public-url.ts
@@ -1,43 +1,137 @@
 import dns from 'node:dns';
+import { isIP, isIPv4, isIPv6 } from 'node:net';
+import ipaddr from 'ipaddr.js';
 
 /**
- * SSRF protection: private/reserved IPv4 CIDR ranges.
+ * The `ipaddr.js` range name its special-range matcher (`subnetMatch`)
+ * reports for an address that matches none of its named special ranges.
+ * This is a FALLBACK DEFAULT (`subnetMatch`'s own `defaultName` parameter
+ * defaults to `'unicast'`), not a positive "this address is allocated and
+ * globally routable" signal: an address in unallocated or reserved space
+ * that `ipaddr.js` has no named range for reports `'unicast'` exactly like
+ * a genuine public address does.
+ *
+ * For {@link isPrivateIpv4} this is safe to rely on alone: IANA's IPv4
+ * special-purpose registry is small and `ipaddr.js` enumerates it in full,
+ * so nothing outside that registry is left unaccounted for. For
+ * {@link isPrivateIpv6} it is not safe alone, because the unallocated
+ * reserved space above the Global Unicast block is vast and largely
+ * unenumerated by `ipaddr.js`; that predicate additionally gates on the
+ * allocated `2000::/3` block before trusting this value.
  */
-const PRIVATE_IP_RANGES: Array<{ prefix: number[]; bits: number }> = [
-  { prefix: [127, 0, 0, 0], bits: 8 }, // Loopback
-  { prefix: [10, 0, 0, 0], bits: 8 }, // Class A private
-  { prefix: [172, 16, 0, 0], bits: 12 }, // Class B private
-  { prefix: [192, 168, 0, 0], bits: 16 }, // Class C private
-  { prefix: [169, 254, 0, 0], bits: 16 }, // Link-local / cloud metadata
-  { prefix: [0, 0, 0, 0], bits: 8 }, // Current network
-];
+const PUBLIC_RANGE = 'unicast';
 
-function ipv4ToNumber(octets: number[]): number {
-  return ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0;
-}
-
+/**
+ * SSRF protection: returns true if `address` is an IPv4 address string that
+ * does not fall in the public unicast range. This covers RFC1918 private
+ * space, loopback, link-local/cloud-metadata (169.254.0.0/16), carrier-grade
+ * NAT, and the IANA-reserved documentation, benchmarking, multicast and
+ * reserved ranges.
+ *
+ * Fails closed: if `ipaddr.js` cannot parse a value that `node:net`'s
+ * `isIPv4` already accepted (parser/grammar skew across versions), the
+ * address is treated as private.
+ *
+ * Returns false for non-IPv4 input (including unparseable strings); callers
+ * are expected to have already established the string is an IPv4 literal.
+ */
 export function isPrivateIpv4(address: string): boolean {
-  const parts = address.split('.').map(Number);
-  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return false;
-  const ip = ipv4ToNumber(parts);
-  return PRIVATE_IP_RANGES.some(({ prefix, bits }) => {
-    const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
-    return (ip & mask) === (ipv4ToNumber(prefix) & mask);
-  });
+  if (!isIPv4(address)) return false;
+  try {
+    return ipaddr.parse(address).range() !== PUBLIC_RANGE;
+  } catch {
+    return true;
+  }
 }
 
+/**
+ * SSRF protection: returns true if `address` is an IPv6 address string that
+ * is not a genuine public Global Unicast address. This is a default-deny
+ * predicate: an address is treated as public only when it is both inside
+ * the allocated `2000::/3` Global Unicast block and not one of the named
+ * special-purpose ranges within it (documentation, teredo, 6to4,
+ * benchmarking); every other address, including reserved or unallocated
+ * space `ipaddr.js` has no name for, is denied. See the block comment
+ * inside for why a bare `range() === 'unicast'` check is not sufficient.
+ *
+ * Addresses that embed an IPv4 address are handled before the Global
+ * Unicast check, and the two embedded forms are NOT treated the same:
+ * - IPv4-mapped (`::ffff:a.b.c.d`) is a real IPv4 destination tunnelled
+ *   through IPv6, so the embedded address is re-checked against
+ *   {@link isPrivateIpv4} and accepted if public.
+ * - IPv4-compatible (`::a.b.c.d`, RFC 4291 §2.5.5.1) is deprecated,
+ *   IANA-reserved space that does not route, so it is rejected
+ *   unconditionally regardless of the embedded address. This also covers
+ *   `::` (unspecified) and `::1` (loopback), which take this same form.
+ *
+ * Fails closed on a parse error, mirroring {@link isPrivateIpv4}.
+ *
+ * Returns false for non-IPv6 input.
+ */
 export function isPrivateIpv6(address: string): boolean {
-  const lower = address.toLowerCase();
-  if (lower === '::1') return true;
-  // fe80::/10 (link-local)
-  if (lower.startsWith('fe80')) {
-    const firstSegment = parseInt(lower.split(':')[0], 16);
-    if ((firstSegment & 0xffc0) === 0xfe80) return true;
+  if (!isIPv6(address)) return false;
+  try {
+    const parsed = ipaddr.parse(address);
+    if (parsed.kind() !== 'ipv6') return true; // Defensive: parser/version skew. Fail closed.
+    const v6 = parsed as ipaddr.IPv6;
+    const bytes = v6.toByteArray();
+
+    // Both embedded-IPv4 forms encode the IPv4 address in the last 4 bytes
+    // with the first 10 bytes zero, differing only in bytes 10-11 (0x0000
+    // for IPv4-compatible, 0xffff for IPv4-mapped). Extracting directly from
+    // the byte array, rather than trusting `::ffff:` textual matching or
+    // `isIPv4MappedAddress()` (which recognises only the mapped form), means
+    // neither encoding can bypass classification through this predicate.
+    const embedsIpv4 = bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === bytes[11];
+    if (embedsIpv4 && bytes[10] === 0xff) {
+      return isPrivateIpv4(bytes.slice(12).join('.'));
+    }
+    if (embedsIpv4 && bytes[10] === 0x00) {
+      return true;
+    }
+
+    // `3ffe::/16` is the decommissioned 6bone experimental block: it sits
+    // inside `2000::/3` (top byte `0x3f`) so the Global Unicast gate below
+    // would otherwise let it through, and `ipaddr.js` 2.4.0 has no named
+    // range for it, so `range()` reports the 'unicast' fallback for it too.
+    // It is IANA-reserved and does not route; deny it explicitly.
+    if (bytes[0] === 0x3f && bytes[1] === 0xfe) {
+      return true;
+    }
+
+    // Default-deny: `range()` reports `PUBLIC_RANGE` ('unicast') for any
+    // address matching none of `ipaddr.js`'s named special ranges (see the
+    // comment on `PUBLIC_RANGE`), so it is not by itself a positive
+    // "allocated and routable" signal. `4000::1`, `fe00::1`, and `101::1`
+    // are all unallocated or IANA-reserved space, and all report
+    // `range() === 'unicast'`, so treating that alone as "public" fails
+    // open. Requiring the address to also fall inside the allocated Global
+    // Unicast block `2000::/3` (top 3 bits `001`) closes that gap while
+    // `range()` still excludes the named special-purpose ranges nested
+    // inside that block (documentation `2001:db8::/32`, teredo
+    // `2001::/32`, 6to4 `2002::/16`, benchmarking `2001:2::/48`).
+    //
+    // This is not a claim of complete IANA-allocation tracking: it denies
+    // everything outside `2000::/3`, everything `ipaddr.js` special-cases
+    // within it, and the explicitly-listed `3ffe::/16` above. It does not
+    // enumerate every IANA reservation inside `2000::/3` and cannot prove an
+    // address is *currently* routed; a maintained IANA-allocation layer
+    // would be needed for that and is out of scope for this predicate.
+    const isAllocatedGlobalUnicast = (bytes[0] & 0xe0) === 0x20;
+    return !(isAllocatedGlobalUnicast && v6.range() === PUBLIC_RANGE);
+  } catch {
+    return true;
   }
-  // ::ffff:<ipv4> (IPv4-mapped IPv6)
-  const v4Mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (v4Mapped) return isPrivateIpv4(v4Mapped[1]);
-  return false;
+}
+
+/**
+ * Strips the brackets `URL.hostname` wraps around an IPv6 literal (e.g.
+ * `[::1]` becomes `::1`) so the value can be passed to `node:net`'s
+ * `isIPv4`/`isIPv6`, to the predicates above, and to DNS resolution.
+ * Non-bracketed hostnames pass through unchanged.
+ */
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, '');
 }
 
 /**
@@ -46,26 +140,55 @@ export function isPrivateIpv6(address: string): boolean {
  * This prevents SSRF attacks where a user-supplied URL could target internal
  * services, cloud metadata endpoints (169.254.169.254), or localhost.
  *
+ * DNS resolution is performed with `{ all: true }`; the URL is rejected if
+ * any resolved address is private, so a hostname that resolves to a mix of
+ * public and private addresses cannot pass on the strength of whichever
+ * record the resolver happened to prefer.
+ *
  * @param url - Parsed URL to validate
  * @throws Error with message 'uri must not point to a private or reserved network address'
+ * @throws Error with message 'uri hostname could not be resolved'
  */
 export async function validatePublicUrl(url: URL): Promise<void> {
-  const hostname = url.hostname;
+  const hostname = stripIpv6Brackets(url.hostname);
 
-  // Check IP literals directly
-  if (isPrivateIpv4(hostname) || isPrivateIpv6(hostname)) {
-    throw new Error('uri must not point to a private or reserved network address');
+  // IP literals are checked directly and never reach DNS: a private literal
+  // is rejected without leaking a lookup, and a public literal is the
+  // resolved address already, so resolving it again would be redundant.
+  if (isIPv4(hostname) || isIPv6(hostname)) {
+    if (isPrivateIpv4(hostname) || isPrivateIpv6(hostname)) {
+      throw new Error('uri must not point to a private or reserved network address');
+    }
+    return;
   }
 
-  // Resolve hostname to IP and check
-  let resolved: { address: string; family: number };
+  let resolved: Array<{ address: string; family: number }>;
   try {
-    resolved = await dns.promises.lookup(hostname);
-  } catch {
+    resolved = await dns.promises.lookup(hostname, { all: true });
+  } catch (cause) {
+    throw new Error('uri hostname could not be resolved', { cause });
+  }
+
+  // An empty result is not an absence of a private address: `[].some(...)`
+  // below is `false`, so without this guard a hostname the resolver
+  // reports as having no records at all would be treated as safe to reach.
+  if (resolved.length === 0) {
     throw new Error('uri hostname could not be resolved');
   }
 
-  const isPrivate = resolved.family === 4 ? isPrivateIpv4(resolved.address) : isPrivateIpv6(resolved.address);
+  // Derive each record's family from the address string itself rather than
+  // trusting `record.family` (typed as a bare `number`, not a 4|6 literal
+  // union, and DNS resolvers have shipped bugs that misreport it). Reject
+  // outright if the address does not parse as an IP at all, or if the
+  // derived family disagrees with what the resolver claimed: contradictory
+  // or unparseable metadata is treated as untrustworthy rather than
+  // silently reconciled. Only a record whose derived family agrees with its
+  // claimed family reaches the matching predicate.
+  const isPrivate = resolved.some((record) => {
+    const derivedFamily = isIP(record.address);
+    if (derivedFamily === 0 || derivedFamily !== record.family) return true;
+    return derivedFamily === 4 ? isPrivateIpv4(record.address) : isPrivateIpv6(record.address);
+  });
 
   if (isPrivate) {
     throw new Error('uri must not point to a private or reserved network address');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       '@vckit/core-types':
         specifier: 1.0.0-beta.7
         version: 1.0.0-beta.7
+      ipaddr.js:
+        specifier: ^2.4.0
+        version: 2.4.0
       jose:
         specifier: ^5.9.3
         version: 5.10.0


### PR DESCRIPTION
This PR hardens the shared server-side SSRF guard (`validatePublicUrl` in `packages/services/src/utils/validate-public-url.ts`), which decides whether an outbound URL's destination is publicly routable before the server fetches it. It is the guard every write-side URL check depends on, including the registrar URL validation that builds on it, so its classification needs to be correct and to fail closed.

The change fixes several classification defects and adopts a default-deny posture:

- Bracketed IPv6 literal hostnames are handled correctly: the brackets `URL.hostname` wraps around an IPv6 literal are stripped before classification, and IP literals are classified directly without a DNS lookup, so a public IPv6 literal is no longer wrongly rejected and a private one is rejected for the right reason.
- IPv4 classification routes through `ipaddr.js`, covering the private, loopback, link-local, carrier-grade NAT, documentation, benchmarking, multicast, and reserved ranges the previous hand-rolled table missed, and fails closed on a parse error.
- DNS resolution uses `{ all: true }` and rejects if any resolved address is private, so a hostname resolving to a mix of public and private addresses cannot pass on whichever record the resolver preferred; an empty result set and an unresolvable hostname both reject; the original resolution error is preserved as the thrown error's cause; and each record is classified by its actual address shape rather than a trusted family label, so a record whose family disagrees with its address, or which is not a valid address, is rejected.
- IPv6 is classified default-deny: an address embedding IPv4 in the mapped form (`::ffff:a.b.c.d`) has its embedded address re-checked, while the deprecated IPv4-compatible form (`::a.b.c.d`) is rejected categorically because that block is reserved and does not route; every other address is treated as public only if it is within allocated global unicast (`2000::/3`) and is not a special-purpose range, with the decommissioned 6bone block (`3ffe::/16`) denied explicitly because it sits inside `2000::/3` yet is reserved. The guard denies anything outside this set, including address space the classification library does not enumerate, rather than accepting it by default.

The default-deny posture closes a class of bypass where the previous logic treated the classification library's fallback category as a positive "public" signal and so accepted reserved and unallocated IPv6 space. The change is verified against every reserved, private, embedded, and documentation form rejecting, and genuine public IPv4 and IPv6 destinations still accepting.

This hardens the existing in-services guard in place. The separate migration to the canonical `@uncefact/untp-utils/node` guard, and the guarded-fetch adoption that closes the redirect-follow and DNS-rebinding gaps in the consumers, remain tracked in #673, #866, and #867.

## Test plan
- [x] Reserved, private, loopback, link-local, unique-local, carrier-grade NAT, documentation, benchmarking, multicast, IPv4-mapped-private, IPv4-compatible, and 6bone addresses are rejected.
- [x] Genuine public IPv4, public IPv6 global unicast, and IPv4-mapped-public addresses are accepted.
- [x] DNS records with a mismatched or invalid family are rejected; empty and unresolvable results are rejected.
- [x] Services suite and the reference implementation's guard-consuming route suites pass.
