### PR TITLE
docs(ri): document encryption key management, backup pairing, and recovery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,3 +47,5 @@ packages/untp-test-suite
 
 packages/reference-implementation/src/constants/app-config.json
 packages/components/src/constants/app-config.json
+# Never ship key material to the image builder (compose reads .env at run time)
+.env

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ AUTH_TRUST_HOST=true # Required for local development (localhost is not trusted 
 # (Renamed from SERVICE_ENCRYPTION_KEY, which is still read as a deprecated fallback.
 # Do not set both names to different values: the run fails before anything encrypted is written.)
 DATA_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
+# Set only while running the rotate:encryption-key maintenance command (the previous
+# key, with DATA_ENCRYPTION_KEY holding the new one). Remove it after the rotation is
+# verified; see the Encryption Key Rotation page in the operations documentation.
+# OUTGOING_DATA_ENCRYPTION_KEY=
 
 # OIDC Provider Configuration
 # Supported providers: keycloak (default), zitadel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,9 @@ services:
       # .env.example), which the quick start copies.
       DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
       SERVICE_ENCRYPTION_KEY: ${SERVICE_ENCRYPTION_KEY:-}
+      # Set only for the duration of a key rotation; see the Encryption Key
+      # Rotation page. The application itself never reads it.
+      OUTGOING_DATA_ENCRYPTION_KEY: ${OUTGOING_DATA_ENCRYPTION_KEY:-}
       # Verification URLs
       DEFAULT_HUMAN_VERIFICATION_URL: http://localhost:3003/verify
       DEFAULT_MACHINE_VERIFICATION_URL: http://localhost:3332/agent/routeVerificationCredential

--- a/documentation/docs/migration-guides/ri-v0.4.md
+++ b/documentation/docs/migration-guides/ri-v0.4.md
@@ -11,9 +11,14 @@ import Disclaimer from '.././\_disclaimer.mdx';
 Back up the Reference Implementation database, and record the encryption key the
 deployment currently runs with (`SERVICE_ENCRYPTION_KEY` in earlier versions). This
 release encrypts credential decryption keys at rest under that key, so from this
-version onwards **losing the key means losing access to every privately stored
-credential**. Store the key with the same care as the database backups: a database
-backup without the matching key cannot be recovered.
+version onwards **losing the key means losing every service instance configuration and
+every credential decryption key stored as an encrypted envelope**. Credential rows
+created before this release keep their plaintext stored keys until the
+[backfill below](#decryption-key-backfill-for-existing-credentials) wraps them, so they,
+like credentials stored unencrypted, are unaffected by key loss. Store the
+key with the same care as the database backups: once a backup holds any encrypted
+envelope, it cannot be recovered without its matching key. The full pairing, retention, and recovery contract lives in
+[Key Management and Recovery](../reference-implementation/operations/key-management).
 :::
 
 ## Overview
@@ -33,6 +38,8 @@ role (it now protects service instance configurations and credential decryption 
   warning. Rename the variable at your convenience; removal of the fallback is tracked
   in [#721](https://github.com/uncefact/tests-untp/issues/721).
 - Setting both names to the same value works and logs a reminder to remove the old name.
+  The active key's backup pairing and recovery contract is documented in
+  [Key Management and Recovery](../reference-implementation/operations/key-management).
 - Setting both names to **different values fails before anything encrypted is
   written** (on the standard Docker path this surfaces at startup, when the seed
   resolves the key). The two names are aliases for the same active key, so two
@@ -62,7 +69,7 @@ unrecoverable, so a human confirms the key before anything is rewritten.
 Before running it:
 
 1. Preview what it would do with the read-only audit command (`pnpm audit:encryption`), which decrypts every stored envelope under the active key and reports what the backfill would wrap, skip, or abort on (see [Encryption Audit](../reference-implementation/operations/encryption-audit)).
-2. Back up the database.
+2. Back up the database (see [Key Management and Recovery](../reference-implementation/operations/key-management#backups-pair-with-the-key) for how backups pair with the key).
 3. Confirm `DATA_ENCRYPTION_KEY` is exactly the key the running application uses.
 4. Stop any older application instances that might still write plaintext keys during a
    rolling upgrade (or plan to re-run the backfill after they are gone; re-running is

--- a/documentation/docs/reference-implementation/operations/encryption-audit.md
+++ b/documentation/docs/reference-implementation/operations/encryption-audit.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: Encryption Audit
 ---
 
@@ -10,7 +10,7 @@ The Reference Implementation [encrypts two kinds of data at rest](../services/se
 Run it:
 
 - before rotating `DATA_ENCRYPTION_KEY`, to confirm the current key decrypts everything the rotation will re-encrypt (see [Encryption Key Rotation](./encryption-key-rotation));
-- after restoring a database backup, to confirm the restored data and the configured key still match;
+- after restoring a database backup, to confirm the restored data and the configured key still match (use the [stopped-writers form](#running-with-the-application-stopped) below, as the [recovery procedure](./key-management#recovery) directs);
 - during incident triage, when decryption errors suggest a key or data problem and you need the full extent rather than the one row a request tripped over.
 
 ## Running the audit
@@ -21,11 +21,26 @@ From a source checkout, in `packages/reference-implementation`:
 pnpm audit:encryption
 ```
 
-Inside the published Docker image (which ships no pnpm):
+Inside the published Docker image (which ships no pnpm), against the running application (live triage):
 
 ```bash
 docker compose exec -w /app ri node_modules/.bin/tsx scripts/audit-encryption.ts
 ```
+
+### Running with the application stopped
+
+Before a [rotation](./encryption-key-rotation), after a [restore](./key-management#recovery), and in any state where writers must stay stopped, the audit runs as a one-off container instead. The key under test is whatever `DATA_ENCRYPTION_KEY` holds in `.env`, exactly as for the serving application, so the command needs no key arguments. The `SKIP_` variables stop the image's entrypoint running migrations and the seed first; the entrypoint otherwise writes to the database before the audit has gated anything, and against a database the configured key cannot yet read the seed's own key validation fails outright. The empty `SERVICE_ENCRYPTION_KEY` override neutralises a stale deprecated alias the compose file would otherwise forward (the audit refuses to run while the two names disagree):
+
+```bash
+docker compose run --rm \
+  -e SKIP_MIGRATIONS=true -e SKIP_SEED=true \
+  -e SERVICE_ENCRYPTION_KEY= \
+  ri node_modules/.bin/tsx scripts/audit-encryption.ts
+```
+
+To audit under a key other than the one in `.env` (verifying a historical backup's key, for example), forward it for this one run by name-only `-e DATA_ENCRYPTION_KEY` with the value loaded from your secret store by command substitution (`DATA_ENCRYPTION_KEY="$(...)" docker compose run ... -e DATA_ENCRYPTION_KEY ...`); never type the literal key into the command, which records it in shell history.
+
+On a source checkout, `pnpm audit:encryption` needs no entrypoint handling, but a stale `SERVICE_ENCRYPTION_KEY` must likewise be unset or overridden.
 
 The command needs `DATA_ENCRYPTION_KEY` and a database target: a pre-set `RI_DATABASE_URL` is honoured as given, and the `RI_POSTGRES_*` variables are used to construct one only when it is absent (the same rule the application and the backfill follow).
 

--- a/documentation/docs/reference-implementation/operations/encryption-key-rotation.md
+++ b/documentation/docs/reference-implementation/operations/encryption-key-rotation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Encryption Key Rotation
 ---
 
@@ -11,13 +11,13 @@ The command is idempotent. A re-run with the same key pair finds rows already on
 
 ## Before you start
 
-1. Back up the database, and keep both key values somewhere safe until the rotation is verified. A backup without its matching key is not a recovery artefact.
+1. Back up the database, and keep both key values somewhere safe until the rotation is verified. A backup without its matching key is not a recovery artefact; see [Key Management and Recovery](./key-management#backups-pair-with-the-key) for the pairing and retention rules.
 2. Run [`audit:encryption`](./encryption-audit) under the current key and resolve any findings. The rotation refuses to write when any stored envelope fails to decrypt under both supplied keys, or any service configuration is corrupted.
 3. Stop every application instance, including replicas and any maintenance jobs. The rotation must be the only thing touching the database. Run it as a one-off process (for Docker deployments, `docker compose run --rm`), never by `exec`-ing into a serving container.
 
 ## Running the rotation
 
-Set `DATA_ENCRYPTION_KEY` to the **new** key and `OUTGOING_DATA_ENCRYPTION_KEY` to the **previous** key, in the rotation process only.
+Set both keys in `.env`: `DATA_ENCRYPTION_KEY` becomes the **new** key (its end state anyway, and an accidental application start before the rotation has written anything then fails loudly at startup validation), and `OUTGOING_DATA_ENCRYPTION_KEY` holds the **previous** key for the duration of the rotation. Compose forwards both to the rotation container; the serving application never reads the outgoing variable, and it is removed before the application starts. Make sure none of the key variables are exported in your shell: the shell environment takes precedence over `.env` for both compose and the source-checkout scripts, so a stale exported value would silently win over what you just wrote to `.env`.
 
 From a source checkout, in `packages/reference-implementation`:
 
@@ -27,18 +27,13 @@ pnpm rotate:encryption-key
 
 Inside the published Docker image (which ships no pnpm):
 
-Export both keys from your secret store first (name-only `-e` forwards the exported value without putting key material in shell history):
-
 ```bash
-export DATA_ENCRYPTION_KEY='<new key>'
-export OUTGOING_DATA_ENCRYPTION_KEY='<previous key>'
 docker compose run --rm \
   -e SKIP_MIGRATIONS=true -e SKIP_SEED=true \
-  -e DATA_ENCRYPTION_KEY -e OUTGOING_DATA_ENCRYPTION_KEY \
   ri node_modules/.bin/tsx scripts/rotate-encryption-key.ts
 ```
 
-Every variable on the command matters. The compose file only forwards the variables it lists, and `OUTGOING_DATA_ENCRYPTION_KEY` is not among them, so both keys are passed to this one container explicitly (which also keeps the outgoing key out of the serving container's environment). The two `SKIP_` variables stop the image's entrypoint running migrations and the database seed before the command: the seed validates `DATA_ENCRYPTION_KEY` against existing encrypted data, which fails by design while the database is still under the old key. Skipping both keeps the rotation the only thing touching the database.
+Both keys arrive from `.env` like every other variable. The two `SKIP_` variables stop the image's entrypoint running migrations and the database seed before the command: the seed validates `DATA_ENCRYPTION_KEY` against existing encrypted data, which fails by design while the database is still under the old key. Skipping both keeps the rotation the only thing touching the database.
 
 The command needs a database target: a pre-set `RI_DATABASE_URL` is honoured as given, and the `RI_POSTGRES_*` variables are used to construct one only when it is absent (the same rule the application, audit, and backfill follow).
 
@@ -56,8 +51,8 @@ Exit codes: `0` when every stored envelope ended under the active key; `1` when 
 
 ## After the rotation
 
-1. Run `audit:encryption` with `DATA_ENCRYPTION_KEY` set to the new key. With the application still stopped, the Docker form needs the same `SKIP_` pair, and an empty `SERVICE_ENCRYPTION_KEY` override when the deployment still carries that deprecated alias (compose forwards it, and the audit refuses to run while the two names disagree): `docker compose run --rm -e SKIP_MIGRATIONS=true -e SKIP_SEED=true -e DATA_ENCRYPTION_KEY -e SERVICE_ENCRYPTION_KEY= ri node_modules/.bin/tsx scripts/audit-encryption.ts`. On a source checkout, likewise make sure a stale `SERVICE_ENCRYPTION_KEY` is unset or overridden for this step. Success means no decrypt failures and no new corruption; credential rows the rotation reported as corrupted-looking will still be flagged, and they match the rotation's report.
-2. If the deployment still sets the deprecated `SERVICE_ENCRYPTION_KEY` alias, set it to the new key or remove it before starting the application; startup fails when the two names disagree.
-3. Start the application, confirm a credential read and a service resolution work, then remove `OUTGOING_DATA_ENCRYPTION_KEY` from the environment and retire the old key.
+1. With writers still stopped, run the [stopped-writers audit](./encryption-audit#running-with-the-application-stopped) with `DATA_ENCRYPTION_KEY` set to the new key. Success means no decrypt failures and no new corruption; credential rows the rotation reported as corrupted-looking will still be flagged, and they match the rotation's report. Do not continue to startup while the audit shows decrypt failures or new corruption.
+2. Remove `OUTGOING_DATA_ENCRYPTION_KEY` from `.env`, and if the deployment still sets the deprecated `SERVICE_ENCRYPTION_KEY` alias, set it to the new key or remove it. Both must happen before the application starts: containers capture their environment when created, so a variable removed from `.env` afterwards lives on in the running container until it is recreated (and startup fails while the alias names disagree).
+3. Start the application and confirm a credential read and a service resolution work. Retire the old key only per the [retention rule](./key-management#backups-pair-with-the-key): retained backups taken while it was active still open only under it.
 
 If the rotation failed partway, keep every writer stopped, fix what the report names, and re-run with the same key pair; the run converges. Do not start the application against a partially rotated database: the sampled startup check can pass on a row under one key while requests fail on rows under the other.

--- a/documentation/docs/reference-implementation/operations/key-management.md
+++ b/documentation/docs/reference-implementation/operations/key-management.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 5
+title: Key Management and Recovery
+---
+
+# Key Management and Recovery
+
+The Reference Implementation [encrypts service instance configurations and credential decryption keys at rest](../services/service-architecture#encryption-at-rest) under `DATA_ENCRYPTION_KEY`. This page is the operational contract for that key: how to generate and hold it, how backups pair with it, and how recovery works. The [Encryption Audit](./encryption-audit) and [Encryption Key Rotation](./encryption-key-rotation) pages own the two procedures this contract relies on.
+
+## The key and what it protects
+
+Generate the key with `openssl rand -hex 32`, producing the 64-character hexadecimal string the application requires. The placeholder value published in `.env.example` is for local development only; [startup validation](./startup#encryption-key-validation) enforces this, and that section defines exactly when a deployment counts as local development.
+
+## Uniqueness and storage
+
+Each environment has one unique key, held in the deployment's secret store and never committed to version control. Every process and replica in an environment shares that one key; replicas configured with different values are a fault, not separate environments. The serving application resolves and caches exactly one active key. `SERVICE_ENCRYPTION_KEY` is a deprecated alias for the same value, not a second key, and startup fails when the two names disagree. The one exception is the offline [rotation command](./encryption-key-rotation), which deliberately reads a second variable while the application is stopped.
+
+Keys do not travel between environments. Supplying a key other than a backup's paired one fails the audit exactly as key loss would (for any backup holding at least one encrypted envelope), and reusing one environment's key in another means new data is silently written under a key that does not belong there.
+
+## Backups pair with the key
+
+A database backup without its paired key is not a recovery artefact. Stored envelopes carry no key identifier, and the serving application holds exactly one active key, so losing the key makes every stored envelope permanently unreadable: every service instance configuration, and every credential decryption key that has been wrapped. Credential rows created before v0.4 keep their stored keys in plaintext until the [backfill](../../migration-guides/ri-v0.4#decryption-key-backfill-for-existing-credentials) wraps them, so they, like credentials stored unencrypted, do not depend on the key and survive its loss.
+
+For every backup, record which key opens it: the backup's identity (timestamp or version), its source environment, the secret-store version of the paired key, and, when a backup sits on one side of a [rotation](./encryption-key-rotation), which side. Record the secret-store reference, never the raw key, and keep raw key material out of logs and tickets.
+
+Retire a key only when every retained backup taken under it has itself been retired. A completed rotation moves the live database to the new key; every retained backup still opens only under whichever key was active when it was taken, which after several rotations spans several key generations. A retired-too-early key turns those backups into dead weight even though the rotation succeeded. A recorded key is recoverable when its secret-store version can actually be retrieved; verify that periodically by retrieving it, rather than by decrypting something from every backup.
+
+## Recovery
+
+1. Stop every application instance and maintenance job. Nothing may write while recovery runs.
+2. Restore the whole paired backup, using however this deployment restores PostgreSQL. Restore complete backups only: mixing rows from backups on different sides of a rotation creates a store split across keys, which the [audit](./encryption-audit) will surface and which the single-key application then fails on for every row under the other key.
+3. Set `DATA_ENCRYPTION_KEY` to the backup's paired key, and set `SERVICE_ENCRYPTION_KEY` to the same value or unset it.
+4. With writers still stopped, run the [stopped-writers audit](./encryption-audit#running-with-the-application-stopped) under that key, and gate on the report's content, never the exit code alone (pre-existing suspect credential rows already recorded for that backup exit 1 while being expected findings). The outcomes:
+   - **Verified**: every envelope kind the backup is expected to contain decrypted, with no decrypt failures and no corruption beyond the rows already recorded for that backup. Continue.
+   - **Clean but unproven**: the audit reports that nothing existed to verify the key against. On any backup expected to contain envelopes (encrypted service configurations or wrapped credential keys), that means the wrong backup or an incomplete restore; do not start the application. Only when the backup genuinely predates any encrypted data may you continue, recording that the key was not proven.
+   - **Unproven with recorded findings only**: no envelope decrypted and the only findings are the suspect rows already recorded for that backup (the audit exits 1 in this state). Treat it as clean-but-unproven: continue only when the backup genuinely predates any encrypted data, recording that the key was not proven.
+   - **Failed**: decrypt failures, corruption beyond the recorded rows, or an audit that could not complete (an unreachable database is a failed recovery step, not a pass). Stop. Check the pairing record and try the other recorded key for that backup, or another backup. Do not rotate as a way out of key loss; [rotation](./encryption-key-rotation) is a planned change that requires a working outgoing key.
+5. Start the application. The first start runs migrations and the seed as [startup](./startup) describes.
+6. Confirm reads for whichever envelope kinds the backup holds: a known privately stored credential (one whose decryption key is wrapped) reads correctly, and a service instance resolves. Either alone proves the key when the backup holds only that kind. If the backup holds neither, the key cannot be cryptographically proven from it; the pairing record is then the evidence.
+7. Return traffic.
+
+## Rotation
+
+Moving the live database to a new key is the [Encryption Key Rotation](./encryption-key-rotation) procedure. Rotation changes what future backups pair with; it does not release the old key until the backups taken under it are gone.

--- a/documentation/docs/reference-implementation/operations/startup.md
+++ b/documentation/docs/reference-implementation/operations/startup.md
@@ -101,7 +101,7 @@ Before the application accepts its first request, it validates the active `DATA_
 
 Without this check, a `DATA_ENCRYPTION_KEY` that does not match the key data was encrypted under only surfaces once a real request tries to decrypt something — for example a `ConfigDecryptionError` when a service instance resolves. Validating at startup turns that into an immediate, loud failure instead of an intermittent one discovered by end users.
 
-If startup fails this check, verify `DATA_ENCRYPTION_KEY` matches the key the application was previously running with, and restore the previous key. Moving data onto a new key is a deliberate offline procedure, never an in-place variable change; see [Encryption Key Rotation](./encryption-key-rotation).
+If startup fails this check, verify `DATA_ENCRYPTION_KEY` matches the key the application was previously running with, and restore the previous key. The backup pairing, retention, and recovery contract for this key lives in [Key Management and Recovery](./key-management). Moving data onto a new key is a deliberate offline procedure, never an in-place variable change; see [Encryption Key Rotation](./encryption-key-rotation).
 
 ### HTTP User-Agent Override Validation
 

--- a/documentation/docs/reference-implementation/services/service-architecture.md
+++ b/documentation/docs/reference-implementation/services/service-architecture.md
@@ -55,7 +55,7 @@ Once resolved, the Reference Implementation looks up the appropriate adapter in 
 
 ## Encryption at rest
 
-When a tenant registers a service instance, the Reference Implementation encrypts the configuration and stores it in the database. Service configurations contain sensitive information such as API keys and authentication tokens; these are encrypted at rest using the `DATA_ENCRYPTION_KEY` (formerly `SERVICE_ENCRYPTION_KEY`, which is still read as a deprecated fallback) and only decrypted at runtime when the service adapter is instantiated. The same key also encrypts the decryption keys of encrypted credentials before they are persisted on the credential record.
+When a tenant registers a service instance, the Reference Implementation encrypts the configuration and stores it in the database. Service configurations contain sensitive information such as API keys and authentication tokens; these are encrypted at rest using the `DATA_ENCRYPTION_KEY` (formerly `SERVICE_ENCRYPTION_KEY`, which is still read as a deprecated fallback) and only decrypted at runtime when the service adapter is instantiated. The same key also encrypts the decryption keys of encrypted credentials before they are persisted on the credential record. The key's operational contract (generation, backup pairing, retention, recovery) is documented in [Key Management and Recovery](../operations/key-management).
 
 ## Service Types
 

--- a/packages/reference-implementation/scripts/rotate-encryption-key.ts
+++ b/packages/reference-implementation/scripts/rotate-encryption-key.ts
@@ -12,14 +12,11 @@
  * Usage (from packages/reference-implementation, source checkout):
  *   pnpm rotate:encryption-key
  *
- * Usage (inside the published Docker image, which ships no pnpm; the SKIP_
- * variables stop the entrypoint's seed, whose own key validation fails by
- * design while the database is still under the old key, and both keys are
- * passed explicitly because the compose file does not forward
- * OUTGOING_DATA_ENCRYPTION_KEY):
- *   export DATA_ENCRYPTION_KEY='<new>' OUTGOING_DATA_ENCRYPTION_KEY='<previous>'
+ * Usage (inside the published Docker image, which ships no pnpm; both keys
+ * arrive from .env via compose, and the SKIP_ variables stop the
+ * entrypoint's seed, whose own key validation fails by design while the
+ * database is still under the old key):
  *   docker compose run --rm -e SKIP_MIGRATIONS=true -e SKIP_SEED=true \
- *     -e DATA_ENCRYPTION_KEY -e OUTGOING_DATA_ENCRYPTION_KEY \
  *     ri node_modules/.bin/tsx scripts/rotate-encryption-key.ts
  *
  * Requires DATA_ENCRYPTION_KEY (the NEW key), OUTGOING_DATA_ENCRYPTION_KEY


### PR DESCRIPTION
This PR adds a Key Management and Recovery page to the operations documentation, so an operator can read the `DATA_ENCRYPTION_KEY` lifecycle as a contract instead of reconstructing it from the audit and rotation procedures. It covers generation and format, one key per environment and where it lives, how database backups pair with the key (a backup holding encrypted envelopes cannot be recovered without its paired key, and a retired key must outlive every retained backup taken under it), and a step-by-step recovery runbook whose gates read the audit's report rather than its exit code.

Supporting edits keep the surrounding pages consistent: the audit page gains the canonical stopped-writers invocation that recovery and rotation both link to, the rotation procedure now sources both keys from `.env` (compose forwards `OUTGOING_DATA_ENCRYPTION_KEY` to the one-off container, a commented `.env.example` entry documents its transient use, and the variable is removed before the application starts), `.env` is excluded from the Docker build context so key material never reaches the image builder, and the v0.4 migration guide's key-loss warning now states the accurate blast radius, with rows created before v0.4 keeping their plaintext keys until the backfill wraps them.

One deliberate deviation from the issue's scope list: no cross-reference was added to the credentials API page, which is a consumer-facing surface that no longer carries operator material.

Closes #761
