### PR TITLE
feat(services): extend default log redaction and expose operator-configurable paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,8 @@ VERIFY_ALLOW_PRIVATE_URLS=true
 # Logging
 # Minimum log level: debug, info, warn, error
 LOG_LEVEL=info
+# Extra log redaction paths (comma-separated pino redact paths) merged with the built-in defaults
+# LOG_REDACT_PATHS=webhookSignature,*.webhookSignature
 
 # API
 # Maximum number of records a list endpoint returns per page. A request that

--- a/documentation/docs/reference-implementation/operations/logging.md
+++ b/documentation/docs/reference-implementation/operations/logging.md
@@ -61,6 +61,34 @@ The log level is controlled by the `LOG_LEVEL` environment variable. Only messag
 |----------|-------------|---------|
 | `LOG_LEVEL` | Minimum log level to emit (`debug`, `info`, `warn`, `error`) | `info` |
 
+## Redaction
+
+Secret-bearing fields are replaced with `[REDACTED]` before a log entry is written. The following field names are redacted by default, at the top level of a logged object, one level deep, and two levels deep:
+
+- `decryptionKey`
+- `apiKey`
+- `authorization` and `Authorization`
+- `token`
+- `password`
+
+`Authorization` and `authorization` are additionally redacted in the HTTP client error shape `error.config.headers`, which nests one level deeper than the other defaults reach.
+
+Deployments can extend the redacted set with the `LOG_REDACT_PATHS` environment variable, a comma-separated list of [pino redact paths](https://getpino.io/#/docs/redaction). This covers a secret shape specific to an environment or an integrated service without waiting for a code change.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LOG_REDACT_PATHS` | Comma-separated pino redact paths merged with the built-in defaults | (unset) |
+
+Each wildcard in a pino path matches exactly one level, and `*[*]` covers both arrays and plain objects. Worked examples:
+
+- `webhookSignature` redacts the field at the top level of a logged object.
+- `*.webhookSignature` redacts it one level deep, such as `{ integration: { webhookSignature } }`.
+- `*[*].webhookSignature` redacts it two levels deep, including inside arrays, such as `{ integrations: [{ webhookSignature }] }`.
+
+Because each wildcard matches a single level, a secret nested deeper than the paths you configure is not redacted.
+
+An invalid path in `LOG_REDACT_PATHS` fails logger construction, which stops the application at startup with an error naming the variable and the configured paths. A redaction path that was silently dropped would leak the very value it was meant to protect, so a typo is surfaced immediately rather than discovered in shipped logs. The one tolerated irregularity is an empty segment (a double or trailing comma): it is ignored with a startup warning rather than failing the boot.
+
 ## Output Format
 
 In production, logs are emitted as structured JSON — one JSON object per line. This format is compatible with log aggregation tools such as CloudWatch, Datadog, ELK, and similar platforms.

--- a/documentation/docs/reference-implementation/operations/startup.md
+++ b/documentation/docs/reference-implementation/operations/startup.md
@@ -106,3 +106,7 @@ Before the application accepts its first request, it validates the active `DATA_
 Without this check, a `DATA_ENCRYPTION_KEY` that does not match the key data was encrypted under only surfaces once a real request tries to decrypt something — for example a `ConfigDecryptionError` when a service instance resolves. Validating at startup turns that into an immediate, loud failure instead of an intermittent one discovered by end users.
 
 If startup fails this check, verify `DATA_ENCRYPTION_KEY` matches the key the application was previously running with. Key rotation is not supported (tracked in [#720](https://github.com/uncefact/tests-untp/issues/720)), so a changed key is not recoverable — restore the previous key rather than trying to move data onto a new one.
+
+### Redaction Path Validation
+
+The first logger constructed during startup validates any paths supplied via `LOG_REDACT_PATHS`. An invalid path fails startup with a message naming the variable and the configured paths. See [Redaction](./logging#redaction) for the path syntax and what the built-in defaults already cover.

--- a/packages/services/src/logging/adapters/pino-logger.test.ts
+++ b/packages/services/src/logging/adapters/pino-logger.test.ts
@@ -289,15 +289,67 @@ describe('PinoLoggerAdapter redaction', () => {
     const logger = new PinoLoggerAdapter({
       level: 'info',
       destination: capture.destination,
-      redactPaths: ['apiKey'],
+      redactPaths: ['sessionSecret'],
     });
 
-    logger.info({ apiKey: 'secret-key', decryptionKey: 'a'.repeat(64) }, 'configuring service');
+    logger.info({ sessionSecret: 'secret-value', decryptionKey: 'a'.repeat(64) }, 'configuring service');
 
     const [entry] = capture.entries();
-    expect(entry.apiKey).toBe('[REDACTED]');
+    expect(entry.sessionSecret).toBe('[REDACTED]');
     expect(entry.decryptionKey).toBe('[REDACTED]');
   });
+
+  it.each(['apiKey', 'authorization', 'Authorization', 'token', 'password'])(
+    'redacts a top-level %s field by default',
+    (field) => {
+      const capture = createCapture();
+      const logger = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+      logger.info({ [field]: 'secret-value' }, 'logging a secret-bearing object');
+
+      const [entry] = capture.entries();
+      expect(entry[field]).toBe('[REDACTED]');
+    },
+  );
+
+  it('redacts apiKey nested one and two levels deep', () => {
+    const capture = createCapture();
+    const logger = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+    logger.info({ config: { apiKey: 'secret-key' } }, 'service configured');
+    logger.info({ error: { config: { apiKey: 'secret-key' } } }, 'request failed');
+
+    const [first, second] = capture.entries();
+    expect((first.config as Record<string, unknown>).apiKey).toBe('[REDACTED]');
+    expect((second.error as { config: Record<string, unknown> }).config.apiKey).toBe('[REDACTED]');
+  });
+
+  it('redacts Authorization two levels deep inside a logged object', () => {
+    const capture = createCapture();
+    const logger = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+    logger.error({ error: { headers: { Authorization: 'Bearer secret-token' } } }, 'request failed');
+
+    const [entry] = capture.entries();
+    const headers = (entry.error as { headers: Record<string, unknown> }).headers;
+    expect(headers.Authorization).toBe('[REDACTED]');
+  });
+
+  it.each(['Authorization', 'authorization'])(
+    'redacts %s in the HTTP client error shape error.config.headers',
+    (field) => {
+      const capture = createCapture();
+      const logger = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+      const error = new Error('request failed') as Error & { config: Record<string, unknown> };
+      error.config = { headers: { [field]: 'Bearer secret-token' } };
+      logger.error({ error }, 'request failed');
+
+      const [entry] = capture.entries();
+      const headers = (entry.error as { config: { headers: Record<string, unknown> } }).config.headers;
+      expect(headers[field]).toBe('[REDACTED]');
+    },
+  );
 
   it('redacts decryptionKey inside an array of objects', () => {
     const capture = createCapture();
@@ -359,5 +411,141 @@ describe('PinoLoggerAdapter redaction', () => {
     expect(entry.credentialId).toBe('cred-1');
     expect(entry.count).toBe(3);
     expect(entry.msg).toBe('credentials listed');
+  });
+});
+
+describe('PinoLoggerAdapter LOG_REDACT_PATHS environment variable', () => {
+  function createCapture(): {
+    destination: { write: (msg: string) => void };
+    entries: () => Record<string, unknown>[];
+  } {
+    const lines: string[] = [];
+    return {
+      destination: { write: (msg: string) => void lines.push(msg.trim()) },
+      entries: () => lines.map((line) => JSON.parse(line)),
+    };
+  }
+
+  const originalValue = process.env.LOG_REDACT_PATHS;
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.LOG_REDACT_PATHS;
+    } else {
+      process.env.LOG_REDACT_PATHS = originalValue;
+    }
+  });
+
+  it('redacts paths supplied via LOG_REDACT_PATHS alongside the defaults', () => {
+    process.env.LOG_REDACT_PATHS = 'tenantSecret, *.webhookSignature';
+    const capture = createCapture();
+    const logger = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+    logger.info(
+      { tenantSecret: 'secret-a', integration: { webhookSignature: 'secret-b' }, decryptionKey: 'secret-c' },
+      'operator-extended redaction',
+    );
+
+    const [entry] = capture.entries();
+    expect(entry.tenantSecret).toBe('[REDACTED]');
+    expect((entry.integration as Record<string, unknown>).webhookSignature).toBe('[REDACTED]');
+    expect(entry.decryptionKey).toBe('[REDACTED]');
+  });
+
+  it('tolerates surrounding whitespace and empty segments in LOG_REDACT_PATHS', () => {
+    process.env.LOG_REDACT_PATHS = ' tenantSecret ,, ';
+    const capture = createCapture();
+    const logger = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+    logger.info({ tenantSecret: 'secret-a' }, 'trimmed path applies');
+
+    const [entry] = capture.entries();
+    expect(entry.tenantSecret).toBe('[REDACTED]');
+  });
+
+  it('redacts defaults, env paths, and config redactPaths together in one construction', () => {
+    process.env.LOG_REDACT_PATHS = 'tenantSecret';
+    const capture = createCapture();
+    const logger = new PinoLoggerAdapter({
+      level: 'info',
+      destination: capture.destination,
+      redactPaths: ['sessionSecret'],
+    });
+
+    logger.info(
+      { apiKey: 'from-defaults', tenantSecret: 'from-env', sessionSecret: 'from-config' },
+      'all three sources apply',
+    );
+
+    const [entry] = capture.entries();
+    expect(entry.apiKey).toBe('[REDACTED]');
+    expect(entry.tenantSecret).toBe('[REDACTED]');
+    expect(entry.sessionSecret).toBe('[REDACTED]');
+  });
+
+  it('children keep the parent redaction snapshot and do not re-read the environment', () => {
+    process.env.LOG_REDACT_PATHS = 'tenantSecret';
+    const capture = createCapture();
+    const parent = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+    process.env.LOG_REDACT_PATHS = 'bad[path';
+    const child = parent.child({ module: 'late-child' });
+    child.info({ tenantSecret: 'still-redacted' }, 'child inherits parent paths');
+
+    const [entry] = capture.entries();
+    expect(entry.tenantSecret).toBe('[REDACTED]');
+    expect(() => new PinoLoggerAdapter({ level: 'info', destination: capture.destination })).toThrow(
+      /LOG_REDACT_PATHS/,
+    );
+  });
+
+  it('warns when LOG_REDACT_PATHS contains an empty segment', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    process.env.LOG_REDACT_PATHS = 'tenantSecret,,';
+    const capture = createCapture();
+
+    void new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('LOG_REDACT_PATHS'));
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('propagates a non-redact construction failure without naming LOG_REDACT_PATHS', () => {
+    const capture = createCapture();
+
+    const config = { level: 'not-a-level', destination: capture.destination };
+
+    expect(
+      () => new PinoLoggerAdapter(config as unknown as ConstructorParameters<typeof PinoLoggerAdapter>[0]),
+    ).toThrow(/^(?!.*LOG_REDACT_PATHS).*level/);
+  });
+
+  it.each(['', '   '])('applies only the defaults when LOG_REDACT_PATHS is %j', (value) => {
+    process.env.LOG_REDACT_PATHS = value;
+    const capture = createCapture();
+    const logger = new PinoLoggerAdapter({ level: 'info', destination: capture.destination });
+
+    logger.info({ apiKey: 'secret-key', tenantSecret: 'not-a-default' }, 'blank env value');
+
+    const [entry] = capture.entries();
+    expect(entry.apiKey).toBe('[REDACTED]');
+    expect(entry.tenantSecret).toBe('not-a-default');
+  });
+
+  it('fails logger construction with an error naming LOG_REDACT_PATHS and the configured paths', () => {
+    process.env.LOG_REDACT_PATHS = 'valid.path,bad[path';
+    const capture = createCapture();
+
+    expect(() => new PinoLoggerAdapter({ level: 'info', destination: capture.destination })).toThrow(
+      /LOG_REDACT_PATHS.*currently: valid\.path, bad\[path/,
+    );
+  });
+
+  it('propagates a code-supplied invalid redactPaths error without naming LOG_REDACT_PATHS', () => {
+    const capture = createCapture();
+
+    expect(
+      () => new PinoLoggerAdapter({ level: 'info', destination: capture.destination, redactPaths: ['bad[path'] }),
+    ).toThrow(/^(?!.*LOG_REDACT_PATHS).*Invalid redaction path/);
   });
 });

--- a/packages/services/src/logging/adapters/pino-logger.ts
+++ b/packages/services/src/logging/adapters/pino-logger.ts
@@ -15,14 +15,51 @@ export function registerRequestContextProvider(fn: RequestContextProvider): void
 }
 
 /**
- * Sensitive paths redacted in every log entry: decryptionKey at the top
+ * Secret-bearing field names redacted by default. `decryptionKey` protects
+ * stored credential keys, `apiKey` covers every service adapter's declared
+ * sensitive config field, and `authorization` / `Authorization` cover request
+ * header objects (constructed adapter headers capitalise the key; the Headers
+ * class normalises it to lower case). `token` and `password` cover generic
+ * credential shapes.
+ */
+const DEFAULT_REDACT_FIELDS = ['decryptionKey', 'apiKey', 'authorization', 'Authorization', 'token', 'password'];
+
+/**
+ * Sensitive paths redacted in every log entry: each default field at the top
  * level, one level deep, and two levels deep (the `*[*]` subscript wildcard
  * matches arrays and plain objects alike, covering shapes such as
  * `{ credentials: [{ decryptionKey }] }`). Pino wildcards match a single
- * level each, so values nested three or more levels deep are not redacted;
- * do not log secret-bearing objects inside wrappers.
+ * level each, so apart from the HTTP-client error exception below, values
+ * nested three or more levels deep are not redacted; do not log
+ * secret-bearing objects inside wrappers.
  */
-const DEFAULT_REDACT_PATHS = ['decryptionKey', '*.decryptionKey', '*[*].decryptionKey'];
+const DEFAULT_REDACT_PATHS = [
+  ...DEFAULT_REDACT_FIELDS.flatMap((field) => [field, `*.${field}`, `*[*].${field}`]),
+  // The canonical HTTP-client error shape, `{ error: { config: { headers:
+  // { Authorization } } } }`, sits one level deeper than the wildcard
+  // defaults reach, so it gets its own narrow pair.
+  '*.config.headers.Authorization',
+  '*.config.headers.authorization',
+];
+
+/**
+ * Deployment-supplied redaction paths from the LOG_REDACT_PATHS environment
+ * variable: comma-separated pino redact paths merged with the defaults, so an
+ * operator can cover a secret shape specific to their environment without a
+ * code change. Read at logger construction; an invalid path fails
+ * construction (see the constructor).
+ */
+function redactPathsFromEnv(): string[] {
+  const raw = process.env.LOG_REDACT_PATHS;
+  if (!raw) return [];
+  const segments = raw.split(',').map((path) => path.trim());
+  const paths = segments.filter((path) => path.length > 0);
+  if (paths.length < segments.length) {
+    // The logger does not exist yet, so console is the only outlet.
+    console.warn(`LOG_REDACT_PATHS contained ${segments.length - paths.length} empty segment(s); they were ignored.`);
+  }
+  return paths;
+}
 
 export class PinoLoggerAdapter implements LoggerService {
   private logger: pino.Logger;
@@ -32,45 +69,68 @@ export class PinoLoggerAdapter implements LoggerService {
       this.logger = configOrLogger;
     } else {
       const config = configOrLogger || {};
-      this.logger = pino(
-        {
-          level: config.level || process.env.LOG_LEVEL || 'info',
-          redact: {
-            paths: [...DEFAULT_REDACT_PATHS, ...(config.redactPaths ?? [])],
-            censor: '[REDACTED]',
-          },
-          mixin() {
-            if (_requestContextProvider) {
-              try {
-                const context = _requestContextProvider();
-                return context ? { ...context } : {};
-              } catch (e) {
-                console.error('Failed to get request context for logging:', e);
-                return {};
-              }
+      const envRedactPaths = redactPathsFromEnv();
+      try {
+        this.logger = this.buildPinoLogger(config, envRedactPaths);
+      } catch (error) {
+        // pino rejects a malformed redact path synchronously with
+        // "Invalid redaction path (<path>)". Failing here fails process
+        // boot, which is deliberate: a dropped redaction path is a silent
+        // secret leak. The wrapper names LOG_REDACT_PATHS only when the
+        // offending path came from it; every other construction failure
+        // propagates untouched so its message points at the actual cause.
+        const offendingPath =
+          error instanceof Error ? /^Invalid redaction path \((.*)\)/.exec(error.message)?.[1] : undefined;
+        if (offendingPath === undefined || !envRedactPaths.includes(offendingPath)) throw error;
+        throw new Error(
+          `Logger construction failed: ${(error as Error).message}. ` +
+            `Check the LOG_REDACT_PATHS environment variable (currently: ${envRedactPaths.join(', ')}) ` +
+            'for an invalid pino redact path.',
+          { cause: error },
+        );
+      }
+    }
+  }
+
+  private buildPinoLogger(config: LoggerConfig, envRedactPaths: string[]): pino.Logger {
+    return pino(
+      {
+        level: config.level || process.env.LOG_LEVEL || 'info',
+        redact: {
+          paths: [...DEFAULT_REDACT_PATHS, ...envRedactPaths, ...(config.redactPaths ?? [])],
+          censor: '[REDACTED]',
+        },
+        mixin() {
+          if (_requestContextProvider) {
+            try {
+              const context = _requestContextProvider();
+              return context ? { ...context } : {};
+            } catch (e) {
+              console.error('Failed to get request context for logging:', e);
+              return {};
             }
-            return {};
-          },
-          ...(config.pretty &&
-            !config.destination && {
-              transport: {
-                target: 'pino-pretty',
-                options: {
-                  colorize: true,
-                  translateTime: 'SYS:standard',
-                  ignore: 'pid,hostname',
-                },
+          }
+          return {};
+        },
+        ...(config.pretty &&
+          !config.destination && {
+            transport: {
+              target: 'pino-pretty',
+              options: {
+                colorize: true,
+                translateTime: 'SYS:standard',
+                ignore: 'pid,hostname',
               },
-            }),
-          ...(config.correlationId && {
-            base: {
-              correlationId: config.correlationId,
             },
           }),
-        },
-        config.destination,
-      );
-    }
+        ...(config.correlationId && {
+          base: {
+            correlationId: config.correlationId,
+          },
+        }),
+      },
+      config.destination,
+    );
   }
 
   debug(msgOrObj: string | LogContext, msg?: string): void {

--- a/packages/services/src/logging/types.ts
+++ b/packages/services/src/logging/types.ts
@@ -24,7 +24,11 @@ export interface LoggerConfig {
   level?: LogLevel;
   pretty?: boolean;
   correlationId?: string;
-  /** Additional redaction paths merged with the built-in sensitive-field defaults. */
+  /**
+   * Additional redaction paths merged with the built-in sensitive-field
+   * defaults and any paths supplied via the LOG_REDACT_PATHS environment
+   * variable. An invalid pino path fails logger construction.
+   */
   redactPaths?: string[];
   /** Custom log sink; defaults to stdout. Disables the pretty transport when set. */
   destination?: { write: (msg: string) => void };


### PR DESCRIPTION
This PR extends the logger's default redaction beyond `decryptionKey` so the common secret field shapes (`apiKey`, `authorization`/`Authorization`, `token`, `password`) are replaced with `[REDACTED]` at the same depths, and adds a `LOG_REDACT_PATHS` environment variable so an operator can extend redaction with their own pino paths without waiting for a code change.

An invalid path in `LOG_REDACT_PATHS` fails startup with an error naming the variable and the configured paths, because a silently dropped redaction path would leak the very value it was meant to protect. Invalid paths supplied in code propagate pino's own error untouched, so a boot failure always points at its actual source. The `Authorization` pair is additionally covered in the HTTP client error shape `error.config.headers`, which nests one level deeper than the wildcard defaults reach.

The logging page gains a Redaction section (defaults, path syntax with worked examples, the depth boundary, and the failure behaviour), and the startup page lists the new fail-loud check.

Closes #763

## Test plan
- [x] Each new default field redacts at the top level, one level, and two levels deep
- [x] The `error.config.headers.Authorization` shape redacts on a real Error instance, both header casings
- [x] Defaults, env paths, and code-supplied paths all apply together in one construction
- [x] Invalid `LOG_REDACT_PATHS` entry fails construction naming the variable and paths; invalid code-supplied path and unrelated construction failures propagate without naming it
- [x] Empty env segments warn and continue; blank env values fall back to defaults only
- [x] Child loggers keep the parent's redaction snapshot and never re-read the environment
