### PR TITLE
fix(documentation): pin pnpm and the node base image for the docker build

### DIFF
--- a/documentation/Dockerfile
+++ b/documentation/Dockerfile
@@ -1,5 +1,5 @@
 # Setup the environment
-FROM node:22-alpine
+FROM node:22.22.2-alpine
 RUN corepack enable
 
 WORKDIR /app

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -49,5 +49,6 @@
   },
   "engines": {
     "node": ">=18.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
This PR pins pnpm to 9.15.4 via the `packageManager` field in `documentation/package.json` and pins the documentation image's base to `node:22.22.2-alpine`, so a fresh `docker compose up -d --build` succeeds instead of failing when corepack's floating default pnpm moves past a breaking major. Verified with `docker build --pull --no-cache documentation/`, where corepack now resolves pnpm 9.15.4 and the build completes.

Closes #869
