### PR TITLE
fix(ri): surface the reason a credential payload failed JSON-LD or schema validation

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -145,7 +145,7 @@ The credential payload is validated in two passes:
 1. **JSON Schema validation** against the data model's schema URL(s). This catches structural issues such as missing required fields, incorrect types, or invalid enum values.
 2. **JSON-LD expansion** to verify the payload is valid linked data with a resolvable `@context`.
 
-If either check fails, the request is rejected with HTTP 400.
+If either check fails, the request is rejected with HTTP 400, the error message says why, and a `code` field distinguishes the two things that can go wrong at each pass. `SCHEMA_DOCUMENT_INVALID` and `JSONLD_DOCUMENT_INVALID` mean the payload itself is invalid; the message carries the detail to fix, such as the missing property or the undefined term. `SCHEMA_FETCH_FAILED` and `JSONLD_CONTEXT_FETCH_FAILED` mean a remote schema or `@context` document could not be fetched or used. The schema message names the schema URL; the context message carries the HTTP status or timeout where one applies, and collapses to a general message when the URL itself was rejected. A document failure is fixed by correcting the payload; a fetch failure usually reflects an upstream or network condition rather than a problem with the credential.
 
 #### Stage 3.5: CVC Compliance Validation (Advisory)
 

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -79,7 +79,17 @@ function defaultHumanVerificationUrl(): string {
  *             schema:
  *               $ref: '#/components/schemas/CredentialIssueResponse'
  *       400:
- *         description: Validation error (invalid payload, unknown data model, or issuer DID not registered to tenant)
+ *         description: >-
+ *           Validation error (invalid payload, unknown data model, or issuer
+ *           DID not registered to tenant). Payload-validation failures carry
+ *           a `code`: `SCHEMA_DOCUMENT_INVALID` or `JSONLD_DOCUMENT_INVALID`
+ *           mean the payload itself is invalid and the message says what to
+ *           fix; `SCHEMA_FETCH_FAILED` or `JSONLD_CONTEXT_FETCH_FAILED` mean
+ *           a remote schema or `@context` could not be fetched or used,
+ *           which reflects an upstream or configuration condition rather
+ *           than a payload fault (the schema message names the schema URL;
+ *           the context message carries the HTTP status or timeout where
+ *           one applies).
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
@@ -55,6 +55,14 @@ describe('handleRouteError', () => {
     expect(body).toEqual({ error: 'bad input' });
   });
 
+  it('includes the ValidationError code in the 400 body when present', async () => {
+    const res = handleRouteError(new ValidationError('context fetch failed', { code: 'JSONLD_CONTEXT_FETCH_FAILED' }));
+
+    expect(res.status).toBe(400);
+    const body = await (res as unknown as MockResponse).json();
+    expect(body).toEqual({ error: 'context fetch failed', code: 'JSONLD_CONTEXT_FETCH_FAILED' });
+  });
+
   it('maps ForbiddenError to 403', async () => {
     const res = handleRouteError(new ForbiddenError('not allowed'));
 

--- a/packages/reference-implementation/src/lib/api/handle-route-error.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.ts
@@ -27,8 +27,12 @@ const logger = apiLogger.child({ handler: 'error' });
  */
 export function handleRouteError(e: unknown): Response {
   if (e instanceof ValidationError) {
+    // The default err serialiser concatenates the messages and stacks of the
+    // native cause chain (not the causes' typed fields), so a ValidationError
+    // constructed with a cause logs the underlying failure's text here.
     logger.warn({ err: e }, 'Validation error');
-    return NextResponse.json({ error: e.message }, { status: 400 });
+    const body = e.code !== undefined ? { error: e.message, code: e.code } : { error: e.message };
+    return NextResponse.json(body, { status: 400 });
   }
   if (e instanceof ForbiddenError) {
     logger.warn({ err: e }, 'Forbidden');

--- a/packages/reference-implementation/src/lib/api/validation.ts
+++ b/packages/reference-implementation/src/lib/api/validation.ts
@@ -9,9 +9,18 @@ import { z } from 'zod';
 import { validatePublicUrl } from '@uncefact/untp-ri-services/server';
 
 export class ValidationError extends Error {
-  constructor(message: string) {
-    super(message);
+  /**
+   * Optional stable identifier for the failure class, returned in the 400
+   * body as `code` so API clients can react programmatically where the
+   * message alone is not enough (e.g. distinguishing an invalid credential
+   * document from a remote context that could not be fetched).
+   */
+  readonly code?: string;
+
+  constructor(message: string, options?: { code?: string; cause?: unknown }) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
     this.name = 'ValidationError';
+    if (options?.code !== undefined) this.code = options.code;
   }
 }
 

--- a/packages/reference-implementation/src/lib/credentials/validate-credential-payload.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-credential-payload.test.ts
@@ -2,12 +2,17 @@ import { ValidationError } from '@/lib/api/validation';
 import {
   SchemaPayloadError,
   SchemaFetchFailedError,
+  SchemaCompilationFailedError,
   JsonLdExpansionFailedError,
 } from '@uncefact/untp-utils/validation';
 import type { SchemaLoader } from '@uncefact/untp-utils/loaders';
 
 const mockValidateAgainstSchemas = jest.fn();
 const mockValidateJsonLd = jest.fn();
+// Classification itself (cause-chain walking, typed-error matching) is
+// unit-tested in untp-utils; here it is mocked so these tests pin only what
+// this module owns: the kind-to-code mapping and message composition.
+const mockDescribeJsonLdFailure = jest.fn();
 
 jest.mock('@uncefact/untp-utils/validation', () => {
   const actual = jest.requireActual('@uncefact/untp-utils/validation');
@@ -15,6 +20,7 @@ jest.mock('@uncefact/untp-utils/validation', () => {
     ...actual,
     validateAgainstSchemas: (...args: unknown[]) => mockValidateAgainstSchemas(...args),
     validateJsonLd: (...args: unknown[]) => mockValidateJsonLd(...args),
+    describeJsonLdFailure: (...args: unknown[]) => mockDescribeJsonLdFailure(...args),
   };
 });
 
@@ -77,6 +83,7 @@ describe('validateCredentialPayload', () => {
     expect(error).toBeInstanceOf(ValidationError);
     expect((error as Error).message).toContain('Missing required property "id"');
     expect((error as Error).message).toContain('Type must be array');
+    expect((error as ValidationError).code).toBe('SCHEMA_DOCUMENT_INVALID');
     expect(mockValidateJsonLd).not.toHaveBeenCalled();
   });
 
@@ -88,16 +95,59 @@ describe('validateCredentialPayload', () => {
     const error = await validateCredentialPayload(payload, schemaUrls, loader).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(ValidationError);
     expect((error as Error).message).toMatch(/Could not load schema/);
+    expect((error as ValidationError).code).toBe('SCHEMA_FETCH_FAILED');
     expect(mockValidateJsonLd).not.toHaveBeenCalled();
   });
 
-  it('translates JsonLdValidationError into ValidationError', async () => {
-    mockValidateAgainstSchemas.mockResolvedValue(undefined);
-    mockValidateJsonLd.mockRejectedValue(new JsonLdExpansionFailedError(new Error('Undefined term: foo')));
+  it('maps a schema compilation failure to SCHEMA_FETCH_FAILED too (deliberate: both mean the schema could not be used)', async () => {
+    mockValidateAgainstSchemas.mockRejectedValue(
+      new SchemaCompilationFailedError('https://example.com/schema.json', new Error('duplicate $id')),
+    );
 
     const error = await validateCredentialPayload(payload, schemaUrls, loader).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(ValidationError);
-    expect((error as Error).message).toContain('JSON-LD validation failed');
+    expect((error as ValidationError).code).toBe('SCHEMA_FETCH_FAILED');
+  });
+
+  it('translates a document-level JSON-LD failure with the classifier detail, the document code, and the cause', async () => {
+    mockValidateAgainstSchemas.mockResolvedValue(undefined);
+    const wrapped = new JsonLdExpansionFailedError(new Error('Undefined term: foo'));
+    mockValidateJsonLd.mockRejectedValue(wrapped);
+    mockDescribeJsonLdFailure.mockReturnValue({ kind: 'document', detail: 'Undefined term: foo' });
+
+    const error = await validateCredentialPayload(payload, schemaUrls, loader).catch((e: unknown) => e);
+    expect(mockDescribeJsonLdFailure).toHaveBeenCalledWith(wrapped);
+    expect(error).toBeInstanceOf(ValidationError);
+    expect((error as ValidationError).message).toContain('JSON-LD validation failed');
+    expect((error as ValidationError).message).toContain('Undefined term: foo');
+    expect((error as ValidationError).code).toBe('JSONLD_DOCUMENT_INVALID');
+    expect((error as Error).cause).toBe(wrapped);
+  });
+
+  it('translates a context-fetch JSON-LD failure with the fetch code and the classifier detail in the message', async () => {
+    mockValidateAgainstSchemas.mockResolvedValue(undefined);
+    const wrapped = new JsonLdExpansionFailedError(new Error('wrapped'));
+    mockValidateJsonLd.mockRejectedValue(wrapped);
+    mockDescribeJsonLdFailure.mockReturnValue({
+      kind: 'context-fetch',
+      detail: 'could not fetch a remote @context: https://www.w3.org/ns/credentials/v2 returned status 429.',
+    });
+
+    const error = await validateCredentialPayload(payload, schemaUrls, loader).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ValidationError);
+    expect((error as ValidationError).code).toBe('JSONLD_CONTEXT_FETCH_FAILED');
+    expect((error as ValidationError).message).toContain('https://www.w3.org/ns/credentials/v2');
+    expect((error as ValidationError).message).toContain('429');
+    expect((error as Error).cause).toBe(wrapped);
+  });
+
+  it('attaches the schema failure as the cause of the mapped ValidationError', async () => {
+    const schemaError = new SchemaPayloadError([{ code: 'schema.payload-invalid', message: 'Missing "id"' }]);
+    mockValidateAgainstSchemas.mockRejectedValue(schemaError);
+
+    const error = await validateCredentialPayload(payload, schemaUrls, loader).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ValidationError);
+    expect((error as Error).cause).toBe(schemaError);
   });
 
   it('rethrows non-validation errors unchanged', async () => {

--- a/packages/reference-implementation/src/lib/credentials/validate-credential-payload.ts
+++ b/packages/reference-implementation/src/lib/credentials/validate-credential-payload.ts
@@ -1,6 +1,7 @@
 import {
   validateAgainstSchemas,
   validateJsonLd,
+  describeJsonLdFailure,
   SchemaPayloadError,
   SchemaValidationError,
   JsonLdValidationError,
@@ -19,10 +20,12 @@ export async function validateCredentialPayload(
   } catch (e) {
     if (e instanceof SchemaPayloadError) {
       const summary = e.failures.map((f) => f.message).join('; ');
-      throw new ValidationError(`Schema validation failed: ${summary}`);
+      throw new ValidationError(`Schema validation failed: ${summary}`, { code: 'SCHEMA_DOCUMENT_INVALID', cause: e });
     }
     if (e instanceof SchemaValidationError) {
-      throw new ValidationError(`Schema validation failed: ${e.message}`);
+      // Fetch and compilation failures alike: the schema could not be used,
+      // which is an upstream or configuration condition, not a payload fault.
+      throw new ValidationError(`Schema validation failed: ${e.message}`, { code: 'SCHEMA_FETCH_FAILED', cause: e });
     }
     throw e;
   }
@@ -31,7 +34,14 @@ export async function validateCredentialPayload(
     await validateJsonLd(credentialPayload, { contextCache });
   } catch (e) {
     if (e instanceof JsonLdValidationError) {
-      throw new ValidationError(`JSON-LD validation failed: ${e.message}`);
+      // Two caller-facing classes (the 400's `code` distinguishes them): a
+      // document problem carries the processor's detail so the caller knows
+      // what to fix; a context-fetch problem names the URL and condition in
+      // the typed diagnostic's terms. Either way the full cause chain rides
+      // on the ValidationError for the server-side log.
+      const failure = describeJsonLdFailure(e);
+      const code = failure.kind === 'context-fetch' ? 'JSONLD_CONTEXT_FETCH_FAILED' : 'JSONLD_DOCUMENT_INVALID';
+      throw new ValidationError(`JSON-LD validation failed: ${failure.detail}`, { code, cause: e });
     }
     throw e;
   }

--- a/packages/untp-utils/src/resolvers/resolve-document.ts
+++ b/packages/untp-utils/src/resolvers/resolve-document.ts
@@ -1,5 +1,4 @@
 import { ReadableStream } from 'node:stream/web';
-import { Agent, fetch as undiciFetch } from 'undici';
 import {
   parseEntityTag,
   parseImfDate,
@@ -130,6 +129,11 @@ export interface ResolveDocumentOptions {
  * @see https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
  */
 export async function resolveDocument(url: string, options?: ResolveDocumentOptions): Promise<LoadResult> {
+  // Dynamic import: undici's module initialisation needs web globals
+  // (TextDecoder) that jsdom test environments lack, so it loads at fetch
+  // time to keep this module, and the resolvers barrel, importable there.
+  // Same pattern as validate-jsonld.ts's lazy jsonld import.
+  const { Agent, fetch: undiciFetch } = await import('undici');
   const maxBytes = options?.maxResponseBytes ?? RESOLVER_DEFAULTS.maxResponseBytes;
   const totalTimeoutMs = options?.totalTimeoutMs ?? RESOLVER_DEFAULTS.totalTimeoutMs;
   const maxRedirects = options?.maxRedirects ?? RESOLVER_DEFAULTS.maxRedirects;

--- a/packages/untp-utils/src/validation/describe-jsonld-failure.test.ts
+++ b/packages/untp-utils/src/validation/describe-jsonld-failure.test.ts
@@ -1,0 +1,188 @@
+import { describeJsonLdFailure } from './describe-jsonld-failure.js';
+import { JsonLdExpansionFailedError, JsonLdInvalidShapeError } from './errors.js';
+import { ResolverHttpError, ResolverTimedOutError } from '../resolvers/errors.js';
+import { PrivateAddressError, ResolutionFailedError } from '../node/errors.js';
+
+/** Builds an error shaped like jsonld.js's JsonLdError (which never sets native `cause`). */
+function jsonLdError(name: string, message: string, details?: Record<string, unknown>): Error {
+  const error = new Error(message) as Error & { details?: Record<string, unknown> };
+  error.name = name;
+  error.details = details;
+  return error;
+}
+
+describe('describeJsonLdFailure', () => {
+  describe('context-fetch: typed loader failures', () => {
+    it('classifies an HTTP failure on the cause chain as context-fetch, naming URL and status', () => {
+      const http = new ResolverHttpError('https://www.w3.org/ns/credentials/v2', 429);
+      const wrapped = new JsonLdExpansionFailedError(new Error('jsonld wrapper', { cause: http }));
+
+      const failure = describeJsonLdFailure(wrapped);
+
+      expect(failure.kind).toBe('context-fetch');
+      expect(failure.detail).toContain('https://www.w3.org/ns/credentials/v2');
+      expect(failure.detail).toContain('429');
+    });
+
+    it('classifies a timeout on the cause chain as context-fetch', () => {
+      const wrapped = new JsonLdExpansionFailedError(new ResolverTimedOutError('https://example.com/ctx', 10_000));
+
+      expect(describeJsonLdFailure(wrapped)).toMatchObject({ kind: 'context-fetch' });
+    });
+
+    it.each([
+      ['PrivateAddressError', new PrivateAddressError('https://internal.example/ctx', ['10.0.0.5'])],
+      ['ResolutionFailedError', new ResolutionFailedError('https://nxdomain.example/ctx', new Error('ENOTFOUND'))],
+    ])('collapses %s to one flat message, leaking neither the URL nor the rejection class', (_name, rejected) => {
+      const wrapped = new JsonLdExpansionFailedError(new Error('scoped context', { cause: rejected }));
+
+      const failure = describeJsonLdFailure(wrapped);
+
+      expect(failure.kind).toBe('context-fetch');
+      // One message for every UrlValidationError subclass: distinguishing
+      // "does not resolve" from "resolves privately" would be a per-hostname
+      // reconnaissance oracle. The typed detail stays on the cause chain.
+      expect(failure.detail).toBe(
+        "a remote @context URL was rejected by this service's URL policy or could not be resolved",
+      );
+      expect(failure.detail).not.toMatch(/10\.0\.0\.5|internal\.example|nxdomain\.example/);
+    });
+
+    it('prefers the flat loader message over the URL-bearing jsonld wrapper above it (rehydrated chain shape)', () => {
+      // The real chain after validateJsonLd rehydration: the loader error
+      // hangs BENEATH jsonld.InvalidUrl, whose message contains the URL.
+      const loaderError = new PrivateAddressError('https://169.254.169.254/latest/meta-data/', ['169.254.169.254']);
+      const wrapper = jsonLdError(
+        'jsonld.InvalidUrl',
+        'Dereferencing a URL did not result in a valid JSON-LD object. URL: "https://169.254.169.254/latest/meta-data/".',
+        { code: 'loading remote context failed' },
+      );
+      wrapper.cause = loaderError;
+      const wrapped = new JsonLdExpansionFailedError(wrapper);
+
+      const failure = describeJsonLdFailure(wrapped);
+
+      expect(failure.kind).toBe('context-fetch');
+      expect(failure.detail).not.toContain('169.254.169.254');
+    });
+
+    it('finds a typed failure at any depth of the cause chain', () => {
+      let chain: Error = new ResolverHttpError('https://example.com/ctx', 503) as unknown as Error;
+      for (let i = 0; i < 20; i += 1) {
+        chain = new Error(`wrapper ${i}`, { cause: chain });
+      }
+
+      expect(describeJsonLdFailure(new JsonLdExpansionFailedError(chain))).toMatchObject({ kind: 'context-fetch' });
+    });
+  });
+
+  describe('context-fetch: fetched but unusable remote contexts', () => {
+    it('classifies non-object remote context content as context-fetch with a generic message', () => {
+      const processor = jsonLdError(
+        'jsonld.InvalidUrl',
+        'Dereferencing a URL did not result in a JSON object. The response was valid JSON, but it was not a JSON object. URL: "https://example.com/ctx".',
+        { code: 'invalid remote context' },
+      );
+
+      const failure = describeJsonLdFailure(new JsonLdExpansionFailedError(processor));
+
+      expect(failure.kind).toBe('context-fetch');
+      expect(failure.detail).toBe('a remote @context document was fetched but could not be used as a context');
+    });
+
+    it('leaves the shared "loading remote context failed" code document-class for other error names', () => {
+      // jsonld.ContextUrlError reuses the code for the JSON-LD 1.0 context
+      // limit; only jsonld.InvalidUrl carries the remote-content meaning.
+      const processor = jsonLdError('jsonld.ContextUrlError', 'Maximum number of @context URLs exceeded.', {
+        code: 'loading remote context failed',
+      });
+
+      expect(describeJsonLdFailure(new JsonLdExpansionFailedError(processor))).toMatchObject({ kind: 'document' });
+    });
+  });
+
+  describe('document: recognised processor shapes', () => {
+    it('extracts the safe-mode event message and offending property (real jsonld@8.3.3 shape)', () => {
+      const processor = jsonLdError('jsonld.ValidationError', 'Safe mode validation error.', {
+        event: {
+          type: ['JsonLdEvent'],
+          code: 'invalid property',
+          level: 'warning',
+          message: 'Dropping property that did not expand into an absolute IRI or keyword.',
+          details: { property: 'unknownTerm', expandedProperty: 'unknownTerm' },
+        },
+      });
+
+      const failure = describeJsonLdFailure(new JsonLdExpansionFailedError(processor));
+
+      expect(failure.kind).toBe('document');
+      expect(failure.detail).toContain('Dropping property that did not expand');
+      expect(failure.detail).toContain('unknownTerm');
+    });
+
+    it('never echoes non-allowlisted event fields, which can carry credential content', () => {
+      const processor = jsonLdError('jsonld.ValidationError', 'Safe mode validation error.', {
+        event: {
+          code: 'object with only @id',
+          message: 'Dropping object with only @id.',
+          details: { value: { '@id': 'urn:secret:batch-7734' } },
+        },
+      });
+
+      const failure = describeJsonLdFailure(new JsonLdExpansionFailedError(processor));
+
+      expect(failure.kind).toBe('document');
+      expect(failure.detail).not.toContain('urn:secret:batch-7734');
+    });
+
+    it('passes a jsonld syntax-error message through (library-authored fixed strings)', () => {
+      const processor = jsonLdError('jsonld.SyntaxError', 'Invalid JSON-LD syntax; @type value must be a string.', {
+        code: 'invalid type value',
+      });
+
+      const failure = describeJsonLdFailure(new JsonLdExpansionFailedError(processor));
+
+      expect(failure.kind).toBe('document');
+      expect(failure.detail).toBe('Invalid JSON-LD syntax; @type value must be a string.');
+    });
+
+    it('keeps the typed invalid-shape diagnostic', () => {
+      const failure = describeJsonLdFailure(new JsonLdInvalidShapeError(null));
+
+      expect(failure.kind).toBe('document');
+      expect(failure.detail).toContain('non-null object');
+    });
+  });
+
+  describe('document: unrecognised failures never leak raw messages', () => {
+    it('returns the generic message for an untyped error instead of echoing its text', () => {
+      const leaky = new Error('internal path /srv/app/private-config.json');
+
+      const failure = describeJsonLdFailure(new JsonLdExpansionFailedError(leaky));
+
+      expect(failure.kind).toBe('document');
+      expect(failure.detail).toBe('the document could not be expanded as valid JSON-LD');
+      expect(failure.detail).not.toContain('/srv/app');
+    });
+
+    it('returns the generic message for an unknown jsonld.* error name', () => {
+      const processor = jsonLdError('jsonld.OptionsError', 'Some future message naming internals.', {});
+
+      const failure = describeJsonLdFailure(new JsonLdExpansionFailedError(processor));
+
+      expect(failure.kind).toBe('document');
+      expect(failure.detail).toBe('the document could not be expanded as valid JSON-LD');
+    });
+
+    it('terminates on a cyclic cause chain and classifies it as document', () => {
+      const a = new Error('a');
+      const b = new Error('b', { cause: a });
+      a.cause = b;
+
+      expect(describeJsonLdFailure(new JsonLdExpansionFailedError(a))).toMatchObject({
+        kind: 'document',
+        detail: 'the document could not be expanded as valid JSON-LD',
+      });
+    });
+  });
+});

--- a/packages/untp-utils/src/validation/describe-jsonld-failure.ts
+++ b/packages/untp-utils/src/validation/describe-jsonld-failure.ts
@@ -1,0 +1,139 @@
+import { JsonLdInvalidShapeError, JsonLdValidationError } from './errors.js';
+import { ResolverError } from '../resolvers/errors.js';
+import { UrlValidationError } from '../node/errors.js';
+
+/**
+ * A caller-facing description of why JSON-LD validation failed, split into
+ * the two classes a caller reacts to differently: a problem with their
+ * document (fix the payload) versus a remote `@context` that could not be
+ * fetched or used (an environment or upstream condition; the payload may be
+ * fine).
+ */
+export interface JsonLdFailureDescription {
+  kind: 'context-fetch' | 'document';
+  /**
+   * Human-facing reason, safe to return to the caller. Every branch below
+   * must preserve that property: detail comes only from explicitly
+   * recognised shapes (the guarded loader's typed diagnostics, jsonld.js
+   * safe-mode events via an allowlist of string fields, jsonld.js's fixed
+   * syntax-error strings, or this package's own typed messages). Messages
+   * from unrecognised errors never reach this field; unknown failures get
+   * a generic message and the full chain stays on `cause` for the log.
+   */
+  detail: string;
+}
+
+const GENERIC_DOCUMENT_DETAIL = 'the document could not be expanded as valid JSON-LD';
+const GENERIC_REMOTE_CONTEXT_DETAIL = 'a remote @context document was fetched but could not be used as a context';
+const FLAT_URL_POLICY_DETAIL =
+  "a remote @context URL was rejected by this service's URL policy or could not be resolved";
+
+/** Event `details` fields safe to echo: identifiers from the caller's own document or a public context, never free-form values that can carry credential content. */
+const SAFE_EVENT_FIELDS = ['property', 'expandedProperty', 'id', 'type', 'term', 'language', 'vocab'] as const;
+const MAX_FIELD_LENGTH = 200;
+
+interface JsonLdProcessorError extends Error {
+  details?: { code?: unknown; event?: { message?: unknown; details?: Record<string, unknown> } };
+}
+
+function isJsonLdProcessorError(value: unknown): value is JsonLdProcessorError {
+  return value instanceof Error && value.name.startsWith('jsonld.');
+}
+
+/** Formats a safe-mode event: its fixed library message plus allowlisted string fields. */
+function describeSafeModeEvent(event: { message?: unknown; details?: Record<string, unknown> }): string {
+  const parts: string[] = [];
+  if (typeof event.message === 'string' && event.message !== '') {
+    parts.push(event.message);
+  }
+  for (const field of SAFE_EVENT_FIELDS) {
+    const value = event.details?.[field];
+    if (typeof value === 'string' && value !== '') {
+      parts.push(`(${field}: "${value.slice(0, MAX_FIELD_LENGTH)}")`);
+    }
+  }
+  return parts.length > 0 ? parts.join(' ') : GENERIC_DOCUMENT_DETAIL;
+}
+
+function* causeChain(error: unknown): Generator<unknown> {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    yield current;
+    current = current instanceof Error ? current.cause : undefined;
+  }
+}
+
+/**
+ * Classifies a {@link JsonLdValidationError} by walking its cause chain
+ * (native `.cause` hops; the chain is rehydrated by `validateJsonLd`, see
+ * issue #773).
+ *
+ * The two passes run in a load-bearing order. The rehydrated chain nests
+ * the guarded loader's error BENEATH jsonld.js's own wrapper
+ * (`JsonLdExpansionFailedError` -> `jsonld.InvalidUrl` -> the loader's
+ * `UrlValidationError`), and the wrapper's message contains the URL, so the
+ * typed-loader pass must exhaust the whole chain before any jsonld.js shape
+ * is considered; matching the wrapper first would echo its message and
+ * reopen the per-hostname reconnaissance oracle the flat message exists to
+ * close.
+ *
+ * `UrlValidationError` deliberately collapses to one flat message: its
+ * subclasses distinguish "does not resolve" from "resolves to a private
+ * address" from "scheme not allowed", and echoing that distinction would
+ * hand an authenticated caller a network-reconnaissance oracle over
+ * attacker-chosen `@context` URLs. The full typed diagnostic stays on the
+ * cause chain for the server-side log. `ResolverError` diagnostics fire
+ * only after the URL passed the public-address check, so their detail
+ * (HTTP status, timeout, size bound) is returned as-is.
+ *
+ * Known limitation, accepted: a malformed term definition inside a
+ * successfully fetched remote context surfaces as a `jsonld.SyntaxError`
+ * indistinguishable from the same defect in an inline context, and is
+ * classified as a document failure.
+ */
+export function describeJsonLdFailure(error: JsonLdValidationError): JsonLdFailureDescription {
+  // Our own pre-expansion diagnostic: safe, typed, and more precise than
+  // the generic fallback (expansion never ran).
+  if (error instanceof JsonLdInvalidShapeError) {
+    return { kind: 'document', detail: error.message };
+  }
+
+  // Pass 1: the guarded loader's typed failures, anywhere on the chain.
+  for (const node of causeChain(error)) {
+    if (node instanceof UrlValidationError) {
+      return { kind: 'context-fetch', detail: FLAT_URL_POLICY_DETAIL };
+    }
+    if (node instanceof ResolverError) {
+      return { kind: 'context-fetch', detail: `could not fetch a remote @context: ${node.message}` };
+    }
+  }
+
+  // Pass 2: recognised jsonld.js processor shapes (name plus details.code
+  // matched exactly; the name prefix alone only locates the processor error,
+  // it does not make its message caller-safe).
+  for (const node of causeChain(error)) {
+    if (!isJsonLdProcessorError(node)) continue;
+    const code = node.details?.code;
+    if (
+      node.name === 'jsonld.InvalidUrl' &&
+      (code === 'invalid remote context' || code === 'loading remote context failed')
+    ) {
+      // Fetched successfully (or rejected by an untyped loader path) but
+      // unusable as a context: an upstream condition, not a payload fault.
+      return { kind: 'context-fetch', detail: GENERIC_REMOTE_CONTEXT_DETAIL };
+    }
+    if (node.name === 'jsonld.ValidationError' && node.details?.event !== undefined) {
+      return { kind: 'document', detail: describeSafeModeEvent(node.details.event) };
+    }
+    if (node.name === 'jsonld.SyntaxError') {
+      // jsonld.js syntax-error messages are library-authored fixed strings
+      // (the variable parts live in details, which is not echoed).
+      return { kind: 'document', detail: node.message };
+    }
+    return { kind: 'document', detail: GENERIC_DOCUMENT_DETAIL };
+  }
+
+  return { kind: 'document', detail: GENERIC_DOCUMENT_DETAIL };
+}

--- a/packages/untp-utils/src/validation/index.ts
+++ b/packages/untp-utils/src/validation/index.ts
@@ -9,3 +9,4 @@ export {
 } from './errors.js';
 export { validateJsonLd, type ValidateJsonLdOptions } from './validate-jsonld.js';
 export { validateAgainstSchemas, type SchemaReference } from './validate-against-schemas.js';
+export { describeJsonLdFailure, type JsonLdFailureDescription } from './describe-jsonld-failure.js';


### PR DESCRIPTION
This PR makes credential-payload validation failures say why they failed, so a caller can tell a problem with their document from a remote schema or context that could not be fetched, and an operator reading the logs sees the underlying failure instead of a fixed string.

Closes #885

The 400 message now carries the failure's detail and the body carries a stable `code`. `SCHEMA_DOCUMENT_INVALID` and `JSONLD_DOCUMENT_INVALID` mean the payload is invalid and the message says what to fix; for JSON-LD safe-mode failures that includes the offending property extracted from the processor's event, which previously surfaced only as "Safe mode validation error." with the useful part hidden. `SCHEMA_FETCH_FAILED` and `JSONLD_CONTEXT_FETCH_FAILED` mean a remote schema or `@context` could not be fetched or used, an upstream condition rather than a payload fault; for public context URLs the message carries the HTTP status or timeout, which is exactly the detail that would have named the recent production 429s on day one. The original error rides the `ValidationError` as its cause, so the server log now records the full chain.

The caller-facing detail is deliberately bounded. URL-policy and DNS rejections collapse to one flat message, because distinguishing "does not resolve" from "resolves to a private address" per attacker-chosen `@context` hostname would hand an authenticated caller a network-reconnaissance oracle. Detail is exposed only from explicitly recognised diagnostic shapes; unrecognised failures return a generic message with the specifics kept to the log.

The classification helper lives in untp-utils so the Playground adoption work can reuse it. The resolvers module now lazy-loads undici, matching the existing lazy jsonld import, so the barrel is importable in jsdom test environments. The Swagger 400 description and the API docs Stage 3 section document the four codes.

## Test plan

- [x] Classifier: real jsonld@8.3.3 shapes for safe-mode events (offending property surfaced, non-allowlisted event fields never echoed), invalid remote-context content, the rehydrated private-address chain (flat message wins over the URL-bearing wrapper), untyped errors (generic message, no leak), unknown processor names, deep and cyclic cause chains
- [x] Mapping: all four codes asserted, cause identity pinned on every mapped error
- [x] 400 body: `code` present when set, exact-match body without it otherwise
- [x] Full untp-utils suite and affected RI suites green
