### PR TITLE
feat(ri): propagate x-correlation-id across service boundaries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,6 +51,15 @@
   },
   "overrides": [
     {
+      // The services package routes all outbound HTTP through src/http/client.ts
+      // so x-correlation-id propagation cannot be forgotten per call site (#654).
+      "files": ["packages/services/src/**/*.ts"],
+      "excludedFiles": ["packages/services/src/http/client.ts", "packages/services/src/**/*.test.ts"],
+      "rules": {
+        "no-restricted-globals": ["error", { "name": "fetch", "message": "Use httpFetch from src/http/client.ts so x-correlation-id propagation is applied (#654)." }]
+      }
+    },
+    {
       "files": [
         "*.js"
       ],

--- a/documentation/docs/reference-implementation/operations/logging.md
+++ b/documentation/docs/reference-implementation/operations/logging.md
@@ -32,13 +32,9 @@ Each log entry automatically includes the following fields where available:
 
 Every request is assigned a correlation ID. This ID is included in every log entry produced during that request, making it possible to trace a single request across all the services and operations it touches.
 
-The correlation ID is determined in the following order of priority:
+The correlation ID is the `x-correlation-id` request header when the caller provides one. An inbound value is validated before it is trusted: it must be at most 128 characters of letters, digits, hyphens, and underscores, and anything else is replaced. Without a valid caller ID, a request carrying an `X-Amzn-Trace-Id` header (as AWS load balancers set) has its Root token adopted, joining these logs to ALB access logs and X-Ray, and otherwise a random UUID is generated.
 
-1. The `x-correlation-id` request header, if provided by the caller
-2. The `x-amzn-trace-id` header, if present (for AWS environments)
-3. A randomly generated UUID
-
-The correlation ID is also returned in the `x-correlation-id` response header, so callers can use it to correlate their own logs with the Reference Implementation's logs.
+The correlation ID is also returned in the `x-correlation-id` response header, so callers can use it to correlate their own logs with the Reference Implementation's logs, and it is forwarded as `x-correlation-id` on outbound calls to the configured UNTP services (storage, identity resolver, and verifiable credential services), so one ID traces a request across service boundaries in a log aggregator. Calls to third-party hosts, such as resolving a `did:web` document from its own domain, deliberately carry no correlation header.
 
 ### Service Names
 

--- a/packages/reference-implementation/src/lib/api/with-public-route.test.ts
+++ b/packages/reference-implementation/src/lib/api/with-public-route.test.ts
@@ -19,6 +19,8 @@ const mockLogger: Record<string, jest.Mock> = {
 mockLogger.child.mockReturnValue(mockLogger);
 
 jest.mock('@uncefact/untp-ri-services/logging', () => ({
+  // Real validator: the wrappers' reject-and-replace behaviour is the code under test.
+  isValidCorrelationId: jest.requireActual('@uncefact/untp-ri-services/logging').isValidCorrelationId,
   runWithRequestContext: (correlationId: string, callback: () => unknown) =>
     mockRunWithRequestContext(correlationId, callback),
   createLogger: () => mockLogger,
@@ -87,6 +89,17 @@ describe('withPublicRoute', () => {
     expect(mockRunWithRequestContext).toHaveBeenCalledTimes(1);
     const correlationId = mockRunWithRequestContext.mock.calls[0][0];
     expect(correlationId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('rejects correlation IDs with characters outside the allowed charset, warns without echoing them', async () => {
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withPublicRoute(handler);
+    await wrapped(fakeRequest('GET', { 'x-correlation-id': 'Root=1-abc;Parent=def' }));
+
+    const correlationId = mockRunWithRequestContext.mock.calls[0][0];
+    expect(correlationId).not.toBe('Root=1-abc;Parent=def');
+    expect(correlationId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain('Root=1-abc;Parent=def');
   });
 
   it('ignores correlation IDs longer than 128 characters', async () => {

--- a/packages/reference-implementation/src/lib/api/with-public-route.ts
+++ b/packages/reference-implementation/src/lib/api/with-public-route.ts
@@ -1,6 +1,6 @@
 import { handleRouteError } from '@/lib/api/handle-route-error';
 import { apiLogger } from '@/lib/api/logger';
-import { runWithRequestContext } from '@uncefact/untp-ri-services/logging';
+import { runWithRequestContext, isValidCorrelationId } from '@uncefact/untp-ri-services/logging';
 
 type PublicRouteHandler = (req: Request) => Promise<Response>;
 
@@ -8,8 +8,16 @@ const logger = apiLogger.child({ handler: 'public-route' });
 
 export function withPublicRoute(handler: PublicRouteHandler) {
   return async (req: Request) => {
+    // Zero trust at the boundary (#654): an inbound ID outside the shared
+    // length/charset rule is replaced, never echoed into logs or responses.
     const raw = req.headers.get('x-correlation-id');
-    const correlationId = raw && raw.length <= 128 ? raw : crypto.randomUUID();
+    const correlationId = raw && isValidCorrelationId(raw) ? raw : crypto.randomUUID();
+    if (raw && correlationId !== raw) {
+      logger.warn(
+        { inboundLength: raw.length, replacedWith: correlationId },
+        'Rejected invalid x-correlation-id header; minted a fresh id',
+      );
+    }
 
     return runWithRequestContext(correlationId, async () => {
       const method = req.method;

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
@@ -23,6 +23,8 @@ const mockLogger = (): Record<string, jest.Mock> => {
 };
 
 jest.mock('@uncefact/untp-ri-services/logging', () => ({
+  // Real validator: the wrappers' reject-and-replace behaviour is the code under test.
+  isValidCorrelationId: jest.requireActual('@uncefact/untp-ri-services/logging').isValidCorrelationId,
   runWithRequestContext: (correlationId: string, callback: () => unknown) =>
     mockRunWithRequestContext(correlationId, callback),
   updateRequestContext: (partial: Record<string, unknown>) => mockUpdateRequestContext(partial),
@@ -596,6 +598,19 @@ describe('withTenantAuth — request context propagation', () => {
 
     expect(mockRunWithRequestContext).toHaveBeenCalledTimes(1);
     const correlationId = mockRunWithRequestContext.mock.calls[0][0];
+    expect(correlationId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('rejects an x-correlation-id with characters outside the allowed charset', async () => {
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockResolvedValue('org-1');
+
+    const handler = jest.fn().mockResolvedValue({ status: 200 });
+    const wrapped = withTenantAuth(handler);
+    await wrapped(fakeRequest('GET', { 'x-correlation-id': 'bad id; DROP TABLE' }), emptyRouteContext);
+
+    const correlationId = mockRunWithRequestContext.mock.calls[0][0];
+    expect(correlationId).not.toBe('bad id; DROP TABLE');
     expect(correlationId).toMatch(/^[0-9a-f-]{36}$/);
   });
 

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
@@ -9,7 +9,7 @@ import { resolveClosedModeTenant } from '@/lib/api/resolve-closed-mode-tenant';
 import { validateServiceAccountToken, extractBearerToken } from '@/lib/auth/token-validator';
 import { prisma } from '@/lib/prisma/prisma';
 import { auth } from '@/auth';
-import { runWithRequestContext, updateRequestContext } from '@uncefact/untp-ri-services/logging';
+import { runWithRequestContext, updateRequestContext, isValidCorrelationId } from '@uncefact/untp-ri-services/logging';
 
 // Re-export for backwards compatibility — consumers that import from
 // this module will continue to work during migration.
@@ -33,8 +33,16 @@ type RouteHandler = (req: Request, context: TenantAuthContext) => Promise<Respon
 
 export function withTenantAuth(handler: RouteHandler) {
   return async (req: Request, routeContext: { params: Promise<Record<string, string>> }) => {
+    // Zero trust at the boundary (#654): an inbound ID outside the shared
+    // length/charset rule is replaced, never echoed into logs or responses.
     const raw = req.headers.get('x-correlation-id');
-    const correlationId = raw && raw.length <= 128 ? raw : crypto.randomUUID();
+    const correlationId = raw && isValidCorrelationId(raw) ? raw : crypto.randomUUID();
+    if (raw && correlationId !== raw) {
+      apiLogger.warn(
+        { inboundLength: raw.length, replacedWith: correlationId },
+        'Rejected invalid x-correlation-id header; minted a fresh id',
+      );
+    }
 
     return runWithRequestContext(correlationId, async () => {
       const method = req.method;

--- a/packages/reference-implementation/src/middleware.test.ts
+++ b/packages/reference-implementation/src/middleware.test.ts
@@ -18,6 +18,9 @@ jest.mock('@/lib/auth/token-validator', () => ({
 }));
 
 jest.mock('@uncefact/untp-ri-services/logging', () => ({
+  // Real validator: the wrappers' reject-and-replace behaviour is the code under test.
+  isValidCorrelationId: jest.requireActual('@uncefact/untp-ri-services/logging').isValidCorrelationId,
+  amznTraceRootToken: jest.requireActual('@uncefact/untp-ri-services/logging').amznTraceRootToken,
   runWithRequestContext: (_id: string, fn: () => unknown) => fn(),
 }));
 
@@ -104,6 +107,76 @@ describe('middleware', () => {
       expect(mockNextResponseNext).toHaveBeenCalledTimes(1);
       // Should NOT attempt bearer token validation
       expect(mockValidateServiceAccountToken).not.toHaveBeenCalled();
+    });
+
+    it('replaces a malformed inbound x-correlation-id with a fresh UUID', async () => {
+      const req = fakeRequest('/api/v1/credentials/verify', {
+        headers: { 'x-correlation-id': 'bad value; not+allowed' },
+      });
+      const response = fakeNextResponse();
+      mockNextResponseNext.mockReturnValueOnce(response);
+
+      await (middleware as any)(req);
+
+      const echoed = response.headers.get('x-correlation-id');
+      expect(echoed).not.toBe('bad value; not+allowed');
+      expect(echoed).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('forwards the chosen correlation ID on the request headers to the route', async () => {
+      // The response echo and the route must carry the same ID: without the
+      // forward, a missing or malformed inbound ID splits into one ID on the
+      // response and a different one in route logs and outbound calls (#654).
+      const req = fakeRequest('/api/v1/credentials/verify', {
+        headers: { 'x-correlation-id': 'bad value; not+allowed' },
+      });
+      const response = fakeNextResponse();
+      mockNextResponseNext.mockReturnValueOnce(response);
+
+      await (middleware as any)(req);
+
+      const forwarded = (mockNextResponseNext.mock.calls[0][0] as { request: { headers: Headers } }).request.headers;
+      expect(forwarded.get('x-correlation-id')).toBe(response.headers.get('x-correlation-id'));
+      expect(forwarded.get('x-correlation-id')).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('adopts the x-amzn-trace-id Root token when no correlation ID is supplied', async () => {
+      const req = fakeRequest('/api/v1/credentials/verify', {
+        headers: { 'x-amzn-trace-id': 'Root=1-67891233-abcdef012345678912345678;Parent=53995c3f42cd8ad8' },
+      });
+      const response = fakeNextResponse();
+      mockNextResponseNext.mockReturnValueOnce(response);
+
+      await (middleware as any)(req);
+
+      expect(response.headers.get('x-correlation-id')).toBe('1-67891233-abcdef012345678912345678');
+    });
+
+    it('prefers a valid x-correlation-id over the amzn trace header', async () => {
+      const req = fakeRequest('/api/v1/credentials/verify', {
+        headers: {
+          'x-correlation-id': 'explicit-id',
+          'x-amzn-trace-id': 'Root=1-67891233-abcdef012345678912345678',
+        },
+      });
+      const response = fakeNextResponse();
+      mockNextResponseNext.mockReturnValueOnce(response);
+
+      await (middleware as any)(req);
+
+      expect(response.headers.get('x-correlation-id')).toBe('explicit-id');
+    });
+
+    it('mints a UUID when the amzn trace header carries no valid Root token', async () => {
+      const req = fakeRequest('/api/v1/credentials/verify', {
+        headers: { 'x-amzn-trace-id': 'Parent=53995c3f42cd8ad8' },
+      });
+      const response = fakeNextResponse();
+      mockNextResponseNext.mockReturnValueOnce(response);
+
+      await (middleware as any)(req);
+
+      expect(response.headers.get('x-correlation-id')).toMatch(/^[0-9a-f-]{36}$/);
     });
 
     it('sets x-correlation-id header on the response', async () => {

--- a/packages/reference-implementation/src/middleware.ts
+++ b/packages/reference-implementation/src/middleware.ts
@@ -20,7 +20,7 @@ import NextAuth from 'next-auth';
 import { authConfig } from '@/lib/auth/auth.config';
 import { NextResponse, type NextRequest } from 'next/server';
 import { validateServiceAccountToken, extractBearerToken } from '@/lib/auth/token-validator';
-import { runWithRequestContext } from '@uncefact/untp-ri-services/logging';
+import { runWithRequestContext, isValidCorrelationId, amznTraceRootToken } from '@uncefact/untp-ri-services/logging';
 import type { JWTPayload } from 'jose';
 
 const { auth } = NextAuth(authConfig);
@@ -31,13 +31,18 @@ const PUBLIC_API_ROUTES = new Set(['/api/v1/credentials/verify']);
 /**
  * Strips all x-auth-* headers from the incoming request to prevent spoofing.
  */
-function stripAuthHeaders(headers: Headers): Headers {
+function stripAuthHeaders(headers: Headers, correlationId: string): Headers {
   const cleaned = new Headers(headers);
   for (const key of [...cleaned.keys()]) {
     if (key.startsWith('x-auth-')) {
       cleaned.delete(key);
     }
   }
+  // Forward the validated-or-minted ID so route handlers, log lines, and
+  // outbound calls all use the same ID the response echoes back to the
+  // caller; without this a missing or malformed inbound ID splits into one
+  // ID on the response and a different one everywhere else (#654).
+  cleaned.set('x-correlation-id', correlationId);
   return cleaned;
 }
 
@@ -57,8 +62,16 @@ async function validateBearerAuth(req: NextRequest): Promise<JWTPayload | null> 
 }
 
 export default auth(async (req) => {
+  // Zero trust at the boundary (#654): an inbound ID outside the shared
+  // length/charset rule is replaced, never echoed into logs or responses.
+  // Behind an AWS ALB the trace header's Root token joins RI logs to ALB
+  // access logs and X-Ray; the raw header never validates, the token does.
+  const inbound = req.headers.get('x-correlation-id');
+  const amznTrace = req.headers.get('x-amzn-trace-id');
   const correlationId =
-    req.headers.get('x-correlation-id') || req.headers.get('x-amzn-trace-id') || crypto.randomUUID();
+    inbound && isValidCorrelationId(inbound)
+      ? inbound
+      : (amznTrace && amznTraceRootToken(amznTrace)) || crypto.randomUUID();
 
   return runWithRequestContext(correlationId, async () => {
     const { pathname } = req.nextUrl;
@@ -68,14 +81,14 @@ export default auth(async (req) => {
     if (pathname.startsWith('/api/v1/')) {
       // Allow public API routes through without authentication
       if (PUBLIC_API_ROUTES.has(pathname)) {
-        const requestHeaders = stripAuthHeaders(req.headers);
+        const requestHeaders = stripAuthHeaders(req.headers, correlationId);
         const response = NextResponse.next({ request: { headers: requestHeaders } });
         response.headers.set('x-correlation-id', correlationId);
         return response;
       }
 
       // Strip x-auth-* headers from incoming request to prevent spoofing
-      const requestHeaders = stripAuthHeaders(req.headers);
+      const requestHeaders = stripAuthHeaders(req.headers, correlationId);
 
       // Check session-based auth first
       if (isSessionAuthenticated) {

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.test.ts
@@ -42,6 +42,18 @@ const mockLogger: LoggerService = {
 
 // -- Tests -------------------------------------------------------------------
 
+// httpFetch normalises headers into a Headers instance; match by reading through it.
+const headersMatching = (pairs: Record<string, string>) => ({
+  asymmetricMatch: (actual: unknown) => {
+    const h = new Headers(actual as HeadersInit);
+    return Object.entries(pairs).every(([k, v]) => h.get(k) === v);
+  },
+  toString: () => `headersMatching(${JSON.stringify(pairs)})`,
+});
+
+const correlationHeaderOf = (init: unknown): string | null =>
+  new Headers((init as RequestInit).headers).get('x-correlation-id');
+
 describe('VCKitDidAdapter', () => {
   let service: VCKitDidAdapter;
 
@@ -102,6 +114,13 @@ describe('VCKitDidAdapter', () => {
         .mockResolvedValueOnce(createMockResponse({ didDocument }));
     }
 
+    it('carries an x-correlation-id header on outbound requests', async () => {
+      mockCreateAndResolve();
+      await service.create({ type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'test-org' });
+
+      expect(correlationHeaderOf((global.fetch as jest.Mock).mock.calls[0][1])).toMatch(/.+/);
+    });
+
     it('sends correct payload and returns DidRecord with document', async () => {
       mockCreateAndResolve();
 
@@ -116,7 +135,7 @@ describe('VCKitDidAdapter', () => {
         `${BASE_URL}/agent/didManagerCreate`,
         expect.objectContaining({
           method: 'POST',
-          headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+          headers: headersMatching({ Authorization: 'Bearer test-token' }),
           body: expect.stringContaining('"provider":"did:web"'),
         }),
       );
@@ -300,7 +319,7 @@ describe('VCKitDidAdapter', () => {
         `${BASE_URL}/agent/didManagerDelete`,
         expect.objectContaining({
           method: 'POST',
-          headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+          headers: headersMatching({ Authorization: 'Bearer test-token' }),
           body: JSON.stringify({ did: 'did:web:example.com:org:123' }),
         }),
       );
@@ -350,7 +369,7 @@ describe('VCKitDidAdapter', () => {
       expect(global.fetch).toHaveBeenCalledWith(
         `${BASE_URL}/agent/resolveDid`,
         expect.objectContaining({
-          headers: expect.objectContaining({
+          headers: headersMatching({
             Host: 'example.com',
             Origin: 'https://example.com',
           }),

--- a/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
+++ b/packages/services/src/did-manager/adapters/vckit/vckit-did.adapter.ts
@@ -1,3 +1,4 @@
+import { httpFetch } from '../../../http/client.js';
 import type { IDidService, CreateDidOptions, DidRecord, DidDocument, DidVerificationResult } from '../../types.js';
 import { DidMethod, DidType, DidVerificationCheckName, SUPPORTED_DID_METHODS } from '../../types.js';
 import { verifyDid } from '../../common/verify.js';
@@ -90,7 +91,7 @@ export class VCKitDidAdapter implements IDidService {
     this.logger.debug({ method: options.method, alias: options.alias }, 'Creating DID');
 
     try {
-      const response = await fetch(`${this.baseURL}/agent/didManagerCreate`, {
+      const response = await httpFetch(`${this.baseURL}/agent/didManagerCreate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -138,7 +139,7 @@ export class VCKitDidAdapter implements IDidService {
     this.logger.debug({ did }, 'Deleting DID');
 
     try {
-      const response = await fetch(`${this.baseURL}/agent/didManagerDelete`, {
+      const response = await httpFetch(`${this.baseURL}/agent/didManagerDelete`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -171,7 +172,7 @@ export class VCKitDidAdapter implements IDidService {
     this.logger.debug({ did, domain }, 'Fetching DID document');
 
     try {
-      const response = await fetch(`${this.baseURL}/agent/resolveDid`, {
+      const response = await httpFetch(`${this.baseURL}/agent/resolveDid`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -212,7 +213,7 @@ export class VCKitDidAdapter implements IDidService {
     let providerKeys: Array<{ kid: string }> = [];
     let keyFetchFailed = false;
     try {
-      const response = await fetch(`${this.baseURL}/agent/didManagerGet`, {
+      const response = await httpFetch(`${this.baseURL}/agent/didManagerGet`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...this.headers },
         body: JSON.stringify({ did }),

--- a/packages/services/src/did-manager/common/verify-did-web.ts
+++ b/packages/services/src/did-manager/common/verify-did-web.ts
@@ -1,3 +1,4 @@
+import { httpFetch } from '../../http/client.js';
 import type { DidDocument, DidVerificationCheck, MethodVerificationResult } from '../types.js';
 import { DidVerificationCheckName } from '../types.js';
 import { didWebToUrl } from './utils.js';
@@ -45,7 +46,9 @@ export async function verifyDidWeb(did: string): Promise<MethodVerificationResul
   // Check 1: Resolve — fetch the DID document
   let response: Response | null = null;
   try {
-    response = await fetch(url);
+    // Third-party host (the DID's own domain): no correlation header, so
+    // internal request identifiers stay within the operator's services (#654).
+    response = await httpFetch(url, { correlate: false });
 
     if (!response.ok) {
       checks.push({ name: C.RESOLVE, passed: false, message: `HTTP ${response.status} from ${url}` });

--- a/packages/services/src/http/client.test.ts
+++ b/packages/services/src/http/client.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import { httpFetch } from './client';
+import { runWithRequestContext } from '../logging/request-context';
+
+describe('httpFetch', () => {
+  const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  const sentHeaders = (): Headers => new Headers((mockFetch.mock.calls[0][1] as RequestInit).headers);
+
+  it('forwards the request context correlation ID on outbound requests', async () => {
+    await runWithRequestContext('ctx-42', () => httpFetch('https://storage.example.com/store'));
+
+    expect(sentHeaders().get('x-correlation-id')).toBe('ctx-42');
+  });
+
+  it('mints a correlation ID when called outside a request context', async () => {
+    await httpFetch('https://storage.example.com/store');
+
+    expect(sentHeaders().get('x-correlation-id')).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('overwrites a caller-supplied correlation header with the request context ID', async () => {
+    await runWithRequestContext('ctx-42', () =>
+      httpFetch('https://storage.example.com/store', { headers: { 'x-correlation-id': 'stale-or-forged' } }),
+    );
+
+    expect(sentHeaders().get('x-correlation-id')).toBe('ctx-42');
+  });
+
+  it.each([
+    ['a plain record', { Accept: 'application/json' } as HeadersInit],
+    ['a tuple array', [['Accept', 'application/json']] as HeadersInit],
+    ['a Headers instance', new Headers({ Accept: 'application/json' }) as HeadersInit],
+  ])('merges the correlation header into %s', async (_shape, headers) => {
+    await runWithRequestContext('ctx-42', () => httpFetch('https://storage.example.com/store', { headers }));
+
+    expect(sentHeaders().get('accept')).toBe('application/json');
+    expect(sentHeaders().get('x-correlation-id')).toBe('ctx-42');
+  });
+
+  it('preserves other request options and headers', async () => {
+    await httpFetch('https://idr.example.com/links', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://idr.example.com/links');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('{}');
+    expect(sentHeaders().get('authorization')).toBe('Bearer t');
+    expect(sentHeaders().get('x-correlation-id')).toBeTruthy();
+  });
+
+  it('sends no correlation header to third-party hosts when correlate is false', async () => {
+    await runWithRequestContext('ctx-42', () =>
+      httpFetch('https://third-party.example.com/did.json', { correlate: false }),
+    );
+
+    expect(sentHeaders().get('x-correlation-id')).toBeNull();
+  });
+
+  it('strips a caller-supplied correlation header when correlate is false', async () => {
+    await httpFetch('https://third-party.example.com/did.json', {
+      correlate: false,
+      headers: { 'x-correlation-id': 'internal-id' },
+    });
+
+    expect(sentHeaders().get('x-correlation-id')).toBeNull();
+  });
+});

--- a/packages/services/src/http/client.ts
+++ b/packages/services/src/http/client.ts
@@ -1,0 +1,35 @@
+import { CORRELATION_ID_HEADER, getOrMintCorrelationId } from '../logging/correlation-id.js';
+
+export interface HttpClientOptions extends RequestInit {
+  /**
+   * Whether to send the request-scoped `x-correlation-id` header. Defaults to
+   * true, which is correct for calls to UNTP services participating in
+   * cross-service log correlation (storage, IDR, VC, DID). Pass false for
+   * third-party hosts (arbitrary `did:web` domains, credential URIs, JSON-LD
+   * contexts): they gain nothing from the ID, and internal request
+   * identifiers should not leak to hosts outside the operator's aggregation.
+   */
+  correlate?: boolean;
+}
+
+/**
+ * The single outbound HTTP entry point for this package (#654). An ESLint
+ * restriction bans bare `fetch` elsewhere under `src/`, so correlation-header
+ * propagation cannot be forgotten at individual call sites.
+ */
+export async function httpFetch(input: string | URL, options: HttpClientOptions = {}): Promise<Response> {
+  const { correlate = true, ...init } = options;
+  const headers = new Headers(init.headers);
+
+  if (correlate) {
+    // The request context is authoritative: a caller-supplied header is
+    // overwritten, so a stale or malformed value can never displace the
+    // active request's ID, and a valid ID always reaches downstream.
+    headers.set(CORRELATION_ID_HEADER, getOrMintCorrelationId());
+  } else {
+    // Exclusion means exclusion: strip the header even if a caller set one,
+    // so internal request identifiers never reach third-party hosts.
+    headers.delete(CORRELATION_ID_HEADER);
+  }
+  return fetch(input, { ...init, headers });
+}

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.test.ts
@@ -18,6 +18,18 @@ import type { Link } from '../../types';
 import type { PyxIdrConfig } from './pyx-idr.schema';
 import type { LoggerService } from '../../../logging/types';
 
+// httpFetch normalises headers into a Headers instance; match by reading through it.
+const headersMatching = (pairs: Record<string, string>) => ({
+  asymmetricMatch: (actual: unknown) => {
+    const h = new Headers(actual as HeadersInit);
+    return Object.entries(pairs).every(([k, v]) => h.get(k) === v);
+  },
+  toString: () => `headersMatching(${JSON.stringify(pairs)})`,
+});
+
+const correlationHeaderOf = (init: unknown): string | null =>
+  new Headers((init as RequestInit).headers).get('x-correlation-id');
+
 describe('PyxIdentityResolverAdapter', () => {
   const mockLogger: LoggerService = {
     info: jest.fn(),
@@ -124,6 +136,13 @@ describe('PyxIdentityResolverAdapter', () => {
       expect(mockFetch).toHaveBeenCalledWith('https://resolver.example.com/api/v4/resolver', expect.any(Object));
     });
 
+    it('carries an x-correlation-id header on outbound requests', async () => {
+      const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
+      await adapter.publishLinks('abn', '51824753556', mockLinks, undefined, mockOptions);
+
+      expect(correlationHeaderOf(mockFetch.mock.calls[0][1])).toMatch(/.+/);
+    });
+
     it('should include authorization and content-type headers', async () => {
       const adapter = new PyxIdentityResolverAdapter(mockConfig, mockLogger);
       await adapter.publishLinks('abn', '51824753556', mockLinks, undefined, mockOptions);
@@ -131,7 +150,7 @@ describe('PyxIdentityResolverAdapter', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          headers: expect.objectContaining({
+          headers: headersMatching({
             Authorization: 'Bearer test-api-key',
             'Content-Type': 'application/json',
           }),
@@ -433,7 +452,7 @@ describe('PyxIdentityResolverAdapter', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://resolver.example.com/api/v4/resolver/links/link-123',
-        expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-api-key' }) }),
+        expect.objectContaining({ headers: headersMatching({ Authorization: 'Bearer test-api-key' }) }),
       );
     });
 
@@ -697,7 +716,7 @@ describe('PyxIdentityResolverAdapter', () => {
         'https://resolver.example.com/api/v4/resolver/links/link-123',
         expect.objectContaining({
           method: 'DELETE',
-          headers: expect.objectContaining({ Authorization: 'Bearer test-api-key' }),
+          headers: headersMatching({ Authorization: 'Bearer test-api-key' }),
         }),
       );
     });
@@ -757,7 +776,7 @@ describe('PyxIdentityResolverAdapter', () => {
       expect(result).toEqual(mockDescription);
       expect(mockFetch).toHaveBeenCalledWith(
         'https://resolver.example.com/.well-known/resolver',
-        expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-api-key' }) }),
+        expect.objectContaining({ headers: headersMatching({ Authorization: 'Bearer test-api-key' }) }),
       );
     });
 
@@ -792,7 +811,7 @@ describe('PyxIdentityResolverAdapter', () => {
       expect(result).toEqual(mockLinkTypes);
       expect(mockFetch).toHaveBeenCalledWith(
         'https://resolver.example.com/api/v4/voc?show=linktypes',
-        expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-api-key' }) }),
+        expect.objectContaining({ headers: headersMatching({ Authorization: 'Bearer test-api-key' }) }),
       );
     });
 

--- a/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
+++ b/packages/services/src/identity-resolver/adapters/pyx/pyx-idr.adapter.ts
@@ -1,3 +1,4 @@
+import { httpFetch } from '../../../http/client.js';
 import type { AdapterRegistryEntry } from '../../../registry/types.js';
 import { BaseServiceAdapter } from '../../../registry/base-adapter.js';
 import type { LoggerService } from '../../../logging/types.js';
@@ -111,7 +112,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
 
     this.logger.info(`Publishing ${links.length} link(s) for ${identifierScheme}/${identifier}`);
 
-    const response = await fetch(`${this.apiBasePath}/resolver`, {
+    const response = await httpFetch(`${this.apiBasePath}/resolver`, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify(payload),
@@ -148,7 +149,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
 
   async getLinkById(linkId: string): Promise<Link> {
     this.logger.info(`Getting link ${linkId}`);
-    const response = await fetch(`${this.apiBasePath}/resolver/links/${linkId}`, {
+    const response = await httpFetch(`${this.apiBasePath}/resolver/links/${linkId}`, {
       headers: this.headers,
     });
 
@@ -183,7 +184,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
     if (link.additionalRels !== undefined) payload.rel = link.additionalRels;
     if (link.public !== undefined) payload.public = link.public;
 
-    const response = await fetch(`${this.apiBasePath}/resolver/links/${linkId}`, {
+    const response = await httpFetch(`${this.apiBasePath}/resolver/links/${linkId}`, {
       method: 'PUT',
       headers: this.headers,
       body: JSON.stringify(payload),
@@ -211,7 +212,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
 
   async deleteLink(linkId: string): Promise<void> {
     this.logger.info(`Deleting link ${linkId}`);
-    const response = await fetch(`${this.apiBasePath}/resolver/links/${linkId}`, {
+    const response = await httpFetch(`${this.apiBasePath}/resolver/links/${linkId}`, {
       method: 'DELETE',
       headers: this.headers,
     });
@@ -227,7 +228,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
 
   async getResolverDescription(): Promise<ResolverDescription> {
     this.logger.info('Fetching resolver description');
-    const response = await fetch(`${this.baseURL}/.well-known/resolver`, {
+    const response = await httpFetch(`${this.baseURL}/.well-known/resolver`, {
       headers: this.headers,
     });
 
@@ -241,7 +242,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
 
   async getLinkTypes(): Promise<LinkType[]> {
     this.logger.info('Fetching link types');
-    const response = await fetch(`${this.apiBasePath}/voc?show=linktypes`, {
+    const response = await httpFetch(`${this.apiBasePath}/voc?show=linktypes`, {
       headers: this.headers,
     });
 
@@ -287,7 +288,7 @@ export class PyxIdentityResolverAdapter extends BaseServiceAdapter implements II
   ): Promise<void> {
     this.logger.info(`Registering ${schemes.length} scheme(s)`);
     for (const scheme of schemes) {
-      const response = await fetch(`${this.apiBasePath}/identifiers`, {
+      const response = await httpFetch(`${this.apiBasePath}/identifiers`, {
         method: 'POST',
         headers: this.headers,
         body: JSON.stringify(scheme),

--- a/packages/services/src/logging/correlation-id.test.ts
+++ b/packages/services/src/logging/correlation-id.test.ts
@@ -1,0 +1,74 @@
+import {
+  CORRELATION_ID_HEADER,
+  amznTraceRootToken,
+  getOrMintCorrelationId,
+  isValidCorrelationId,
+} from './correlation-id';
+import { runWithRequestContext } from './request-context';
+
+describe('isValidCorrelationId', () => {
+  it('accepts alphanumeric IDs with hyphens and underscores up to 128 characters', () => {
+    expect(isValidCorrelationId('abc-DEF_123')).toBe(true);
+    expect(isValidCorrelationId('a'.repeat(128))).toBe(true);
+  });
+
+  it('rejects empty and over-length values', () => {
+    expect(isValidCorrelationId('')).toBe(false);
+    expect(isValidCorrelationId('a'.repeat(129))).toBe(false);
+  });
+
+  it.each([
+    ['spaces', 'has space'],
+    ['semicolons', 'a;b'],
+    ['equals', 'Root=1-abc'],
+    ['newlines', 'a\nb'],
+    ['unicode', 'idé'],
+  ])('rejects values containing %s', (_name, value) => {
+    expect(isValidCorrelationId(value)).toBe(false);
+  });
+});
+
+describe('getOrMintCorrelationId', () => {
+  it('returns the context correlation ID when inside a request context', () => {
+    runWithRequestContext('ctx-id-1', () => {
+      expect(getOrMintCorrelationId()).toBe('ctx-id-1');
+    });
+  });
+
+  it('mints a UUID when outside any request context', () => {
+    const minted = getOrMintCorrelationId();
+    expect(minted).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});
+
+describe('CORRELATION_ID_HEADER', () => {
+  it('names the wire header', () => {
+    expect(CORRELATION_ID_HEADER).toBe('x-correlation-id');
+  });
+});
+
+describe('amznTraceRootToken', () => {
+  it('extracts the Root token from a full trace header', () => {
+    expect(amznTraceRootToken('Root=1-67891233-abcdef012345678912345678;Parent=53995c3f42cd8ad8;Sampled=1')).toBe(
+      '1-67891233-abcdef012345678912345678',
+    );
+  });
+
+  it('extracts Root when it is not the first segment', () => {
+    expect(amznTraceRootToken('Self=1-abc;Root=1-67891233-abcdef012345678912345678')).toBe(
+      '1-67891233-abcdef012345678912345678',
+    );
+  });
+
+  it('returns null when no Root segment exists', () => {
+    expect(amznTraceRootToken('Parent=53995c3f42cd8ad8')).toBeNull();
+  });
+
+  it('returns null when the Root token is not X-Ray shaped, even if fleet-valid', () => {
+    expect(amznTraceRootToken('Root=bad value with spaces')).toBeNull();
+    expect(amznTraceRootToken(`Root=${'a'.repeat(200)}`)).toBeNull();
+    expect(amznTraceRootToken('Root=abc')).toBeNull();
+    expect(amznTraceRootToken('Root=not_an_xray_id')).toBeNull();
+    expect(amznTraceRootToken('Root=1-67891233-zzzzzzzzzzzzzzzzzzzzzzzz')).toBeNull();
+  });
+});

--- a/packages/services/src/logging/correlation-id.ts
+++ b/packages/services/src/logging/correlation-id.ts
@@ -1,0 +1,62 @@
+import { getRequestContext } from './request-context.js';
+
+export const CORRELATION_ID_HEADER = 'x-correlation-id';
+
+const MAX_CORRELATION_ID_LENGTH = 128;
+const CORRELATION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Zero-trust check for inbound correlation IDs, shared by every UNTP service
+ * in this repository that accepts them. Mirrors the storage service's
+ * `src/middleware/correlation-id.ts` posture: length-capped, alphanumeric
+ * plus `-` and `_`. Reject-and-replace callers must not echo the offending
+ * value into logs.
+ */
+export function isValidCorrelationId(value: string): boolean {
+  return value.length > 0 && value.length <= MAX_CORRELATION_ID_LENGTH && CORRELATION_ID_PATTERN.test(value);
+}
+
+/**
+ * Extracts the Root token from an AWS `X-Amzn-Trace-Id` header value
+ * (`Root=1-67891233-abcdef012345678912345678;Parent=...`). The raw header can
+ * never pass {@link isValidCorrelationId} (it carries `=` and `;`), but the
+ * Root token is hex-and-hyphens and flows cleanly through every UNTP
+ * service's validator, joining RI logs to ALB access logs and X-Ray. Returns
+ * null when no valid Root token is present.
+ */
+export function amznTraceRootToken(headerValue: string): string | null {
+  const match = /(?:^|;)Root=([^;]+)/.exec(headerValue);
+  const root = match?.[1];
+  // Strict X-Ray Root syntax (1-<8 hex>-<24 hex>), not merely fleet-valid:
+  // anything looser would launder arbitrary attacker-chosen strings into a
+  // value the logs present as an AWS trace ID.
+  return root && /^1-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{24}$/.test(root) ? root : null;
+}
+
+/**
+ * The current request's correlation ID, or a freshly minted one when running
+ * outside a request context (e.g. a background job), so downstream services
+ * always receive a valid ID.
+ */
+export function getOrMintCorrelationId(): string {
+  return getRequestContext()?.correlationId ?? randomUuid();
+}
+
+/**
+ * Web Crypto (globalThis.crypto) rather than node:crypto: this module is
+ * imported by the Next.js Edge middleware bundle via the logging barrel, and
+ * a node:crypto import trips Edge-runtime build warnings. randomUUID is
+ * available in Node and Edge; the getRandomValues fallback covers runtimes
+ * that expose only the lower-level primitive (e.g. jsdom).
+ */
+function randomUuid(): string {
+  const c = globalThis.crypto;
+  if (typeof c.randomUUID === 'function') {
+    return c.randomUUID();
+  }
+  const bytes = c.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/services/src/logging/index.ts
+++ b/packages/services/src/logging/index.ts
@@ -2,6 +2,12 @@ export type { LoggerService, LogContext, LoggerConfig, LogLevel } from './types.
 export { createLogger } from './factory.js';
 export { getRequestContext, updateRequestContext, runWithRequestContext } from './request-context.js';
 export { registerRequestContextProvider } from './adapters/pino-logger.js';
+export {
+  CORRELATION_ID_HEADER,
+  amznTraceRootToken,
+  getOrMintCorrelationId,
+  isValidCorrelationId,
+} from './correlation-id.js';
 
 // Auto-register the request context provider so that ALL loggers include
 // request-scoped fields (correlationId, userId, tenantId, etc.) in every

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.test.ts
@@ -19,6 +19,18 @@ const MULTIBASE_A = `zTEST${HEX_A}`;
 const HEX_B = '9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7';
 const MULTIBASE_B = `zTEST${HEX_B}`;
 
+// httpFetch normalises headers into a Headers instance; match by reading through it.
+const headersMatching = (pairs: Record<string, string>) => ({
+  asymmetricMatch: (actual: unknown) => {
+    const h = new Headers(actual as HeadersInit);
+    return Object.entries(pairs).every(([k, v]) => h.get(k) === v);
+  },
+  toString: () => `headersMatching(${JSON.stringify(pairs)})`,
+});
+
+const correlationHeaderOf = (init: unknown): string | null =>
+  new Headers((init as RequestInit).headers).get('x-correlation-id');
+
 describe('UncefactStorageAdapter', () => {
   const MOCK_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 
@@ -85,6 +97,14 @@ describe('UncefactStorageAdapter', () => {
       expect(adapter).toBeInstanceOf(UncefactStorageAdapter);
     });
 
+    it('carries the request context correlation ID on outbound requests', async () => {
+      const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
+      const { runWithRequestContext } = jest.requireActual('../../../logging/request-context');
+      await runWithRequestContext('ctx-storage-1', () => adapter.store(mockCredential));
+
+      expect(correlationHeaderOf(mockFetch.mock.calls[0][1])).toBe('ctx-storage-1');
+    });
+
     it('should include X-API-Key header when apiKey is provided', async () => {
       const adapter = new UncefactStorageAdapter(mockConfig, mockLogger);
       await adapter.store(mockCredential);
@@ -92,7 +112,7 @@ describe('UncefactStorageAdapter', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          headers: expect.objectContaining({
+          headers: headersMatching({
             'Content-Type': 'application/json',
             'X-API-Key': 'test-api-key',
           }),
@@ -111,9 +131,9 @@ describe('UncefactStorageAdapter', () => {
       await adapter.store(mockCredential);
 
       const callArgs = mockFetch.mock.calls[0];
-      const headers = callArgs[1].headers;
-      expect(headers['Content-Type']).toBe('application/json');
-      expect(headers['X-API-Key']).toBeUndefined();
+      const headers = new Headers((callArgs[1] as RequestInit).headers);
+      expect(headers.get('Content-Type')).toBe('application/json');
+      expect(headers.get('X-API-Key')).toBeNull();
     });
 
     it('should call logger.child with service name', () => {
@@ -806,8 +826,8 @@ describe('UncefactStorageAdapter', () => {
       await adapter.storeBinary('<html>Hello</html>', 'template.html', 'text/html');
 
       const callArgs = mockFetch.mock.calls[0];
-      const headers = callArgs[1].headers;
-      expect(headers['Content-Type']).toBeUndefined();
+      const headers = new Headers((callArgs[1] as RequestInit).headers);
+      expect(headers.get('Content-Type')).toBeNull();
     });
 
     it('should include X-API-Key header when configured', async () => {
@@ -815,8 +835,8 @@ describe('UncefactStorageAdapter', () => {
       await adapter.storeBinary('<html>Hello</html>', 'template.html', 'text/html');
 
       const callArgs = mockFetch.mock.calls[0];
-      const headers = callArgs[1].headers;
-      expect(headers['X-API-Key']).toBe('test-api-key');
+      const headers = new Headers((callArgs[1] as RequestInit).headers);
+      expect(headers.get('X-API-Key')).toBe('test-api-key');
     });
 
     it('should not include X-API-Key header when apiKey is omitted', async () => {
@@ -830,8 +850,8 @@ describe('UncefactStorageAdapter', () => {
       await adapter.storeBinary('<html>Hello</html>', 'template.html', 'text/html');
 
       const callArgs = mockFetch.mock.calls[0];
-      const headers = callArgs[1].headers;
-      expect(headers['X-API-Key']).toBeUndefined();
+      const headers = new Headers((callArgs[1] as RequestInit).headers);
+      expect(headers.get('X-API-Key')).toBeNull();
     });
 
     it('should return StorageRecord with uri, hash, externalId, bucket, and mimeType', async () => {
@@ -1094,7 +1114,7 @@ describe('UncefactStorageAdapter', () => {
       await adapter.delete('resource-id-42', 'my-bucket');
 
       const callArgs = mockFetch.mock.calls[0];
-      expect(callArgs[1].headers['X-API-Key']).toBe('test-api-key');
+      expect(new Headers((callArgs[1] as RequestInit).headers).get('X-API-Key')).toBe('test-api-key');
     });
 
     it('should not include X-API-Key header when apiKey is omitted', async () => {
@@ -1110,7 +1130,7 @@ describe('UncefactStorageAdapter', () => {
       await adapter.delete('resource-id-42', 'my-bucket');
 
       const callArgs = mockFetch.mock.calls[0];
-      expect(callArgs[1].headers['X-API-Key']).toBeUndefined();
+      expect(new Headers((callArgs[1] as RequestInit).headers).get('X-API-Key')).toBeNull();
     });
 
     it('should not send Content-Type header', async () => {
@@ -1120,7 +1140,7 @@ describe('UncefactStorageAdapter', () => {
       await adapter.delete('resource-id-42', 'my-bucket');
 
       const callArgs = mockFetch.mock.calls[0];
-      expect(callArgs[1].headers['Content-Type']).toBeUndefined();
+      expect(new Headers((callArgs[1] as RequestInit).headers).get('Content-Type')).toBeNull();
     });
 
     it('should resolve without error on 204 response', async () => {

--- a/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.ts
+++ b/packages/services/src/storage/adapters/uncefact/uncefact-storage.adapter.ts
@@ -1,3 +1,4 @@
+import { httpFetch } from '../../../http/client.js';
 import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
 import { BaseServiceAdapter } from '../../../registry/base-adapter.js';
 import type { LoggerService } from '../../../logging/types.js';
@@ -112,7 +113,7 @@ export class UncefactStorageAdapter extends BaseServiceAdapter implements IStora
 
     this.logger.debug({ url, encrypt, bucket, externalId }, 'Storing credential');
 
-    const response = await fetch(url, {
+    const response = await httpFetch(url, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify(payload),
@@ -204,7 +205,7 @@ export class UncefactStorageAdapter extends BaseServiceAdapter implements IStora
       multipartHeaders['X-API-Key'] = this.headers['X-API-Key'];
     }
 
-    const response = await fetch(url, {
+    const response = await httpFetch(url, {
       method: 'POST',
       headers: multipartHeaders,
       body: formData,
@@ -289,7 +290,7 @@ export class UncefactStorageAdapter extends BaseServiceAdapter implements IStora
       deleteHeaders['X-API-Key'] = this.headers['X-API-Key'];
     }
 
-    const response = await fetch(url, {
+    const response = await httpFetch(url, {
       method: 'DELETE',
       headers: deleteHeaders,
     });

--- a/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.test.ts
+++ b/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.test.ts
@@ -9,6 +9,18 @@ import type { VCKitVerifiableCredentialConfig } from './vckit-verifiable-credent
 import type { LoggerService } from '../../../logging/types';
 import type { CredentialPayload, EnvelopedVerifiableCredential, CredentialStatus } from '../../types';
 
+// httpFetch normalises headers into a Headers instance; match by reading through it.
+const headersMatching = (pairs: Record<string, string>) => ({
+  asymmetricMatch: (actual: unknown) => {
+    const h = new Headers(actual as HeadersInit);
+    return Object.entries(pairs).every(([k, v]) => h.get(k) === v);
+  },
+  toString: () => `headersMatching(${JSON.stringify(pairs)})`,
+});
+
+const correlationHeaderOf = (init: unknown): string | null =>
+  new Headers((init as RequestInit).headers).get('x-correlation-id');
+
 describe('VCKitVerifiableCredentialService', () => {
   const mockLogger: LoggerService = {
     debug: jest.fn(),
@@ -77,6 +89,19 @@ describe('VCKitVerifiableCredentialService', () => {
       expect(adapter).toBeInstanceOf(VCKitVerifiableCredentialService);
     });
 
+    it('carries an x-correlation-id header on outbound requests', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValue(mockCredentialStatus) })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ verifiableCredential: mockEnvelopedCredential }),
+        });
+      const adapter = new VCKitVerifiableCredentialService(mockConfig, mockLogger);
+      await adapter.sign(mockCredentialPayload);
+
+      expect(correlationHeaderOf(mockFetch.mock.calls[0][1])).toMatch(/.+/);
+    });
+
     it('should construct Bearer token from apiKey', async () => {
       // Set up fetch mocks for sign flow: status call + issue call
       mockFetch
@@ -96,7 +121,7 @@ describe('VCKitVerifiableCredentialService', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          headers: expect.objectContaining({
+          headers: headersMatching({
             Authorization: 'Bearer test-api-key',
           }),
         }),
@@ -131,7 +156,7 @@ describe('VCKitVerifiableCredentialService', () => {
         'https://vckit.example.com/agent/issueBitstringStatusList',
         expect.objectContaining({
           method: 'POST',
-          headers: expect.objectContaining({
+          headers: headersMatching({
             'Content-Type': 'application/json',
             Authorization: 'Bearer test-api-key',
           }),
@@ -147,7 +172,7 @@ describe('VCKitVerifiableCredentialService', () => {
         'https://vckit.example.com/v2/credentials/issue',
         expect.objectContaining({
           method: 'POST',
-          headers: expect.objectContaining({
+          headers: headersMatching({
             'Content-Type': 'application/json',
             Authorization: 'Bearer test-api-key',
           }),
@@ -263,7 +288,7 @@ describe('VCKitVerifiableCredentialService', () => {
         'https://vckit.example.com/agent/routeVerificationCredential',
         expect.objectContaining({
           method: 'POST',
-          headers: expect.objectContaining({
+          headers: headersMatching({
             'Content-Type': 'application/json',
             Authorization: 'Bearer test-api-key',
           }),

--- a/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.ts
+++ b/packages/services/src/verifiable-credential/adapters/vckit/vckit-verifiable-credential.adapter.ts
@@ -1,3 +1,4 @@
+import { httpFetch } from '../../../http/client.js';
 import type { IVerifyResult } from '@vckit/core-types';
 import { BaseServiceAdapter } from '../../../registry/base-adapter.js';
 import type { LoggerService } from '../../../logging/types.js';
@@ -95,7 +96,7 @@ export class VCKitVerifiableCredentialService extends BaseServiceAdapter impleme
 
     this.logger.debug('Verifying credential');
     const host = new URL(this.baseURL).origin;
-    const response = await fetch(`${host}/agent/routeVerificationCredential`, {
+    const response = await httpFetch(`${host}/agent/routeVerificationCredential`, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify(verifyParams),
@@ -125,7 +126,7 @@ export class VCKitVerifiableCredentialService extends BaseServiceAdapter impleme
 
   private async issueVerifiableCredential(vc: UNTPVerifiableCredential): Promise<EnvelopedVerifiableCredential> {
     const host = new URL(this.baseURL).origin;
-    const response = await fetch(`${host}/v2/credentials/issue`, {
+    const response = await httpFetch(`${host}/v2/credentials/issue`, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify({ credential: vc, options: { proofFormat: PROOF_FORMAT } }),
@@ -147,7 +148,7 @@ export class VCKitVerifiableCredentialService extends BaseServiceAdapter impleme
     if (!issuerId) throw new VcCredentialStatusError('Issuer ID is required');
 
     const host = new URL(this.baseURL).origin;
-    const response = await fetch(`${host}/agent/issueBitstringStatusList`, {
+    const response = await httpFetch(`${host}/agent/issueBitstringStatusList`, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify({ statusPurpose: 'revocation', bitstringStatusIssuer: issuerId }),


### PR DESCRIPTION
This PR makes one correlation ID trace a request across the Reference Implementation and the UNTP services it calls. Outbound calls to the configured storage, identity resolver, and verifiable credential services now carry the request's `x-correlation-id` (minted when no request context exists), so an operator can search their log aggregator by the single ID the response echoed.

All outbound HTTP in the services package now routes through one client (`httpFetch`), which is authoritative about the header: it always sets the context ID, and its `correlate: false` mode, used for third-party hosts like `did:web` domains, strips the header so internal request identifiers never leak outside the operator's services. An ESLint rule bans bare `fetch` in the package so propagation cannot be forgotten at new call sites, and per-adapter tests pin the wiring at runtime.

Inbound, all three entry points (middleware and both route wrappers) now validate `x-correlation-id` with the storage service's zero-trust rule (128 chars, `[A-Za-z0-9_-]`), replacing anything else with a fresh UUID and warning without echoing the rejected value. The middleware forwards its chosen ID to the route, so the response echo, the logs, and the outbound calls always agree. Without a valid caller ID, a request carrying an `X-Amzn-Trace-Id` header has its Root token adopted when it matches the strict X-Ray shape (`1-<8 hex>-<24 hex>`), joining these logs to ALB access logs and X-Ray; the old fallback adopted the raw header value, which the fleet-wide validation rule would now reject downstream.

Closes #654