### PR TITLE
feat(ri): add a read-only encryption audit command

### DIFF
--- a/documentation/docs/migration-guides/ri-v0.4.md
+++ b/documentation/docs/migration-guides/ri-v0.4.md
@@ -59,9 +59,10 @@ unrecoverable, so a human confirms the key before anything is rewritten.
 
 Before running it:
 
-1. Back up the database.
-2. Confirm `DATA_ENCRYPTION_KEY` is exactly the key the running application uses.
-3. Stop any older application instances that might still write plaintext keys during a
+1. Preview what it would do with the read-only audit command (`pnpm audit:encryption`), which decrypts every stored envelope under the active key and reports what the backfill would wrap, skip, or abort on (see [Encryption Audit](../reference-implementation/operations/encryption-audit)).
+2. Back up the database.
+3. Confirm `DATA_ENCRYPTION_KEY` is exactly the key the running application uses.
+4. Stop any older application instances that might still write plaintext keys during a
    rolling upgrade (or plan to re-run the backfill after they are gone; re-running is
    safe and converges).
 

--- a/documentation/docs/reference-implementation/operations/encryption-audit.md
+++ b/documentation/docs/reference-implementation/operations/encryption-audit.md
@@ -1,0 +1,47 @@
+---
+sidebar_position: 5
+title: Encryption Audit
+---
+
+# Encryption Audit
+
+The Reference Implementation encrypts two kinds of data at rest under `DATA_ENCRYPTION_KEY`: service instance configurations and credential decryption keys. Startup validation decrypts a single sampled envelope, so a mixed-key database, or rows corrupted after that check, can pass boot and only surface when a request happens to touch an affected row. The `audit:encryption` command answers the question exhaustively: it attempts to decrypt every stored envelope under the active key and reports the result per store, without writing anything.
+
+Run it:
+
+- before rotating `DATA_ENCRYPTION_KEY`, to confirm the current key decrypts everything the rotation will re-encrypt (key rotation itself is tracked in [#720](https://github.com/uncefact/tests-untp/issues/720));
+- after restoring a database backup, to confirm the restored data and the configured key still match;
+- during incident triage, when decryption errors suggest a key or data problem and you need the full extent rather than the one row a request tripped over.
+
+## Running the audit
+
+From a source checkout, in `packages/reference-implementation`:
+
+```bash
+pnpm audit:encryption
+```
+
+Inside the published Docker image (which ships no pnpm):
+
+```bash
+docker compose exec -w /app ri node_modules/.bin/tsx scripts/audit-encryption.ts
+```
+
+The command needs `DATA_ENCRYPTION_KEY` and a database target: a pre-set `RI_DATABASE_URL` is honoured as given, and the `RI_POSTGRES_*` variables are used to construct one only when it is absent (the same rule the application and the backfill follow).
+
+## Reading the report
+
+For each store the audit prints how many values decrypted cleanly, then the ids of any rows that failed to decrypt (a valid envelope that will not open, meaning a key mismatch or corruption of the envelope's ciphertext, IV, or authentication tag) and of any rows holding corrupted values (data that is not a valid envelope at all). Service instance configurations are always written encrypted, so any non-envelope value there is corruption. Credential keys can legitimately predate encryption at rest, so only values that look like a damaged envelope are flagged; other plain values are counted as legacy plaintext.
+
+The audit doubles as the dry run for the [decryption-key backfill](../../migration-guides/ri-v0.4#decryption-key-backfill-for-existing-credentials): it reports how many legacy plaintext keys a backfill run would wrap, notes any corrupted-looking credential rows a backfill would skip untouched, and states when a backfill would refuse to run without `--force` because no stored envelope proves the key. When the audit finds decrypt failures or corrupted service instance configurations, a backfill run aborts before writing anything, and `--force` does not change that; resolve those rows first.
+
+When the database holds nothing encrypted (a fresh deployment, or only legacy plaintext keys), the audit says so explicitly: a clean result in that state means nothing failed, not that the key was proven able to decrypt anything.
+
+## Exit codes
+
+- `0`: the audit completed and every stored envelope decrypted cleanly (including the nothing-to-verify case, which is stated in the output).
+- `1`: the audit found decrypt failures or corrupted rows, or it could not complete (for example, the database was unreachable). The output distinguishes the two.
+
+## Concurrent writes
+
+The audit reads in id order with cursor pagination and no transaction, so it is a point-in-time report: a row changed after it was scanned, or inserted behind the scan position, is not re-examined. When the result gates a rotation or a restore, stop application writers first and keep them stopped until the follow-up action is done. A run against a live system is fine for triage; re-run it quiesced before acting on the result.

--- a/packages/reference-implementation/Dockerfile
+++ b/packages/reference-implementation/Dockerfile
@@ -162,6 +162,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation
 # Encryption key startup validation, required by prisma/seed.ts (#762)
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/validate-encryption-key-startup.ts ./src/lib/credentials/validate-encryption-key-startup.ts
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.ts ./src/lib/credentials/backfill-decryption-keys.ts
+# Read-only encryption audit and shared envelope-store iteration, required by
+# scripts/audit-encryption.ts and (via the preflight) the backfill (#764)
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/audit-encryption.ts ./src/lib/credentials/audit-encryption.ts
+COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/src/lib/credentials/envelope-stores.ts ./src/lib/credentials/envelope-stores.ts
 # Operator-run maintenance scripts (run via node_modules/.bin/tsx; see each
 # script's header for the in-image invocation)
 COPY --from=builder --chown=nextjs:nodejs /app/packages/reference-implementation/scripts ./scripts

--- a/packages/reference-implementation/package.json
+++ b/packages/reference-implementation/package.json
@@ -39,6 +39,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "audit:encryption": "npx tsx scripts/audit-encryption.ts",
     "backfill:decryption-keys": "npx tsx scripts/backfill-decryption-keys.ts"
   },
   "browserslist": {

--- a/packages/reference-implementation/scripts/audit-encryption.ts
+++ b/packages/reference-implementation/scripts/audit-encryption.ts
@@ -1,0 +1,66 @@
+/**
+ * Read-only audit of data encrypted at rest under DATA_ENCRYPTION_KEY.
+ *
+ * Attempts to decrypt every stored envelope (service instance configurations
+ * and credential decryption keys) under the active key and reports the
+ * result per store, without writing anything. Run it before a key rotation,
+ * after a database restore, and during incident triage; it also doubles as
+ * the dry run for `backfill:decryption-keys`, reporting what that command
+ * would change.
+ *
+ * Usage (from packages/reference-implementation, source checkout):
+ *   pnpm audit:encryption
+ *
+ * Usage (inside the published Docker image, which ships no pnpm):
+ *   docker compose exec -w /app ri node_modules/.bin/tsx scripts/audit-encryption.ts
+ *
+ * Requires DATA_ENCRYPTION_KEY and a database target: a pre-set
+ * RI_DATABASE_URL is honoured as given, and the RI_POSTGRES_* variables are
+ * used to construct one only when it is absent.
+ *
+ * The scan is best-effort under concurrent writes: quiesce writers when the
+ * result gates a rotation or a restore; a run against a live system is a
+ * point-in-time report.
+ *
+ * Exit codes: 0 when every envelope decrypted cleanly (including when
+ * nothing existed to verify the key against, which is stated explicitly);
+ * 1 when any decrypt failure or corrupted row was found, or the audit could
+ * not complete (the output distinguishes the two).
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+
+const DOCS_URL = 'https://uncefact.github.io/tests-untp/docs/next/reference-implementation/operations/encryption-audit';
+
+// Honour a pre-set RI_DATABASE_URL; construct from parts only when absent
+// (same rule as docker-entrypoint.sh). Guarded assignment: process.env
+// coerces undefined to the string "undefined", which would later read as a
+// configured (nonsense) connection target.
+const { databaseUrlFromEnvParts } = await import('../src/lib/prisma/database-url.js');
+const constructedDatabaseUrl = databaseUrlFromEnvParts();
+if (!process.env.RI_DATABASE_URL && constructedDatabaseUrl) {
+  process.env.RI_DATABASE_URL = constructedDatabaseUrl;
+}
+
+const { prisma } = await import('../src/lib/prisma/prisma.js');
+const { auditEncryption, buildAuditReport } = await import('../src/lib/credentials/audit-encryption.js');
+const { getEncryptionService } = await import('../src/lib/encryption/encryption.js');
+
+try {
+  const result = await auditEncryption(prisma, getEncryptionService());
+  const report = buildAuditReport(result, DOCS_URL);
+  for (const line of report.lines) {
+    (line.stream === 'err' ? console.error : console.log)(line.text);
+  }
+  process.exitCode = report.exitCode;
+} catch (error) {
+  console.error('Audit could not complete:', error);
+  console.error(`See ${DOCS_URL}`);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}

--- a/packages/reference-implementation/src/lib/credentials/audit-encryption.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/audit-encryption.test.ts
@@ -1,0 +1,386 @@
+export {};
+
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: { child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }) },
+}));
+
+const originalEnv = process.env;
+
+const ACTIVE_KEY = 'a'.repeat(64);
+const OTHER_KEY = 'd'.repeat(64);
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv, DATA_ENCRYPTION_KEY: ACTIVE_KEY };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+type Row = { id: string; decryptionKey: string | null };
+type ServiceInstanceRow = { id: string; config: string };
+
+function createFakeClient(rows: Row[], serviceInstances: ServiceInstanceRow[] = []) {
+  return {
+    credential: {
+      findMany: jest.fn(
+        async (args: { where: { decryptionKey: { not: null }; id?: { gt: string } }; take: number }): Promise<Row[]> =>
+          rows
+            .filter((row) => row.decryptionKey !== null)
+            .filter((row) => (args.where.id ? row.id > args.where.id.gt : true))
+            .sort((a, b) => a.id.localeCompare(b.id))
+            .slice(0, args.take)
+            .map((row) => ({ id: row.id, decryptionKey: row.decryptionKey })),
+      ),
+      update: jest.fn(async () => {
+        throw new Error('the audit must never write');
+      }),
+    },
+    serviceInstance: {
+      findMany: jest.fn(
+        async (args: { where?: { id?: { gt: string } }; take: number }): Promise<ServiceInstanceRow[]> =>
+          serviceInstances
+            .filter((row) => (args.where?.id ? row.id > args.where.id.gt : true))
+            .sort((a, b) => a.id.localeCompare(b.id))
+            .slice(0, args.take)
+            .map((row) => ({ id: row.id, config: row.config })),
+      ),
+    },
+  };
+}
+
+async function activeService() {
+  const { getEncryptionService } = await import('../encryption/encryption');
+  return getEncryptionService();
+}
+
+/** An envelope produced under a key other than the active DATA_ENCRYPTION_KEY. */
+async function envelopeUnderOtherKey(plaintext: string): Promise<string> {
+  const { AesGcmEncryptionAdapter, EncryptionAlgorithm } = await import('@uncefact/untp-ri-services/encryption');
+  const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+  logger.child.mockReturnValue(logger);
+  const adapter = new AesGcmEncryptionAdapter(OTHER_KEY, logger as never);
+  return JSON.stringify(adapter.encrypt(plaintext, EncryptionAlgorithm.AES_256_GCM));
+}
+
+describe('auditEncryption', () => {
+  it('reports all clean and a verified key when every envelope decrypts', async () => {
+    const { auditEncryption, auditFoundProblems } = await import('./audit-encryption');
+    const { protectDecryptionKey } = await import('./decryption-key-protection');
+
+    const rows: Row[] = [
+      { id: 'cred-1', decryptionKey: protectDecryptionKey('b'.repeat(64)) },
+      { id: 'cred-2', decryptionKey: null },
+    ];
+    const serviceInstances: ServiceInstanceRow[] = [{ id: 'svc-1', config: protectDecryptionKey('{"apiUrl":"x"}') }];
+    const client = createFakeClient(rows, serviceInstances);
+
+    const result = await auditEncryption(client, await activeService());
+
+    expect(result).toEqual({
+      keyVerified: true,
+      serviceInstances: { okCount: 1, decryptFailedIds: [], corruptedIds: [] },
+      credentials: { okCount: 1, decryptFailedIds: [], suspectRowIds: [], wrappablePlaintextCount: 0 },
+    });
+    expect(auditFoundProblems(result)).toBe(false);
+  });
+
+  it('collects every decrypt failure across both stores without aborting mid-scan', async () => {
+    const { auditEncryption, auditFoundProblems } = await import('./audit-encryption');
+    const { protectDecryptionKey } = await import('./decryption-key-protection');
+
+    const rows: Row[] = [
+      { id: 'cred-1', decryptionKey: await envelopeUnderOtherKey('b'.repeat(64)) },
+      { id: 'cred-2', decryptionKey: protectDecryptionKey('c'.repeat(64)) },
+      { id: 'cred-3', decryptionKey: await envelopeUnderOtherKey('e'.repeat(64)) },
+    ];
+    const serviceInstances: ServiceInstanceRow[] = [
+      { id: 'svc-1', config: await envelopeUnderOtherKey('{"a":1}') },
+      { id: 'svc-2', config: protectDecryptionKey('{"b":2}') },
+    ];
+    const client = createFakeClient(rows, serviceInstances);
+
+    const result = await auditEncryption(client, await activeService());
+
+    expect(result.serviceInstances).toEqual({ okCount: 1, decryptFailedIds: ['svc-1'], corruptedIds: [] });
+    expect(result.credentials.decryptFailedIds).toEqual(['cred-1', 'cred-3']);
+    expect(result.credentials.okCount).toBe(1);
+    expect(result.keyVerified).toBe(true);
+    expect(auditFoundProblems(result)).toBe(true);
+    // The first failure's original error rides along for cause-chaining.
+    expect(result.firstDecryptFailure?.rowDescription).toBe('service instance svc-1');
+    // Duck-typed: the services package throws from another realm under jest,
+    // so instanceof Error is unreliable here.
+    expect((result.firstDecryptFailure?.error as { message?: unknown })?.message).toEqual(expect.any(String));
+  });
+
+  it('classifies any non-envelope service configuration as corrupted, whatever it looks like', async () => {
+    const { auditEncryption } = await import('./audit-encryption');
+    const { protectDecryptionKey } = await import('./decryption-key-protection');
+
+    const serviceInstances: ServiceInstanceRow[] = [
+      { id: 'svc-1', config: '' },
+      { id: 'svc-2', config: 'plain text' },
+      { id: 'svc-3', config: '[]' },
+      { id: 'svc-4', config: '{"cipherText":"tru' },
+      { id: 'svc-5', config: '{"cipherText":null,"iv":null,"tag":null,"type":null}' },
+      { id: 'svc-6', config: protectDecryptionKey('{"ok":true}') },
+    ];
+    const client = createFakeClient([], serviceInstances);
+
+    const result = await auditEncryption(client, await activeService());
+
+    expect(result.serviceInstances.corruptedIds).toEqual(['svc-1', 'svc-2', 'svc-3', 'svc-4', 'svc-5']);
+    expect(result.serviceInstances.okCount).toBe(1);
+  });
+
+  it('classifies credential values per the backfill taxonomy: suspect, plaintext, or decrypt failure', async () => {
+    const { auditEncryption } = await import('./audit-encryption');
+
+    const rows: Row[] = [
+      { id: 'cred-1', decryptionKey: '{"cipherText":"q1w2' },
+      { id: 'cred-2', decryptionKey: 'b'.repeat(64) },
+      { id: 'cred-3', decryptionKey: '' },
+      { id: 'cred-4', decryptionKey: await envelopeUnderOtherKey('c'.repeat(64)) },
+      { id: 'cred-5', decryptionKey: null },
+    ];
+    const client = createFakeClient(rows);
+
+    const result = await auditEncryption(client, await activeService());
+
+    expect(result.credentials.suspectRowIds).toEqual(['cred-1']);
+    expect(result.credentials.wrappablePlaintextCount).toBe(2);
+    expect(result.credentials.decryptFailedIds).toEqual(['cred-4']);
+    expect(result.credentials.okCount).toBe(0);
+  });
+
+  it('reports an unverified key on empty stores and on plaintext-only stores', async () => {
+    const { auditEncryption, auditFoundProblems } = await import('./audit-encryption');
+
+    const empty = await auditEncryption(createFakeClient([]), await activeService());
+    expect(empty.keyVerified).toBe(false);
+    expect(auditFoundProblems(empty)).toBe(false);
+
+    const plaintextOnly = await auditEncryption(
+      createFakeClient([{ id: 'cred-1', decryptionKey: 'b'.repeat(64) }]),
+      await activeService(),
+    );
+    expect(plaintextOnly.keyVerified).toBe(false);
+    expect(plaintextOnly.credentials.wrappablePlaintextCount).toBe(1);
+    expect(auditFoundProblems(plaintextOnly)).toBe(false);
+  });
+
+  it('decrypts with the injected service, not the environment', async () => {
+    const { auditEncryption } = await import('./audit-encryption');
+    const { AesGcmEncryptionAdapter } = await import('@uncefact/untp-ri-services/encryption');
+
+    // An envelope written under OTHER_KEY fails under the active env key but
+    // must decrypt cleanly when an OTHER_KEY-built service is injected: the
+    // shape #720's rotation preflight relies on.
+    const rows: Row[] = [{ id: 'cred-1', decryptionKey: await envelopeUnderOtherKey('b'.repeat(64)) }];
+    const logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() };
+    logger.child.mockReturnValue(logger);
+    const outgoingKeyService = new AesGcmEncryptionAdapter(OTHER_KEY, logger as never);
+
+    const result = await auditEncryption(createFakeClient(rows), outgoingKeyService);
+
+    expect(result.credentials.okCount).toBe(1);
+    expect(result.credentials.decryptFailedIds).toEqual([]);
+    expect(result.keyVerified).toBe(true);
+  });
+
+  describe('buildAuditReport', () => {
+    const DOCS = 'https://docs.example/audit';
+
+    function baseResult() {
+      return {
+        keyVerified: true,
+        serviceInstances: { okCount: 0, decryptFailedIds: [] as string[], corruptedIds: [] as string[] },
+        credentials: {
+          okCount: 0,
+          decryptFailedIds: [] as string[],
+          suspectRowIds: [] as string[],
+          wrappablePlaintextCount: 0,
+        },
+      };
+    }
+
+    it('exits 0 on a clean verified result without the nothing-to-verify note', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.serviceInstances.okCount = 2;
+      result.credentials.okCount = 3;
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(0);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('all stored envelopes decrypted cleanly');
+      expect(text).not.toContain('nothing existed to verify');
+    });
+
+    it('exits 1 and lists ids on stderr when findings exist', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.serviceInstances.corruptedIds = ['si-corrupt'];
+      result.credentials.suspectRowIds = ['cred-suspect'];
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(1);
+      const errText = report.lines
+        .filter((line) => line.stream === 'err')
+        .map((line) => line.text)
+        .join('\n');
+      expect(errText).toContain('si-corrupt');
+      expect(errText).toContain('cred-suspect');
+      expect(errText).toContain(DOCS);
+    });
+
+    it('omits the nothing-to-verify note on a wrong key, where envelopes existed but all failed', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.keyVerified = false;
+      result.serviceInstances.decryptFailedIds = ['si-1'];
+      result.credentials.decryptFailedIds = ['cred-1', 'cred-2'];
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(1);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).not.toContain('nothing existed to verify');
+      const errText = report.lines
+        .filter((line) => line.stream === 'err')
+        .map((line) => line.text)
+        .join('\n');
+      expect(errText).toContain('failed to decrypt');
+      expect(errText).toContain('si-1');
+      expect(errText).toContain('cred-1, cred-2');
+    });
+
+    it('reports that a backfill would abort, never offering --force, when a service config is corrupted', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.keyVerified = false;
+      result.serviceInstances.corruptedIds = ['si-corrupt'];
+      result.credentials.wrappablePlaintextCount = 2;
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(1);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('would abort before any write');
+      expect(text).toContain('2 plaintext key(s) are otherwise wrappable');
+      expect(text).not.toContain('--force');
+      expect(text).not.toContain('would wrap');
+    });
+
+    it('reports the abort, not a wrap count, when a verified key coexists with a decrypt failure', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.serviceInstances.okCount = 1;
+      result.credentials.decryptFailedIds = ['cred-bad'];
+      result.credentials.wrappablePlaintextCount = 3;
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(1);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('would abort before any write');
+      expect(text).not.toContain('would wrap 3');
+      expect(text).not.toContain('--force');
+    });
+
+    it('still prints the abort dry-run line when nothing is wrappable', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.keyVerified = false;
+      result.credentials.decryptFailedIds = ['cred-bad'];
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(1);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('would abort before any write');
+      expect(text).not.toContain('--force');
+    });
+
+    it('does not call a dirty structural-findings-only run clean in the nothing-to-verify note', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.keyVerified = false;
+      result.credentials.suspectRowIds = ['cred-suspect'];
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(1);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('nothing existed to verify');
+      expect(text).not.toContain('a clean result here');
+    });
+
+    it('prints the nothing-to-verify note, exiting 0, when no envelope existed at all', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+
+      const result = baseResult();
+      result.keyVerified = false;
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(0);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('nothing existed to verify');
+    });
+
+    it('states the force refusal in the dry run when plaintext exists and the key is unproven', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.keyVerified = false;
+      result.credentials.wrappablePlaintextCount = 2;
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(0);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('would wrap 2 plaintext key(s), but would refuse without --force');
+    });
+
+    it('states a plain dry-run wrap count when the key is verified', async () => {
+      const { buildAuditReport } = await import('./audit-encryption');
+      const result = baseResult();
+      result.serviceInstances.okCount = 1;
+      result.credentials.wrappablePlaintextCount = 3;
+
+      const report = buildAuditReport(result, DOCS);
+
+      expect(report.exitCode).toBe(0);
+      const text = report.lines.map((line) => line.text).join('\n');
+      expect(text).toContain('would wrap 3 plaintext key(s).');
+      expect(text).not.toContain('--force');
+    });
+  });
+
+  it('never writes, and paginates past a single batch', async () => {
+    const { auditEncryption } = await import('./audit-encryption');
+    const { protectDecryptionKey } = await import('./decryption-key-protection');
+
+    const rows: Row[] = Array.from({ length: 150 }, (_, index) => ({
+      id: `cred-${String(index).padStart(3, '0')}`,
+      decryptionKey: protectDecryptionKey('b'.repeat(64)),
+    }));
+    const serviceInstances: ServiceInstanceRow[] = Array.from({ length: 120 }, (_, index) => ({
+      id: `svc-${String(index).padStart(3, '0')}`,
+      config: protectDecryptionKey('{"x":1}'),
+    }));
+    const client = createFakeClient(rows, serviceInstances);
+
+    const result = await auditEncryption(client, await activeService());
+
+    expect(result.credentials.okCount).toBe(150);
+    expect(result.serviceInstances.okCount).toBe(120);
+    expect(client.credential.update).not.toHaveBeenCalled();
+    expect(client.credential.findMany.mock.calls.length).toBeGreaterThan(1);
+    expect(client.serviceInstance.findMany.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/reference-implementation/src/lib/credentials/audit-encryption.ts
+++ b/packages/reference-implementation/src/lib/credentials/audit-encryption.ts
@@ -1,0 +1,229 @@
+import type { IEncryptionService } from '@uncefact/untp-ri-services/encryption';
+// Relative imports (not the @/ alias): this module runs inside the Docker
+// image via tsx, where no tsconfig.json exists to resolve path aliases.
+import { looksEnvelopeLikeButInvalid, parseEnvelope } from './decryption-key-protection';
+import { eachKeyedCredentialRow, eachServiceInstanceRow, type EnvelopeStoresClient } from './envelope-stores';
+
+/**
+ * Per-store outcome of the read-only encryption audit. Id arrays are
+ * unbounded and never truncated: the report's contract is every affected
+ * row, so memory grows with the number of findings (worst case, every row
+ * after a wrong-key deploy).
+ */
+export type AuditEncryptionResult = {
+  /**
+   * True once at least one stored envelope decrypted under the supplied
+   * service. False means nothing existed to prove the key: an empty
+   * database, all-null credential keys, or plaintext-only credential keys
+   * all audit "clean" without demonstrating that the key can decrypt
+   * anything. Callers gating on the audit (rotation preflight, post-restore
+   * checks) must treat false as "unproven", not "verified".
+   */
+  keyVerified: boolean;
+  /**
+   * The error thrown by the first failed decrypt, kept so callers that turn
+   * the audit into an abort (the backfill preflight) can chain the original
+   * diagnostic instead of reporting only the row list. The id arrays remain
+   * the complete record; this is one sample for debugging.
+   */
+  firstDecryptFailure?: { rowDescription: string; error: unknown };
+  serviceInstances: {
+    okCount: number;
+    /** Valid envelopes the supplied service failed to decrypt (key mismatch). */
+    decryptFailedIds: string[];
+    /**
+     * Rows whose config is not a valid envelope at all. Service instance
+     * configurations have no plaintext form (every writer encrypts before
+     * persistence), so any non-envelope value is corruption, whatever it
+     * looks like. This is deliberately stricter than the credential store's
+     * envelope-like test, and stricter than the startup validator, which
+     * skips such rows while sampling for one good envelope.
+     */
+    corruptedIds: string[];
+  };
+  credentials: {
+    okCount: number;
+    /** Valid envelopes the supplied service failed to decrypt (key mismatch). */
+    decryptFailedIds: string[];
+    /**
+     * Rows that look like an envelope without being one (brace-prefixed,
+     * unparseable). Neither decryptable nor plausible legacy plaintext; a
+     * backfill run skips them untouched.
+     */
+    suspectRowIds: string[];
+    /**
+     * Legacy plaintext keys (pre-#697 rows) that a backfill run would wrap.
+     * A count, not ids: plaintext is expected legacy state, not a finding.
+     */
+    wrappablePlaintextCount: number;
+  };
+};
+
+/** Whether the audit found any decrypt failure or corrupted/suspect row. */
+export function auditFoundProblems(result: AuditEncryptionResult): boolean {
+  return (
+    result.serviceInstances.decryptFailedIds.length > 0 ||
+    result.serviceInstances.corruptedIds.length > 0 ||
+    result.credentials.decryptFailedIds.length > 0 ||
+    result.credentials.suspectRowIds.length > 0
+  );
+}
+
+/**
+ * Attempts to decrypt every stored envelope in both encrypted-at-rest stores
+ * (service instance configurations, credential decryption keys) under the
+ * supplied encryption service, and reports the outcome per store. Reads
+ * only; never writes.
+ *
+ * The encryption service is a required argument (mirroring
+ * validateEncryptionKeyAtStartup) rather than resolved internally: the
+ * audit's callers decide which key is being audited. The CLI supplies the
+ * active service; a rotation preflight (#720) can supply one built from the
+ * outgoing key while the environment already holds the new key.
+ *
+ * The scan is best-effort under concurrent writes: rows are read in id
+ * order with cursor pagination and no transaction, so a row changed after
+ * it was scanned, or inserted behind the cursor, is not re-examined. Run
+ * with writers quiesced when the result gates a rotation or restore.
+ */
+export async function auditEncryption(
+  client: EnvelopeStoresClient,
+  encryptionService: Pick<IEncryptionService, 'decrypt'>,
+): Promise<AuditEncryptionResult> {
+  const result: AuditEncryptionResult = {
+    keyVerified: false,
+    serviceInstances: { okCount: 0, decryptFailedIds: [], corruptedIds: [] },
+    credentials: { okCount: 0, decryptFailedIds: [], suspectRowIds: [], wrappablePlaintextCount: 0 },
+  };
+
+  for await (const row of eachServiceInstanceRow(client)) {
+    const envelope = parseEnvelope(row.config);
+    if (envelope === null) {
+      result.serviceInstances.corruptedIds.push(row.id);
+      continue;
+    }
+    const failure = decryptFailure(encryptionService, envelope);
+    if (failure === null) {
+      result.serviceInstances.okCount += 1;
+      result.keyVerified = true;
+    } else {
+      result.serviceInstances.decryptFailedIds.push(row.id);
+      result.firstDecryptFailure ??= { rowDescription: `service instance ${row.id}`, error: failure.error };
+    }
+  }
+
+  for await (const row of eachKeyedCredentialRow(client)) {
+    const envelope = parseEnvelope(row.decryptionKey);
+    if (envelope !== null) {
+      const failure = decryptFailure(encryptionService, envelope);
+      if (failure === null) {
+        result.credentials.okCount += 1;
+        result.keyVerified = true;
+      } else {
+        result.credentials.decryptFailedIds.push(row.id);
+        result.firstDecryptFailure ??= { rowDescription: `credential ${row.id}`, error: failure.error };
+      }
+      continue;
+    }
+    if (looksEnvelopeLikeButInvalid(row.decryptionKey)) {
+      result.credentials.suspectRowIds.push(row.id);
+    } else {
+      result.credentials.wrappablePlaintextCount += 1;
+    }
+  }
+
+  return result;
+}
+
+/** One line of the operator-facing audit report, tagged with its stream. */
+export type AuditReportLine = { text: string; stream: 'out' | 'err' };
+
+export type AuditReport = { lines: AuditReportLine[]; exitCode: 0 | 1 };
+
+/**
+ * Renders the audit result as the operator-facing report and exit code, kept
+ * separate from the CLI's process wiring so the output contract is testable.
+ * Exit 0 covers the nothing-to-verify state (stated explicitly in the
+ * report); exit 1 means findings. Operational failures never reach this
+ * function; the CLI reports those itself.
+ */
+export function buildAuditReport(result: AuditEncryptionResult, docsUrl: string): AuditReport {
+  const { serviceInstances, credentials } = result;
+  const lines: AuditReportLine[] = [];
+  const out = (text: string) => lines.push({ text, stream: 'out' });
+  const err = (text: string) => lines.push({ text, stream: 'err' });
+  const ids = (label: string, rowIds: string[]) => {
+    if (rowIds.length > 0) {
+      err(`  ${label} (${rowIds.length}): ${rowIds.join(', ')}`);
+    }
+  };
+
+  out('Service instance configurations:');
+  out(`  decrypted cleanly: ${serviceInstances.okCount}`);
+  ids('failed to decrypt', serviceInstances.decryptFailedIds);
+  ids('not a valid encrypted envelope', serviceInstances.corruptedIds);
+
+  out('Credential decryption keys:');
+  out(`  decrypted cleanly: ${credentials.okCount}`);
+  ids('failed to decrypt', credentials.decryptFailedIds);
+  ids('corrupted envelope-like (a backfill would skip these untouched)', credentials.suspectRowIds);
+
+  // The dry run mirrors the backfill's own gate order: hard-abort buckets
+  // first (which --force never bypasses), then the unverified-key force
+  // gate, then the wrap. Deciding from the wrappable count alone would
+  // offer --force in states where the backfill aborts regardless of it.
+  const wouldHardAbort =
+    serviceInstances.corruptedIds.length > 0 ||
+    serviceInstances.decryptFailedIds.length > 0 ||
+    credentials.decryptFailedIds.length > 0;
+  if (wouldHardAbort) {
+    out(
+      'Dry run: a backfill:decryption-keys run would abort before any write until the reported failures are resolved' +
+        (credentials.wrappablePlaintextCount > 0
+          ? `; ${credentials.wrappablePlaintextCount} plaintext key(s) are otherwise wrappable.`
+          : '.'),
+    );
+  } else if (credentials.wrappablePlaintextCount > 0) {
+    out(
+      `Dry run: a backfill:decryption-keys run would wrap ${credentials.wrappablePlaintextCount} plaintext key(s)` +
+        (result.keyVerified
+          ? '.'
+          : ', but would refuse without --force because no envelope proves DATA_ENCRYPTION_KEY.'),
+    );
+  }
+
+  // "Nothing to verify" means no valid envelope was encountered at all. A
+  // wrong key also leaves keyVerified false, but there the decrypt failures
+  // are the story and this note would misleadingly suggest an empty store.
+  const anyEnvelopeExamined =
+    result.keyVerified || serviceInstances.decryptFailedIds.length > 0 || credentials.decryptFailedIds.length > 0;
+  if (!anyEnvelopeExamined) {
+    out(
+      auditFoundProblems(result)
+        ? 'Note: nothing existed to verify the active DATA_ENCRYPTION_KEY against; the findings above are ' +
+            'structural, and the key itself remains unproven.'
+        : 'Note: nothing existed to verify the active DATA_ENCRYPTION_KEY against; a clean result here does not ' +
+            'prove the key can decrypt anything.',
+    );
+  }
+
+  if (auditFoundProblems(result)) {
+    err(`Audit found problems. Nothing was modified. See ${docsUrl}`);
+    return { lines, exitCode: 1 };
+  }
+  out('Audit complete: all stored envelopes decrypted cleanly. Nothing was modified.');
+  return { lines, exitCode: 0 };
+}
+
+/** Null on success; the thrown error (wrapped, so a thrown falsy still registers) on failure. */
+function decryptFailure(
+  encryptionService: Pick<IEncryptionService, 'decrypt'>,
+  envelope: Parameters<IEncryptionService['decrypt']>[0],
+): { error: unknown } | null {
+  try {
+    encryptionService.decrypt(envelope);
+    return null;
+  } catch (error) {
+    return { error };
+  }
+}

--- a/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.test.ts
@@ -217,7 +217,7 @@ describe('backfillDecryptionKeys', () => {
     const client = createFakeClient(rows, serviceInstances);
 
     await expect(backfillDecryptionKeys(client)).rejects.toThrow(
-      'Service instance svc-1 holds a configuration that is not a valid encrypted envelope',
+      'Service instance(s) svc-1 hold configurations that are not valid encrypted envelopes',
     );
     expect(client.credential.update).not.toHaveBeenCalled();
   });
@@ -237,7 +237,7 @@ describe('backfillDecryptionKeys', () => {
     const client = createFakeClient(rows, serviceInstances);
 
     await expect(backfillDecryptionKeys(client)).rejects.toThrow(
-      'Service instance svc-1 holds a configuration that is not a valid encrypted envelope',
+      'Service instance(s) svc-1 hold configurations that are not valid encrypted envelopes',
     );
     expect(client.credential.update).not.toHaveBeenCalled();
   });
@@ -280,6 +280,62 @@ describe('backfillDecryptionKeys', () => {
     const client = createFakeClient(rows);
 
     await expect(backfillDecryptionKeys(client)).rejects.toThrow('credential cred-3');
+    expect(client.credential.update).not.toHaveBeenCalled();
+  });
+
+  it('names every failing row in the preflight abort, not only the first', async () => {
+    const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
+
+    const rows: Row[] = [
+      { id: 'cred-1', decryptionKey: await envelopeUnderOtherKey('b'.repeat(64)) },
+      { id: 'cred-2', decryptionKey: await envelopeUnderOtherKey('c'.repeat(64)) },
+    ];
+    const serviceInstances: ServiceInstanceRow[] = [{ id: 'svc-1', config: await envelopeUnderOtherKey('{"a":1}') }];
+    const client = createFakeClient(rows, serviceInstances);
+
+    const error: Error = await backfillDecryptionKeys(client).then(
+      () => {
+        throw new Error('expected the preflight to abort');
+      },
+      (thrown: Error) => thrown,
+    );
+    expect(error.message).toContain('service instance svc-1, credential cred-1, credential cred-2');
+    expect(error.message).toContain('First failure (service instance svc-1):');
+    expect((error.cause as { message?: unknown })?.message).toEqual(expect.any(String));
+    expect(client.credential.update).not.toHaveBeenCalled();
+  });
+
+  it('aborts on a decrypt failure even under --force', async () => {
+    const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
+
+    const rows: Row[] = [{ id: 'cred-1', decryptionKey: await envelopeUnderOtherKey('b'.repeat(64)) }];
+    const client = createFakeClient(rows, []);
+
+    await expect(backfillDecryptionKeys(client, { force: true })).rejects.toThrow('credential cred-1');
+    expect(client.credential.update).not.toHaveBeenCalled();
+  });
+
+  it('names corruption and decrypt failures together in one abort, even under --force', async () => {
+    const { backfillDecryptionKeys } = await import('./backfill-decryption-keys');
+
+    const rows: Row[] = [{ id: 'cred-1', decryptionKey: await envelopeUnderOtherKey('b'.repeat(64)) }];
+    const serviceInstances: ServiceInstanceRow[] = [
+      { id: 'svc-corrupt', config: 'not an envelope' },
+      { id: 'svc-wrong', config: await envelopeUnderOtherKey('{"a":1}') },
+    ];
+    const client = createFakeClient(rows, serviceInstances);
+
+    const error: Error = await backfillDecryptionKeys(client, { force: true }).then(
+      () => {
+        throw new Error('expected the preflight to abort');
+      },
+      (thrown: Error) => thrown,
+    );
+    expect(error.message).toContain(
+      'Service instance(s) svc-corrupt hold configurations that are not valid encrypted envelopes',
+    );
+    expect(error.message).toContain('Preflight decrypt failed for service instance svc-wrong, credential cred-1');
+    expect(error.message).toContain('aborting before any write');
     expect(client.credential.update).not.toHaveBeenCalled();
   });
 

--- a/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.ts
+++ b/packages/reference-implementation/src/lib/credentials/backfill-decryption-keys.ts
@@ -2,8 +2,10 @@ import {
   isProtectedDecryptionKey,
   looksEnvelopeLikeButInvalid,
   protectDecryptionKey,
-  revealDecryptionKey,
 } from './decryption-key-protection';
+import { auditEncryption } from './audit-encryption';
+import { eachKeyedCredentialRow, type EnvelopeStoresClient } from './envelope-stores';
+import { getEncryptionService } from '../encryption/encryption';
 
 export type BackfillDecryptionKeysResult = {
   wrapped: number;
@@ -30,34 +32,12 @@ export type BackfillDecryptionKeysOptions = {
   force?: boolean;
 };
 
-type CredentialKeyRow = { id: string; decryptionKey: string | null };
-type ServiceInstanceConfigRow = { id: string; config: string };
-
 /**
  * The subset of the Prisma client the backfill needs; structural so tests can
- * supply an in-memory fake.
+ * supply an in-memory fake. Shared with the read-only audit
+ * (audit-encryption.ts), which walks the same stores.
  */
-export type BackfillClient = {
-  credential: {
-    findMany(args: {
-      where: { decryptionKey: { not: null }; id?: { gt: string } };
-      select: { id: true; decryptionKey: true };
-      orderBy: { id: 'asc' };
-      take: number;
-    }): Promise<CredentialKeyRow[]>;
-    update(args: { where: { id: string }; data: { decryptionKey: string } }): Promise<unknown>;
-  };
-  serviceInstance: {
-    findMany(args: {
-      where?: { id?: { gt: string } };
-      select: { id: true; config: true };
-      orderBy: { id: 'asc' };
-      take: number;
-    }): Promise<ServiceInstanceConfigRow[]>;
-  };
-};
-
-const BATCH_SIZE = 100;
+export type BackfillClient = EnvelopeStoresClient;
 
 /**
  * Error thrown when no existing envelope is available to prove the active
@@ -81,34 +61,77 @@ export class KeyUnverifiedError extends Error {
  * holding an encrypted envelope are left untouched, so re-running converges
  * to no changes.
  *
- * Before writing anything, the preflight decrypts every existing envelope it
- * can find: all protected credential keys and all service instance
- * configurations (both are encrypted under the same DATA_ENCRYPTION_KEY).
- * Any decrypt failure aborts the run, naming the failing row: wrapping
- * plaintext under a wrong key would be unrecoverable (the plaintext is
- * overwritten, and a re-run would count the rows as already protected).
- * When no envelope exists anywhere and there is plaintext to wrap, the run
- * refuses unless `force` is passed.
+ * Before writing anything, the preflight audits every existing envelope
+ * (all service instance configurations and all protected credential keys,
+ * both encrypted under the same DATA_ENCRYPTION_KEY) via the shared
+ * read-only audit. Any decrypt failure, or any service instance
+ * configuration that is not a valid envelope, aborts the run naming every
+ * affected row; `force` bypasses neither (force exists for the absence of
+ * evidence, not for damaged or undecryptable evidence). Wrapping plaintext
+ * under a wrong key would be unrecoverable (the plaintext is overwritten,
+ * and a re-run would count the rows as already protected). Credential rows
+ * whose value merely resembles a corrupted envelope are reported and
+ * skipped while other plaintext rows still wrap. When no envelope exists
+ * anywhere and there is plaintext to wrap, the run refuses unless `force`
+ * is passed.
  */
 export async function backfillDecryptionKeys(
   client: BackfillClient,
   options: BackfillDecryptionKeysOptions = {},
 ): Promise<BackfillDecryptionKeysResult> {
-  const preflight = await verifyKeyAgainstAllEnvelopes(client);
+  const audit = await auditEncryption(client, getEncryptionService());
 
-  if (!preflight.keyVerified && preflight.wrappableRows > 0 && !options.force) {
+  // One aggregated abort naming every blocking row across both buckets, so a
+  // run hitting structural corruption AND decrypt failures reports the full
+  // picture rather than the first bucket only. `force` bypasses neither:
+  // service instance configurations have no legacy plaintext form (every
+  // writer encrypts them before persistence, so a non-envelope config is
+  // corruption), and force exists for the absence of evidence, not for
+  // damaged or undecryptable evidence.
+  const blockers: string[] = [];
+  if (audit.serviceInstances.corruptedIds.length > 0) {
+    blockers.push(
+      `Service instance(s) ${audit.serviceInstances.corruptedIds.join(', ')} hold configurations that are ` +
+        'not valid encrypted envelopes',
+    );
+  }
+  const decryptFailures = [
+    ...audit.serviceInstances.decryptFailedIds.map((id) => `service instance ${id}`),
+    ...audit.credentials.decryptFailedIds.map((id) => `credential ${id}`),
+  ];
+  if (decryptFailures.length > 0) {
+    blockers.push(`Preflight decrypt failed for ${decryptFailures.join(', ')}`);
+  }
+  if (blockers.length > 0) {
+    const first = audit.firstDecryptFailure;
+    // Duck-typed rather than `instanceof Error`: the error is thrown by the
+    // built services package, whose Error identity can differ from this
+    // module's realm (it does under jest), which would silently drop the detail.
+    const firstMessage =
+      first !== undefined && typeof (first.error as { message?: unknown } | null)?.message === 'string'
+        ? (first.error as { message: string }).message
+        : undefined;
+    const keyNote =
+      decryptFailures.length > 0
+        ? ' DATA_ENCRYPTION_KEY may not match the key the data was encrypted under.' +
+          (firstMessage !== undefined ? ` First failure (${first?.rowDescription}): ${firstMessage}` : '')
+        : '';
+    throw new Error(`${blockers.join('; and ')}; aborting before any write.${keyNote}`, { cause: first?.error });
+  }
+
+  if (!audit.keyVerified && audit.credentials.wrappablePlaintextCount > 0 && !options.force) {
     throw new KeyUnverifiedError();
   }
 
   const result: BackfillDecryptionKeysResult = {
     wrapped: 0,
     alreadyProtected: 0,
-    keyVerified: preflight.keyVerified,
+    keyVerified: audit.keyVerified,
     suspectRowIds: [],
     deletedRowIds: [],
   };
 
-  for await (const row of eachKeyedRow(client)) {
+  for await (const row of eachKeyedCredentialRow(client)) {
     if (isProtectedDecryptionKey(row.decryptionKey)) {
       result.alreadyProtected += 1;
       continue;
@@ -145,57 +168,6 @@ export async function backfillDecryptionKeys(
 }
 
 /**
- * Decrypts every existing envelope (credential keys and service instance
- * configurations) under the active key, throwing on the first failure so
- * nothing is written over a database the key cannot read. Also counts the
- * plaintext rows the wrap pass would change, so the caller can distinguish
- * "nothing to verify against but also nothing to write" from the
- * unverified-write hazard.
- */
-async function verifyKeyAgainstAllEnvelopes(
-  client: BackfillClient,
-): Promise<{ keyVerified: boolean; wrappableRows: number }> {
-  let keyVerified = false;
-  let wrappableRows = 0;
-
-  for await (const row of eachServiceInstanceRow(client)) {
-    // Service instance configurations have no legacy plaintext form: every
-    // writer encrypts them before persistence. A config that does not parse
-    // as an envelope is corruption, and `force` does not bypass it (force
-    // exists for the absence of evidence, not for damaged evidence).
-    if (!isProtectedDecryptionKey(row.config)) {
-      throw new Error(
-        `Service instance ${row.id} holds a configuration that is not a valid encrypted envelope; aborting before any write`,
-      );
-    }
-    decryptOrThrow(row.config, `service instance ${row.id}`);
-    keyVerified = true;
-  }
-
-  for await (const row of eachKeyedRow(client)) {
-    if (isProtectedDecryptionKey(row.decryptionKey)) {
-      decryptOrThrow(row.decryptionKey, `credential ${row.id}`);
-      keyVerified = true;
-    } else if (!looksEnvelopeLikeButInvalid(row.decryptionKey)) {
-      wrappableRows += 1;
-    }
-  }
-
-  return { keyVerified, wrappableRows };
-}
-
-function decryptOrThrow(stored: string, rowDescription: string): void {
-  try {
-    revealDecryptionKey(stored);
-  } catch (error) {
-    const detail = error instanceof Error ? ` ${error.message}` : '';
-    throw new Error(`Preflight decrypt failed for ${rowDescription}; aborting before any write.${detail}`, {
-      cause: error,
-    });
-  }
-}
-
-/**
  * Whether an update failed because the row no longer exists. Prisma raises
  * PrismaClientKnownRequestError with code P2025 ("record not found") when a
  * row is deleted between fetch and update; the backfill treats that as a
@@ -203,48 +175,4 @@ function decryptOrThrow(stored: string, rowDescription: string): void {
  */
 function isRecordNotFoundError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'P2025';
-}
-
-/**
- * Iterates every credential row holding a decryption key, in id order via
- * cursor pagination (`id > cursor`), which does not skip surviving rows when
- * other rows are deleted mid-run.
- */
-async function* eachKeyedRow(client: BackfillClient): AsyncGenerator<{ id: string; decryptionKey: string }> {
-  let cursor: string | undefined;
-  for (;;) {
-    const rows = await client.credential.findMany({
-      where: { decryptionKey: { not: null }, ...(cursor !== undefined && { id: { gt: cursor } }) },
-      select: { id: true, decryptionKey: true },
-      orderBy: { id: 'asc' },
-      take: BATCH_SIZE,
-    });
-    if (rows.length === 0) {
-      return;
-    }
-    cursor = rows[rows.length - 1].id;
-    for (const row of rows) {
-      if (row.decryptionKey !== null) {
-        yield { id: row.id, decryptionKey: row.decryptionKey };
-      }
-    }
-  }
-}
-
-/** Iterates every service instance row, in id order via cursor pagination. */
-async function* eachServiceInstanceRow(client: BackfillClient): AsyncGenerator<ServiceInstanceConfigRow> {
-  let cursor: string | undefined;
-  for (;;) {
-    const rows = await client.serviceInstance.findMany({
-      ...(cursor !== undefined && { where: { id: { gt: cursor } } }),
-      select: { id: true, config: true },
-      orderBy: { id: 'asc' },
-      take: BATCH_SIZE,
-    });
-    if (rows.length === 0) {
-      return;
-    }
-    cursor = rows[rows.length - 1].id;
-    yield* rows;
-  }
 }

--- a/packages/reference-implementation/src/lib/credentials/envelope-stores.ts
+++ b/packages/reference-implementation/src/lib/credentials/envelope-stores.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared iteration over the two stores encrypted at rest under
+ * DATA_ENCRYPTION_KEY: credential decryption keys and service instance
+ * configurations. Consumed by the backfill (backfill-decryption-keys.ts) and
+ * the read-only audit (audit-encryption.ts) so both walk the stores the same
+ * way.
+ */
+
+export type CredentialKeyRow = { id: string; decryptionKey: string };
+export type ServiceInstanceConfigRow = { id: string; config: string };
+
+/**
+ * The subset of the Prisma client the envelope-store scans need; structural
+ * so tests can supply an in-memory fake. The credential `update` member is
+ * used only by the backfill's wrap pass; the audit never calls it.
+ */
+export type EnvelopeStoresClient = {
+  credential: {
+    findMany(args: {
+      where: { decryptionKey: { not: null }; id?: { gt: string } };
+      select: { id: true; decryptionKey: true };
+      orderBy: { id: 'asc' };
+      take: number;
+    }): Promise<Array<{ id: string; decryptionKey: string | null }>>;
+    update(args: { where: { id: string }; data: { decryptionKey: string } }): Promise<unknown>;
+  };
+  serviceInstance: {
+    findMany(args: {
+      where?: { id?: { gt: string } };
+      select: { id: true; config: true };
+      orderBy: { id: 'asc' };
+      take: number;
+    }): Promise<ServiceInstanceConfigRow[]>;
+  };
+};
+
+const BATCH_SIZE = 100;
+
+/**
+ * Iterates every credential row holding a decryption key, in id order via
+ * cursor pagination (`id > cursor`), which does not skip surviving rows when
+ * other rows are deleted mid-run.
+ */
+export async function* eachKeyedCredentialRow(client: EnvelopeStoresClient): AsyncGenerator<CredentialKeyRow> {
+  let cursor: string | undefined;
+  for (;;) {
+    const rows = await client.credential.findMany({
+      where: { decryptionKey: { not: null }, ...(cursor !== undefined && { id: { gt: cursor } }) },
+      select: { id: true, decryptionKey: true },
+      orderBy: { id: 'asc' },
+      take: BATCH_SIZE,
+    });
+    if (rows.length === 0) {
+      return;
+    }
+    cursor = rows[rows.length - 1].id;
+    for (const row of rows) {
+      if (row.decryptionKey !== null) {
+        yield { id: row.id, decryptionKey: row.decryptionKey };
+      }
+    }
+  }
+}
+
+/** Iterates every service instance row, in id order via cursor pagination. */
+export async function* eachServiceInstanceRow(client: EnvelopeStoresClient): AsyncGenerator<ServiceInstanceConfigRow> {
+  let cursor: string | undefined;
+  for (;;) {
+    const rows = await client.serviceInstance.findMany({
+      ...(cursor !== undefined && { where: { id: { gt: cursor } } }),
+      select: { id: true, config: true },
+      orderBy: { id: 'asc' },
+      take: BATCH_SIZE,
+    });
+    if (rows.length === 0) {
+      return;
+    }
+    cursor = rows[rows.length - 1].id;
+    yield* rows;
+  }
+}


### PR DESCRIPTION
This PR adds `pnpm audit:encryption`, a read-only maintenance command that attempts to decrypt every stored envelope (service instance configurations and credential decryption keys) under the active `DATA_ENCRYPTION_KEY` and reports the result per store. Operators get the full picture before a key rotation, after a database restore, or during incident triage, instead of discovering a mismatch one request at a time. The command writes nothing and exits 0 only when everything decrypted cleanly, so it can gate automation.

It also doubles as the dry run for `backfill:decryption-keys`: the report states what a backfill run would wrap, skip, or abort on. The backfill's preflight now consumes the same decrypt-all core, so its abort names every blocking row across both stores rather than only the first, with the original decrypt error kept as the cause. The audit core takes the encryption service as a required argument, so the rotation work in #720 can reuse it with an outgoing key.

The command ships in the Docker image alongside the backfill, and is documented on a new operations page and in the v0.4 migration guide.

Closes #764
