### PR TITLE
fix(ri): cache JSON-LD contexts on issuance and send a User-Agent on guarded fetches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,24 @@ LOG_LEVEL=info
 # Extra log redaction paths (comma-separated pino redact paths) merged with the built-in defaults
 # LOG_REDACT_PATHS=webhookSignature,*.webhookSignature
 
+# Outbound document fetching
+# User-Agent sent on outbound document fetches (remote JSON-LD contexts and
+# JSON Schemas). Unset uses the built-in default. When set, startup validates
+# the value can be sent as an HTTP header (plain Latin-1 text, no control
+# characters) and fails with a message naming the variable otherwise.
+# RI_HTTP_USER_AGENT=
+
+# How long fetched documents are reused, in milliseconds (default one hour;
+# 0 disables caching). Contexts and schemas each have their own cache.
+# CONTEXT_CACHE_TTL_MS=3600000
+# SCHEMA_CACHE_TTL_MS=3600000
+
+# Maximum entries each document cache retains (default 1000); expired entries
+# are evicted first, then the least recently used. When set, startup validates
+# it is a positive integer and fails with a message naming the variable
+# otherwise.
+# CACHE_MAX_ENTRIES=1000
+
 # API
 # Maximum number of records a list endpoint returns per page. A request that
 # asks for more is bounded to this maximum, rejected with a 400 on routes using

--- a/documentation/docs/reference-implementation/operations/startup.md
+++ b/documentation/docs/reference-implementation/operations/startup.md
@@ -107,6 +107,12 @@ Without this check, a `DATA_ENCRYPTION_KEY` that does not match the key data was
 
 If startup fails this check, verify `DATA_ENCRYPTION_KEY` matches the key the application was previously running with. Key rotation is not supported (tracked in [#720](https://github.com/uncefact/tests-untp/issues/720)), so a changed key is not recoverable — restore the previous key rather than trying to move data onto a new one.
 
+### HTTP User-Agent Override Validation
+
+Every outbound document fetch the application makes (remote JSON-LD `@context` documents and JSON Schemas during credential validation) sends a `User-Agent` header identifying the software. `RI_HTTP_USER_AGENT` overrides the built-in default; it is optional, and unset or blank means the default is used. When it is set, startup validates that the value can actually be sent as an HTTP header: it must be plain Latin-1 text with no control characters (no newlines or tabs, and no characters such as emoji). An invalid value fails startup with a message naming the variable, because it would otherwise break every outbound fetch at request time.
+
+Remote `@context` documents fetched during credential issuance are cached in memory. `CONTEXT_CACHE_TTL_MS` controls how long a fetched context is reused (default one hour; `0` disables caching), matching `SCHEMA_CACHE_TTL_MS` for JSON Schemas. A change to a remote context document is therefore observed at most one TTL after it is published. Both caches also bound how many entries they retain: `CACHE_MAX_ENTRIES` (default 1000, applied to each cache) caps the entry count, evicting expired entries first and then the least recently used. When it is set, startup validates it is a positive integer and fails with a message naming the variable otherwise.
+
 ### Redaction Path Validation
 
 The first logger constructed during startup validates any paths supplied via `LOG_REDACT_PATHS`. An invalid path fails startup with a message naming the variable and the configured paths. See [Redaction](./logging#redaction) for the path syntax and what the built-in defaults already cover.

--- a/packages/reference-implementation/src/instrumentation.node.test.ts
+++ b/packages/reference-implementation/src/instrumentation.node.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Wiring tests for the boot sequence: the per-check validators each have
+ * their own unit suites, but nothing else asserts that registerNode actually
+ * invokes them, so any of the calls could be deleted with every other suite
+ * staying green. These tests pin the wiring and that a validator failure
+ * fails the boot instead of being swallowed.
+ */
+const mockResolveAppUrl = jest.fn();
+const mockValidateHttpUserAgentOnBoot = jest.fn();
+const mockResolveDataEncryptionKey = jest.fn();
+const mockValidateCacheMaxEntriesOnBoot = jest.fn();
+
+jest.mock('@/lib/config/app-url.config', () => ({
+  resolveAppUrl: (...args: unknown[]) => mockResolveAppUrl(...args),
+}));
+jest.mock('@/lib/config/http-user-agent.config', () => ({
+  validateHttpUserAgentOnBoot: (...args: unknown[]) => mockValidateHttpUserAgentOnBoot(...args),
+}));
+jest.mock('@/lib/config/cache-max-entries.config', () => ({
+  validateCacheMaxEntriesOnBoot: (...args: unknown[]) => mockValidateCacheMaxEntriesOnBoot(...args),
+}));
+jest.mock('@/lib/encryption/resolve-data-encryption-key', () => ({
+  resolveDataEncryptionKey: (...args: unknown[]) => mockResolveDataEncryptionKey(...args),
+}));
+jest.mock('@/lib/encryption/encryption', () => ({ getEncryptionService: jest.fn() }));
+jest.mock('@/lib/prisma/prisma', () => ({ prisma: {} }));
+jest.mock('@/lib/credentials/validate-encryption-key-startup', () => ({
+  assertNotPlaceholderEncryptionKey: jest.fn(),
+  validateEncryptionKeyAtStartup: jest.fn(),
+}));
+jest.mock('@/lib/api/pagination', () => ({ warnOnRejectedMaxPageLimitOverride: jest.fn() }));
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: { child: () => ({ warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() }) },
+}));
+jest.mock('@/lib/observability/instrumentations', () => ({ buildInstrumentations: () => [] }));
+jest.mock('@/lib/observability/resource', () => ({ buildResource: () => ({}) }));
+jest.mock('@opentelemetry/exporter-trace-otlp-grpc', () => ({ OTLPTraceExporter: jest.fn() }));
+jest.mock('@opentelemetry/sdk-node', () => ({
+  NodeSDK: jest.fn().mockImplementation(() => ({ start: jest.fn(), shutdown: jest.fn() })),
+}));
+
+import { registerNode } from './instrumentation.node';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolveDataEncryptionKey.mockReturnValue({ key: undefined });
+});
+
+describe('registerNode boot wiring', () => {
+  it('runs every boot validation: app URL, HTTP User-Agent, encryption key', async () => {
+    await registerNode();
+
+    expect(mockResolveAppUrl).toHaveBeenCalledTimes(1);
+    expect(mockValidateHttpUserAgentOnBoot).toHaveBeenCalledTimes(1);
+    expect(mockResolveDataEncryptionKey).toHaveBeenCalledTimes(1);
+    expect(mockValidateCacheMaxEntriesOnBoot).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails the boot when a cache entry-cap override is invalid', async () => {
+    mockValidateCacheMaxEntriesOnBoot.mockImplementation(() => {
+      throw new Error('CACHE_MAX_ENTRIES must be a positive integer when set');
+    });
+
+    await expect(registerNode()).rejects.toThrow('CACHE_MAX_ENTRIES');
+  });
+
+  it('fails the boot when the User-Agent validation throws', async () => {
+    mockValidateHttpUserAgentOnBoot.mockImplementation(() => {
+      throw new Error('RI_HTTP_USER_AGENT is not a valid HTTP User-Agent value');
+    });
+
+    await expect(registerNode()).rejects.toThrow('RI_HTTP_USER_AGENT');
+  });
+
+  it('fails the boot when the app URL validation throws', async () => {
+    mockResolveAppUrl.mockImplementation(() => {
+      throw new Error('RI_APP_URL is required.');
+    });
+
+    await expect(registerNode()).rejects.toThrow('RI_APP_URL');
+    expect(mockValidateHttpUserAgentOnBoot).not.toHaveBeenCalled();
+  });
+});

--- a/packages/reference-implementation/src/instrumentation.node.ts
+++ b/packages/reference-implementation/src/instrumentation.node.ts
@@ -28,12 +28,16 @@ import {
   validateEncryptionKeyAtStartup,
 } from './lib/credentials/validate-encryption-key-startup';
 import { resolveAppUrl } from './lib/config/app-url.config';
+import { validateHttpUserAgentOnBoot } from './lib/config/http-user-agent.config';
 
 export async function registerNode(): Promise<void> {
   // Fail the boot on a missing or unusable RI_APP_URL: it backs the OIDC
   // post-logout redirect and the default human verification link, and the
   // identity-provider documentation requires it (#823).
   resolveAppUrl();
+  // Fail the boot on an unsendable RI_HTTP_USER_AGENT override; unset and
+  // blank are fine (the guarded fetchers use their built-in default).
+  validateHttpUserAgentOnBoot();
   await validateEncryptionKeyOnBoot();
   startOpenTelemetry();
 }

--- a/packages/reference-implementation/src/instrumentation.node.ts
+++ b/packages/reference-implementation/src/instrumentation.node.ts
@@ -29,6 +29,7 @@ import {
 } from './lib/credentials/validate-encryption-key-startup';
 import { resolveAppUrl } from './lib/config/app-url.config';
 import { validateHttpUserAgentOnBoot } from './lib/config/http-user-agent.config';
+import { validateCacheMaxEntriesOnBoot } from './lib/config/cache-max-entries.config';
 
 export async function registerNode(): Promise<void> {
   // Fail the boot on a missing or unusable RI_APP_URL: it backs the OIDC
@@ -38,6 +39,8 @@ export async function registerNode(): Promise<void> {
   // Fail the boot on an unsendable RI_HTTP_USER_AGENT override; unset and
   // blank are fine (the guarded fetchers use their built-in default).
   validateHttpUserAgentOnBoot();
+  // Fail the boot on an invalid CACHE_MAX_ENTRIES override; unset uses the default.
+  validateCacheMaxEntriesOnBoot();
   await validateEncryptionKeyOnBoot();
   startOpenTelemetry();
 }

--- a/packages/reference-implementation/src/lib/config/cache-max-entries.config.test.ts
+++ b/packages/reference-implementation/src/lib/config/cache-max-entries.config.test.ts
@@ -1,0 +1,26 @@
+import { readCacheMaxEntries, validateCacheMaxEntriesOnBoot } from './cache-max-entries.config';
+
+describe('readCacheMaxEntries', () => {
+  it('returns the default when CACHE_MAX_ENTRIES is unset or blank', () => {
+    expect(readCacheMaxEntries({})).toBe(1000);
+    expect(readCacheMaxEntries({ CACHE_MAX_ENTRIES: '   ' })).toBe(1000);
+  });
+
+  it('parses a positive integer', () => {
+    expect(readCacheMaxEntries({ CACHE_MAX_ENTRIES: '250' })).toBe(250);
+  });
+
+  it.each(['0', '-5', '1.5', 'many', 'Infinity'])('throws on %s, naming the variable', (raw) => {
+    expect(() => readCacheMaxEntries({ CACHE_MAX_ENTRIES: raw })).toThrow(/CACHE_MAX_ENTRIES/);
+  });
+});
+
+describe('validateCacheMaxEntriesOnBoot', () => {
+  it('passes when CACHE_MAX_ENTRIES is unset', () => {
+    expect(() => validateCacheMaxEntriesOnBoot({})).not.toThrow();
+  });
+
+  it('throws at boot when CACHE_MAX_ENTRIES is invalid', () => {
+    expect(() => validateCacheMaxEntriesOnBoot({ CACHE_MAX_ENTRIES: 'many' })).toThrow(/CACHE_MAX_ENTRIES/);
+  });
+});

--- a/packages/reference-implementation/src/lib/config/cache-max-entries.config.ts
+++ b/packages/reference-implementation/src/lib/config/cache-max-entries.config.ts
@@ -1,0 +1,33 @@
+const DEFAULT_MAX_ENTRIES = 1000;
+
+/**
+ * CACHE_MAX_ENTRIES caps how many entries each in-memory document cache
+ * (remote JSON-LD contexts, JSON Schemas) retains; expired entries are
+ * evicted first, then the least recently used. The bound exists because
+ * context cache keys come from caller-controlled `@context` URLs; without
+ * it, a stream of unique URLs grows process memory until restart. Unset or
+ * blank uses the default; a provided value that is not a positive integer
+ * throws, surfaced at process boot (instrumentation.node.ts), so a
+ * misconfigured cap fails the container start instead of silently running
+ * with a different bound.
+ */
+export function readCacheMaxEntries(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.CACHE_MAX_ENTRIES;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MAX_ENTRIES;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `CACHE_MAX_ENTRIES must be a positive integer when set; fix or unset it (unset uses ${DEFAULT_MAX_ENTRIES}).`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Boot-time check (instrumentation.node.ts): parses CACHE_MAX_ENTRIES for
+ * its side effect only, so a provided-and-invalid value fails startup with
+ * the reader's message instead of surfacing when a cache is first built.
+ */
+export function validateCacheMaxEntriesOnBoot(env: Record<string, string | undefined> = process.env): void {
+  readCacheMaxEntries(env);
+}

--- a/packages/reference-implementation/src/lib/config/http-user-agent.config.test.ts
+++ b/packages/reference-implementation/src/lib/config/http-user-agent.config.test.ts
@@ -1,0 +1,39 @@
+import { validateHttpUserAgentOnBoot } from './http-user-agent.config';
+
+// The validator only reads RI_HTTP_USER_AGENT; a plain record is enough.
+const validate = (env: Record<string, string | undefined>) => validateHttpUserAgentOnBoot(env as NodeJS.ProcessEnv);
+
+describe('validateHttpUserAgentOnBoot', () => {
+  it('passes when RI_HTTP_USER_AGENT is unset', () => {
+    expect(() => validate({})).not.toThrow();
+  });
+
+  it('passes when RI_HTTP_USER_AGENT is blank (treated as unset)', () => {
+    expect(() => validate({ RI_HTTP_USER_AGENT: '   ' })).not.toThrow();
+  });
+
+  it('passes for an ordinary product-token value', () => {
+    expect(() => validate({ RI_HTTP_USER_AGENT: 'acme-ri/1.2 (+https://ri.acme.example)' })).not.toThrow();
+  });
+
+  it('throws at boot when the value contains CR/LF (header injection)', () => {
+    expect(() => validate({ RI_HTTP_USER_AGENT: 'evil\r\nX-Injected: 1' })).toThrow(/RI_HTTP_USER_AGENT/);
+  });
+
+  it('throws at boot when the value contains other control characters', () => {
+    expect(() => validate({ RI_HTTP_USER_AGENT: 'bad\u0000agent' })).toThrow(/RI_HTTP_USER_AGENT/);
+  });
+
+  it('does not echo the raw value in the thrown message', () => {
+    const error = (() => {
+      try {
+        validate({ RI_HTTP_USER_AGENT: 'evil\r\nX-Injected: 1' });
+        return undefined;
+      } catch (e) {
+        return e as Error;
+      }
+    })();
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).not.toContain('evil');
+  });
+});

--- a/packages/reference-implementation/src/lib/config/http-user-agent.config.test.ts
+++ b/packages/reference-implementation/src/lib/config/http-user-agent.config.test.ts
@@ -20,6 +20,15 @@ describe('validateHttpUserAgentOnBoot', () => {
     expect(() => validate({ RI_HTTP_USER_AGENT: 'evil\r\nX-Injected: 1' })).toThrow(/RI_HTTP_USER_AGENT/);
   });
 
+  it('throws at boot when the value contains characters undici cannot send as a header (above U+00FF)', () => {
+    expect(() => validate({ RI_HTTP_USER_AGENT: 'agent\u{1f642}' })).toThrow(/RI_HTTP_USER_AGENT/);
+    expect(() => validate({ RI_HTTP_USER_AGENT: 'agent\u0100' })).toThrow(/RI_HTTP_USER_AGENT/);
+  });
+
+  it('passes for Latin-1 text, which undici can send', () => {
+    expect(() => validate({ RI_HTTP_USER_AGENT: 'caf\u00e9-agent/1.0' })).not.toThrow();
+  });
+
   it('throws at boot when the value contains other control characters', () => {
     expect(() => validate({ RI_HTTP_USER_AGENT: 'bad\u0000agent' })).toThrow(/RI_HTTP_USER_AGENT/);
   });

--- a/packages/reference-implementation/src/lib/config/http-user-agent.config.ts
+++ b/packages/reference-implementation/src/lib/config/http-user-agent.config.ts
@@ -1,0 +1,29 @@
+import { USER_AGENT_ENV_VAR, isValidHttpUserAgent } from '@uncefact/untp-utils/http-headers';
+
+/**
+ * RI_HTTP_USER_AGENT overrides the `User-Agent` the guarded fetchers send on
+ * every outbound document fetch (JSON-LD contexts, schemas). It is optional;
+ * unset or blank means the untp-utils default is used. Validating it at
+ * process boot (instrumentation.node.ts) turns a value that cannot be sent
+ * as a header into a failed container start instead of a per-request
+ * fallback deep in the issuance path.
+ */
+
+/**
+ * Throws when RI_HTTP_USER_AGENT is set to a value that cannot be sent as an
+ * HTTP header field value. Unset and blank values pass: the override is
+ * optional and blank is treated as unset (the guarded fetchers fall back to
+ * their default). The raw value is deliberately not echoed because an
+ * invalid value contains control characters that must not reach logs.
+ */
+export function validateHttpUserAgentOnBoot(env: NodeJS.ProcessEnv = process.env): void {
+  const value = env[USER_AGENT_ENV_VAR];
+  if (value === undefined || value.trim() === '') {
+    return;
+  }
+  if (!isValidHttpUserAgent(value)) {
+    throw new Error(
+      `${USER_AGENT_ENV_VAR} is not a valid HTTP User-Agent value: it must contain only visible ASCII characters, spaces, and tabs. Fix or unset it (unset uses the built-in default).`,
+    );
+  }
+}

--- a/packages/reference-implementation/src/lib/config/http-user-agent.config.ts
+++ b/packages/reference-implementation/src/lib/config/http-user-agent.config.ts
@@ -23,7 +23,7 @@ export function validateHttpUserAgentOnBoot(env: NodeJS.ProcessEnv = process.env
   }
   if (!isValidHttpUserAgent(value)) {
     throw new Error(
-      `${USER_AGENT_ENV_VAR} is not a valid HTTP User-Agent value: it must contain only visible ASCII characters, spaces, and tabs. Fix or unset it (unset uses the built-in default).`,
+      `${USER_AGENT_ENV_VAR} is not a valid HTTP User-Agent value: it must be plain Latin-1 text with no control characters (no newlines or tabs, and no characters such as emoji). Fix or unset it (unset uses the built-in default).`,
     );
   }
 }

--- a/packages/reference-implementation/src/lib/credentials/context-cache.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/context-cache.test.ts
@@ -1,0 +1,58 @@
+const mockWarn = jest.fn();
+
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: {
+    child: () => ({
+      warn: mockWarn,
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    }),
+  },
+}));
+
+import { readContextCacheTtlMs } from './context-cache';
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('readContextCacheTtlMs', () => {
+  describe('returns the parsed value without logging', () => {
+    it('parses a positive integer string', () => {
+      expect(readContextCacheTtlMs({ CONTEXT_CACHE_TTL_MS: '120000' })).toBe(120_000);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('accepts 0 as a no-cache policy', () => {
+      expect(readContextCacheTtlMs({ CONTEXT_CACHE_TTL_MS: '0' })).toBe(0);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('falls back to the default silently', () => {
+    it('when CONTEXT_CACHE_TTL_MS is unset', () => {
+      expect(readContextCacheTtlMs({})).toBe(DEFAULT_TTL_MS);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+
+    it('when CONTEXT_CACHE_TTL_MS is blank', () => {
+      expect(readContextCacheTtlMs({ CONTEXT_CACHE_TTL_MS: '   ' })).toBe(DEFAULT_TTL_MS);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('falls back to the default with a warning', () => {
+    it('when CONTEXT_CACHE_TTL_MS is not a number', () => {
+      expect(readContextCacheTtlMs({ CONTEXT_CACHE_TTL_MS: 'soon' })).toBe(DEFAULT_TTL_MS);
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+    });
+
+    it('when CONTEXT_CACHE_TTL_MS is negative', () => {
+      expect(readContextCacheTtlMs({ CONTEXT_CACHE_TTL_MS: '-1' })).toBe(DEFAULT_TTL_MS);
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/reference-implementation/src/lib/credentials/context-cache.ts
+++ b/packages/reference-implementation/src/lib/credentials/context-cache.ts
@@ -1,0 +1,31 @@
+import { createInMemoryTtlCache, type TtlCache } from '@uncefact/untp-utils/cache';
+import type { LoadedRemoteDocument } from '@uncefact/untp-utils/loaders';
+import { apiLogger } from '../api/logger';
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+const logger = apiLogger.child({ module: 'context-cache' });
+
+export function readContextCacheTtlMs(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.CONTEXT_CACHE_TTL_MS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_TTL_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    logger.warn(
+      { received: raw, fallbackTtlMs: DEFAULT_TTL_MS },
+      'CONTEXT_CACHE_TTL_MS is not a non-negative finite number; falling back to the default TTL.',
+    );
+    return DEFAULT_TTL_MS;
+  }
+  return parsed;
+}
+
+/**
+ * Shared cache for remote JSON-LD `@context` documents, passed to
+ * `validateJsonLd` on the issuance and verification paths so a burst of
+ * validations fetches each context once per TTL instead of once per
+ * credential. Mirrors the schema loader's cache (`schema-loader.ts`);
+ * see uncefact/tests-untp#886.
+ */
+export const contextCache: TtlCache<LoadedRemoteDocument> = createInMemoryTtlCache<LoadedRemoteDocument>({
+  ttlMs: readContextCacheTtlMs(),
+});

--- a/packages/reference-implementation/src/lib/credentials/context-cache.ts
+++ b/packages/reference-implementation/src/lib/credentials/context-cache.ts
@@ -1,6 +1,7 @@
 import { createInMemoryTtlCache, type TtlCache } from '@uncefact/untp-utils/cache';
 import type { LoadedRemoteDocument } from '@uncefact/untp-utils/loaders';
 import { apiLogger } from '../api/logger';
+import { readCacheMaxEntries } from '../config/cache-max-entries.config';
 
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
 const logger = apiLogger.child({ module: 'context-cache' });
@@ -21,11 +22,11 @@ export function readContextCacheTtlMs(env: Record<string, string | undefined> = 
 
 /**
  * Shared cache for remote JSON-LD `@context` documents, passed to
- * `validateJsonLd` on the issuance and verification paths so a burst of
- * validations fetches each context once per TTL instead of once per
- * credential. Mirrors the schema loader's cache (`schema-loader.ts`);
- * see uncefact/tests-untp#886.
+ * `validateJsonLd` on the issuance path so a burst of validations fetches
+ * each context once per TTL instead of once per credential. Mirrors the
+ * schema loader's cache (`schema-loader.ts`); see uncefact/tests-untp#886.
  */
 export const contextCache: TtlCache<LoadedRemoteDocument> = createInMemoryTtlCache<LoadedRemoteDocument>({
   ttlMs: readContextCacheTtlMs(),
+  maxEntries: readCacheMaxEntries(),
 });

--- a/packages/reference-implementation/src/lib/credentials/schema-loader.ts
+++ b/packages/reference-implementation/src/lib/credentials/schema-loader.ts
@@ -1,6 +1,7 @@
 import { createInMemoryTtlCache } from '@uncefact/untp-utils/cache';
 import { createSchemaLoader, type SchemaLoader } from '@uncefact/untp-utils/loaders';
 import { apiLogger } from '../api/logger';
+import { readCacheMaxEntries } from '../config/cache-max-entries.config';
 
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
 const logger = apiLogger.child({ module: 'schema-loader' });
@@ -20,5 +21,5 @@ export function readSchemaCacheTtlMs(env: Record<string, string | undefined> = p
 }
 
 export const schemaLoader: SchemaLoader = createSchemaLoader(
-  createInMemoryTtlCache<object>({ ttlMs: readSchemaCacheTtlMs() }),
+  createInMemoryTtlCache<object>({ ttlMs: readSchemaCacheTtlMs(), maxEntries: readCacheMaxEntries() }),
 );

--- a/packages/reference-implementation/src/lib/credentials/validate-credential-payload.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-credential-payload.test.ts
@@ -19,6 +19,7 @@ jest.mock('@uncefact/untp-utils/validation', () => {
 });
 
 import { validateCredentialPayload } from './validate-credential-payload';
+import { contextCache } from './context-cache';
 
 const payload = { '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['DigitalProductPassport'] };
 const schemaUrls = ['https://example.com/schema.json'];
@@ -42,7 +43,19 @@ describe('validateCredentialPayload', () => {
 
     expect(callOrder).toEqual(['schema', 'jsonld']);
     expect(mockValidateAgainstSchemas).toHaveBeenCalledWith(payload, schemaUrls, loader);
-    expect(mockValidateJsonLd).toHaveBeenCalledWith(payload);
+    expect(mockValidateJsonLd).toHaveBeenCalledWith(payload, { contextCache });
+  });
+
+  it('passes the same shared context cache on every call, so repeated validations reuse fetched contexts', async () => {
+    mockValidateAgainstSchemas.mockResolvedValue(undefined);
+    mockValidateJsonLd.mockResolvedValue(undefined);
+
+    await validateCredentialPayload(payload, schemaUrls, loader);
+    await validateCredentialPayload(payload, schemaUrls, loader);
+
+    const caches = mockValidateJsonLd.mock.calls.map((call) => (call[1] as { contextCache: unknown }).contextCache);
+    expect(caches[0]).toBe(contextCache);
+    expect(caches[1]).toBe(contextCache);
   });
 
   it('does not throw when both validations resolve', async () => {

--- a/packages/reference-implementation/src/lib/credentials/validate-credential-payload.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-credential-payload.ts
@@ -7,6 +7,7 @@ import {
 } from '@uncefact/untp-utils/validation';
 import type { SchemaLoader } from '@uncefact/untp-utils/loaders';
 import { ValidationError } from '@/lib/api/validation';
+import { contextCache } from './context-cache';
 
 export async function validateCredentialPayload(
   credentialPayload: unknown,
@@ -27,7 +28,7 @@ export async function validateCredentialPayload(
   }
 
   try {
-    await validateJsonLd(credentialPayload);
+    await validateJsonLd(credentialPayload, { contextCache });
   } catch (e) {
     if (e instanceof JsonLdValidationError) {
       throw new ValidationError(`JSON-LD validation failed: ${e.message}`);

--- a/packages/untp-utils/src/cache/in-memory-ttl-cache.test.ts
+++ b/packages/untp-utils/src/cache/in-memory-ttl-cache.test.ts
@@ -95,6 +95,72 @@ describe('createInMemoryTtlCache', () => {
     });
   });
 
+  describe('retention bound (maxEntries)', () => {
+    it('rejects a non-positive or non-integer maxEntries', () => {
+      expect(() => createInMemoryTtlCache<string>({ ttlMs: 1000, maxEntries: 0 })).toThrow(RangeError);
+      expect(() => createInMemoryTtlCache<string>({ ttlMs: 1000, maxEntries: 1.5 })).toThrow(RangeError);
+      expect(() => createInMemoryTtlCache<string>({ ttlMs: 1000, maxEntries: -1 })).toThrow(RangeError);
+    });
+
+    it('evicts the least recently used entry when the cap is reached', async () => {
+      const cache = createInMemoryTtlCache<string>({ ttlMs: 60_000, maxEntries: 2 });
+      const fetches: string[] = [];
+      const fetcher = (v: string) => async () => {
+        fetches.push(v);
+        return v;
+      };
+
+      await cache.get('a', fetcher('a'));
+      await cache.get('b', fetcher('b'));
+      await cache.get('a', fetcher('a-refetch')); // touch a, so b is now least recent
+      await cache.get('c', fetcher('c')); // cap reached: evicts b
+
+      expect(await cache.get('a', fetcher('a-refetch'))).toBe('a'); // still cached
+      expect(await cache.get('b', fetcher('b-refetch'))).toBe('b-refetch'); // evicted, refetched
+      expect(fetches).toEqual(['a', 'b', 'c', 'b-refetch']);
+    });
+
+    it('evicts expired entries before evicting live ones', async () => {
+      const realNow = Date.now;
+      let now = 1_000_000;
+      Date.now = () => now;
+      try {
+        const cache = createInMemoryTtlCache<string>({ ttlMs: 1000, maxEntries: 2 });
+        await cache.get('old', async () => 'old');
+        now += 2000; // 'old' expires
+        await cache.get('live', async () => 'live');
+        await cache.get('new', async () => 'new'); // cap: removes expired 'old', keeps 'live'
+        const fetches: string[] = [];
+        expect(
+          await cache.get('live', async () => {
+            fetches.push('live-refetch');
+            return 'live-refetch';
+          }),
+        ).toBe('live');
+        expect(fetches).toEqual([]);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    it('removes an expired entry when it is met, even with no cap configured', async () => {
+      const realNow = Date.now;
+      let now = 1_000_000;
+      Date.now = () => now;
+      try {
+        const cache = createInMemoryTtlCache<string>({ ttlMs: 1000 });
+        await cache.get('k', async () => 'v1');
+        now += 2000;
+        // Expired: refetches, and the stale entry is deleted rather than
+        // lingering until this key happens to be rewritten.
+        await expect(cache.get('k', async () => 'v2')).resolves.toBe('v2');
+        expect(await cache.get('k', async () => 'v3')).toBe('v2');
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+
   describe('deduplication', () => {
     it('deduplicates concurrent fetches for the same key', async () => {
       const cache = createInMemoryTtlCache<string>({ ttlMs: 1000 });

--- a/packages/untp-utils/src/cache/in-memory-ttl-cache.ts
+++ b/packages/untp-utils/src/cache/in-memory-ttl-cache.ts
@@ -1,19 +1,47 @@
 import type { TtlCache, TtlCacheOptions } from './ttl-cache.js';
 
 export function createInMemoryTtlCache<T>(options: TtlCacheOptions): TtlCache<T> {
-  const { ttlMs } = options;
+  const { ttlMs, maxEntries } = options;
   if (!Number.isFinite(ttlMs) || ttlMs < 0) {
     throw new RangeError(`ttlMs must be a non-negative finite number, got ${ttlMs}.`);
   }
+  if (maxEntries !== undefined && (!Number.isInteger(maxEntries) || maxEntries < 1)) {
+    throw new RangeError(`maxEntries must be a positive integer when supplied, got ${maxEntries}.`);
+  }
   const cache = new Map<string, { value: T; storedAt: number }>();
   const inflight = new Map<string, Promise<T>>();
+
+  const isFresh = (storedAt: number): boolean => Date.now() - storedAt < ttlMs;
+
+  // Retention bound: expired entries go first (they are dead weight whatever
+  // the cap), then the least recently used live entry. Recency comes from
+  // Map insertion order: hits re-insert their key (see get), so iteration
+  // order is oldest-touched first.
+  const evictForCapacity = (): void => {
+    if (maxEntries === undefined || cache.size < maxEntries) return;
+    for (const [key, entry] of cache) {
+      if (!isFresh(entry.storedAt)) cache.delete(key);
+    }
+    while (cache.size >= maxEntries) {
+      const oldest = cache.keys().next().value as string;
+      cache.delete(oldest);
+    }
+  };
 
   return {
     async get(key, fetcher) {
       if (ttlMs > 0) {
         const cached = cache.get(key);
-        if (cached && Date.now() - cached.storedAt < ttlMs) {
-          return cached.value;
+        if (cached) {
+          if (isFresh(cached.storedAt)) {
+            // Re-insert so Map iteration order tracks recency for eviction.
+            cache.delete(key);
+            cache.set(key, cached);
+            return cached.value;
+          }
+          // Expired entries are removed when met rather than lingering until
+          // the same key happens to be rewritten.
+          cache.delete(key);
         }
       }
 
@@ -25,6 +53,7 @@ export function createInMemoryTtlCache<T>(options: TtlCacheOptions): TtlCache<T>
         try {
           const value = await fetcher();
           if (ttlMs > 0 && inflight.get(key) === promise) {
+            evictForCapacity();
             cache.set(key, { value, storedAt: Date.now() });
           }
           return value;

--- a/packages/untp-utils/src/cache/ttl-cache.ts
+++ b/packages/untp-utils/src/cache/ttl-cache.ts
@@ -1,6 +1,14 @@
 export interface TtlCacheOptions {
   /** TTL in ms. `0` disables caching. */
   ttlMs: number;
+  /**
+   * Maximum number of stored entries. When a write would exceed it, expired
+   * entries are removed first, then the least recently used live entry is
+   * evicted. Omit for no bound (suitable only when keys come from trusted
+   * configuration; caller-controlled keys need a cap so a stream of unique
+   * keys cannot grow process memory without limit).
+   */
+  maxEntries?: number;
 }
 
 export interface TtlCache<T> {

--- a/packages/untp-utils/src/http-headers/index.ts
+++ b/packages/untp-utils/src/http-headers/index.ts
@@ -2,3 +2,4 @@ export { isSafeHeaderValue } from './is-safe-header-value.js';
 export { parseEntityTag } from './parse-entity-tag.js';
 export { parseImfDate } from './parse-imf-date.js';
 export { parseMediaType } from './parse-media-type.js';
+export { DEFAULT_USER_AGENT, USER_AGENT_ENV_VAR, isValidHttpUserAgent } from './user-agent.js';

--- a/packages/untp-utils/src/http-headers/user-agent.test.ts
+++ b/packages/untp-utils/src/http-headers/user-agent.test.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_USER_AGENT, isValidHttpUserAgent } from './user-agent.js';
+
+describe('isValidHttpUserAgent', () => {
+  it('accepts an ordinary product token', () => {
+    expect(isValidHttpUserAgent('acme-ri/1.2 (+https://ri.acme.example)')).toBe(true);
+  });
+
+  it('accepts the library default', () => {
+    expect(isValidHttpUserAgent(DEFAULT_USER_AGENT)).toBe(true);
+  });
+
+  it('accepts Latin-1 text, which undici can send', () => {
+    expect(isValidHttpUserAgent('café-agent')).toBe(true);
+    expect(isValidHttpUserAgent('agentÿ')).toBe(true);
+  });
+
+  it('rejects blank and whitespace-only values', () => {
+    expect(isValidHttpUserAgent('')).toBe(false);
+    expect(isValidHttpUserAgent('   ')).toBe(false);
+  });
+
+  it('rejects control characters, including CR/LF and tab', () => {
+    expect(isValidHttpUserAgent('evil\r\nX-Injected: 1')).toBe(false);
+    expect(isValidHttpUserAgent('a\tb')).toBe(false);
+    expect(isValidHttpUserAgent('a\u0000b')).toBe(false);
+  });
+
+  it('rejects code units above U+00FF, which undici refuses as ByteString', () => {
+    expect(isValidHttpUserAgent('agentĀ')).toBe(false);
+    expect(isValidHttpUserAgent('agent\u{1f642}')).toBe(false);
+  });
+});

--- a/packages/untp-utils/src/http-headers/user-agent.ts
+++ b/packages/untp-utils/src/http-headers/user-agent.ts
@@ -4,10 +4,12 @@ import { isSafeHeaderValue } from './is-safe-header-value.js';
  * `User-Agent` sent on every guarded fetch (`resolveDocument` and
  * everything composed on it) unless overridden.
  *
- * Anonymous (UA-less) automated fetches are challenged by bot protection on
- * well-known context hosts (w3.org's Cloudflare returns 429 challenge pages;
- * observed in production, see uncefact/tests-untp#886), so every request
- * identifies itself. Operators override via the `RI_HTTP_USER_AGENT`
+ * Anonymous (UA-less) automated fetches risk being challenged by bot
+ * protection on well-known context hosts (observed 2026-08-12 on a
+ * production RI: w3.org returned 429 challenge pages to UA-less fetches
+ * while identified requests from the same host passed), so every request
+ * identifies itself. See uncefact/tests-untp#886 for the fetch-per-issuance
+ * pattern that provoked it. Operators override via the `RI_HTTP_USER_AGENT`
  * environment variable (read per request, so it applies without a rebuild),
  * and a caller-supplied `user-agent` header takes precedence over both.
  *
@@ -21,13 +23,23 @@ export const DEFAULT_USER_AGENT = 'uncefact-untp-utils (+https://github.com/unce
 export const USER_AGENT_ENV_VAR = 'RI_HTTP_USER_AGENT';
 
 /**
- * Whether `value` can be sent as an HTTP `User-Agent` field value: non-blank
- * and free of control characters (notably CR/LF, which would corrupt or
- * split the request's header block).
+ * Whether `value` can be sent as an HTTP `User-Agent` field value: non-blank,
+ * free of control characters (notably CR/LF, which would corrupt or split
+ * the request's header block; HTAB is also rejected, deliberately stricter
+ * than the wire grammar), and within the fetch ByteString range. undici
+ * converts header values to ByteString and throws on any UTF-16 code unit
+ * above U+00FF (undici@6.25.0 `lib/web/fetch/webidl.js`), so a value the
+ * ByteString check fails here would otherwise pass boot validation and then
+ * break every guarded fetch at request time. Latin-1 text (e.g. `café`)
+ * remains sendable and accepted.
  *
  * Exported so deployments can validate their configured override at boot
- * (fail-fast) instead of meeting the guarded fetch's request-time fallback.
+ * (fail-fast) instead of meeting the guarded fetch's request-time failure.
  */
 export function isValidHttpUserAgent(value: string): boolean {
-  return value.trim() !== '' && isSafeHeaderValue(value);
+  if (value.trim() === '' || !isSafeHeaderValue(value)) return false;
+  for (let i = 0; i < value.length; i += 1) {
+    if (value.charCodeAt(i) > 0xff) return false;
+  }
+  return true;
 }

--- a/packages/untp-utils/src/http-headers/user-agent.ts
+++ b/packages/untp-utils/src/http-headers/user-agent.ts
@@ -1,0 +1,33 @@
+import { isSafeHeaderValue } from './is-safe-header-value.js';
+
+/**
+ * `User-Agent` sent on every guarded fetch (`resolveDocument` and
+ * everything composed on it) unless overridden.
+ *
+ * Anonymous (UA-less) automated fetches are challenged by bot protection on
+ * well-known context hosts (w3.org's Cloudflare returns 429 challenge pages;
+ * observed in production, see uncefact/tests-untp#886), so every request
+ * identifies itself. Operators override via the `RI_HTTP_USER_AGENT`
+ * environment variable (read per request, so it applies without a rebuild),
+ * and a caller-supplied `user-agent` header takes precedence over both.
+ *
+ * These live in `http-headers` (not `resolvers`) so boot-time validation can
+ * import them in environments that cannot load the resolver stack's undici
+ * dependency (e.g. jsdom test environments).
+ */
+export const DEFAULT_USER_AGENT = 'uncefact-untp-utils (+https://github.com/uncefact/tests-untp)';
+
+/** Environment variable that overrides {@link DEFAULT_USER_AGENT}. */
+export const USER_AGENT_ENV_VAR = 'RI_HTTP_USER_AGENT';
+
+/**
+ * Whether `value` can be sent as an HTTP `User-Agent` field value: non-blank
+ * and free of control characters (notably CR/LF, which would corrupt or
+ * split the request's header block).
+ *
+ * Exported so deployments can validate their configured override at boot
+ * (fail-fast) instead of meeting the guarded fetch's request-time fallback.
+ */
+export function isValidHttpUserAgent(value: string): boolean {
+  return value.trim() !== '' && isSafeHeaderValue(value);
+}

--- a/packages/untp-utils/src/resolvers/index.ts
+++ b/packages/untp-utils/src/resolvers/index.ts
@@ -14,6 +14,7 @@ export {
   type LoadResult,
   type ResolveDocumentOptions,
 } from './resolve-document.js';
+export { DEFAULT_USER_AGENT, USER_AGENT_ENV_VAR, isValidHttpUserAgent } from '../http-headers/index.js';
 export {
   resolveJsonDocument,
   type ResolveJsonDocumentOptions,

--- a/packages/untp-utils/src/resolvers/resolve-document.test.ts
+++ b/packages/untp-utils/src/resolvers/resolve-document.test.ts
@@ -341,16 +341,34 @@ describe('resolveDocument', () => {
       expect(sentHeaders()['User-Agent']).toBe('operator-agent/1.0');
     });
 
-    it('never overrides a caller-supplied user-agent header, whatever its casing', async () => {
-      process.env[USER_AGENT_ENV_VAR] = 'acme-operator/1.0';
+    it('passes an invalid override through raw rather than silently substituting the default', async () => {
+      process.env[USER_AGENT_ENV_VAR] = 'evil\r\nX-Injected: 1';
       validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
       undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
 
-      await resolveDocument('https://example.com/doc.json', { headers: { 'user-agent': 'caller/2.0' } });
+      await resolveDocument('https://example.com/doc.json');
 
-      expect(sentHeaders()['user-agent']).toBe('caller/2.0');
-      expect(sentHeaders()['User-Agent']).toBeUndefined();
+      // The load-bearing rule: no request-time fallback. The raw value reaches
+      // the fetch layer, which rejects it loudly in real undici; deployments
+      // that want fail-fast validate at boot instead.
+      expect(sentHeaders()['User-Agent']).toBe('evil\r\nX-Injected: 1');
     });
+
+    it.each(['user-agent', 'User-Agent', 'USER-AGENT', 'uSeR-aGeNt'])(
+      'never overrides a caller-supplied %s header',
+      async (headerName) => {
+        process.env[USER_AGENT_ENV_VAR] = 'acme-operator/1.0';
+        validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+        undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
+
+        await resolveDocument('https://example.com/doc.json', { headers: { [headerName]: 'caller/2.0' } });
+
+        const headers = sentHeaders();
+        expect(headers[headerName]).toBe('caller/2.0');
+        const uaKeys = Object.keys(headers).filter((k) => k.toLowerCase() === 'user-agent');
+        expect(uaKeys).toEqual([headerName]);
+      },
+    );
 
     it('sends the User-Agent on every redirect hop', async () => {
       validatePublicUrl.mockResolvedValue(resolvedAddress() as never);

--- a/packages/untp-utils/src/resolvers/resolve-document.test.ts
+++ b/packages/untp-utils/src/resolvers/resolve-document.test.ts
@@ -33,6 +33,7 @@ jest.unstable_mockModule('../node/index.js', () => ({
 }));
 
 const { resolveDocument } = await import('./resolve-document.js');
+const { DEFAULT_USER_AGENT, USER_AGENT_ENV_VAR } = await import('../http-headers/index.js');
 
 function makeResponse(opts: {
   status?: number;
@@ -278,6 +279,92 @@ describe('resolveDocument', () => {
       const pullOrder = bodyPull.mock.invocationCallOrder[0];
       const closeOrder = lastAgentClose.mock.invocationCallOrder[0];
       expect(closeOrder).toBeGreaterThan(pullOrder);
+    });
+  });
+
+  describe('User-Agent', () => {
+    afterEach(() => {
+      delete process.env[USER_AGENT_ENV_VAR];
+    });
+
+    function sentHeaders(callIndex = 0): Record<string, string> {
+      const init = undiciFetch.mock.calls[callIndex][1] as { headers?: Record<string, string> };
+      return init.headers ?? {};
+    }
+
+    it('sends the default User-Agent when the caller supplies none', async () => {
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
+
+      await resolveDocument('https://example.com/doc.json', { headers: { Accept: 'application/json' } });
+
+      expect(sentHeaders()['User-Agent']).toBe(DEFAULT_USER_AGENT);
+      expect(sentHeaders()['Accept']).toBe('application/json');
+    });
+
+    it('sends the default User-Agent when no headers are supplied at all', async () => {
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
+
+      await resolveDocument('https://example.com/doc.json');
+
+      expect(sentHeaders()['User-Agent']).toBe(DEFAULT_USER_AGENT);
+    });
+
+    it('prefers the RI_HTTP_USER_AGENT environment override to the default', async () => {
+      process.env[USER_AGENT_ENV_VAR] = 'acme-operator/1.0';
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
+
+      await resolveDocument('https://example.com/doc.json');
+
+      expect(sentHeaders()['User-Agent']).toBe('acme-operator/1.0');
+    });
+
+    it('falls back to the default when the environment override is blank (blank is treated as unset)', async () => {
+      process.env[USER_AGENT_ENV_VAR] = '   ';
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
+
+      await resolveDocument('https://example.com/doc.json');
+
+      expect(sentHeaders()['User-Agent']).toBe(DEFAULT_USER_AGENT);
+    });
+
+    it('passes a non-blank override through unvalidated (boot-time validation owns rejection)', async () => {
+      process.env[USER_AGENT_ENV_VAR] = 'operator-agent/1.0';
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
+
+      await resolveDocument('https://example.com/doc.json');
+
+      expect(sentHeaders()['User-Agent']).toBe('operator-agent/1.0');
+    });
+
+    it('never overrides a caller-supplied user-agent header, whatever its casing', async () => {
+      process.env[USER_AGENT_ENV_VAR] = 'acme-operator/1.0';
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch.mockResolvedValue(makeResponse({ body: '{}' }) as never);
+
+      await resolveDocument('https://example.com/doc.json', { headers: { 'user-agent': 'caller/2.0' } });
+
+      expect(sentHeaders()['user-agent']).toBe('caller/2.0');
+      expect(sentHeaders()['User-Agent']).toBeUndefined();
+    });
+
+    it('sends the User-Agent on every redirect hop', async () => {
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch
+        .mockResolvedValueOnce(
+          makeResponse({ status: 302, headers: { location: 'https://example.com/final' }, body: null }) as never,
+        )
+        .mockResolvedValueOnce(makeResponse({ body: '{}' }) as never);
+
+      await resolveDocument('https://example.com/doc.json');
+
+      expect(undiciFetch).toHaveBeenCalledTimes(2);
+      expect(sentHeaders(0)['User-Agent']).toBe(DEFAULT_USER_AGENT);
+      expect(sentHeaders(1)['User-Agent']).toBe(DEFAULT_USER_AGENT);
     });
   });
 

--- a/packages/untp-utils/src/resolvers/resolve-document.ts
+++ b/packages/untp-utils/src/resolvers/resolve-document.ts
@@ -1,6 +1,13 @@
 import { ReadableStream } from 'node:stream/web';
 import { Agent, fetch as undiciFetch } from 'undici';
-import { parseEntityTag, parseImfDate, parseMediaType } from '../http-headers/index.js';
+import {
+  parseEntityTag,
+  parseImfDate,
+  parseMediaType,
+  DEFAULT_USER_AGENT,
+  USER_AGENT_ENV_VAR,
+  isValidHttpUserAgent,
+} from '../http-headers/index.js';
 import { MultibaseDigest, type HashAlgorithm, type MultibaseEncoding } from '../multibase-digest/index.js';
 import { validatePublicUrl } from '../node/index.js';
 import {
@@ -35,6 +42,23 @@ export const RESOLVER_DEFAULTS = {
   digestAlgorithm: HashAlgorithm;
   digestEncoding: MultibaseEncoding;
 };
+
+/**
+ * Merges the resolved `User-Agent` into the caller's headers. A caller-supplied
+ * `user-agent` (any casing) wins; otherwise the `RI_HTTP_USER_AGENT` env
+ * override (blank treated as unset), then the default. The override is not
+ * validated here: deployments validate it at boot via
+ * {@link isValidHttpUserAgent} (the RI does, in instrumentation.node.ts),
+ * and a value that slips through with control characters makes the fetch
+ * itself fail loudly rather than being silently replaced.
+ */
+function withUserAgent(headers: Record<string, string> | undefined): Record<string, string> {
+  const hasExplicit = Object.keys(headers ?? {}).some((key) => key.toLowerCase() === 'user-agent');
+  if (hasExplicit) return headers as Record<string, string>;
+  const fromEnv = process.env[USER_AGENT_ENV_VAR];
+  const userAgent = fromEnv !== undefined && fromEnv.trim() !== '' ? fromEnv : DEFAULT_USER_AGENT;
+  return { ...headers, 'User-Agent': userAgent };
+}
 
 /**
  * Result of a fetch that produced a final response (any non-redirect status,
@@ -141,7 +165,7 @@ export async function resolveDocument(url: string, options?: ResolveDocumentOpti
           method: 'GET',
           redirect: 'manual',
           signal: controller.signal,
-          headers: options?.headers,
+          headers: withUserAgent(options?.headers),
           dispatcher,
         });
 


### PR DESCRIPTION
This PR makes credential issuance stop refetching remote JSON-LD contexts on every request and makes every guarded outbound fetch identify itself with a User-Agent header, which restores bulk issuance in deployments whose anonymous context fetches are being challenged by upstream bot protection.

Closes #886

The issuance path now passes a shared in-memory TTL cache for remote `@context` documents to `validateJsonLd`, mirroring the schema loader: one fetch per context per TTL (default one hour, `CONTEXT_CACHE_TTL_MS`, `0` disables) instead of one per credential. Both document caches now bound retention as well as freshness: expired entries are evicted, and `CACHE_MAX_ENTRIES` (default 1000 per cache, validated at startup) caps the entry count with least-recently-used eviction, so caller-controlled `@context` URLs cannot grow process memory without bound.

Separately, `resolveDocument` in untp-utils sends a `User-Agent` on every request and redirect hop. Precedence: a caller-supplied header wins, then the `RI_HTTP_USER_AGENT` environment override (validated at RI boot; an unsendable value fails startup rather than breaking every fetch at request time), then a library default naming this repository. All four operator settings are documented in the startup operations page and `.env.example`.

Background: on a production deployment, w3.org returned 429 challenge pages to the RI's UA-less context fetches while identified requests from the same host passed, and the per-credential refetch pattern is what provoked the challenge. The RI hides the underlying reason today (#885, separate change), which is why this took live diagnosis to find.

## Test plan

- [x] Default, env-override, blank-override, caller-header, and redirect-hop User-Agent behaviour covered in the resolver suite
- [x] Boot validation covers unset, blank, Latin-1, control-character, and above-U+00FF values, and the wiring test proves a validator failure fails startup
- [x] Cache cap: least-recently-used eviction, expired-before-live eviction, expired-entry removal on read, and cap-value validation
- [x] Issuance passes the shared context cache on every call (regression-pinned by reference identity)
- [x] Full untp-utils suite and affected RI suites green
