### PR TITLE
fix(ri): show the credential validity date in ISO 8601 on the verify page

### DIFF
--- a/documentation/docs/reference-implementation/verify-page.md
+++ b/documentation/docs/reference-implementation/verify-page.md
@@ -34,7 +34,7 @@ sequenceDiagram
     V->>U: Display result
 ```
 
-The verified credential is displayed with its type, issuer, and issue date. The issue date is rendered as the credential's UTC calendar date in ISO 8601 (`YYYY-MM-DD`); the row is omitted when the credential has no parseable issue date, which is the case for VC data model v2 credentials (they carry `validFrom`/`validUntil` rather than `issuanceDate`). The credential itself contains a `renderMethod` property that specifies the template used to render it for human review. Users can switch between the rendered template and the raw JSON data, and download the credential.
+The verified credential is displayed with its type, issuer, and validity start date. The `Valid from` date is rendered as the credential's UTC calendar date in ISO 8601 (`YYYY-MM-DD`); the row is omitted when the credential carries no parseable `validFrom`. The credential itself contains a `renderMethod` property that specifies the template used to render it for human review. Users can switch between the rendered template and the raw JSON data, and download the credential.
 
 ## Verification Link Format
 

--- a/documentation/docs/reference-implementation/verify-page.md
+++ b/documentation/docs/reference-implementation/verify-page.md
@@ -34,7 +34,7 @@ sequenceDiagram
     V->>U: Display result
 ```
 
-The verified credential is displayed with its type, issuer, and issue date. The credential itself contains a `renderMethod` property that specifies the template used to render it for human review. Users can switch between the rendered template and the raw JSON data, and download the credential.
+The verified credential is displayed with its type, issuer, and issue date. The issue date is rendered as the credential's UTC calendar date in ISO 8601 (`YYYY-MM-DD`); the row is omitted when the credential has no parseable issue date, which is the case for VC data model v2 credentials (they carry `validFrom`/`validUntil` rather than `issuanceDate`). The credential itself contains a `renderMethod` property that specifies the template used to render it for human review. Users can switch between the rendered template and the raw JSON data, and download the credential.
 
 ## Verification Link Format
 

--- a/packages/reference-implementation/e2e/cypress/page/renderPage.ts
+++ b/packages/reference-implementation/e2e/cypress/page/renderPage.ts
@@ -6,10 +6,7 @@ class RenderPage {
     cy.contains('Issued by').should('be.visible');
     cy.contains(expectedIssuerId).should('be.visible');
 
-    // UNTP credentials are VCDM 2.0: the page shows Valid from, and the
-    // VCDM 1.1 Issue date row (previously a fabricated "today") is gone (#855).
     cy.contains('Valid from').should('be.visible');
-    cy.contains('Issue date').should('not.exist');
   }
 
   verifyButtonsVisibilityAndText() {

--- a/packages/reference-implementation/e2e/cypress/page/renderPage.ts
+++ b/packages/reference-implementation/e2e/cypress/page/renderPage.ts
@@ -6,7 +6,10 @@ class RenderPage {
     cy.contains('Issued by').should('be.visible');
     cy.contains(expectedIssuerId).should('be.visible');
 
-    cy.contains('Issue date').should('be.visible');
+    // Credentials issued by the RI follow VC data model v2 (validFrom, no
+    // issuanceDate), so the Issue date row is omitted rather than showing a
+    // fabricated date (#855).
+    cy.contains('Issue date').should('not.exist');
   }
 
   verifyButtonsVisibilityAndText() {

--- a/packages/reference-implementation/e2e/cypress/page/renderPage.ts
+++ b/packages/reference-implementation/e2e/cypress/page/renderPage.ts
@@ -6,9 +6,9 @@ class RenderPage {
     cy.contains('Issued by').should('be.visible');
     cy.contains(expectedIssuerId).should('be.visible');
 
-    // Credentials issued by the RI follow VC data model v2 (validFrom, no
-    // issuanceDate), so the Issue date row is omitted rather than showing a
-    // fabricated date (#855).
+    // UNTP credentials are VCDM 2.0: the page shows Valid from, and the
+    // VCDM 1.1 Issue date row (previously a fabricated "today") is gone (#855).
+    cy.contains('Valid from').should('be.visible');
     cy.contains('Issue date').should('not.exist');
   }
 

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
@@ -113,33 +113,21 @@ describe('Credential info content', () => {
   it('renders Valid from as the UTC calendar date in ISO 8601 (YYYY-MM-DD)', () => {
     render(<CredentialInfo credential={{ ...credential, validFrom: '2023-12-20T03:31:45.547Z' }} />);
     // The literal UTC date must render regardless of the viewer's timezone (a
-    // local-time rendering would show 2023-12-19 west of UTC), never
-    // MM/DD/YYYY, and never under the VCDM 1.1 "Issue date" label (#855).
+    // local-time rendering would show 2023-12-19 west of UTC).
     expect(screen.getByText('Valid from')).not.toBeNull();
     expect(screen.getByText('2023-12-20')).not.toBeNull();
-    expect(screen.queryByText('12/20/2023')).toBeNull();
-    expect(screen.queryByText('Issue date')).toBeNull();
   });
 
   it('omits the Valid from row when the credential has no validFrom', () => {
-    // moment(undefined) would render today's date, fabricating a validity
-    // date the credential never stated (#855).
+    // A missing value must omit the row, not fall through to moment's
+    // "undefined means now" behaviour and render today's date (#855).
     render(<CredentialInfo credential={credential} />);
     expect(screen.queryByText('Valid from')).toBeNull();
-    expect(screen.queryByText('Issue date')).toBeNull();
   });
 
   it('omits the Valid from row when validFrom is unparseable', () => {
     render(<CredentialInfo credential={{ ...credential, validFrom: 'not-a-date' }} />);
     expect(screen.queryByText('Valid from')).toBeNull();
-  });
-
-  it('never renders the VCDM 1.1 issuanceDate, even when present', () => {
-    // UNTP credentials are VCDM 2.0; issuanceDate exists only on the stale
-    // v1 typing and must not surface as a date on the page (#855).
-    render(<CredentialInfo credential={credential} />);
-    expect(screen.queryByText('Issue date')).toBeNull();
-    expect(screen.queryByText('2023-12-20')).toBeNull();
   });
 
   it('should show an issuer with string type', () => {

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import moment from 'moment';
 import { CredentialInfo } from '../CredentialInfo';
 
 // Mocking MUI components
@@ -111,12 +110,30 @@ describe('Credential info content', () => {
     expect(screen.getByText('OtherType')).not.toBeNull();
   });
 
-  it('renders the issue date in ISO 8601 (YYYY-MM-DD) format', () => {
+  it('renders the issue date as the UTC calendar date in ISO 8601 (YYYY-MM-DD)', () => {
     render(<CredentialInfo credential={credential} />);
-    // The fixture's issuanceDate is 2023-12-20T03:31:45.547Z; the displayed
-    // date must be the unambiguous ISO form, not MM/DD/YYYY (#855).
-    expect(screen.getByText(moment('2023-12-20T03:31:45.547Z').format('YYYY-MM-DD'))).not.toBeNull();
+    // The fixture's issuanceDate is 2023-12-20T03:31:45.547Z. The literal UTC
+    // date must render regardless of the viewer's timezone (a local-time
+    // rendering would show 2023-12-19 west of UTC), and never MM/DD/YYYY (#855).
+    expect(screen.getByText('2023-12-20')).not.toBeNull();
     expect(screen.queryByText('12/20/2023')).toBeNull();
+  });
+
+  it('omits the issue date row when the credential has no issuanceDate', () => {
+    // VC data model v2 credentials carry validFrom/validUntil, not
+    // issuanceDate. moment(undefined) would render today's date, fabricating
+    // an issue date the credential never stated (#855).
+    const { issuanceDate: _omitted, ...v2Credential } = credential;
+    // The @vckit v1 type requires issuanceDate; v2 payloads genuinely omit it.
+    render(
+      <CredentialInfo credential={v2Credential as unknown as Parameters<typeof CredentialInfo>[0]['credential']} />,
+    );
+    expect(screen.queryByText('Issue date')).toBeNull();
+  });
+
+  it('omits the issue date row when issuanceDate is unparseable', () => {
+    render(<CredentialInfo credential={{ ...credential, issuanceDate: 'not-a-date' }} />);
+    expect(screen.queryByText('Issue date')).toBeNull();
   });
 
   it('should show an issuer with string type', () => {

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
@@ -110,30 +110,36 @@ describe('Credential info content', () => {
     expect(screen.getByText('OtherType')).not.toBeNull();
   });
 
-  it('renders the issue date as the UTC calendar date in ISO 8601 (YYYY-MM-DD)', () => {
-    render(<CredentialInfo credential={credential} />);
-    // The fixture's issuanceDate is 2023-12-20T03:31:45.547Z. The literal UTC
-    // date must render regardless of the viewer's timezone (a local-time
-    // rendering would show 2023-12-19 west of UTC), and never MM/DD/YYYY (#855).
+  it('renders Valid from as the UTC calendar date in ISO 8601 (YYYY-MM-DD)', () => {
+    render(<CredentialInfo credential={{ ...credential, validFrom: '2023-12-20T03:31:45.547Z' }} />);
+    // The literal UTC date must render regardless of the viewer's timezone (a
+    // local-time rendering would show 2023-12-19 west of UTC), never
+    // MM/DD/YYYY, and never under the VCDM 1.1 "Issue date" label (#855).
+    expect(screen.getByText('Valid from')).not.toBeNull();
     expect(screen.getByText('2023-12-20')).not.toBeNull();
     expect(screen.queryByText('12/20/2023')).toBeNull();
-  });
-
-  it('omits the issue date row when the credential has no issuanceDate', () => {
-    // VC data model v2 credentials carry validFrom/validUntil, not
-    // issuanceDate. moment(undefined) would render today's date, fabricating
-    // an issue date the credential never stated (#855).
-    const { issuanceDate: _omitted, ...v2Credential } = credential;
-    // The @vckit v1 type requires issuanceDate; v2 payloads genuinely omit it.
-    render(
-      <CredentialInfo credential={v2Credential as unknown as Parameters<typeof CredentialInfo>[0]['credential']} />,
-    );
     expect(screen.queryByText('Issue date')).toBeNull();
   });
 
-  it('omits the issue date row when issuanceDate is unparseable', () => {
-    render(<CredentialInfo credential={{ ...credential, issuanceDate: 'not-a-date' }} />);
+  it('omits the Valid from row when the credential has no validFrom', () => {
+    // moment(undefined) would render today's date, fabricating a validity
+    // date the credential never stated (#855).
+    render(<CredentialInfo credential={credential} />);
+    expect(screen.queryByText('Valid from')).toBeNull();
     expect(screen.queryByText('Issue date')).toBeNull();
+  });
+
+  it('omits the Valid from row when validFrom is unparseable', () => {
+    render(<CredentialInfo credential={{ ...credential, validFrom: 'not-a-date' }} />);
+    expect(screen.queryByText('Valid from')).toBeNull();
+  });
+
+  it('never renders the VCDM 1.1 issuanceDate, even when present', () => {
+    // UNTP credentials are VCDM 2.0; issuanceDate exists only on the stale
+    // v1 typing and must not surface as a date on the page (#855).
+    render(<CredentialInfo credential={credential} />);
+    expect(screen.queryByText('Issue date')).toBeNull();
+    expect(screen.queryByText('2023-12-20')).toBeNull();
   });
 
   it('should show an issuer with string type', () => {

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import moment from 'moment';
 import { CredentialInfo } from '../CredentialInfo';
 
 // Mocking MUI components
@@ -108,6 +109,14 @@ describe('Credential info content', () => {
     render(<CredentialInfo credential={rewriteCredential2} />);
     // Expecting the text 'OtherType' to be present in the rendered component
     expect(screen.getByText('OtherType')).not.toBeNull();
+  });
+
+  it('renders the issue date in ISO 8601 (YYYY-MM-DD) format', () => {
+    render(<CredentialInfo credential={credential} />);
+    // The fixture's issuanceDate is 2023-12-20T03:31:45.547Z; the displayed
+    // date must be the unambiguous ISO form, not MM/DD/YYYY (#855).
+    expect(screen.getByText(moment('2023-12-20T03:31:45.547Z').format('YYYY-MM-DD'))).not.toBeNull();
+    expect(screen.queryByText('12/20/2023')).toBeNull();
   });
 
   it('should show an issuer with string type', () => {

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
@@ -39,14 +39,11 @@ const CredentialInfo = ({ credential }: { credential: VerifiableCredential | Uns
       <ListItem>
         <ListItemText primary='Issued by' secondary={processIssuer(credential.issuer)} />
       </ListItem>
-      {/* UNTP credentials follow the W3C VC data model 2.0, whose temporal
-          property is validFrom; the VCDM 1.1 issuanceDate the previous code
-          read never exists on them, and moment(undefined) means "now", which
-          fabricated today's date as an issue date (#855). Rendered as the
-          UTC calendar date in ISO 8601: MM/DD vs DD/MM is ambiguous, and a
-          viewer-local date can differ between reviewers of the same
-          credential. The row is omitted when validFrom is absent or
-          unparseable, rather than inventing a value. */}
+      {/* Rendered as the UTC calendar date in ISO 8601: MM/DD vs DD/MM is
+          ambiguous, and a viewer-local date can differ between reviewers of
+          the same credential (#855). The validity guard matters because
+          moment(undefined) means "now": an absent or unparseable validFrom
+          must omit the row, never invent a date. */}
       {moment.utc(validFrom ?? NaN).isValid() && (
         <ListItem>
           <ListItemText primary='Valid from' secondary={moment.utc(validFrom).format('YYYY-MM-DD')} />

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
@@ -6,6 +6,9 @@ import { List, ListItem, ListItemText } from '@mui/material';
 import { IssuerType, UnsignedCredential, VerifiableCredential } from '@vckit/core-types';
 
 const CredentialInfo = ({ credential }: { credential: VerifiableCredential | UnsignedCredential }) => {
+  // The @vckit types predate VCDM 2.0 and do not declare validFrom.
+  const { validFrom } = credential as { validFrom?: string };
+
   const credentialType = useMemo(() => {
     if (typeof credential.type === 'string') {
       return credential.type;
@@ -36,15 +39,17 @@ const CredentialInfo = ({ credential }: { credential: VerifiableCredential | Uns
       <ListItem>
         <ListItemText primary='Issued by' secondary={processIssuer(credential.issuer)} />
       </ListItem>
-      {/* ISO 8601 in UTC for an international audience: MM/DD vs DD/MM is
-          ambiguous, and a viewer-local date can differ between reviewers of
-          the same credential (#855). The row is omitted entirely when the
-          credential carries no parseable issuanceDate (VC data model v2 uses
-          validFrom/validUntil instead): moment(undefined) means "now", which
-          would fabricate an issue date the credential never stated. */}
-      {moment.utc(credential.issuanceDate ?? NaN).isValid() && (
+      {/* UNTP credentials follow the W3C VC data model 2.0, whose temporal
+          property is validFrom; the VCDM 1.1 issuanceDate the previous code
+          read never exists on them, and moment(undefined) means "now", which
+          fabricated today's date as an issue date (#855). Rendered as the
+          UTC calendar date in ISO 8601: MM/DD vs DD/MM is ambiguous, and a
+          viewer-local date can differ between reviewers of the same
+          credential. The row is omitted when validFrom is absent or
+          unparseable, rather than inventing a value. */}
+      {moment.utc(validFrom ?? NaN).isValid() && (
         <ListItem>
-          <ListItemText primary='Issue date' secondary={moment.utc(credential.issuanceDate).format('YYYY-MM-DD')} />
+          <ListItemText primary='Valid from' secondary={moment.utc(validFrom).format('YYYY-MM-DD')} />
         </ListItem>
       )}
     </List>

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
@@ -39,11 +39,7 @@ const CredentialInfo = ({ credential }: { credential: VerifiableCredential | Uns
       <ListItem>
         <ListItemText primary='Issued by' secondary={processIssuer(credential.issuer)} />
       </ListItem>
-      {/* Rendered as the UTC calendar date in ISO 8601: MM/DD vs DD/MM is
-          ambiguous, and a viewer-local date can differ between reviewers of
-          the same credential (#855). The validity guard matters because
-          moment(undefined) means "now": an absent or unparseable validFrom
-          must omit the row, never invent a date. */}
+      {/* moment(undefined) means "now": omit the row rather than invent a date (#855). */}
       {moment.utc(validFrom ?? NaN).isValid() && (
         <ListItem>
           <ListItemText primary='Valid from' secondary={moment.utc(validFrom).format('YYYY-MM-DD')} />

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
@@ -36,10 +36,17 @@ const CredentialInfo = ({ credential }: { credential: VerifiableCredential | Uns
       <ListItem>
         <ListItemText primary='Issued by' secondary={processIssuer(credential.issuer)} />
       </ListItem>
-      <ListItem>
-        {/* ISO 8601 for an international audience: MM/DD vs DD/MM is ambiguous (#855). */}
-        <ListItemText primary='Issue date' secondary={moment(credential.issuanceDate).format('YYYY-MM-DD')} />
-      </ListItem>
+      {/* ISO 8601 in UTC for an international audience: MM/DD vs DD/MM is
+          ambiguous, and a viewer-local date can differ between reviewers of
+          the same credential (#855). The row is omitted entirely when the
+          credential carries no parseable issuanceDate (VC data model v2 uses
+          validFrom/validUntil instead): moment(undefined) means "now", which
+          would fabricate an issue date the credential never stated. */}
+      {moment.utc(credential.issuanceDate ?? NaN).isValid() && (
+        <ListItem>
+          <ListItemText primary='Issue date' secondary={moment.utc(credential.issuanceDate).format('YYYY-MM-DD')} />
+        </ListItem>
+      )}
     </List>
   );
 };

--- a/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
+++ b/packages/reference-implementation/src/components/CredentialInfo/CredentialInfo.tsx
@@ -37,7 +37,8 @@ const CredentialInfo = ({ credential }: { credential: VerifiableCredential | Uns
         <ListItemText primary='Issued by' secondary={processIssuer(credential.issuer)} />
       </ListItem>
       <ListItem>
-        <ListItemText primary='Issue date' secondary={moment(credential.issuanceDate).format('MM/DD/YYYY')} />
+        {/* ISO 8601 for an international audience: MM/DD vs DD/MM is ambiguous (#855). */}
+        <ListItemText primary='Issue date' secondary={moment(credential.issuanceDate).format('YYYY-MM-DD')} />
       </ListItem>
     </List>
   );


### PR DESCRIPTION
This PR replaces the verify page's Issue date with a Valid from row rendered as the credential's UTC calendar date in ISO 8601 (`2024-01-15` for `2024-01-15T22:51:31Z`), so two reviewers in different timezones see the same unambiguous value.

The replacement matters more than the format: UNTP credentials follow the W3C VC data model 2.0, whose temporal property is `validFrom`. The `issuanceDate` the previous code read is a VCDM 1.1 property that no UNTP credential carries, and `moment(undefined)` means "now", so every credential was showing today's date as its issue date. The row is omitted when `validFrom` is absent or unparseable rather than inventing a value. Valid until display is deliberately left out for now.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/a1153757-2d6c-48e6-b735-88e014bdc46a) | ![after](https://github.com/user-attachments/assets/50ea360f-a75c-455e-9e73-59d2b12c8d8c) |

Closes #855