### PR TITLE
refactor(ri): migrate CVC read routes to Zod query schemas

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/cvc/criteria/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/criteria/route.test.ts
@@ -29,6 +29,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 }));
 
 import { GET } from './route';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 
 type Ctx = Parameters<typeof GET>[1];
 const CTX = { tenantId: 'tenant-1', params: Promise.resolve({}) } as unknown as Ctx;
@@ -42,8 +43,97 @@ beforeEach(() => jest.clearAllMocks());
 describe('GET /api/v1/cvc/criteria', () => {
   it('returns 400 when profileId is missing', async () => {
     const res = await GET(req('http://localhost/api/v1/cvc/criteria'), CTX);
+    const json = await res.json();
+
     expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^profileId:/);
     expect(mockListCriteria).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a blank profileId', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/criteria?profileId=%20'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^profileId:/);
+    expect(mockListCriteria).not.toHaveBeenCalled();
+  });
+
+  it('reports the profileId issue before a pagination issue', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/criteria?limit=abc'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^profileId:/);
+  });
+
+  it('returns 400 for a non-numeric limit', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/criteria?profileId=https://a.example/p/1&limit=abc'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit: must be a positive integer');
+  });
+
+  it('rejects a limit above the maximum with a 400 and does not load the catalogue', async () => {
+    const res = await GET(
+      req(`http://localhost/api/v1/cvc/criteria?profileId=https://a.example/p/1&limit=${MAX_PAGE_LIMIT + 1}`),
+      CTX,
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain(`maximum of ${MAX_PAGE_LIMIT}`);
+    expect(mockListCriteria).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a negative offset', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/criteria?profileId=https://a.example/p/1&offset=-1'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset: must be a non-negative integer');
+  });
+
+  it('returns 400 for a repeated query key', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/criteria?profileId=a&profileId=b'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListCriteria).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when listConformityCriteria throws', async () => {
+    mockListCriteria.mockRejectedValue(new Error('Database error'));
+
+    const res = await GET(req('http://localhost/api/v1/cvc/criteria?profileId=https://a.example/p/1'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+
+  it('applies limit and offset to the page', async () => {
+    mockListCriteria.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `c${i}`,
+        name: `C${i}`,
+        version: '1',
+        status: 'active',
+        topics: [],
+        tags: [],
+      })),
+    );
+
+    const res = await GET(
+      req('http://localhost/api/v1/cvc/criteria?profileId=https://a.example/p/1&limit=2&offset=1'),
+      CTX,
+    );
+    const json = await res.json();
+
+    expect(json.data.map((c: { id: string }) => c.id)).toEqual(['c1', 'c2']);
+    expect(json.pagination).toEqual({ total: 5, limit: 2, offset: 1, hasMore: true });
   });
 
   it('lists the criteria for the requested profile', async () => {
@@ -56,7 +146,7 @@ describe('GET /api/v1/cvc/criteria', () => {
 
     expect(res.status).toBe(200);
     expect(json.data).toHaveLength(1);
-    expect(json.pagination).toEqual({ total: 1, limit: 20, offset: 0, hasMore: false });
+    expect(json.pagination).toEqual({ total: 1, limit: DEFAULT_PAGE_LIMIT, offset: 0, hasMore: false });
     expect(mockListCriteria).toHaveBeenCalledWith('https://a.example/p/1', 'tenant-1');
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/cvc/criteria/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/criteria/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
 import { listConformityCriteria } from '@/lib/prisma/repositories';
-import { paginateInMemory, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { paginateInMemory } from '@/lib/api/pagination';
+import { parseQueryParams } from '@/lib/api/validation';
+import { listCvcCriteriaQuerySchema } from '@/lib/api/request-schemas/cvc';
 
 const logger = apiLogger.child({ route: '/api/v1/cvc/criteria' });
 
@@ -26,35 +27,32 @@ const logger = apiLogger.child({ route: '/api/v1/cvc/criteria' });
  *         required: true
  *         schema:
  *           type: string
- *         description: Canonical URI of the profile whose criteria to list
+ *           minLength: 1
+ *         description: Canonical URI of the profile whose criteria to list. A whitespace-only value is rejected with a 400.
  *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
+ *           minimum: 1
+ *         description: Number of entries to return per page. Defaults to 20, or the configured maximum when it is lower. A larger value is rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:
  *           type: integer
+ *           minimum: 0
+ *         description: Number of entries to skip for pagination
  *     responses:
  *       200:
  *         description: A page of conformity criteria
  *       400:
- *         description: profileId is missing, or a pagination parameter is invalid
+ *         description: Validation error (e.g. a missing or blank profileId, a limit above the maximum, a repeated query parameter)
  *       401:
  *         description: Unauthorised
  *       403:
  *         description: No tenant found for user
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  const url = new URL(req.url);
-  const profileId = url.searchParams.get('profileId');
-  if (!isNonEmptyString(profileId)) {
-    throw new ValidationError('profileId is required');
-  }
-
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  const { profileId, limit, offset } = parseQueryParams(new URL(req.url), listCvcCriteriaQuerySchema);
 
   logger.info({ tenantId, profileId }, 'Listing conformity criteria');
   const criteria = await listConformityCriteria(profileId, tenantId);

--- a/packages/reference-implementation/src/app/api/v1/cvc/profiles/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/profiles/route.test.ts
@@ -29,6 +29,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 }));
 
 import { GET } from './route';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 
 type Ctx = Parameters<typeof GET>[1];
 const CTX = { tenantId: 'tenant-1', params: Promise.resolve({}) } as unknown as Ctx;
@@ -42,8 +43,87 @@ beforeEach(() => jest.clearAllMocks());
 describe('GET /api/v1/cvc/profiles', () => {
   it('returns 400 when schemeId is missing', async () => {
     const res = await GET(req('http://localhost/api/v1/cvc/profiles'), CTX);
+    const json = await res.json();
+
     expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^schemeId:/);
     expect(mockListProfiles).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a blank schemeId', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/profiles?schemeId=%20'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^schemeId:/);
+    expect(mockListProfiles).not.toHaveBeenCalled();
+  });
+
+  it('reports the schemeId issue before a pagination issue', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/profiles?limit=abc'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^schemeId:/);
+  });
+
+  it('returns 400 for a non-numeric limit', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/profiles?schemeId=https://a.example&limit=abc'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit: must be a positive integer');
+  });
+
+  it('rejects a limit above the maximum with a 400 and does not load the catalogue', async () => {
+    const res = await GET(
+      req(`http://localhost/api/v1/cvc/profiles?schemeId=https://a.example&limit=${MAX_PAGE_LIMIT + 1}`),
+      CTX,
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain(`maximum of ${MAX_PAGE_LIMIT}`);
+    expect(mockListProfiles).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a negative offset', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/profiles?schemeId=https://a.example&offset=-1'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset: must be a non-negative integer');
+  });
+
+  it('returns 400 for a repeated query key', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/profiles?schemeId=a&schemeId=b'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListProfiles).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when listConformityProfiles throws', async () => {
+    mockListProfiles.mockRejectedValue(new Error('Database error'));
+
+    const res = await GET(req('http://localhost/api/v1/cvc/profiles?schemeId=https://a.example'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
+  });
+
+  it('applies limit and offset to the page', async () => {
+    mockListProfiles.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => ({ id: `p${i}`, name: `P${i}`, version: '1', status: 'active' })),
+    );
+
+    const res = await GET(req('http://localhost/api/v1/cvc/profiles?schemeId=https://a.example&limit=2&offset=1'), CTX);
+    const json = await res.json();
+
+    expect(json.data.map((p: { id: string }) => p.id)).toEqual(['p1', 'p2']);
+    expect(json.pagination).toEqual({ total: 5, limit: 2, offset: 1, hasMore: true });
   });
 
   it('lists the profiles for the requested scheme', async () => {
@@ -54,7 +134,7 @@ describe('GET /api/v1/cvc/profiles', () => {
 
     expect(res.status).toBe(200);
     expect(json.data).toHaveLength(1);
-    expect(json.pagination).toEqual({ total: 1, limit: 20, offset: 0, hasMore: false });
+    expect(json.pagination).toEqual({ total: 1, limit: DEFAULT_PAGE_LIMIT, offset: 0, hasMore: false });
     expect(mockListProfiles).toHaveBeenCalledWith('https://a.example', 'tenant-1');
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/cvc/profiles/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/profiles/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
 import { listConformityProfiles } from '@/lib/prisma/repositories';
-import { paginateInMemory, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
-import { ValidationError, isNonEmptyString, parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { paginateInMemory } from '@/lib/api/pagination';
+import { parseQueryParams } from '@/lib/api/validation';
+import { listCvcProfilesQuerySchema } from '@/lib/api/request-schemas/cvc';
 
 const logger = apiLogger.child({ route: '/api/v1/cvc/profiles' });
 
@@ -26,35 +27,32 @@ const logger = apiLogger.child({ route: '/api/v1/cvc/profiles' });
  *         required: true
  *         schema:
  *           type: string
- *         description: Canonical URI of the scheme whose profiles to list
+ *           minLength: 1
+ *         description: Canonical URI of the scheme whose profiles to list. A whitespace-only value is rejected with a 400.
  *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
+ *           minimum: 1
+ *         description: Number of entries to return per page. Defaults to 20, or the configured maximum when it is lower. A larger value is rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:
  *           type: integer
+ *           minimum: 0
+ *         description: Number of entries to skip for pagination
  *     responses:
  *       200:
  *         description: A page of conformity profiles
  *       400:
- *         description: schemeId is missing, or a pagination parameter is invalid
+ *         description: Validation error (e.g. a missing or blank schemeId, a limit above the maximum, a repeated query parameter)
  *       401:
  *         description: Unauthorised
  *       403:
  *         description: No tenant found for user
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  const url = new URL(req.url);
-  const schemeId = url.searchParams.get('schemeId');
-  if (!isNonEmptyString(schemeId)) {
-    throw new ValidationError('schemeId is required');
-  }
-
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  const { schemeId, limit, offset } = parseQueryParams(new URL(req.url), listCvcProfilesQuerySchema);
 
   logger.info({ tenantId, schemeId }, 'Listing conformity profiles');
   const profiles = await listConformityProfiles(schemeId, tenantId);

--- a/packages/reference-implementation/src/app/api/v1/cvc/schemes/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/schemes/route.test.ts
@@ -29,6 +29,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 }));
 
 import { GET } from './route';
+import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 
 type Ctx = Parameters<typeof GET>[1];
 const CTX = { tenantId: 'tenant-1', params: Promise.resolve({}) } as unknown as Ctx;
@@ -51,7 +52,7 @@ describe('GET /api/v1/cvc/schemes', () => {
 
     expect(res.status).toBe(200);
     expect(json.data).toHaveLength(2);
-    expect(json.pagination).toEqual({ total: 2, limit: 20, offset: 0, hasMore: false });
+    expect(json.pagination).toEqual({ total: 2, limit: DEFAULT_PAGE_LIMIT, offset: 0, hasMore: false });
     expect(mockListSchemes).toHaveBeenCalledWith('tenant-1');
   });
 
@@ -67,8 +68,75 @@ describe('GET /api/v1/cvc/schemes', () => {
     expect(json.pagination).toEqual({ total: 5, limit: 2, offset: 1, hasMore: true });
   });
 
-  it('returns 400 for an invalid limit', async () => {
+  it('returns 400 for a non-numeric limit', async () => {
     const res = await GET(req('http://localhost/api/v1/cvc/schemes?limit=abc'), CTX);
+    const json = await res.json();
+
     expect(res.status).toBe(400);
+    expect(json.error).toContain('limit: must be a positive integer');
+    expect(mockListSchemes).not.toHaveBeenCalled();
+  });
+
+  it('accepts a limit of exactly the maximum', async () => {
+    mockListSchemes.mockResolvedValue([]);
+
+    const res = await GET(req(`http://localhost/api/v1/cvc/schemes?limit=${MAX_PAGE_LIMIT}`), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.pagination).toEqual({ total: 0, limit: MAX_PAGE_LIMIT, offset: 0, hasMore: false });
+  });
+
+  it('rejects a limit one above the maximum', async () => {
+    const res = await GET(req(`http://localhost/api/v1/cvc/schemes?limit=${MAX_PAGE_LIMIT + 1}`), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain(`maximum of ${MAX_PAGE_LIMIT}`);
+    expect(mockListSchemes).not.toHaveBeenCalled();
+  });
+
+  it.each(['0', '-1'])('returns 400 for a limit of %s', async (limit) => {
+    const res = await GET(req(`http://localhost/api/v1/cvc/schemes?limit=${limit}`), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('limit: must be a positive integer');
+    expect(mockListSchemes).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-numeric offset', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/schemes?offset=abc'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset: must be a non-negative integer');
+  });
+
+  it('returns 400 for a negative offset', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/schemes?offset=-1'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('offset: must be a non-negative integer');
+  });
+
+  it('returns 400 for a repeated query key', async () => {
+    const res = await GET(req('http://localhost/api/v1/cvc/schemes?limit=10&limit=20'), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('repeated query parameter');
+    expect(mockListSchemes).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when listConformitySchemes throws', async () => {
+    mockListSchemes.mockRejectedValue(new Error('Database error'));
+
+    const res = await GET(req(), CTX);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('Database error');
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/cvc/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/schemes/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
 import { apiLogger } from '@/lib/api/logger';
 import { listConformitySchemes } from '@/lib/prisma/repositories';
-import { paginateInMemory, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
-import { parsePositiveInt, parseNonNegativeInt } from '@/lib/api/validation';
+import { paginateInMemory } from '@/lib/api/pagination';
+import { parseQueryParams } from '@/lib/api/validation';
+import { listCvcSchemesQuerySchema } from '@/lib/api/request-schemas/cvc';
 
 const logger = apiLogger.child({ route: '/api/v1/cvc/schemes' });
 
@@ -25,27 +26,26 @@ const logger = apiLogger.child({ route: '/api/v1/cvc/schemes' });
  *         name: limit
  *         schema:
  *           type: integer
- *         description: Maximum entries per page (capped at the server maximum)
+ *           minimum: 1
+ *         description: Number of entries to return per page. Defaults to 20, or the configured maximum when it is lower. A larger value is rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:
  *           type: integer
- *         description: Number of entries to skip
+ *           minimum: 0
+ *         description: Number of entries to skip for pagination
  *     responses:
  *       200:
  *         description: A page of conformity schemes
  *       400:
- *         description: Invalid pagination parameter (limit or offset)
+ *         description: Validation error (e.g. an invalid or above-maximum limit or offset, a repeated query parameter)
  *       401:
  *         description: Unauthorised
  *       403:
  *         description: No tenant found for user
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  const url = new URL(req.url);
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  const { limit, offset } = parseQueryParams(new URL(req.url), listCvcSchemesQuerySchema);
 
   logger.info({ tenantId }, 'Listing conformity schemes');
   const schemes = await listConformitySchemes(tenantId);

--- a/packages/reference-implementation/src/lib/api/request-schemas/cvc.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/cvc.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { nonBlankString, paginationQuerySchema } from './shared';
+
+/** Query parameters for GET /cvc/schemes. */
+export const listCvcSchemesQuerySchema = paginationQuerySchema;
+
+/**
+ * Query parameters for GET /cvc/profiles. The required `schemeId` filter is a
+ * canonical scheme URI, not a database id, so it takes the non-blank string
+ * contract rather than idSchema. Merged ahead of pagination so a filter issue
+ * is reported before a pagination issue among the zod schema's own issues
+ * (ADR-037). A repeated query key is rejected by parseQueryParams before
+ * schema parsing runs at all, so that check takes precedence over both.
+ */
+export const listCvcProfilesQuerySchema = z
+  .object({
+    schemeId: nonBlankString,
+  })
+  .merge(paginationQuerySchema);
+
+/** Query parameters for GET /cvc/criteria. `profileId` is a canonical profile URI. */
+export const listCvcCriteriaQuerySchema = z
+  .object({
+    profileId: nonBlankString,
+  })
+  .merge(paginationQuerySchema);


### PR DESCRIPTION
This PR migrates the three CVC read routes (`/cvc/schemes`, `/cvc/profiles`, `/cvc/criteria`) from the ad-hoc query helpers to Zod query schemas via `parseQueryParams`, so their query contract matches the per-resource schema pattern the rest of the API uses.

The mechanism change carries a few observable tightenings, all matching the already-migrated routes:

- A `limit` above the configured maximum now returns a 400 naming the maximum instead of being silently clamped. This is the same reject-not-clamp behaviour decided in #834 and shipped on the identifiers, schemes, and registrars routes.
- A whitespace-only `schemeId`/`profileId` is now rejected with a 400. Previously it was accepted and returned an empty list.
- A repeated query key is now rejected with a 400. Previously the first value was silently used.
- Integer parsing is strict, so values like `1abc` or `0x10` are rejected rather than prefix-parsed.
- Validation error messages take the shared `param: message` shape.

The Swagger annotations on the three routes state the new contract. The ad-hoc helpers stay in `lib/api/validation.ts` because other routes still use them; each remaining route migrates with its own resource story under #788.

Closes #802

## Test plan
- [x] Happy paths with default and explicit pagination, including sliced page content
- [x] Boundary values: limit at exactly the maximum accepted, one above rejected, `0`/`-1`/non-numeric rejected, negative and non-numeric offset rejected
- [x] Missing, empty-adjacent (whitespace-only) filters rejected without loading the catalogue; filter errors report before pagination errors
- [x] Repeated query keys rejected
- [x] Repository failure surfaces as 500