### PR TITLE
feat(ri): prompt for a decryption key on the verify page and harden the verify fetch

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -308,15 +308,15 @@ sequenceDiagram
     participant Storage as Storage URI
     participant VC as System VC Service
 
-    Client->>RI: POST /api/v1/credentials/verify { uri, hash?, decryptionKey? }
-    RI->>RI: Validate input + SSRF check
-    RI->>Storage: Fetch credential (10s timeout)
+    Client->>RI: POST /api/v1/credentials/verify { uri, digestMultibase?, hash?, decryptionKey? }
+    RI->>RI: Validate input
+    RI->>Storage: Guarded fetch (SSRF check per redirect hop, 10s timeout)
     Storage-->>RI: Credential (possibly encrypted)
     opt encrypted
-        RI->>RI: Decrypt with decryptionKey
+        RI->>RI: Check envelope structure, decrypt with decryptionKey
     end
-    opt hash provided
-        RI->>RI: Compute hash and compare
+    opt digest provided
+        RI->>RI: Compute digest and compare
     end
     RI->>RI: Validate credential type (EnvelopedVerifiableCredential)
     RI->>VC: Verify credential signature
@@ -330,10 +330,27 @@ sequenceDiagram
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `uri` | string (URL) | Yes | Storage URI where the credential is stored. Must be HTTP(S). |
-| `hash` | string | No | Expected SHA-256 hash (64-character hex string). If provided, the fetched credential's hash is verified against it. |
+| `digestMultibase` | string | No | Expected multibase-encoded digest of the credential content. If provided, the fetched credential's digest is verified against it. |
+| `hash` | string | No | Expected SHA-256 hash (64-character hex string), accepted for links created before [the digest migration](../../migration-guides/v0.7.0#dependent-service-updates). Prefer `digestMultibase`. |
 | `decryptionKey` | string | No | AES-GCM decryption key (64-character hex string). Required for encrypted credentials. |
 
-The endpoint always returns HTTP 200 for a completed verification attempt, even if the credential fails verification. Check the `verified` field for the outcome. Processing errors (decryption failure, hash mismatch, unsupported type) that prevent a verification attempt return non-200 status codes with a `code` field.
+The endpoint always returns HTTP 200 for a completed verification attempt, even if the credential fails verification. Check the `verified` field for the outcome. Processing errors that prevent a verification attempt return 422 with a `code` field:
+
+| Code | Meaning |
+|------|---------|
+| `INVALID_RESPONSE` | The storage URI did not return valid JSON. |
+| `DECRYPTION_REQUIRED` | The credential is encrypted and no `decryptionKey` was supplied. The [verify page](../verify-page#decryption) prompts for the key in this case. |
+| `ENVELOPE_INVALID` | The stored encrypted envelope is structurally corrupted (wrong IV or auth-tag length). Re-supplying the key will not help. |
+| `DECRYPTION_FAILED` | The decryption key does not match the credential. This is almost always a wrong key, but AES-GCM cannot distinguish a wrong key from ciphertext tampered at valid lengths. |
+| `DECRYPTED_NOT_JSON` | Decryption succeeded but the content is not valid JSON, so the stored credential is corrupted. |
+| `DIGEST_MISMATCH` | The fetched credential does not match the digest in the request. |
+| `UNSUPPORTED_CREDENTIAL_TYPE` | The credential is not an `EnvelopedVerifiableCredential`. |
+
+Upstream failures (storage unreachable, non-2xx, oversized response, VC service failure) return 502 with `UPSTREAM_ERROR` or `VC_SERVICE_ERROR`.
+
+The storage URI is fetched through a guarded resolver that validates the hostname against private and reserved ranges on every redirect hop and pins the connection to the validated address, so neither a redirect nor a DNS change between check and connect can reach a private network.
+
+Decryption happens on the server, so a `decryptionKey` travels in the request body. Production deployments must serve this endpoint over HTTPS so the key is protected in transit.
 
 ### Environment Variables
 

--- a/documentation/docs/reference-implementation/verify-page.md
+++ b/documentation/docs/reference-implementation/verify-page.md
@@ -9,29 +9,35 @@ The verify page (`/verify`) is a publicly accessible web page for verifying UNTP
 
 ## How It Works
 
-When a user navigates to the verify page via a [verification link](#verify-link), the page:
+When a user navigates to the verify page via a [verification link](#verify-link), the page sends the link's parameters to the reference implementation's verification API, which:
 
 1. Fetches the credential from the URL provided in the verification link
-2. Decrypts the credential, if it is encrypted (the decryption key is included in the verification link)
-3. Validates the credential's integrity against the hash, if one is included in the URL
-4. Sends the credential to the verifiable credential service for verification — this checks that the credential was issued by the entity claiming to have issued it, that it has not been tampered with, that it is temporally valid (issued in the past and not expired), and that it has not been revoked
-5. Renders the verified credential for the user
+2. Decrypts the credential, if it is encrypted, using the decryption key from the link or, for a keyless link, the key the user enters at the [prompt](#decryption)
+3. Validates the credential's integrity against the digest, if one is included in the URL
+4. Sends the credential to the verifiable credential service for verification. This checks that the credential was issued by the entity claiming to have issued it, that it has not been tampered with, that it is temporally valid (issued in the past and not expired), and that it has not been revoked
+5. Returns the result, which the page renders for the user
+
+Fetching and decryption happen on the server, so an entered decryption key travels to the backend in the request body. Production deployments must serve the reference implementation over HTTPS so the key is protected in transit.
 
 ```mermaid
 sequenceDiagram
     participant U as User
     participant V as Verify Page
+    participant API as Verification API
     participant CS as Credential Store
     participant VS as Verifiable Credential Service
     U->>V: Open verification link
-    V->>CS: Fetch credential
-    CS-->>V: Return credential
-    V->>V: Decrypt (if encrypted)
-    V->>V: Validate hash (if provided)
-    V->>VS: Verify credential
-    VS-->>V: Return verification result
+    V->>API: Verify request (uri, digest, key if held)
+    API->>CS: Fetch credential
+    CS-->>API: Return credential
+    API->>API: Decrypt (if encrypted)
+    API->>API: Validate digest (if provided)
+    API->>VS: Verify credential
+    VS-->>API: Return verification result
+    API-->>V: Return result
     V->>V: Render credential
     V->>U: Display result
+    Note over U,V: If the credential is encrypted and the link has no key,<br/>the page prompts the user and repeats the request with the entered key
 ```
 
 The verified credential is displayed with its type, issuer, and validity start date. The `Valid from` date is rendered as the credential's UTC calendar date in ISO 8601 (`YYYY-MM-DD`); the row is omitted when the credential carries no parseable `validFrom`. The credential itself contains a `renderMethod` property that specifies the template used to render it for human review. Users can switch between the rendered template and the raw JSON data, and download the credential.
@@ -52,7 +58,7 @@ The preferred format passes parameters directly as query parameters:
 |-----------|----------|-------------|
 | `uri` | Yes | The URL of the stored credential |
 | `digestMultibase` | No | A multibase-encoded digest of the credential for integrity validation |
-| `hash` | No | A legacy SHA-256 hex hash, accepted for backwards compatibility with links created before the digest migration. Prefer `digestMultibase`. |
+| `hash` | No | A legacy SHA-256 hex hash, accepted for backwards compatibility with links created before [the digest migration](../migration-guides/v0.7.0#dependent-service-updates). Prefer `digestMultibase`. |
 | `decryptionKey` | No | The decryption key for encrypted credentials |
 
 **Example:**
@@ -82,4 +88,12 @@ A verification link may include a digest of the credential. When present, the ve
 
 ## Decryption
 
-If the credential is encrypted and the decryption key is included in the verification link, the verify page uses that key to decrypt the credential before proceeding with verification. This allows a private credential to be shared directly via a single link without requiring the recipient to manage keys separately. A link published to the Identity Resolver omits the key, which is shared out of band instead (see [IDR publishing](./api/credentials#stage-8-idr-publishing-optional)).
+If the credential is encrypted and the decryption key is included in the verification link, the verify page uses that key to decrypt the credential before proceeding with verification. This allows a private credential to be shared directly via a single link without requiring the recipient to manage keys separately.
+
+A link published to the Identity Resolver omits the key, which is shared out of band instead (see [IDR publishing](./api/credentials#stage-8-idr-publishing-optional)). When such a keyless link opens an encrypted credential, the verify page prompts for the decryption key. Enter the key received from the issuer and submit; the credential is decrypted and verified as if the key had been in the link. A mistyped key can be corrected and resubmitted.
+
+The entered key is used for the current attempt only and is never persisted: it is not written into the URL, not stored in the browser (no local storage, session storage, or cookies), and not retained or logged by the backend. Refreshing the page discards it.
+
+If decryption fails, the message distinguishes what can be fixed. A key that does not match the credential can be re-entered, although a credential whose stored ciphertext has been tampered with produces the same failure, since AES-GCM cannot tell the two apart. If the stored envelope itself is corrupted, the page says so rather than asking for the key again.
+
+The issuing tenant can retrieve a credential's decryption key from `GET /api/v1/credentials/{id}` (see [Credentials API](./api/credentials)).

--- a/packages/reference-implementation/e2e/cypress/e2e/api/credential_api/credential-verify-page.cy.ts
+++ b/packages/reference-implementation/e2e/cypress/e2e/api/credential_api/credential-verify-page.cy.ts
@@ -225,8 +225,8 @@ describe('Verify Page', { testIsolation: false }, () => {
       // Should not show the "invalid link" message (the link itself is valid)
       cy.contains('Invalid verification link').should('not.exist');
 
-      // The API returns 422 DIGEST_MISMATCH; the page displays the thrown error
-      cy.contains('DIGEST_MISMATCH', { timeout: 30000 }).should('be.visible');
+      // The API returns 422 DIGEST_MISMATCH; the page displays its message
+      cy.contains('digest does not match', { matchCase: false, timeout: 30000 }).should('be.visible');
     });
 
     it('shows error when legacy hex hash does not match', () => {
@@ -234,7 +234,7 @@ describe('Verify Page', { testIsolation: false }, () => {
       cy.visit(buildDirectVerifyUrl({ uri: unencryptedUri, hash: wrongHash }));
 
       cy.contains('Invalid verification link').should('not.exist');
-      cy.contains('DIGEST_MISMATCH', { timeout: 30000 }).should('be.visible');
+      cy.contains('digest does not match', { matchCase: false, timeout: 30000 }).should('be.visible');
     });
 
     it('shows error for unreachable URI', () => {
@@ -245,20 +245,60 @@ describe('Verify Page', { testIsolation: false }, () => {
 
       if (ssrfEnabled) {
         // SSRF validation rejects the URL — page shows the rejection message
-        cy.contains('could not be resolved', { matchCase: false, timeout: 30000 }).should('be.visible');
+        cy.contains('DNS resolution failed', { matchCase: false, timeout: 30000 }).should('be.visible');
       } else {
-        // The API returns 502 UPSTREAM_ERROR; the page displays the thrown error
-        cy.contains('UPSTREAM_ERROR', { timeout: 30000 }).should('be.visible');
+        // The API returns 502 UPSTREAM_ERROR; the page displays its message
+        cy.contains('Failed to fetch credential', { timeout: 30000 }).should('be.visible');
       }
     });
+  });
 
-    it('shows error when encrypted credential has no decryptionKey', () => {
-      cy.visit(buildDirectVerifyUrl({ uri: encryptedUri }));
+  // ── Decryption key prompt ────────────────────────────────────────
+  // A credential published to the Identity Resolver carries a keyless ?q=
+  // link (the key travels out of band), so that link shape is the one the
+  // prompt exists for.
 
-      cy.contains('Invalid verification link').should('not.exist');
+  describe('Decryption key prompt', () => {
+    it('prompts on a keyless ?q= link, then verifies with the entered key without touching the URL', () => {
+      cy.visit(buildLegacyVerifyUrl({ uri: encryptedUri, digestMultibase: encryptedDigest }));
 
-      // The API returns 422 DECRYPTION_REQUIRED; the page displays the thrown error
-      cy.contains('DECRYPTION_REQUIRED', { timeout: 30000 }).should('be.visible');
+      cy.contains('Decryption key required', { timeout: 30000 }).should('be.visible');
+
+      cy.get('#decryption-key').type(encryptedKey);
+      cy.contains('button', 'Decrypt and verify').click();
+
+      cy.contains('JSON', { timeout: 30000 }).should('be.visible');
+      cy.location('search').should((search) => {
+        expect(search).to.not.contain(encryptedKey);
+      });
+    });
+
+    it('prompts on keyless direct params too', () => {
+      cy.visit(buildDirectVerifyUrl({ uri: encryptedUri, digestMultibase: encryptedDigest }));
+      cy.contains('Decryption key required', { timeout: 30000 }).should('be.visible');
+    });
+
+    it('rejects a malformed key inline and allows correction', () => {
+      cy.visit(buildLegacyVerifyUrl({ uri: encryptedUri, digestMultibase: encryptedDigest }));
+      cy.contains('Decryption key required', { timeout: 30000 }).should('be.visible');
+
+      cy.get('#decryption-key').type('not-a-valid-key');
+      cy.contains('button', 'Decrypt and verify').click();
+      cy.contains('64-character hexadecimal').should('be.visible');
+      cy.get('#decryption-key').should('have.value', 'not-a-valid-key');
+    });
+
+    it('keeps the form on a wrong key and verifies after re-entry', () => {
+      cy.visit(buildLegacyVerifyUrl({ uri: encryptedUri, digestMultibase: encryptedDigest }));
+      cy.contains('Decryption key required', { timeout: 30000 }).should('be.visible');
+
+      cy.get('#decryption-key').type('f'.repeat(64));
+      cy.contains('button', 'Decrypt and verify').click();
+      cy.contains('does not match', { timeout: 30000 }).should('be.visible');
+
+      cy.get('#decryption-key').clear().type(encryptedKey);
+      cy.contains('button', 'Decrypt and verify').click();
+      cy.contains('JSON', { timeout: 30000 }).should('be.visible');
     });
   });
 });

--- a/packages/reference-implementation/e2e/cypress/e2e/api/vc_render/render_credential.cy.ts
+++ b/packages/reference-implementation/e2e/cypress/e2e/api/vc_render/render_credential.cy.ts
@@ -115,10 +115,10 @@ describe('Verify page credential rendering', () => {
 
       cy.visit('/verify?uri=https://example.com/test-credential');
       cy.wait('@verifyCredential');
-      verifyErrorDisplayed('DIGEST_MISMATCH');
+      verifyErrorDisplayed('Credential digest does not match the expected digest');
     });
 
-    it('should display error when decryption key is missing', () => {
+    it('should show the decryption key prompt when the key is missing', () => {
       cy.intercept('POST', '/api/v1/credentials/verify', {
         statusCode: 422,
         body: {
@@ -129,21 +129,22 @@ describe('Verify page credential rendering', () => {
 
       cy.visit('/verify?uri=https://example.com/test-credential');
       cy.wait('@verifyCredential');
-      verifyErrorDisplayed('DECRYPTION_REQUIRED');
+      cy.contains('Decryption key required').should('be.visible');
+      cy.get('#decryption-key').should('be.visible');
     });
 
     it('should display error when decryption fails', () => {
       cy.intercept('POST', '/api/v1/credentials/verify', {
         statusCode: 422,
         body: {
-          error: 'Failed to decrypt credential',
+          error: 'The decryption key does not match this credential. Check the key and try again.',
           code: 'DECRYPTION_FAILED',
         },
       }).as('verifyCredential');
 
       cy.visit('/verify?uri=https://example.com/test-credential');
       cy.wait('@verifyCredential');
-      verifyErrorDisplayed('DECRYPTION_FAILED');
+      verifyErrorDisplayed('The decryption key does not match this credential');
     });
 
     it('should display error when credential type is unsupported', () => {
@@ -157,7 +158,7 @@ describe('Verify page credential rendering', () => {
 
       cy.visit('/verify?uri=https://example.com/test-credential');
       cy.wait('@verifyCredential');
-      verifyErrorDisplayed('UNSUPPORTED_CREDENTIAL_TYPE');
+      verifyErrorDisplayed('Only EnvelopedVerifiableCredential is supported');
     });
 
     it('should display error when upstream service fails', () => {
@@ -171,7 +172,7 @@ describe('Verify page credential rendering', () => {
 
       cy.visit('/verify?uri=https://example.com/test-credential');
       cy.wait('@verifyCredential');
-      verifyErrorDisplayed('UPSTREAM_ERROR');
+      verifyErrorDisplayed('Failed to fetch credential: network error');
     });
 
     it('should display error when VC service fails', () => {
@@ -185,7 +186,7 @@ describe('Verify page credential rendering', () => {
 
       cy.visit('/verify?uri=https://example.com/test-credential');
       cy.wait('@verifyCredential');
-      verifyErrorDisplayed('VC_SERVICE_ERROR');
+      verifyErrorDisplayed('Credential verification service failed');
     });
   });
 

--- a/packages/reference-implementation/src/app/(public)/verify/page.test.tsx
+++ b/packages/reference-implementation/src/app/(public)/verify/page.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { useSearchParams } from 'next/navigation';
-import { verifyCredential } from '@/services/credentials';
+import { verifyCredential, VerifyCredentialError } from '@/services/credentials';
 import VerifyPage from './page';
 
 console.error = jest.fn();
@@ -11,9 +11,11 @@ jest.mock('next/navigation', () => ({
   useSearchParams: jest.fn(),
 }));
 
-// Mock the service
+// Mock the service, keeping the real typed error class so the page's
+// `instanceof` branching is exercised against the class it actually uses.
 jest.mock('@/services/credentials', () => ({
   verifyCredential: jest.fn(),
+  VerifyCredentialError: jest.requireActual('@/services/credentials/verify-credential').VerifyCredentialError,
 }));
 
 // Mock Credential component
@@ -225,6 +227,197 @@ describe('VerifyPage', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('message-text')).toHaveTextContent('Invalid verification link');
+    });
+  });
+
+  describe('decryption key prompt', () => {
+    const VALID_KEY = 'b'.repeat(64);
+    const KEYLESS_Q_PAYLOAD = JSON.stringify({
+      payload: {
+        uri: 'http://localhost:3333/v1/credentials/abc.json',
+        digestMultibase: 'zQmDigest',
+      },
+    });
+
+    function decryptionRequired() {
+      return new VerifyCredentialError(
+        'Credential is encrypted but no decryptionKey was provided',
+        422,
+        'DECRYPTION_REQUIRED',
+      );
+    }
+
+    async function renderKeyPrompt() {
+      mockUseSearchParams.mockReturnValue(makeLegacySearchParams(KEYLESS_Q_PAYLOAD));
+      mockVerifyCredential.mockRejectedValueOnce(decryptionRequired());
+      await act(async () => {
+        render(<VerifyPage />);
+      });
+      await screen.findByLabelText('Decryption key');
+    }
+
+    it('prompts for a key when a keyless ?q= link hits an encrypted credential', async () => {
+      await renderKeyPrompt();
+
+      expect(screen.getByLabelText('Decryption key')).toBeInTheDocument();
+      expect(screen.getByText(/used for this attempt only and is not stored/)).toBeInTheDocument();
+      expect(mockVerifyCredential).toHaveBeenCalledTimes(1);
+    });
+
+    it('the key input does not invite browser retention', async () => {
+      await renderKeyPrompt();
+
+      const input = screen.getByLabelText('Decryption key');
+      expect(input).toHaveAttribute('type', 'text');
+      expect(input).toHaveAttribute('autocomplete', 'off');
+      expect(input).toHaveAttribute('spellcheck', 'false');
+    });
+
+    it('rejects a malformed key inline without calling the API', async () => {
+      await renderKeyPrompt();
+
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: 'not-hex' } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent('64-character hexadecimal');
+      expect(mockVerifyCredential).toHaveBeenCalledTimes(1); // the initial attempt only
+      expect(screen.getByLabelText('Decryption key')).toHaveValue('not-hex');
+    });
+
+    it('retries with the trimmed key and the originally parsed link parameters, then renders the credential', async () => {
+      await renderKeyPrompt();
+      mockVerifyCredential.mockResolvedValueOnce({ verified: true, credential: { type: 'VerifiableCredential' } });
+
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: `  ${VALID_KEY}\n` } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+
+      await screen.findByTestId('credential');
+      expect(mockVerifyCredential).toHaveBeenLastCalledWith({
+        uri: 'http://localhost:3333/v1/credentials/abc.json',
+        digestMultibase: 'zQmDigest',
+        hash: undefined,
+        decryptionKey: VALID_KEY,
+      });
+    });
+
+    it('never writes the key into the URL or web storage', async () => {
+      await renderKeyPrompt();
+      mockVerifyCredential.mockResolvedValueOnce({ verified: true, credential: {} });
+      const hrefBefore = window.location.href;
+
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: VALID_KEY } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+      await screen.findByTestId('credential');
+
+      expect(window.location.href).toBe(hrefBefore);
+      expect(window.localStorage.length).toBe(0);
+      expect(window.sessionStorage.length).toBe(0);
+      expect(document.cookie).toBe('');
+    });
+
+    it('keeps the form and the typed key on a wrong key, showing the API message', async () => {
+      await renderKeyPrompt();
+      mockVerifyCredential.mockRejectedValueOnce(
+        new VerifyCredentialError(
+          'The decryption key does not match this credential. Check the key and try again.',
+          422,
+          'DECRYPTION_FAILED',
+        ),
+      );
+
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: VALID_KEY } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent('does not match this credential');
+      expect(screen.getByLabelText('Decryption key')).toHaveValue(VALID_KEY);
+
+      // Re-entry works: a corrected key verifies.
+      mockVerifyCredential.mockResolvedValueOnce({ verified: true, credential: {} });
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: 'c'.repeat(64) } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+      await screen.findByTestId('credential');
+    });
+
+    it.each([
+      ['DECRYPTED_NOT_JSON', 'The credential was decrypted but its content is not valid JSON.'],
+      ['INVALID_RESPONSE', 'Response from storage URI is not valid JSON'],
+      ['DIGEST_MISMATCH', 'Credential digest does not match the expected digest'],
+      ['UNSUPPORTED_CREDENTIAL_TYPE', 'Only EnvelopedVerifiableCredential is supported'],
+    ])('goes terminal on %s instead of keeping the key form', async (code, message) => {
+      await renderKeyPrompt();
+      mockVerifyCredential.mockRejectedValueOnce(new VerifyCredentialError(message, 422, code));
+
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: VALID_KEY } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('message-text')).toHaveTextContent(message);
+      });
+      expect(screen.queryByLabelText('Decryption key')).not.toBeInTheDocument();
+    });
+
+    it('goes terminal on ENVELOPE_INVALID instead of inviting pointless re-entry', async () => {
+      await renderKeyPrompt();
+      mockVerifyCredential.mockRejectedValueOnce(
+        new VerifyCredentialError(
+          'The stored credential data is corrupted and cannot be decrypted. Re-entering the key will not help.',
+          422,
+          'ENVELOPE_INVALID',
+        ),
+      );
+
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: VALID_KEY } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('message-text')).toHaveTextContent('Re-entering the key will not help');
+      });
+      expect(screen.queryByLabelText('Decryption key')).not.toBeInTheDocument();
+    });
+
+    it('keeps the form on a transient failure during the retry', async () => {
+      await renderKeyPrompt();
+      mockVerifyCredential.mockRejectedValueOnce(new Error('Unable to connect to the verification service'));
+
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: VALID_KEY } });
+      fireEvent.submit(screen.getByLabelText('Decryption key').closest('form') as HTMLFormElement);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent('Unable to connect');
+      expect(screen.getByLabelText('Decryption key')).toBeInTheDocument();
+    });
+
+    it('clears the typed key when the page is restored from the back/forward cache', async () => {
+      await renderKeyPrompt();
+      fireEvent.change(screen.getByLabelText('Decryption key'), { target: { value: VALID_KEY } });
+
+      const pageshow = new Event('pageshow') as PageTransitionEvent;
+      Object.defineProperty(pageshow, 'persisted', { value: true });
+      await act(async () => {
+        window.dispatchEvent(pageshow);
+      });
+
+      expect(screen.getByLabelText('Decryption key')).toHaveValue('');
+    });
+
+    it('does not prompt when the link itself carried a wrong key (terminal DECRYPTION_FAILED)', async () => {
+      mockUseSearchParams.mockReturnValue(
+        makeDirectSearchParams({
+          uri: 'http://localhost:3333/v1/credentials/abc.json',
+          decryptionKey: VALID_KEY,
+        }),
+      );
+      mockVerifyCredential.mockRejectedValueOnce(
+        new VerifyCredentialError('The decryption key does not match this credential.', 422, 'DECRYPTION_FAILED'),
+      );
+
+      await act(async () => {
+        render(<VerifyPage />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('message-text')).toHaveTextContent('does not match');
+      });
+      expect(screen.queryByLabelText('Decryption key')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/reference-implementation/src/app/(public)/verify/page.tsx
+++ b/packages/reference-implementation/src/app/(public)/verify/page.tsx
@@ -7,13 +7,39 @@ import { VerifiableCredential, UnsignedCredential } from '@vckit/core-types';
 import { Loader } from '@reference-implementation/components';
 import Credential from '@/components/Credential/Credential';
 import { MessageText } from '@/components/MessageText';
-import { verifyCredential, VerifyCredentialResult } from '@/services/credentials';
+import {
+  verifyCredential,
+  VerifyCredentialError,
+  VerifyCredentialParams,
+  VerifyCredentialResult,
+  VerifyErrorCode,
+} from '@/services/credentials';
+
+const HEX_64 = /^[a-f0-9]{64}$/i;
+
+// Failures a re-entered key cannot fix: the credential itself (or its stored
+// envelope) is unusable, so the prompt would invite pointless retries. Typed
+// against VerifyErrorCode so a typo here fails to compile; declared as a set
+// of strings so `.has` accepts the API's open-ended code field.
+const KEY_RETRY_POINTLESS_CODES: ReadonlySet<string> = new Set<VerifyErrorCode>([
+  'ENVELOPE_INVALID',
+  'DECRYPTED_NOT_JSON',
+  'INVALID_RESPONSE',
+  'DIGEST_MISMATCH',
+  'UNSUPPORTED_CREDENTIAL_TYPE',
+]);
 
 const Verify = () => {
   const search = useSearchParams();
-  const [state, setState] = useState<'loading' | 'success' | 'error'>('loading');
+  const [state, setState] = useState<'loading' | 'success' | 'error' | 'keyRequired'>('loading');
   const [result, setResult] = useState<VerifyCredentialResult | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>('');
+  // The parsed link parameters are kept in state so key-prompt retries reuse
+  // exactly what the link carried, rather than re-deriving it.
+  const [params, setParams] = useState<VerifyCredentialParams | null>(null);
+  const [keyInput, setKeyInput] = useState<string>('');
+  const [keyError, setKeyError] = useState<string>('');
+  const [submitting, setSubmitting] = useState<boolean>(false);
 
   useEffect(() => {
     const run = async () => {
@@ -21,6 +47,15 @@ const Verify = () => {
       let digestMultibase: string | undefined;
       let hash: string | undefined;
       let decryptionKey: string | undefined;
+
+      // A changed link resets the whole flow, including any typed key.
+      setState('loading');
+      setResult(null);
+      setErrorMessage('');
+      setParams(null);
+      setKeyInput('');
+      setKeyError('');
+      setSubmitting(false);
 
       // Support individual query params and a legacy ?q= JSON envelope. The
       // verify URL has historically carried a hex `hash`; new URLs carry
@@ -53,11 +88,18 @@ const Verify = () => {
         return;
       }
 
+      const parsedParams: VerifyCredentialParams = { uri, digestMultibase, hash, decryptionKey };
+      setParams(parsedParams);
+
       try {
-        const result = await verifyCredential({ uri, digestMultibase, hash, decryptionKey });
+        const result = await verifyCredential(parsedParams);
         setResult(result);
         setState('success');
       } catch (e: unknown) {
+        if (e instanceof VerifyCredentialError && e.code === 'DECRYPTION_REQUIRED' && !parsedParams.decryptionKey) {
+          setState('keyRequired');
+          return;
+        }
         setErrorMessage(e instanceof Error ? e.message : 'Verification failed');
         setState('error');
       }
@@ -66,9 +108,98 @@ const Verify = () => {
     run();
   }, [search]);
 
+  // A back/forward-cache restore brings the JavaScript heap back, including a
+  // typed key. The key is for the attempt it was typed into only, so clear it.
+  useEffect(() => {
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        setKeyInput('');
+        setKeyError('');
+        setSubmitting(false);
+      }
+    };
+    window.addEventListener('pageshow', onPageShow);
+    return () => window.removeEventListener('pageshow', onPageShow);
+  }, []);
+
+  const handleKeySubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    // The form must never submit natively: a native submit is a GET that
+    // writes the key into the URL and browser history.
+    event.preventDefault();
+    if (submitting || !params) return;
+
+    const trimmedKey = keyInput.trim();
+    if (!HEX_64.test(trimmedKey)) {
+      setKeyError('The key must be a 64-character hexadecimal string.');
+      return;
+    }
+
+    setSubmitting(true);
+    setKeyError('');
+    try {
+      const result = await verifyCredential({ ...params, decryptionKey: trimmedKey });
+      // Clear the key before rendering the result; it has done its job.
+      setKeyInput('');
+      setResult(result);
+      setState('success');
+    } catch (e: unknown) {
+      if (e instanceof VerifyCredentialError && e.code && KEY_RETRY_POINTLESS_CODES.has(e.code)) {
+        setErrorMessage(e.message);
+        setState('error');
+      } else {
+        // Wrong key, transient network trouble, or upstream failure: keep the
+        // form (and the typed key) so the verifier can correct and retry.
+        setKeyError(e instanceof Error ? e.message : 'Verification failed');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   if (state === 'loading') {
     return (
       <Loader text='Verifying the credential' className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2' />
+    );
+  }
+
+  if (state === 'keyRequired') {
+    return (
+      <div className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md px-4'>
+        <h1 className='text-lg font-semibold mb-2'>Decryption key required</h1>
+        <p className='mb-4 text-sm'>
+          This credential is encrypted and the link does not include its decryption key. Enter the key you received from
+          the issuer to verify the credential. The key is used for this attempt only and is not stored.
+        </p>
+        <form onSubmit={handleKeySubmit} noValidate>
+          <label htmlFor='decryption-key' className='block text-sm font-medium mb-1'>
+            Decryption key
+          </label>
+          <input
+            id='decryption-key'
+            type='text'
+            autoComplete='off'
+            spellCheck={false}
+            autoCapitalize='none'
+            autoCorrect='off'
+            className='w-full border rounded px-3 py-2 mb-2 font-mono text-sm'
+            placeholder='64-character hexadecimal key'
+            value={keyInput}
+            onChange={(event) => setKeyInput(event.target.value)}
+          />
+          {keyError && (
+            <p role='alert' className='text-sm text-red-600 mb-2'>
+              {keyError}
+            </p>
+          )}
+          <button
+            type='submit'
+            disabled={submitting}
+            className='bg-primary text-white rounded px-4 py-2 text-sm disabled:opacity-50'
+          >
+            {submitting ? 'Verifying…' : 'Decrypt and verify'}
+          </button>
+        </form>
+      </div>
     );
   }
 
@@ -96,6 +227,15 @@ const Verify = () => {
   );
 };
 
+// The App Router keeps the page mounted when only the query string changes,
+// so an in-flight verification for one link could otherwise write its result
+// into a newly opened link's state. Keying by the query string remounts
+// instead, discarding stale requests along with the old state.
+const KeyedVerify = () => {
+  const search = useSearchParams();
+  return <Verify key={search?.toString() ?? ''} />;
+};
+
 /**
  * Verify component wrapped with Suspense boundary
  */
@@ -104,7 +244,7 @@ const VerifyPage = () => {
     <Suspense
       fallback={<Loader text='Loading...' className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2' />}
     >
-      <Verify />
+      <KeyedVerify />
     </Suspense>
   );
 };

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.no-key-logging.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.no-key-logging.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Pins that a submitted decryption key never appears in the verify route's
+ * serialised log output, on the success path and on the decryption-failure
+ * path. The route's main suite replaces the logger with a discarding mock, so
+ * an assertion there could never fail; this suite runs a real pino logger
+ * (production redaction config included) into a capturing destination, the
+ * real withPublicRoute wrapper, and real AES-256-GCM decryption so the logged
+ * `err` objects are the real ones. The crypto layer's own logger (built
+ * inside the services package) is pinned by the sibling suite
+ * packages/services/src/encryption/decrypt-credential.no-key-logging.test.ts;
+ * the two suites together cover both destinations a key could leak through.
+ */
+
+// Polyfill AbortSignal.timeout for jsdom (not available in jsdom)
+if (typeof AbortSignal.timeout !== 'function') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (AbortSignal as any).timeout = (ms: number) => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), ms);
+    return controller.signal;
+  };
+}
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+// The real wrapper is used (with next/server mocked above) so its request and
+// error logging goes through the same captured logger as the route's own.
+jest.mock('@/lib/api/with-public-route', () => jest.requireActual('@/lib/api/with-public-route'));
+
+const capturedLogLines: string[] = [];
+
+jest.mock('@/lib/api/logger', () => {
+  const { createLogger } = jest.requireActual('@uncefact/untp-ri-services/logging');
+  return {
+    apiLogger: createLogger({
+      level: 'debug',
+      destination: {
+        write: (msg: string) => {
+          capturedLogLines.push(msg);
+        },
+      },
+    }).child({ module: 'api' }),
+  };
+});
+
+const mockResolveVcService = jest.fn();
+jest.mock('@/lib/services/resolve-vc-service', () => ({
+  resolveVcService: (...args: unknown[]) => mockResolveVcService(...args),
+}));
+
+const mockResolveDocument = jest.fn();
+jest.mock('@uncefact/untp-utils/resolvers', () => ({
+  resolveDocument: (...args: unknown[]) => mockResolveDocument(...args),
+  ResolverError: class ResolverError extends Error {},
+  ResolverHttpError: class ResolverHttpError extends Error {},
+  ResolverTooLargeError: class ResolverTooLargeError extends Error {},
+  ResolverTimedOutError: class ResolverTimedOutError extends Error {},
+}));
+jest.mock('@uncefact/untp-utils/node', () => ({
+  UrlValidationError: class UrlValidationError extends Error {},
+}));
+
+import { createCipheriv, randomBytes } from 'node:crypto';
+import { POST } from './route';
+
+const SENTINEL_KEY = 'deadbeefcafe0042'.repeat(4); // 64 hex chars, distinctive
+const WRONG_KEY = 'a'.repeat(64);
+
+const CREDENTIAL = {
+  '@context': ['https://www.w3.org/ns/credentials/v2'],
+  id: 'data:application/vc+jwt,eyJhbGciOiJFZDI1NTE5In0.eyJpc3MiOiJkaWQ6d2ViOmV4YW1wbGUuY29tIn0.sig',
+  type: 'EnvelopedVerifiableCredential',
+};
+
+/** Real AES-256-GCM envelope in the storage service's shape. */
+function encryptEnvelope(plaintext: string, hexKey: string) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', Buffer.from(hexKey, 'hex'), iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return {
+    cipherText: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    type: 'aes-256-gcm',
+  };
+}
+
+function createFakeRequest(body: Record<string, unknown>): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost/api/v1/credentials/verify',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: async () => body,
+  } as unknown as Request;
+}
+
+function mockStorageDocument(body: unknown) {
+  mockResolveDocument.mockResolvedValue({
+    body: new TextEncoder().encode(JSON.stringify(body)),
+  });
+}
+
+describe('verify route never logs the decryption key', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedLogLines.length = 0;
+    delete process.env.VERIFY_ALLOW_PRIVATE_URLS;
+    mockResolveVcService.mockResolvedValue({
+      service: { verify: jest.fn().mockResolvedValue({ verified: true }) },
+      instanceId: 'inst-1',
+    });
+  });
+
+  it('emits log lines but none containing the key on successful decryption and verification', async () => {
+    mockStorageDocument(encryptEnvelope(JSON.stringify(CREDENTIAL), SENTINEL_KEY));
+
+    const res = await POST(createFakeRequest({ uri: 'https://storage.example.com/cred', decryptionKey: SENTINEL_KEY }));
+    expect(res.status).toBe(200);
+
+    const output = capturedLogLines.join('');
+    expect(capturedLogLines.length).toBeGreaterThan(0); // the capture actually captured
+    expect(output).not.toContain(SENTINEL_KEY);
+  });
+
+  it('does not log the key when decryption fails with a wrong key (err serialisation included)', async () => {
+    mockStorageDocument(encryptEnvelope(JSON.stringify(CREDENTIAL), SENTINEL_KEY));
+
+    const res = await POST(createFakeRequest({ uri: 'https://storage.example.com/cred', decryptionKey: WRONG_KEY }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.code).toBe('DECRYPTION_FAILED');
+
+    const output = capturedLogLines.join('');
+    expect(capturedLogLines.length).toBeGreaterThan(0);
+    expect(output).not.toContain(WRONG_KEY);
+    expect(output).not.toContain(SENTINEL_KEY);
+  });
+
+  it('the capture would catch a leak (self-check that this suite can fail)', async () => {
+    // Guard against the capture silently detaching from the logger: log the
+    // sentinel deliberately and confirm it shows up in the captured output.
+    mockStorageDocument(encryptEnvelope(JSON.stringify(CREDENTIAL), SENTINEL_KEY));
+    await POST(createFakeRequest({ uri: 'https://storage.example.com/cred', decryptionKey: SENTINEL_KEY }));
+
+    const { apiLogger } = jest.requireMock('@/lib/api/logger');
+    apiLogger.info({ leakCheck: SENTINEL_KEY }, 'deliberate sentinel write');
+
+    expect(capturedLogLines.join('')).toContain(SENTINEL_KEY);
+  });
+});

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.test.ts
@@ -43,9 +43,11 @@ jest.mock('@/lib/api/with-public-route', () => {
 const mockResolveVcService = jest.fn();
 const mockDecryptCredential = jest.fn();
 const mockIsEncryptedEnvelope = jest.fn();
+const mockHasValidEnvelopeStructure = jest.fn();
 const mockDecodeJwt = jest.fn();
 const mockMultibaseDigestVerify = jest.fn();
 const mockMultibaseDigestFromString = jest.fn((_input: string) => ({ verify: mockMultibaseDigestVerify }));
+const mockResolveDocument = jest.fn();
 
 jest.mock('@/lib/services/resolve-vc-service', () => ({
   resolveVcService: (...args: unknown[]) => mockResolveVcService(...args),
@@ -56,6 +58,7 @@ jest.mock('@uncefact/untp-ri-services', () => {
   return {
     decryptCredential: (...args: unknown[]) => mockDecryptCredential(...args),
     isEncryptedEnvelope: (...args: unknown[]) => mockIsEncryptedEnvelope(...args),
+    hasValidEnvelopeStructure: (...args: unknown[]) => mockHasValidEnvelopeStructure(...args),
     VcVerifyError: actual.VcVerifyError,
   };
 });
@@ -66,13 +69,46 @@ jest.mock('@uncefact/untp-utils/multibase-digest', () => ({
   },
 }));
 
+// The route does `instanceof` checks against these classes, so the classes
+// created here (which the route receives via the module mock) are the same
+// identities the tests construct below.
+jest.mock('@uncefact/untp-utils/resolvers', () => {
+  class ResolverError extends Error {}
+  class ResolverHttpError extends ResolverError {
+    status: number;
+    constructor(url: string, status: number) {
+      super(`${url} returned status ${status}.`);
+      this.status = status;
+    }
+  }
+  class ResolverTooLargeError extends ResolverError {
+    limit: number;
+    constructor(url: string, limit: number) {
+      super(`Response body for ${url} exceeds ${limit}-byte limit.`);
+      this.limit = limit;
+    }
+  }
+  class ResolverTimedOutError extends ResolverError {
+    constructor(url: string, timeoutMs: number) {
+      super(`Timed out fetching ${url} after ${timeoutMs}ms.`);
+    }
+  }
+  return {
+    resolveDocument: (...args: unknown[]) => mockResolveDocument(...args),
+    ResolverError,
+    ResolverHttpError,
+    ResolverTooLargeError,
+    ResolverTimedOutError,
+  };
+});
+
+jest.mock('@uncefact/untp-utils/node', () => {
+  class UrlValidationError extends Error {}
+  return { UrlValidationError };
+});
+
 jest.mock('jose', () => ({
   decodeJwt: (...args: unknown[]) => mockDecodeJwt(...args),
-}));
-
-const mockValidatePublicUrl = jest.fn();
-jest.mock('@uncefact/untp-ri-services/server', () => ({
-  validatePublicUrl: (...args: unknown[]) => mockValidatePublicUrl(...args),
 }));
 
 jest.mock('@/lib/api/logger', () => ({
@@ -86,11 +122,17 @@ import { ServiceResolutionError } from '@/lib/api/errors';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 import { POST } from './route';
 
+const { ResolverError, ResolverHttpError, ResolverTooLargeError, ResolverTimedOutError } = jest.requireMock(
+  '@uncefact/untp-utils/resolvers',
+);
+const { UrlValidationError } = jest.requireMock('@uncefact/untp-utils/node');
+
 // ── Fixtures ──────────────────────────────────────────────────────────
 
 const VALID_URI = 'https://storage.example.com/credentials/abc123';
 const VALID_HASH = 'a'.repeat(64);
 const VALID_KEY = 'b'.repeat(64);
+const MAX_SIZE = 10_485_760;
 
 const ENVELOPED_CREDENTIAL = {
   '@context': ['https://www.w3.org/ns/credentials/v2'],
@@ -129,17 +171,19 @@ function createBadJsonRequest(): Request {
   } as unknown as Request;
 }
 
-function createFetchResponse(body: unknown, opts?: { ok?: boolean; status?: number; textThrows?: boolean }) {
+/** Makes the guarded resolver return the given document (JSON-encoded unless a string). */
+function mockStorageDocument(body: unknown) {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  mockResolveDocument.mockResolvedValue({ body: new TextEncoder().encode(text) });
+}
+
+function createFetchResponse(body: unknown, opts?: { ok?: boolean; status?: number }) {
   const ok = opts?.ok ?? true;
   const status = opts?.status ?? (ok ? 200 : 500);
   return {
     ok,
     status,
-    text: opts?.textThrows
-      ? async () => {
-          throw new Error('read error');
-        }
-      : async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   };
 }
 
@@ -154,7 +198,7 @@ describe('POST /api/v1/credentials/verify', () => {
     mockDecodeJwt.mockReturnValue(DECODED_JWT);
     mockMultibaseDigestVerify.mockResolvedValue(true);
     mockIsEncryptedEnvelope.mockReturnValue(false);
-    mockValidatePublicUrl.mockResolvedValue(undefined);
+    mockHasValidEnvelopeStructure.mockReturnValue(true);
     delete process.env.VERIFY_ALLOW_PRIVATE_URLS;
   });
 
@@ -209,10 +253,12 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.error).toBe('decryptionKey must be a 64-character hex string');
   });
 
-  // ── SSRF Protection (400) ────────────────────────────────────────
+  // ── SSRF Protection (guarded fetch) ───────────────────────────────
 
-  it('returns 400 when validatePublicUrl rejects the URI', async () => {
-    mockValidatePublicUrl.mockRejectedValue(new Error('uri must not point to a private or reserved network address'));
+  it('returns 400 when the guarded resolver rejects the URI as private', async () => {
+    mockResolveDocument.mockRejectedValue(
+      new UrlValidationError('uri must not point to a private or reserved network address'),
+    );
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(400);
@@ -220,33 +266,34 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.error).toBe('uri must not point to a private or reserved network address');
   });
 
-  it('calls validatePublicUrl with parsed URL', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+  it('fetches via the guarded resolver with the size cap, not plain fetch', async () => {
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
-    await POST(createFakeRequest({ uri: VALID_URI }));
-
-    expect(mockValidatePublicUrl).toHaveBeenCalledTimes(1);
-    const calledUrl = mockValidatePublicUrl.mock.calls[0][0];
-    expect(calledUrl).toBeInstanceOf(URL);
-    expect(calledUrl.href).toBe(VALID_URI);
+    const res = await POST(createFakeRequest({ uri: VALID_URI }));
+    expect(res.status).toBe(200);
+    expect(mockResolveDocument).toHaveBeenCalledWith(VALID_URI, {
+      maxResponseBytes: MAX_SIZE,
+      totalTimeoutMs: 10_000,
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('skips validatePublicUrl when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
+  it('uses plain fetch and skips the guarded resolver when VERIFY_ALLOW_PRIVATE_URLS=true', async () => {
     process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
     mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(200);
-    expect(mockValidatePublicUrl).not.toHaveBeenCalled();
+    expect(mockResolveDocument).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   // ── Upstream Errors (502) ─────────────────────────────────────────
 
-  it('returns 502 when fetch times out', async () => {
-    const timeoutError = Object.assign(new Error('Timeout'), { name: 'TimeoutError' });
-    mockFetch.mockImplementation(() => Promise.reject(timeoutError));
+  it('returns 502 when the guarded fetch times out', async () => {
+    mockResolveDocument.mockRejectedValue(new ResolverTimedOutError(VALID_URI, 10_000));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(502);
@@ -255,8 +302,8 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.code).toBe('UPSTREAM_ERROR');
   });
 
-  it('returns 502 when fetch fails with network error', async () => {
-    mockFetch.mockRejectedValue(new Error('fetch failed'));
+  it('returns 502 when the guarded fetch fails with a network error', async () => {
+    mockResolveDocument.mockRejectedValue(new ResolverError('socket hang up'));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(502);
@@ -266,7 +313,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('returns 502 when storage returns non-2xx', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(null, { ok: false, status: 404 }));
+    mockResolveDocument.mockRejectedValue(new ResolverHttpError(VALID_URI, 404));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(502);
@@ -275,13 +322,8 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.code).toBe('UPSTREAM_ERROR');
   });
 
-  it('returns 502 when response exceeds size limit', async () => {
-    const hugeText = 'x'.repeat(10_485_761); // 10 MB + 1 byte
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: async () => hugeText,
-    });
+  it('returns 502 when the response exceeds the size limit', async () => {
+    mockResolveDocument.mockRejectedValue(new ResolverTooLargeError(VALID_URI, MAX_SIZE));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(502);
@@ -290,30 +332,85 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.code).toBe('UPSTREAM_ERROR');
   });
 
-  it('returns 502 when response.text() throws', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: async () => {
-        throw new Error('stream error');
-      },
-    });
+  it('rethrows unrecognised resolver failures as a 500', async () => {
+    mockResolveDocument.mockRejectedValue(new Error('unexpected'));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
-    expect(res.status).toBe(502);
-    const json = await res.json();
-    expect(json.error).toBe('Failed to read credential response');
-    expect(json.code).toBe('UPSTREAM_ERROR');
+    expect(res.status).toBe(500);
+  });
+
+  describe('development bypass (VERIFY_ALLOW_PRIVATE_URLS=true) plain-fetch path', () => {
+    beforeEach(() => {
+      process.env.VERIFY_ALLOW_PRIVATE_URLS = 'true';
+    });
+
+    it('returns 502 when fetch times out', async () => {
+      const timeoutError = Object.assign(new Error('Timeout'), { name: 'TimeoutError' });
+      mockFetch.mockImplementation(() => Promise.reject(timeoutError));
+
+      const res = await POST(createFakeRequest({ uri: VALID_URI }));
+      expect(res.status).toBe(502);
+      const json = await res.json();
+      expect(json.error).toBe('Failed to fetch credential: request timed out');
+      expect(json.code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('returns 502 when fetch fails with network error', async () => {
+      mockFetch.mockRejectedValue(new Error('fetch failed'));
+
+      const res = await POST(createFakeRequest({ uri: VALID_URI }));
+      expect(res.status).toBe(502);
+      const json = await res.json();
+      expect(json.error).toBe('Failed to fetch credential: network error');
+      expect(json.code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('returns 502 when storage returns non-2xx', async () => {
+      mockFetch.mockResolvedValue(createFetchResponse(null, { ok: false, status: 404 }));
+
+      const res = await POST(createFakeRequest({ uri: VALID_URI }));
+      expect(res.status).toBe(502);
+      const json = await res.json();
+      expect(json.error).toBe('Failed to fetch credential: storage returned 404');
+      expect(json.code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('returns 502 when response exceeds size limit', async () => {
+      const hugeText = 'x'.repeat(MAX_SIZE + 1);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => hugeText,
+      });
+
+      const res = await POST(createFakeRequest({ uri: VALID_URI }));
+      expect(res.status).toBe(502);
+      const json = await res.json();
+      expect(json.error).toContain('exceeds maximum size');
+      expect(json.code).toBe('UPSTREAM_ERROR');
+    });
+
+    it('returns 502 when response.text() throws', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => {
+          throw new Error('stream error');
+        },
+      });
+
+      const res = await POST(createFakeRequest({ uri: VALID_URI }));
+      expect(res.status).toBe(502);
+      const json = await res.json();
+      expect(json.error).toBe('Failed to read credential response');
+      expect(json.code).toBe('UPSTREAM_ERROR');
+    });
   });
 
   // ── Credential Processing (422) ───────────────────────────────────
 
   it('returns 422 when response is not valid JSON', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: async () => 'not-json{{{',
-    });
+    mockStorageDocument('not-json{{{');
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(422);
@@ -323,7 +420,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('returns 422 when credential is encrypted but no decryption key provided', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+    mockStorageDocument(ENCRYPTED_DATA);
     mockIsEncryptedEnvelope.mockReturnValue(true);
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -333,8 +430,22 @@ describe('POST /api/v1/credentials/verify', () => {
     expect(json.code).toBe('DECRYPTION_REQUIRED');
   });
 
-  it('returns 422 when decryption fails', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+  it('returns 422 ENVELOPE_INVALID when the envelope is structurally corrupted, without attempting decryption', async () => {
+    mockStorageDocument(ENCRYPTED_DATA);
+    mockIsEncryptedEnvelope.mockReturnValue(true);
+    mockHasValidEnvelopeStructure.mockReturnValue(false);
+
+    const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.code).toBe('ENVELOPE_INVALID');
+    expect(json.error).toContain('corrupted');
+    expect(json.error).toContain('Re-entering the key will not help');
+    expect(mockDecryptCredential).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 DECRYPTION_FAILED with a key-mismatch message when decryption fails', async () => {
+    mockStorageDocument(ENCRYPTED_DATA);
     mockIsEncryptedEnvelope.mockReturnValue(true);
     mockDecryptCredential.mockImplementation(() => {
       throw new Error('decryption failure');
@@ -343,23 +454,39 @@ describe('POST /api/v1/credentials/verify', () => {
     const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY }));
     expect(res.status).toBe(422);
     const json = await res.json();
-    expect(json.error).toBe('Failed to decrypt credential');
+    expect(json.error).toBe('The decryption key does not match this credential. Check the key and try again.');
     expect(json.code).toBe('DECRYPTION_FAILED');
   });
 
-  it('returns 422 when decrypted output is not valid JSON', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENCRYPTED_DATA));
+  it('returns 422 DECRYPTED_NOT_JSON when decrypted output is not valid JSON', async () => {
+    mockStorageDocument(ENCRYPTED_DATA);
     mockIsEncryptedEnvelope.mockReturnValue(true);
     mockDecryptCredential.mockReturnValue('not-valid-json{{{');
 
     const res = await POST(createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY }));
     expect(res.status).toBe(422);
     const json = await res.json();
-    expect(json.code).toBe('DECRYPTION_FAILED');
+    expect(json.code).toBe('DECRYPTED_NOT_JSON');
+    expect(json.error).toContain('not valid JSON');
+  });
+
+  it('verifies the digest against the decrypted credential bytes, not the encrypted envelope', async () => {
+    mockStorageDocument(ENCRYPTED_DATA);
+    mockIsEncryptedEnvelope.mockReturnValue(true);
+    mockDecryptCredential.mockReturnValue(JSON.stringify(ENVELOPED_CREDENTIAL));
+    mockVcService.verify.mockResolvedValue({ verified: true });
+
+    const res = await POST(
+      createFakeRequest({ uri: VALID_URI, decryptionKey: VALID_KEY, digestMultibase: 'zQmSomeDigest' }),
+    );
+    expect(res.status).toBe(200);
+
+    const verifiedBytes = mockMultibaseDigestVerify.mock.calls[0][0] as Uint8Array;
+    expect(Buffer.from(verifiedBytes).toString('utf8')).toBe(JSON.stringify(ENVELOPED_CREDENTIAL));
   });
 
   it('returns 422 when digestMultibase does not match', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockMultibaseDigestVerify.mockResolvedValueOnce(false);
 
     const res = await POST(createFakeRequest({ uri: VALID_URI, digestMultibase: 'zNOMATCH' }));
@@ -370,7 +497,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('returns 422 when legacy hex hash does not match', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     // VALID_HASH is `a`.repeat(64); the real sha-256 of the JSON credential
     // will not equal that, so the legacy path's comparison fails.
     const res = await POST(createFakeRequest({ uri: VALID_URI, hash: VALID_HASH }));
@@ -382,7 +509,7 @@ describe('POST /api/v1/credentials/verify', () => {
 
   it('returns 422 when credential is not an EnvelopedVerifiableCredential', async () => {
     const plainCredential = { type: 'SomeOtherType', id: 'urn:uuid:123' };
-    mockFetch.mockResolvedValue(createFetchResponse(plainCredential));
+    mockStorageDocument(plainCredential);
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
     expect(res.status).toBe(422);
@@ -394,7 +521,7 @@ describe('POST /api/v1/credentials/verify', () => {
   // ── Verification Outcomes (200) ───────────────────────────────────
 
   it('returns verified: true for successful verification', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -408,7 +535,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('returns verified: false with error details when verification fails', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     const verificationError = { type: 'status', message: 'Credential revoked' };
     mockVcService.verify.mockResolvedValue({ verified: false, error: verificationError });
 
@@ -424,7 +551,7 @@ describe('POST /api/v1/credentials/verify', () => {
   // ── Edge Cases ────────────────────────────────────────────────────
 
   it('skips decryption for unencrypted credentials', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -433,7 +560,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('skips digest check when neither digestMultibase nor hash is provided', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -442,7 +569,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('omits decodedCredential and adds warning when JWT decode fails', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockResolvedValue({ verified: true });
     mockDecodeJwt.mockImplementation(() => {
       throw new Error('invalid JWT');
@@ -458,7 +585,7 @@ describe('POST /api/v1/credentials/verify', () => {
 
   it('adds warning when credential.id is not a string', async () => {
     const credNoId = { ...ENVELOPED_CREDENTIAL, id: 42 };
-    mockFetch.mockResolvedValue(createFetchResponse(credNoId));
+    mockStorageDocument(credNoId);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -470,7 +597,7 @@ describe('POST /api/v1/credentials/verify', () => {
 
   it('adds warning when credential.id does not start with data:application/vc+jwt,', async () => {
     const credBadId = { ...ENVELOPED_CREDENTIAL, id: 'urn:uuid:123' };
-    mockFetch.mockResolvedValue(createFetchResponse(credBadId));
+    mockStorageDocument(credBadId);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -481,7 +608,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('resolves VC service with SYSTEM_TENANT_ID', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     await POST(createFakeRequest({ uri: VALID_URI }));
@@ -490,7 +617,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('includes decodedCredential for enveloped credentials', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -506,7 +633,7 @@ describe('POST /api/v1/credentials/verify', () => {
       ...ENVELOPED_CREDENTIAL,
       type: ['VerifiableCredential', 'EnvelopedVerifiableCredential'],
     };
-    mockFetch.mockResolvedValue(createFetchResponse(arrayTypeCredential));
+    mockStorageDocument(arrayTypeCredential);
     mockVcService.verify.mockResolvedValue({ verified: true });
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -518,7 +645,7 @@ describe('POST /api/v1/credentials/verify', () => {
   // ── Service Errors ────────────────────────────────────────────────
 
   it('returns 500 when VC service resolution fails', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockResolveVcService.mockRejectedValue(new ServiceResolutionError('VC', SYSTEM_TENANT_ID));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -529,7 +656,7 @@ describe('POST /api/v1/credentials/verify', () => {
 
   it('returns 502 when VC service returns an error during verification', async () => {
     const { VcVerifyError } = jest.requireActual('@uncefact/untp-ri-services');
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockRejectedValue(new VcVerifyError('HTTP 404: Not Found', 404));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));
@@ -540,7 +667,7 @@ describe('POST /api/v1/credentials/verify', () => {
   });
 
   it('returns 500 when vcService.verify() throws unexpectedly', async () => {
-    mockFetch.mockResolvedValue(createFetchResponse(ENVELOPED_CREDENTIAL));
+    mockStorageDocument(ENVELOPED_CREDENTIAL);
     mockVcService.verify.mockRejectedValue(new Error('VCKit connection refused'));
 
     const res = await POST(createFakeRequest({ uri: VALID_URI }));

--- a/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/verify/route.ts
@@ -1,12 +1,25 @@
+import { TextDecoder } from 'node:util';
 import { NextResponse } from 'next/server';
 import { apiLogger } from '@/lib/api/logger';
 import { ValidationError } from '@/lib/api/validation';
 import { withPublicRoute } from '@/lib/api/with-public-route';
 import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
-import { decryptCredential, isEncryptedEnvelope, VcVerifyError } from '@uncefact/untp-ri-services';
+import {
+  decryptCredential,
+  hasValidEnvelopeStructure,
+  isEncryptedEnvelope,
+  VcVerifyError,
+} from '@uncefact/untp-ri-services';
 import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
-import { validatePublicUrl } from '@uncefact/untp-ri-services/server';
+import {
+  resolveDocument,
+  ResolverError,
+  ResolverHttpError,
+  ResolverTimedOutError,
+  ResolverTooLargeError,
+} from '@uncefact/untp-utils/resolvers';
+import { UrlValidationError } from '@uncefact/untp-utils/node';
 import type { EnvelopedVerifiableCredential, VerifyResult } from '@uncefact/untp-ri-services';
 import { decodeJwt } from 'jose';
 
@@ -35,9 +48,16 @@ function getMaxCredentialSize(): number {
  *
  *       This is an unauthenticated endpoint — no bearer token is required.
  *
- *       SSRF protection: the URI hostname is resolved via DNS and the
- *       resolved IP is checked against private/reserved ranges. Set
- *       `VERIFY_ALLOW_PRIVATE_URLS=true` to bypass (development only).
+ *       Decryption happens server-side, so a `decryptionKey` travels in the
+ *       request body. Production deployments must serve this endpoint over
+ *       HTTPS so the key is protected in transit.
+ *
+ *       SSRF protection: the URI is fetched through a guarded resolver that
+ *       validates the hostname against private/reserved ranges on every
+ *       redirect hop and pins the connection to the validated address, so
+ *       neither a redirect nor a DNS change between check and connect can
+ *       reach a private network. Set `VERIFY_ALLOW_PRIVATE_URLS=true` to
+ *       bypass (development only).
  *     tags:
  *       - Credentials
  *     security: []
@@ -121,9 +141,24 @@ function getMaxCredentialSize(): number {
  *                   enum:
  *                     - INVALID_RESPONSE
  *                     - DECRYPTION_REQUIRED
+ *                     - ENVELOPE_INVALID
  *                     - DECRYPTION_FAILED
- *                     - HASH_MISMATCH
+ *                     - DECRYPTED_NOT_JSON
+ *                     - DIGEST_MISMATCH
  *                     - UNSUPPORTED_CREDENTIAL_TYPE
+ *                   description: |
+ *                     `DECRYPTION_REQUIRED`: the credential is encrypted and no
+ *                     `decryptionKey` was supplied.
+ *                     `ENVELOPE_INVALID`: the stored encrypted envelope is
+ *                     structurally corrupted (wrong IV or auth-tag length);
+ *                     re-supplying the key will not help.
+ *                     `DECRYPTION_FAILED`: the decryption key does not match
+ *                     the credential. This is almost always a wrong key, but
+ *                     AES-GCM cannot distinguish a wrong key from ciphertext
+ *                     tampered at valid lengths.
+ *                     `DECRYPTED_NOT_JSON`: decryption succeeded but the
+ *                     content is not valid JSON, so the stored credential is
+ *                     corrupted.
  *       502:
  *         description: Upstream service error
  *         content:
@@ -199,52 +234,88 @@ export const POST = withPublicRoute(async (req) => {
     throw new ValidationError('decryptionKey must be a 64-character hex string');
   }
 
-  // ── SSRF protection: block private/reserved network addresses ──────
-  if (process.env.VERIFY_ALLOW_PRIVATE_URLS !== 'true') {
-    try {
-      await validatePublicUrl(parsedUri);
-    } catch (e) {
-      throw new ValidationError(
-        e instanceof Error ? e.message : 'uri must not point to a private or reserved network address',
-      );
-    }
-  }
-
   // ── Step 2: Fetch credential from storage URI ──────────────────────
+  // The guarded resolver validates the hostname against private/reserved
+  // ranges on every redirect hop and pins the connection to the validated
+  // address, closing the redirect-following and DNS-rebinding gaps a
+  // validate-then-fetch sequence leaves open. VERIFY_ALLOW_PRIVATE_URLS=true
+  // (development only) falls back to a plain fetch so private storage hosts
+  // in local compose setups keep working.
   logger.info({ uri: body.uri }, 'Fetching credential from storage');
 
-  let fetchResponse: Response;
-  try {
-    fetchResponse = await fetch(body.uri, { signal: AbortSignal.timeout(10_000) });
-  } catch (e: unknown) {
-    const message =
-      e instanceof Error && e.name === 'TimeoutError'
-        ? 'Failed to fetch credential: request timed out'
-        : 'Failed to fetch credential: network error';
-    logger.warn({ uri: body.uri, error: message }, 'Credential fetch failed');
-    return NextResponse.json({ error: message, code: 'UPSTREAM_ERROR' }, { status: 502 });
-  }
-
-  if (!fetchResponse.ok) {
-    const message = `Failed to fetch credential: storage returned ${fetchResponse.status}`;
-    logger.warn({ uri: body.uri, status: fetchResponse.status }, 'Credential fetch failed');
-    return NextResponse.json({ error: message, code: 'UPSTREAM_ERROR' }, { status: 502 });
-  }
-
-  let responseText: string;
-  try {
-    responseText = await fetchResponse.text();
-  } catch (e: unknown) {
-    logger.warn({ uri: body.uri, err: e }, 'Failed to read credential response body');
-    return NextResponse.json({ error: 'Failed to read credential response', code: 'UPSTREAM_ERROR' }, { status: 502 });
-  }
-
   const maxSize = getMaxCredentialSize();
-  if (responseText.length > maxSize) {
-    return NextResponse.json(
-      { error: `Credential response exceeds maximum size of ${maxSize} bytes`, code: 'UPSTREAM_ERROR' },
-      { status: 502 },
-    );
+  let responseText: string;
+
+  if (process.env.VERIFY_ALLOW_PRIVATE_URLS === 'true') {
+    let fetchResponse: Response;
+    try {
+      fetchResponse = await fetch(body.uri, { signal: AbortSignal.timeout(10_000) });
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error && e.name === 'TimeoutError'
+          ? 'Failed to fetch credential: request timed out'
+          : 'Failed to fetch credential: network error';
+      logger.warn({ uri: body.uri, error: message }, 'Credential fetch failed');
+      return NextResponse.json({ error: message, code: 'UPSTREAM_ERROR' }, { status: 502 });
+    }
+
+    if (!fetchResponse.ok) {
+      const message = `Failed to fetch credential: storage returned ${fetchResponse.status}`;
+      logger.warn({ uri: body.uri, status: fetchResponse.status }, 'Credential fetch failed');
+      return NextResponse.json({ error: message, code: 'UPSTREAM_ERROR' }, { status: 502 });
+    }
+
+    try {
+      responseText = await fetchResponse.text();
+    } catch (e: unknown) {
+      logger.warn({ uri: body.uri, err: e }, 'Failed to read credential response body');
+      return NextResponse.json(
+        { error: 'Failed to read credential response', code: 'UPSTREAM_ERROR' },
+        { status: 502 },
+      );
+    }
+
+    if (responseText.length > maxSize) {
+      return NextResponse.json(
+        { error: `Credential response exceeds maximum size of ${maxSize} bytes`, code: 'UPSTREAM_ERROR' },
+        { status: 502 },
+      );
+    }
+  } else {
+    try {
+      const resolved = await resolveDocument(body.uri, { maxResponseBytes: maxSize, totalTimeoutMs: 10_000 });
+      responseText = new TextDecoder().decode(resolved.body);
+    } catch (e: unknown) {
+      if (e instanceof UrlValidationError) {
+        throw new ValidationError(e.message);
+      }
+      if (e instanceof ResolverTooLargeError) {
+        return NextResponse.json(
+          { error: `Credential response exceeds maximum size of ${maxSize} bytes`, code: 'UPSTREAM_ERROR' },
+          { status: 502 },
+        );
+      }
+      if (e instanceof ResolverHttpError) {
+        const message = `Failed to fetch credential: storage returned ${e.status}`;
+        logger.warn({ uri: body.uri, status: e.status }, 'Credential fetch failed');
+        return NextResponse.json({ error: message, code: 'UPSTREAM_ERROR' }, { status: 502 });
+      }
+      if (e instanceof ResolverTimedOutError) {
+        logger.warn({ uri: body.uri }, 'Credential fetch timed out');
+        return NextResponse.json(
+          { error: 'Failed to fetch credential: request timed out', code: 'UPSTREAM_ERROR' },
+          { status: 502 },
+        );
+      }
+      if (e instanceof ResolverError) {
+        logger.warn({ uri: body.uri, err: e }, 'Credential fetch failed');
+        return NextResponse.json(
+          { error: 'Failed to fetch credential: network error', code: 'UPSTREAM_ERROR' },
+          { status: 502 },
+        );
+      }
+      throw e;
+    }
   }
 
   let fetchedData: unknown;
@@ -272,19 +343,53 @@ export const POST = withPublicRoute(async (req) => {
       );
     }
 
+    // Structural validity must be checked before decryption: Node's AES-GCM
+    // throws the same error for a wrong-length IV/tag as for a wrong key, so
+    // corruption is only distinguishable from a key mismatch up front.
+    if (!hasValidEnvelopeStructure(fetchedData)) {
+      logger.warn({ uri: body.uri }, 'Encrypted envelope is structurally invalid');
+      return NextResponse.json(
+        {
+          error: 'The stored credential data is corrupted and cannot be decrypted. Re-entering the key will not help.',
+          code: 'ENVELOPE_INVALID',
+        },
+        { status: 422 },
+      );
+    }
+
     logger.info('Decrypting credential');
+    let decryptedString: string;
     try {
-      const decryptedString = decryptCredential({
+      decryptedString = decryptCredential({
         cipherText: fetchedData.cipherText,
         key: body.decryptionKey,
         iv: fetchedData.iv,
         tag: fetchedData.tag,
         type: fetchedData.type,
       });
-      credential = JSON.parse(decryptedString);
     } catch (e: unknown) {
       logger.warn({ uri: body.uri, err: e }, 'Credential decryption failed');
-      return NextResponse.json({ error: 'Failed to decrypt credential', code: 'DECRYPTION_FAILED' }, { status: 422 });
+      return NextResponse.json(
+        {
+          error: 'The decryption key does not match this credential. Check the key and try again.',
+          code: 'DECRYPTION_FAILED',
+        },
+        { status: 422 },
+      );
+    }
+
+    try {
+      credential = JSON.parse(decryptedString);
+    } catch {
+      logger.warn({ uri: body.uri }, 'Decrypted credential is not valid JSON');
+      return NextResponse.json(
+        {
+          error:
+            'The credential was decrypted but its content is not valid JSON; the stored credential data is corrupted.',
+          code: 'DECRYPTED_NOT_JSON',
+        },
+        { status: 422 },
+      );
     }
   } else {
     credential = fetchedData as Record<string, unknown>;

--- a/packages/reference-implementation/src/services/credentials/index.ts
+++ b/packages/reference-implementation/src/services/credentials/index.ts
@@ -1,2 +1,2 @@
-export { verifyCredential } from './verify-credential';
-export type { VerifyCredentialParams, VerifyCredentialResult } from './verify-credential';
+export { verifyCredential, VerifyCredentialError } from './verify-credential';
+export type { VerifyCredentialParams, VerifyCredentialResult, VerifyErrorCode } from './verify-credential';

--- a/packages/reference-implementation/src/services/credentials/verify-credential.test.ts
+++ b/packages/reference-implementation/src/services/credentials/verify-credential.test.ts
@@ -1,4 +1,4 @@
-import { verifyCredential } from './verify-credential';
+import { verifyCredential, VerifyCredentialError } from './verify-credential';
 
 describe('verifyCredential', () => {
   const mockFetch = jest.fn();
@@ -82,7 +82,7 @@ describe('verifyCredential', () => {
     await expect(verifyCredential({ uri: 'https://example.com/cred' })).rejects.toThrow('uri is required');
   });
 
-  it('throws on 422 processing error with code', async () => {
+  it('throws a typed error carrying code and status on 422 processing errors', async () => {
     mockFetch.mockResolvedValue({
       ok: false,
       status: 422,
@@ -92,12 +92,39 @@ describe('verifyCredential', () => {
       }),
     });
 
-    await expect(verifyCredential({ uri: 'https://example.com/cred', hash: 'abc' })).rejects.toThrow(
-      'Credential digest does not match (DIGEST_MISMATCH)',
+    const error = await verifyCredential({ uri: 'https://example.com/cred', hash: 'abc' }).then(
+      () => {
+        throw new Error('expected verifyCredential to reject');
+      },
+      (e) => e,
     );
+    expect(error).toBeInstanceOf(VerifyCredentialError);
+    expect(error.message).toBe('Credential digest does not match');
+    expect(error.code).toBe('DIGEST_MISMATCH');
+    expect(error.status).toBe(422);
   });
 
-  it('throws on 502 upstream error with code', async () => {
+  it('exposes DECRYPTION_REQUIRED so the verify page can branch to the key prompt', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({
+        error: 'Credential is encrypted but no decryptionKey was provided',
+        code: 'DECRYPTION_REQUIRED',
+      }),
+    });
+
+    const error = await verifyCredential({ uri: 'https://example.com/cred' }).then(
+      () => {
+        throw new Error('expected verifyCredential to reject');
+      },
+      (e) => e,
+    );
+    expect(error).toBeInstanceOf(VerifyCredentialError);
+    expect(error.code).toBe('DECRYPTION_REQUIRED');
+  });
+
+  it('throws a typed error carrying code and status on 502 upstream errors', async () => {
     mockFetch.mockResolvedValue({
       ok: false,
       status: 502,
@@ -107,9 +134,34 @@ describe('verifyCredential', () => {
       }),
     });
 
-    await expect(verifyCredential({ uri: 'https://example.com/cred' })).rejects.toThrow(
-      'Upstream service unavailable (UPSTREAM_ERROR)',
+    const error = await verifyCredential({ uri: 'https://example.com/cred' }).then(
+      () => {
+        throw new Error('expected verifyCredential to reject');
+      },
+      (e) => e,
     );
+    expect(error).toBeInstanceOf(VerifyCredentialError);
+    expect(error.message).toBe('Upstream service unavailable');
+    expect(error.code).toBe('UPSTREAM_ERROR');
+    expect(error.status).toBe(502);
+  });
+
+  it('throws a typed error with undefined code when the response has none', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'decryptionKey must be a 64-character hex string' }),
+    });
+
+    const error = await verifyCredential({ uri: 'https://example.com/cred', decryptionKey: 'zz' }).then(
+      () => {
+        throw new Error('expected verifyCredential to reject');
+      },
+      (e) => e,
+    );
+    expect(error).toBeInstanceOf(VerifyCredentialError);
+    expect(error.code).toBeUndefined();
+    expect(error.status).toBe(400);
   });
 
   it('throws on 500 server error', async () => {

--- a/packages/reference-implementation/src/services/credentials/verify-credential.ts
+++ b/packages/reference-implementation/src/services/credentials/verify-credential.ts
@@ -25,6 +25,41 @@ type FailedVerificationResult = {
 
 export type VerifyCredentialResult = VerifiedResult | FailedVerificationResult;
 
+/**
+ * Error codes the verification API can return with a 422/502, as documented
+ * on `POST /api/v1/credentials/verify`. `VerifyCredentialError.code` stays a
+ * plain string because the API can grow codes this client has not seen; this
+ * union types the finite set the UI branches on so a typo fails to compile.
+ */
+export type VerifyErrorCode =
+  | 'INVALID_RESPONSE'
+  | 'DECRYPTION_REQUIRED'
+  | 'ENVELOPE_INVALID'
+  | 'DECRYPTION_FAILED'
+  | 'DECRYPTED_NOT_JSON'
+  | 'DIGEST_MISMATCH'
+  | 'UNSUPPORTED_CREDENTIAL_TYPE'
+  | 'UPSTREAM_ERROR'
+  | 'VC_SERVICE_ERROR';
+
+/**
+ * A non-OK response from the verification API, carrying the HTTP status and
+ * the API's error code so callers can branch on specific failures (the verify
+ * page prompts for a key on `DECRYPTION_REQUIRED` and offers re-entry on
+ * `DECRYPTION_FAILED`) instead of parsing the message text.
+ */
+export class VerifyCredentialError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = 'VerifyCredentialError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
 export async function verifyCredential(params: VerifyCredentialParams): Promise<VerifyCredentialResult> {
   if (!params.uri) {
     throw new Error('uri is required');
@@ -57,8 +92,8 @@ export async function verifyCredential(params: VerifyCredentialParams): Promise<
     throw new Error(`Verification request failed with status ${response.status}`, { cause: e });
   }
 
-  const errorMessage = body.error as string;
-  const code = body.code as string | undefined;
+  const errorMessage = typeof body.error === 'string' ? body.error : 'Verification failed';
+  const code = typeof body.code === 'string' ? body.code : undefined;
 
-  throw new Error(code ? `${errorMessage} (${code})` : errorMessage);
+  throw new VerifyCredentialError(errorMessage, response.status, code);
 }

--- a/packages/services/src/encryption/decrypt-credential.no-key-logging.test.ts
+++ b/packages/services/src/encryption/decrypt-credential.no-key-logging.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Pins that the decryption key never appears in the crypto layer's serialised
+ * log output. `decryptCredential` builds its own logger from the logging
+ * factory (separate from any caller's logger), so the reference
+ * implementation's route-level no-key-logging suite cannot see this
+ * destination; this suite captures it at the source. Together the two suites
+ * cover both destinations a submitted key could leak through.
+ */
+
+const capturedLogLines: string[] = [];
+
+jest.mock('../logging/factory.js', () => {
+  const actual = jest.requireActual('../logging/factory.js');
+  return {
+    createLogger: () =>
+      actual.createLogger({
+        level: 'debug',
+        destination: {
+          write: (msg: string) => {
+            capturedLogLines.push(msg);
+          },
+        },
+      }),
+  };
+});
+
+import { createCipheriv, randomBytes } from 'node:crypto';
+import { decryptCredential } from './decrypt-credential.js';
+import { EncryptionAlgorithm } from './encryption.interface.js';
+
+const SENTINEL_KEY = 'deadbeefcafe0042'.repeat(4); // 64 hex chars, distinctive
+const WRONG_KEY = 'a'.repeat(64);
+const PLAINTEXT = JSON.stringify({ type: 'EnvelopedVerifiableCredential', id: 'urn:uuid:no-key-logging' });
+
+function encryptEnvelope(plaintext: string, hexKey: string) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(
+    'aes-256-gcm',
+    Buffer.from(hexKey, 'hex') as unknown as Uint8Array,
+    iv as unknown as Uint8Array,
+  );
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()] as unknown as Uint8Array[]);
+  return {
+    cipherText: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    type: EncryptionAlgorithm.AES_256_GCM,
+  };
+}
+
+describe('decryptCredential never logs the key', () => {
+  beforeEach(() => {
+    capturedLogLines.length = 0;
+  });
+
+  it('emits debug log lines but none containing the key on successful decryption', () => {
+    const result = decryptCredential({ ...encryptEnvelope(PLAINTEXT, SENTINEL_KEY), key: SENTINEL_KEY });
+    expect(result).toBe(PLAINTEXT);
+
+    expect(capturedLogLines.length).toBeGreaterThan(0); // the capture actually captured
+    expect(capturedLogLines.join('')).not.toContain(SENTINEL_KEY);
+  });
+
+  it('does not log either key when decryption fails with a wrong key', () => {
+    expect(() => decryptCredential({ ...encryptEnvelope(PLAINTEXT, SENTINEL_KEY), key: WRONG_KEY })).toThrow();
+
+    const output = capturedLogLines.join('');
+    expect(output).not.toContain(SENTINEL_KEY);
+    expect(output).not.toContain(WRONG_KEY);
+  });
+
+  it('the capture would catch a leak (self-check that this suite can fail)', () => {
+    const { createLogger } = jest.requireMock('../logging/factory.js');
+    createLogger().info({ leakCheck: SENTINEL_KEY }, 'deliberate sentinel write');
+    expect(capturedLogLines.join('')).toContain(SENTINEL_KEY);
+  });
+});


### PR DESCRIPTION
This PR makes the verify page prompt for a decryption key when an encrypted credential is opened from a keyless link, so a verifier holding the key from an out-of-band exchange can complete verification instead of hitting a dead-end error. Keyless links are what credentials published to the Identity Resolver carry, so this unblocks that whole flow. The recording below shows the E2E run covering the prompt, wrong-key re-entry, and success paths.

The entered key is used for the current attempt only. It is held in component state, never written to the URL or browser storage, cleared on success and on back/forward restore, and never retained or logged by the backend, which is pinned by tests that capture real serialised log output at both the route and crypto layers.

Two related changes ride along. The verification endpoint's storage fetch now goes through the guarded resolver from untp-utils, which re-validates the hostname on every redirect hop and pins the connection to the validated address, closing the redirect and DNS-rebinding gaps of the previous check-then-fetch sequence. And decryption failures are split into three codes with messages as specific as AES-GCM allows: a structurally corrupted envelope (`ENVELOPE_INVALID`, re-entry will not help), a key that does not match (`DECRYPTION_FAILED`, retryable), and decrypted content that is not valid JSON (`DECRYPTED_NOT_JSON`). The docs and Swagger describe all three, and the client error now carries the code and status as fields.

<img width="1200" height="870" alt="820-1-key-prompt" src="https://github.com/user-attachments/assets/66c1e30c-3dbb-49dc-8d0f-c57a53898bda" />

<img width="1200" height="870" alt="820-2-wrong-key" src="https://github.com/user-attachments/assets/21abce22-0d7d-4eb5-80e4-ba07e0fa7d89" />

Closes #820

## Test plan
- [x] Keyless `?q=` link on an encrypted credential shows the prompt; correct key decrypts and verifies; the key never appears in the URL
- [x] Wrong key keeps the form with a clear message and re-entry works; malformed key is rejected inline without a round trip
- [x] Corrupted envelope and non-JSON plaintext go terminal instead of inviting pointless retries
- [x] Embedded-key links, legacy `?q=` and `hash` links, and unencrypted credentials all verify as before
- [x] Submitted keys are absent from serialised backend logs on success and failure
- [x] Full RI unit suite, services suite, and RI open-mode E2E green
