### PR TITLE
fix(ri): require and validate RI_APP_URL at application startup

### DIFF
--- a/documentation/docs/migration-guides/ri-v0.4.md
+++ b/documentation/docs/migration-guides/ri-v0.4.md
@@ -41,6 +41,10 @@ role (it now protects service instance configurations and credential decryption 
   into an existing deployment that still has its real `SERVICE_ENCRYPTION_KEY`; rename
   your existing variable instead, keeping its value.
 
+## RI_APP_URL is required at startup
+
+The application now validates `RI_APP_URL` when it starts and refuses to boot when it is unset, is not a valid `http(s)` URL, or carries a username or password. Earlier versions started without it, skipped the identity provider's end-session redirect on logout, and rejected the first publish that needed the default human verification link. Set `RI_APP_URL` to the deployment's public base URL before upgrading; the shipped `.env.example` and Docker Compose files already default it for local development.
+
 ## Decryption-key backfill for existing credentials
 
 Credentials created by earlier versions still hold their decryption key in plaintext.

--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -218,7 +218,7 @@ The IDR entry's `description` field is taken from the primary entity's `descript
 
 The published link does **not** carry the credential's decryption key. The key is not registered on the Identity Resolver; it is shared out of band, so access to an encrypted credential does not travel with its discovery link (regardless of whether a given resolver is publicly readable). A credential stored encrypted (the storage default) therefore needs its decryption key supplied out of band to verify, and the published link alone verifies a credential stored unencrypted. The issuing tenant can retrieve that decryption key from the credential's [Get a Credential](#get-a-credential) response and share it through a channel of its choosing. This differs from a link shared directly as a single-link capability, which may embed the key (see [the verify page](../verify-page#decryption)).
 
-If `RI_APP_URL` is unset, is not a valid `http(s)` URL, or carries userinfo when the default is needed, the request is rejected (`400`) up front, before the credential is issued, so a misconfigured deployment fails at request time rather than publishing a broken or secret-bearing link. Set `RI_APP_URL`, or pass `humanVerificationUrl`, to resolve it.
+`RI_APP_URL` is validated when the application starts (see [Startup](../operations/startup#base-url-validation)), so a deployment that could not build a safe default link fails at boot rather than at request time. Omitting `humanVerificationUrl` is always a valid request; supplying it overrides the default for deployments that host verification elsewhere.
 
 | Publishing Option | Type | Description |
 |-------------------|------|-------------|

--- a/documentation/docs/reference-implementation/operations/startup.md
+++ b/documentation/docs/reference-implementation/operations/startup.md
@@ -88,6 +88,10 @@ A mechanism for supplying custom seed data (such as render templates) via Docker
 
 Once migrations and seeding are complete, the application starts and begins accepting requests on port 3003.
 
+### Base URL Validation
+
+Before the application accepts its first request, it validates `RI_APP_URL` (the deployment's public base URL, which backs the OIDC post-logout redirect and the [default human verification link](../api/credentials#stage-8-idr-publishing-optional) on published credentials). Startup fails with a message naming the variable when it is unset, is not a valid `http(s)` URL, or carries a username or password. See [Identity provider requirements](../authentication/idp-requirements) for how the value is used.
+
 ### Encryption Key Validation
 
 Before the application accepts its first request, it validates the active `DATA_ENCRYPTION_KEY` by decrypting one existing encrypted value — a service instance configuration, or (when no service instance has a usable one, whether because none exists yet or because every existing configuration is corrupted) a protected credential decryption key. This runs once per process start, using the same check the [seed](#step-2-database-seed) already runs before it writes.

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -1055,60 +1055,6 @@ describe('POST /api/v1/credentials', () => {
         );
       });
 
-      it('fails with 400 before issuance when RI_APP_URL is unset and no humanVerificationUrl is given', async () => {
-        setupPublishingHappyPath();
-        delete process.env.RI_APP_URL;
-
-        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
-        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
-        const json = await res.json();
-
-        expect(res.status).toBe(400);
-        expect(json.error).toContain('RI_APP_URL');
-        // Failure is early: nothing is signed, stored, or published.
-        expect(mockIssueCredential).not.toHaveBeenCalled();
-        expect(mockPublishLinks).not.toHaveBeenCalled();
-      });
-
-      it('fails with 400 when RI_APP_URL is syntactically not a URL', async () => {
-        setupPublishingHappyPath();
-        process.env.RI_APP_URL = 'not a url';
-
-        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
-        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
-        const json = await res.json();
-
-        expect(res.status).toBe(400);
-        expect(json.error).toContain('RI_APP_URL');
-        expect(mockIssueCredential).not.toHaveBeenCalled();
-      });
-
-      it('fails with 400 when RI_APP_URL parses but is not an http(s) URL', async () => {
-        setupPublishingHappyPath();
-        process.env.RI_APP_URL = 'ftp://ri.example.com';
-
-        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
-        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
-        const json = await res.json();
-
-        expect(res.status).toBe(400);
-        expect(json.error).toContain('RI_APP_URL');
-        expect(mockIssueCredential).not.toHaveBeenCalled();
-      });
-
-      it('fails with 400 when RI_APP_URL carries userinfo, rather than publishing the secret', async () => {
-        setupPublishingHappyPath();
-        process.env.RI_APP_URL = 'https://user:pass@ri.example.com';
-
-        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
-        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
-        const json = await res.json();
-
-        expect(res.status).toBe(400);
-        expect(json.error).toContain('RI_APP_URL');
-        expect(mockIssueCredential).not.toHaveBeenCalled();
-      });
-
       it('uses an explicit humanVerificationUrl even when RI_APP_URL is unset', async () => {
         setupPublishingHappyPath();
         delete process.env.RI_APP_URL;

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/api/validation';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { errorMessage } from '@/lib/api/errors';
+import { resolveAppUrl, buildVerifyUrl } from '@/lib/config/app-url.config';
 import { apiLogger } from '@/lib/api/logger';
 import { resolveDataModel } from '@/lib/credentials/resolve-data-model';
 import { validateCredentialPayload } from '@/lib/credentials/validate-credential-payload';
@@ -39,53 +40,12 @@ type CredentialWarning = {
 const logger = apiLogger.child({ route: '/api/v1/credentials' });
 
 /**
- * Builds the default human verification link base URL from `RI_APP_URL`.
- *
- * Used when a caller requests publishing without an explicit
- * `publishingOptions.humanVerificationUrl`, so every published credential
- * carries a link to this Reference Implementation's own verify page. `RI_APP_URL`
- * is the RI's public base URL (the same variable that backs the OIDC
- * post-logout redirect); the verify page lives at `/verify`.
- *
- * Throws a {@link ValidationError} when `RI_APP_URL` is missing, is not a valid
- * http(s) URL, or carries userinfo (a `user:pass@` component, which would be
- * published into a public link). A deployment that asked to publish but cannot
- * build a safe link fails with an actionable message instead of publishing a
- * broken or secret-bearing link. The caller can also remedy it per-request by
- * supplying `publishingOptions.humanVerificationUrl`.
+ * Default human verification link: this RI's own verify page, built from the
+ * boot-validated RI_APP_URL (see instrumentation.node.ts). Used when a caller
+ * requests publishing without an explicit publishingOptions.humanVerificationUrl.
  */
 function defaultHumanVerificationUrl(): string {
-  const base = process.env.RI_APP_URL;
-  if (!base) {
-    throw new ValidationError(
-      'Publishing requires a human verification URL. Set the RI_APP_URL environment variable, or pass publishingOptions.humanVerificationUrl.',
-    );
-  }
-
-  let url: URL | undefined;
-  try {
-    url = new URL(base);
-  } catch {
-    url = undefined;
-  }
-  if (!url || (url.protocol !== 'http:' && url.protocol !== 'https:')) {
-    throw new ValidationError(
-      'RI_APP_URL is not a valid http(s) URL. Set a valid RI_APP_URL, or pass publishingOptions.humanVerificationUrl.',
-    );
-  }
-  if (url.username || url.password) {
-    throw new ValidationError(
-      'RI_APP_URL must not contain a username or password; the verify link is published to a public directory. Remove the userinfo from RI_APP_URL, or pass publishingOptions.humanVerificationUrl.',
-    );
-  }
-
-  // Build from URL components so a query or fragment on RI_APP_URL cannot land
-  // ahead of the appended path segment (e.g. `https://ri/?x=1` must not become
-  // `https://ri/?x=1/verify`). Any base path is preserved.
-  url.search = '';
-  url.hash = '';
-  url.pathname = `${url.pathname.replace(/\/+$/, '')}/verify`;
-  return url.toString();
+  return buildVerifyUrl(resolveAppUrl());
 }
 
 // ---------------------------------------------------------------------------
@@ -227,9 +187,8 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   }
 
   // ── Default the human verification link (see defaultHumanVerificationUrl) ─
-  // Resolved here, before issuance (Step 7), so a deployment that requested
-  // publishing but cannot build the link fails before any credential is signed
-  // or stored. The derived default is trusted operator config, so it is
+  // RI_APP_URL is boot-validated (instrumentation.node.ts), so this is plain
+  // construction. The derived default is trusted operator config, so it is
   // intentionally not SSRF-checked and a localhost RI_APP_URL is accepted in
   // development.
   const effectiveHumanVerificationUrl =

--- a/packages/reference-implementation/src/instrumentation.node.ts
+++ b/packages/reference-implementation/src/instrumentation.node.ts
@@ -27,8 +27,13 @@ import {
   assertNotPlaceholderEncryptionKey,
   validateEncryptionKeyAtStartup,
 } from './lib/credentials/validate-encryption-key-startup';
+import { resolveAppUrl } from './lib/config/app-url.config';
 
 export async function registerNode(): Promise<void> {
+  // Fail the boot on a missing or unusable RI_APP_URL: it backs the OIDC
+  // post-logout redirect and the default human verification link, and the
+  // identity-provider documentation requires it (#823).
+  resolveAppUrl();
   await validateEncryptionKeyOnBoot();
   startOpenTelemetry();
 }

--- a/packages/reference-implementation/src/lib/config/app-url.config.test.ts
+++ b/packages/reference-implementation/src/lib/config/app-url.config.test.ts
@@ -1,0 +1,46 @@
+import { buildVerifyUrl, resolveAppUrl } from './app-url.config';
+
+const asEnv = (vars: Record<string, string | undefined>): NodeJS.ProcessEnv => vars as unknown as NodeJS.ProcessEnv;
+
+describe('resolveAppUrl', () => {
+  it('returns the parsed URL for a valid http(s) base', () => {
+    expect(resolveAppUrl(asEnv({ RI_APP_URL: 'https://ri.example.com' })).origin).toBe('https://ri.example.com');
+    expect(resolveAppUrl(asEnv({ RI_APP_URL: 'http://localhost:3003' })).origin).toBe('http://localhost:3003');
+  });
+
+  it('throws naming the variable when RI_APP_URL is unset', () => {
+    expect(() => resolveAppUrl(asEnv({}))).toThrow('RI_APP_URL is required');
+  });
+
+  it('throws when RI_APP_URL is not parseable as a URL', () => {
+    expect(() => resolveAppUrl(asEnv({ RI_APP_URL: 'not a url' }))).toThrow('not a valid http(s) URL');
+  });
+
+  it('throws when RI_APP_URL parses but is not http(s)', () => {
+    expect(() => resolveAppUrl(asEnv({ RI_APP_URL: 'ftp://ri.example.com' }))).toThrow('not a valid http(s) URL');
+  });
+
+  it('throws when RI_APP_URL carries userinfo', () => {
+    expect(() => resolveAppUrl(asEnv({ RI_APP_URL: 'https://user:pass@ri.example.com' }))).toThrow(
+      'must not contain a username or password',
+    );
+  });
+});
+
+describe('buildVerifyUrl', () => {
+  it('appends /verify to the origin', () => {
+    expect(buildVerifyUrl(new URL('https://ri.example.com'))).toBe('https://ri.example.com/verify');
+  });
+
+  it('preserves a base path and trims its trailing slash', () => {
+    expect(buildVerifyUrl(new URL('https://ri.example.com/app/'))).toBe('https://ri.example.com/app/verify');
+  });
+
+  it('drops a query string rather than appending after it', () => {
+    expect(buildVerifyUrl(new URL('https://ri.example.com?tenant=1'))).toBe('https://ri.example.com/verify');
+  });
+
+  it('drops a fragment rather than appending after it', () => {
+    expect(buildVerifyUrl(new URL('https://ri.example.com#section'))).toBe('https://ri.example.com/verify');
+  });
+});

--- a/packages/reference-implementation/src/lib/config/app-url.config.ts
+++ b/packages/reference-implementation/src/lib/config/app-url.config.ts
@@ -1,0 +1,52 @@
+/**
+ * RI_APP_URL is the Reference Implementation's public base URL. It backs the
+ * OIDC post-logout redirect and the default human verification link on
+ * published credentials, and the identity-provider documentation lists it as
+ * required. Validating it at process boot (instrumentation.node.ts) turns a
+ * misconfigured deployment into a failed container start instead of a
+ * runtime failure on the first logout or publish (#823).
+ */
+
+/**
+ * Returns the validated RI_APP_URL as a URL, or throws with a message naming
+ * the variable and the constraint it violated. Userinfo is rejected because
+ * the base URL is embedded into publicly published verification links.
+ */
+export function resolveAppUrl(env: NodeJS.ProcessEnv = process.env): URL {
+  const base = env.RI_APP_URL;
+  if (!base) {
+    throw new Error("RI_APP_URL is required. Set it to this deployment's public base URL, e.g. https://ri.example.com");
+  }
+
+  let url: URL | undefined;
+  try {
+    url = new URL(base);
+  } catch {
+    url = undefined;
+  }
+  if (!url || (url.protocol !== 'http:' && url.protocol !== 'https:')) {
+    // The raw value is deliberately not echoed: a malformed URL can carry
+    // userinfo (https://user:secret@host:badport) that must not reach logs.
+    throw new Error('RI_APP_URL is not a valid http(s) URL.');
+  }
+  if (url.username || url.password) {
+    throw new Error(
+      'RI_APP_URL must not contain a username or password; it is embedded into publicly published verification links.',
+    );
+  }
+  return url;
+}
+
+/**
+ * Builds the verify-page URL from the validated base. Query and fragment are
+ * dropped so they cannot land ahead of the appended path segment (e.g.
+ * `https://ri/?x=1` must not become `https://ri/?x=1/verify`); a base path is
+ * preserved.
+ */
+export function buildVerifyUrl(appUrl: URL): string {
+  const url = new URL(appUrl.toString());
+  url.search = '';
+  url.hash = '';
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/verify`;
+  return url.toString();
+}


### PR DESCRIPTION
This PR makes `RI_APP_URL` required: the application validates it at startup and refuses to boot when it is unset, is not a valid `http(s)` URL, or carries a username or password, so a misconfigured deployment fails at container start instead of on the first logout redirect or publish. The identity-provider documentation already listed the variable as required, so this aligns the code with the documented contract.

With the value guaranteed at boot, the credentials route's default human verification link collapses to plain construction, deleting the request-time missing/invalid classification (and the 400 from #491) that #823 was originally about. The startup documentation gains a Base URL Validation section, and the v0.4 migration guide notes the upgrade behaviour for deployments that never set the variable; the shipped `.env.example` and compose files already set it.

Closes #823