### PR TITLE
fix(test-suite): make Tier 3 claim inference UNTP 0.7.0-aware

### DIFF
--- a/packages/untp-test-suite/src/inferences/11-infer-product-claim-criteria-verified-untp070.n3
+++ b/packages/untp-test-suite/src/inferences/11-infer-product-claim-criteria-verified-untp070.n3
@@ -1,0 +1,50 @@
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix result: <http://example.org/result#> .
+@prefix schemaorg: <https://schema.org/> .
+@prefix untp: <https://vocabulary.uncefact.org/untp/> .
+@prefix vc: <https://www.w3.org/2018/credentials#> .
+
+# UNTP 0.7.0 counterpart of 10-infer-product-claim-criteria-verified.n3.
+# In 0.7.0 the vocabulary is unified under https://vocabulary.uncefact.org/untp/,
+# the DPP credentialSubject IS the product (no intermediate untp:product node),
+# claims are untp:performanceClaim (was untp:conformityClaim) and their criteria
+# are untp:referenceCriteria (was untp:assessmentCriteria).
+# The 0.6.x rule is left untouched and still applies to 0.6.x credentials.
+{
+   # Find product passport claims
+   ?dppCredential a untp:DigitalProductPassport .
+   ?dppCredential vc:credentialSubject ?product .
+   ?product schemaorg:name ?productName .
+   ?product untp:performanceClaim ?claim .
+   ?claim untp:conformityTopic ?topic .
+   ?claim untp:referenceCriteria ?criterion .
+   ?criterion schemaorg:name ?criterionName .
+
+   # Find matching conformity credential
+   ?dccCredential a untp:DigitalConformityCredential .
+   ?dccCredential vc:issuer ?dccIssuer .
+   ?dccIssuer schemaorg:name ?dccIssuerName .
+   ?dccCredential vc:credentialSubject ?attestation .
+   ?attestation untp:conformityAssessment ?assessment .
+   ?assessment untp:assessedProduct ?assessedProduct .
+   ?assessedProduct untp:product ?assessedProductId .
+   ?assessment untp:conformityTopic ?assessedTopic .
+   ?assessment untp:conformance ?dccConformance .
+   ?assessment untp:assessmentCriteria ?dccCriterion .
+
+   # Only match when the assessed product Id is for the same product as the
+   # claim AND the assessed topic is the same topic as the claim AND the
+   # assessed conformance is true.
+   ?assessedProductId log:equalTo ?product .
+   ?assessedTopic log:equalTo ?topic .
+   ?dccConformance log:equalTo true .
+   ?dccCriterion log:equalTo ?criterion .
+}
+=>
+{
+   ?claim result:verifiedCriterion ?criterion .
+   ?claim result:dependsOn ?dccCredential .
+   ?dppCredential result:claimsAttestedBy ?dccCredential .
+} .

--- a/packages/untp-test-suite/src/inferences/21-infer-product-claim-verified-untp070.n3
+++ b/packages/untp-test-suite/src/inferences/21-infer-product-claim-verified-untp070.n3
@@ -1,0 +1,24 @@
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix result: <http://example.org/result#> .
+@prefix untp: <https://vocabulary.uncefact.org/untp/> .
+
+# UNTP 0.7.0 counterpart of 20-infer-product-claim-verified.n3.
+# Depends on inferences created in 11-infer-product-claim-criteria-verified-untp070.n3
+# and so must be run after it. In 0.7.0 a claim's criteria are untp:referenceCriteria.
+{
+   ?claim a untp:Claim .
+   (
+       {
+           ?claim untp:referenceCriteria ?criterion
+       }
+       {
+           ?claim result:verifiedCriterion ?criterion
+       }
+   ) log:forAllIn _:t .
+}
+=>
+{
+   ?claim result:allCriteriaVerified true .
+} .


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

Follow-up to #714, which made Tier 3 product/claim *discovery* 0.7.0-aware. The inference rules themselves were left on the 0.6.x vocabulary, so for a 0.7.0 credential nothing binds and every claim stays unverified — even when a valid Digital Conformity Credential is present in the graph:

```
Claim "resource-circularity": should be verified: expected false to be true
```

**Why this affects every 0.7.0 issuer, not just one implementation.** The rules resolve `https://test.uncefact.org/vocabulary/untp/{core,dcc,dpp}/0/`, while a 0.7.0 credential expands under `https://vocabulary.uncefact.org/untp/`. This repository's own 0.7.0 DCC fixture (`packages/services/src/data-model-bridges/data-models/dcc/versions/v070/__fixtures__/ConformityCredential_instance.json`) expands to `untp:DigitalConformityCredential` and `untp:conformityAssessment` — neither of which appears anywhere in the rules. The `example-credentials/UNTP/` set is still entirely 0.6.1, which is why the gap isn't visible from the bundled examples.

**Approach.** Two 0.7.0 rules are added *alongside* the existing ones rather than editing them, so the 0.6.x path is untouched — same approach as #713/#714:

- `11-infer-product-claim-criteria-verified-untp070.n3`
- `21-infer-product-claim-verified-untp070.n3`

What changes in 0.7.0, and what the new rules account for:

| 0.6.x | 0.7.0 |
|---|---|
| per-type vocabularies under `test.uncefact.org` | unified `https://vocabulary.uncefact.org/untp/` |
| `?dppSubject untp:product ?product` | the DPP `credentialSubject` **is** the product |
| `untp:conformityClaim` | `untp:performanceClaim` |
| `untp:assessmentCriteria` (DPP side) | `untp:referenceCriteria` |
| `dcc:assessment` | `untp:conformityAssessment` |

**Verification.** Run with the CLI against a 0.7.0 DPP and a DCC attesting its claim, and against the bundled examples:

| Input | Result |
|---|---|
| 0.7.0 DPP + a DCC attesting its claim | **12 passing, 0 failing** (was 1 failing) |
| 0.7.0 DPP alone, no DCC | 1 failing — unchanged, so the check still detects unattested claims and is not defanged |
| `example-credentials/UNTP/` (0.6.1) | 23 passing, 1 failing — unchanged baseline, the documented intentional failure |

Happy to adjust the approach — merging the 0.6.x and 0.7.0 rules into one set instead of keeping them side by side, or adding a 0.7.0 counterpart for `30-infer-identity-verified.n3` (DIA) in the same PR. That last one isn't exercised by the case above, since issuer trust is supplied via `--trust-did`.

## Related Tickets & Documents

Fixes #726

## Mobile & Desktop Screenshots/Recordings

N/A — no visual changes. The behavioural change is covered by the CLI results in the table above.

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

`example-credentials/` currently has no 0.7.0 material to assert against — every bundled example is 0.6.1 — so there is nothing in-tree for a regression test to consume. I'd be glad to contribute a 0.7.0 DPP + DCC example pair under `example-credentials/` in a follow-up PR, which would give both these rules and the 0.7.0 path in general something to regress against. Say the word and I'll open it.

## Added to documentation?

- [ ] 📖 [Reference Implementation docs site](https://uncefact.github.io/tests-untp/docs/reference-implementation/)
- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

The rules are self-documenting via header comments, and the CLI usage is unchanged.

## API Documentation Updated?

- [ ] 📚 Updated Swagger schemas in `schemas.ts`
- [ ] ✅ Verified Zod schemas match Prisma database schema
- [x] 🙅 No API changes in this PR

## [optional] Are there any post-deployment tasks we need to perform?

None. The rules are picked up by `scripts/generate-inference-bundle.js` during the normal build, so no extra step beyond the usual `pnpm run build`.