### PR TITLE
fix(ri): honour a pre-set RI_DATABASE_URL in the seed, prisma config, and next config

### DIFF
--- a/documentation/docs/reference-implementation/operations/database.md
+++ b/documentation/docs/reference-implementation/operations/database.md
@@ -13,15 +13,18 @@ When using the Docker Compose configuration from the [repository](https://github
 
 ## Configuration
 
-The following environment variables must be passed to the Reference Implementation to configure the database connection:
+The database connection can be configured either as a single connection string or as separate parts.
 
 | Variable | Required | Description | Default |
 |----------|----------|-------------|---------|
-| `RI_POSTGRES_HOST` | Yes | Database hostname | — |
+| `RI_DATABASE_URL` | No | A complete PostgreSQL connection string. Takes precedence over the `RI_POSTGRES_*` variables below when set. | — |
+| `RI_POSTGRES_HOST` | Yes, if `RI_DATABASE_URL` is not set | Database hostname | — |
 | `RI_POSTGRES_PORT` | No | Database port | `5432` |
 | `RI_POSTGRES_USER` | No | Database user | `postgres` |
 | `RI_POSTGRES_PASSWORD` | No | Database password | `postgres` |
 | `RI_POSTGRES_DB` | No | Database name | `ri` |
+
+Set `RI_DATABASE_URL` directly when the connection string carries options the `RI_POSTGRES_*` parts cannot express, or when a secrets manager already supplies one. When it is set, the Reference Implementation uses it as given and does not construct a URL from the other variables.
 
 ## Migrations and Seeding
 

--- a/packages/reference-implementation/next.config.ts
+++ b/packages/reference-implementation/next.config.ts
@@ -3,40 +3,29 @@ import path from 'path';
 import type { NextConfig } from 'next';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 
+import { databaseUrlFromEnvParts } from './src/lib/prisma/database-url';
+
 // Load .env from repository root
 // Local dev: Loads environment variables from .env file
 // Docker: Silently skips if file doesn't exist (vars already set by docker-compose)
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 const nextConfig = (phase: string): NextConfig => {
-  const { RI_POSTGRES_USER, RI_POSTGRES_PASSWORD, RI_POSTGRES_DB, RI_POSTGRES_HOST, RI_POSTGRES_PORT } = process.env;
-
-  // Validate required environment variables (skip during build phase for Docker)
-  if (phase !== PHASE_PRODUCTION_BUILD) {
-    const requiredEnvVars = {
-      RI_POSTGRES_USER,
-      RI_POSTGRES_PASSWORD,
-      RI_POSTGRES_DB,
-      RI_POSTGRES_HOST,
-      RI_POSTGRES_PORT,
-    };
-
-    const missingVars = Object.entries(requiredEnvVars)
-      .filter(([_, value]) => !value)
-      .map(([key]) => key);
-
-    if (missingVars.length > 0) {
-      throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`);
-    }
+  // Honour a pre-set RI_DATABASE_URL; construct one from the RI_POSTGRES_*
+  // variables only when it is absent (the same rule as docker-entrypoint.sh,
+  // prisma.config.ts, the seed, and the backfill scripts), so an explicit URL
+  // is never silently retargeted by stale component variables (#766). Outside
+  // the production build phase (where Docker supplies env at runtime), fail
+  // loudly when neither form of database target is available.
+  const constructedDatabaseUrl = databaseUrlFromEnvParts();
+  if (!process.env.RI_DATABASE_URL && constructedDatabaseUrl) {
+    process.env.RI_DATABASE_URL = constructedDatabaseUrl;
   }
-
-  // Construct the database URL from individual environment variables
-  const databaseUrl = `postgresql://${RI_POSTGRES_USER || ''}:${RI_POSTGRES_PASSWORD || ''}@${RI_POSTGRES_HOST || ''}:${
-    RI_POSTGRES_PORT || ''
-  }/${RI_POSTGRES_DB || ''}?schema=public`;
-
-  // Set RI_DATABASE_URL for runtime access
-  process.env.RI_DATABASE_URL = databaseUrl;
+  if (!process.env.RI_DATABASE_URL && phase !== PHASE_PRODUCTION_BUILD) {
+    throw new Error(
+      'No database target configured: set RI_DATABASE_URL, or all of RI_POSTGRES_USER, RI_POSTGRES_PASSWORD, RI_POSTGRES_DB, RI_POSTGRES_HOST and RI_POSTGRES_PORT',
+    );
+  }
 
   return {
     output: 'standalone',

--- a/packages/reference-implementation/prisma/prisma.config.ts
+++ b/packages/reference-implementation/prisma/prisma.config.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { defineConfig } from 'prisma/config';
 
+import { databaseUrlFromEnvParts } from '../src/lib/prisma/database-url.js';
+
 // Resolve the directory containing this file in ESM mode (the `prisma/`
 // directory was scoped to ESM via `prisma/package.json` so the seed and
 // backfill scripts can import `@uncefact/untp-utils/multibase-digest`).
@@ -14,30 +16,20 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // Docker: Silently skips if file doesn't exist (vars already set by docker-compose)
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
-const { RI_POSTGRES_USER, RI_POSTGRES_PASSWORD, RI_POSTGRES_DB, RI_POSTGRES_HOST, RI_POSTGRES_PORT } = process.env;
-
-// Validate required environment variables
-const requiredEnvVars = {
-  RI_POSTGRES_USER,
-  RI_POSTGRES_PASSWORD,
-  RI_POSTGRES_DB,
-  RI_POSTGRES_HOST,
-  RI_POSTGRES_PORT,
-};
-
-const missingVars = Object.entries(requiredEnvVars)
-  .filter(([_, value]) => !value)
-  .map(([key]) => key);
-
-if (missingVars.length > 0) {
-  throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`);
+// Honour a pre-set RI_DATABASE_URL; construct one from the RI_POSTGRES_*
+// variables only when it is absent (the same rule as docker-entrypoint.sh
+// and the backfill scripts), so an explicit URL is never silently retargeted
+// by stale component variables (#766). Fail loudly when neither form of
+// database target is available, since every Prisma command needs one.
+const constructedDatabaseUrl = databaseUrlFromEnvParts();
+if (!process.env.RI_DATABASE_URL && constructedDatabaseUrl) {
+  process.env.RI_DATABASE_URL = constructedDatabaseUrl;
 }
-
-// Construct the database URL from individual environment variables
-const url = `postgresql://${RI_POSTGRES_USER}:${RI_POSTGRES_PASSWORD}@${RI_POSTGRES_HOST}:${RI_POSTGRES_PORT}/${RI_POSTGRES_DB}?schema=public`;
-
-// Set RI_DATABASE_URL for Prisma schema to reference
-process.env.RI_DATABASE_URL = url;
+if (!process.env.RI_DATABASE_URL) {
+  throw new Error(
+    'No database target configured: set RI_DATABASE_URL, or all of RI_POSTGRES_USER, RI_POSTGRES_PASSWORD, RI_POSTGRES_DB, RI_POSTGRES_HOST and RI_POSTGRES_PORT',
+  );
+}
 
 export default defineConfig({
   schema: './schema.prisma',

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -28,6 +28,7 @@ import {
   ServiceType,
 } from '@uncefact/untp-ri-services';
 import { getDidConfig } from '../src/lib/config/did.config.js';
+import { databaseUrlFromEnvParts } from '../src/lib/prisma/database-url.js';
 import {
   resolveDataEncryptionKey,
   warnIfDeprecatedEncryptionKeyName,
@@ -50,11 +51,13 @@ const logger = createLogger().child({ module: 'prisma-seed' });
 // Load .env before accessing config (seed runs outside Next.js)
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
-// Construct RI_DATABASE_URL from individual env vars (same as prisma.config.ts)
-// In Docker, these come from docker-compose; locally, from .env
-const { RI_POSTGRES_USER, RI_POSTGRES_PASSWORD, RI_POSTGRES_DB, RI_POSTGRES_HOST, RI_POSTGRES_PORT } = process.env;
-if (RI_POSTGRES_USER && RI_POSTGRES_PASSWORD && RI_POSTGRES_DB && RI_POSTGRES_HOST && RI_POSTGRES_PORT) {
-  process.env.RI_DATABASE_URL = `postgresql://${RI_POSTGRES_USER}:${RI_POSTGRES_PASSWORD}@${RI_POSTGRES_HOST}:${RI_POSTGRES_PORT}/${RI_POSTGRES_DB}?schema=public`;
+// Honour a pre-set RI_DATABASE_URL; construct one from the RI_POSTGRES_*
+// variables only when it is absent (the same rule as docker-entrypoint.sh
+// and the backfill scripts), so an explicit URL is never silently retargeted
+// by stale component variables (#766).
+const constructedDatabaseUrl = databaseUrlFromEnvParts();
+if (!process.env.RI_DATABASE_URL && constructedDatabaseUrl) {
+  process.env.RI_DATABASE_URL = constructedDatabaseUrl;
 }
 
 const prisma = new PrismaClient();

--- a/packages/reference-implementation/src/__tests__/next-config-database-url.test.ts
+++ b/packages/reference-implementation/src/__tests__/next-config-database-url.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment node
+ */
+import { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD } from 'next/constants';
+
+import nextConfig from '../../next.config';
+
+const PARTS = {
+  RI_POSTGRES_USER: 'parts-user',
+  RI_POSTGRES_PASSWORD: 'parts-pass',
+  RI_POSTGRES_DB: 'parts-db',
+  RI_POSTGRES_HOST: 'parts-host',
+  RI_POSTGRES_PORT: '6543',
+};
+
+const ENV_KEYS = ['RI_DATABASE_URL', ...Object.keys(PARTS)] as const;
+
+describe('next.config database URL precedence (#766)', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('keeps a pre-set RI_DATABASE_URL over stale component variables', () => {
+    process.env.RI_DATABASE_URL = 'postgresql://preset:pw@preset-host:5432/preset-db';
+    Object.assign(process.env, PARTS);
+
+    nextConfig(PHASE_DEVELOPMENT_SERVER);
+
+    expect(process.env.RI_DATABASE_URL).toBe('postgresql://preset:pw@preset-host:5432/preset-db');
+  });
+
+  it('constructs RI_DATABASE_URL from component variables only when absent', () => {
+    Object.assign(process.env, PARTS);
+
+    nextConfig(PHASE_DEVELOPMENT_SERVER);
+
+    expect(process.env.RI_DATABASE_URL).toBe(
+      'postgresql://parts-user:parts-pass@parts-host:6543/parts-db?schema=public',
+    );
+  });
+
+  it('fails loudly outside the production build phase when no database target exists', () => {
+    expect(() => nextConfig(PHASE_DEVELOPMENT_SERVER)).toThrow('No database target configured');
+  });
+
+  it('tolerates a missing database target during the production build phase', () => {
+    expect(() => nextConfig(PHASE_PRODUCTION_BUILD)).not.toThrow();
+    expect(process.env.RI_DATABASE_URL).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR makes every constructor of `RI_DATABASE_URL` honour a pre-set value and build one from the `RI_POSTGRES_*` parts only when it is absent, matching `docker-entrypoint.sh` and the backfill script, so an operator's explicit URL is never silently retargeted by stale component variables.

The issue named the seed; the sweep it asked for also caught `prisma.config.ts` (which additionally threw when parts were missing even with a URL set) and `next.config.ts` (which retargeted the app in `next dev`). All three now use the shared `databaseUrlFromEnvParts` helper, a regression test pins the precedence through the real Next config function, and the database operations page documents `RI_DATABASE_URL` and its precedence. On the encoding question the issue raised: every constructor passes credentials through verbatim today and that is deliberately kept, so no migration note is needed.

Closes #766