### PR TITLE
fix(docs): retarget six broken anchor links on the credentials and data-models API pages

### DIFF
--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -71,9 +71,9 @@ Every stored credential has a **content hash** — a fingerprint computed from t
 
 A credential on its own is just a file at a URL. To make it useful, it needs to be **discoverable** — someone who knows a product's identifier should be able to find the credential. This is the role of the [UNTP Identity Resolver](https://untp.unece.org/docs/specification/IdentityResolver) and [Decentralised Access Control](https://untp.unece.org/docs/specification/DecentralisedAccessControl) specifications.
 
-This is where the [Identity Resolver](./identifiers#links) comes in. When a credential is published, the Reference Implementation registers a link with the Identity Resolver that connects the entity's identifier (e.g., a GS1 GTIN) to the credential's storage URL. Now anyone who resolves that identifier can find the credential.
+This is where the [Identity Resolver](./identifiers#what-are-links) comes in. When a credential is published, the Reference Implementation registers a link with the Identity Resolver that connects the entity's identifier (e.g., a GS1 GTIN) to the credential's storage URL. Now anyone who resolves that identifier can find the credential.
 
-Publishing is optional and requires the credential's primary entity (product, facility, or organisation) to have a configured [identifier scheme](./identifiers#identifier-schemes) with an IDR service.
+Publishing is optional and requires the credential's primary entity (product, facility, or organisation) to have a configured [identifier scheme](./identifiers#what-is-an-identifier-scheme) with an IDR service.
 
 ### CVC Compliance (Conformity Credentials Only)
 
@@ -136,7 +136,7 @@ The three required fields are validated:
 
 The `credentialType` and `version` are used to look up a registered [data model](./data-models). The data model provides the JSON Schema URL(s) for validation, the JSON-LD context URL, and the [bridge](./data-models#data-model-bridges) that extracts entity references from the payload.
 
-For [extension data models](./data-models#extension-data-models), both the parent schema and the extension schema are validated.
+For [extension data models](./data-models#untp-core-data-models-and-extensions), both the parent schema and the extension schema are validated.
 
 #### Stage 3: Payload Validation
 
@@ -203,10 +203,10 @@ The credential payload is signed by the VC service, producing an [Enveloped Veri
 
 #### Stage 8: IDR Publishing (Optional)
 
-When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#links) for the primary entity's identifier. This makes the credential discoverable via the entity's identifier scheme (e.g., resolving a GS1 GTIN leads to the credential).
+When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#what-are-links) for the primary entity's identifier. This makes the credential discoverable via the entity's identifier scheme (e.g., resolving a GS1 GTIN leads to the credential).
 
 Publishing requires the primary entity to have:
-- A primary identifier with a configured [identifier scheme](./identifiers#identifier-schemes)
+- A primary identifier with a configured [identifier scheme](./identifiers#what-is-an-identifier-scheme)
 - The scheme must have a registrar with a namespace
 - An IDR service instance (configured on the scheme, or the tenant/system default)
 

--- a/documentation/docs/reference-implementation/api/data-models.md
+++ b/documentation/docs/reference-implementation/api/data-models.md
@@ -17,9 +17,9 @@ But the credential structures that *reference* those entities do change. A produ
 
 This is what [**data model bridges**](#data-model-bridges) solve. Each UNTP core data model type and version has a corresponding bridge that maps between the evolving UNTP credential structure and the Reference Implementation's stable internal entity models. This enables the system to:
 
-- [**Extract**](#extraction) entity references from issued credentials and link them to database records
-- [**Populate**](#population) credential payloads from existing entity data, so users don't re-enter information for each credential
-- [**Validate**](#validation) credential content against expected requirements
+- [**Extract**](../data-models/index.md#extraction) entity references from issued credentials and link them to database records
+- [**Populate**](../data-models/index.md#population) credential payloads from existing entity data, so users don't re-enter information for each credential
+- [**Validate**](../data-models/index.md#validation) credential content against expected requirements
 
 Beyond UNTP core data models, tenants can create [extensions](#untp-core-data-models-and-extensions) for industry-specific or regional variants. Each data model — whether core or extension — also has associated [render templates](./render-templates) that control how credentials of that type and version are visually presented.
 

--- a/documentation/versioned_docs/version-0.3.0/reference-implementation/api/credentials.md
+++ b/documentation/versioned_docs/version-0.3.0/reference-implementation/api/credentials.md
@@ -71,9 +71,9 @@ Every stored credential has a **content hash** — a fingerprint computed from t
 
 A credential on its own is just a file at a URL. To make it useful, it needs to be **discoverable** — someone who knows a product's identifier should be able to find the credential. This is the role of the [UNTP Identity Resolver](https://untp.unece.org/docs/specification/IdentityResolver) and [Decentralised Access Control](https://untp.unece.org/docs/specification/DecentralisedAccessControl) specifications.
 
-This is where the [Identity Resolver](./identifiers#links) comes in. When a credential is published, the Reference Implementation registers a link with the Identity Resolver that connects the entity's identifier (e.g., a GS1 GTIN) to the credential's storage URL. Now anyone who resolves that identifier can find the credential.
+This is where the [Identity Resolver](./identifiers#what-are-links) comes in. When a credential is published, the Reference Implementation registers a link with the Identity Resolver that connects the entity's identifier (e.g., a GS1 GTIN) to the credential's storage URL. Now anyone who resolves that identifier can find the credential.
 
-Publishing is optional and requires the credential's primary entity (product, facility, or organisation) to have a configured [identifier scheme](./identifiers#identifier-schemes) with an IDR service.
+Publishing is optional and requires the credential's primary entity (product, facility, or organisation) to have a configured [identifier scheme](./identifiers#what-is-an-identifier-scheme) with an IDR service.
 
 ### CVC Compliance (Conformity Credentials Only)
 
@@ -136,7 +136,7 @@ The three required fields are validated:
 
 The `credentialType` and `version` are used to look up a registered [data model](./data-models). The data model provides the JSON Schema URL(s) for validation, the JSON-LD context URL, and the [bridge](./data-models#data-model-bridges) that extracts entity references from the payload.
 
-For [extension data models](./data-models#extension-data-models), both the parent schema and the extension schema are validated.
+For [extension data models](./data-models#untp-core-data-models-and-extensions), both the parent schema and the extension schema are validated.
 
 #### Stage 3: Payload Validation
 
@@ -197,10 +197,10 @@ The credential payload is signed by the VC service, producing an [Enveloped Veri
 
 #### Stage 8: IDR Publishing (Optional)
 
-When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#links) for the primary entity's identifier. This makes the credential discoverable via the entity's identifier scheme (e.g., resolving a GS1 GTIN leads to the credential).
+When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#what-are-links) for the primary entity's identifier. This makes the credential discoverable via the entity's identifier scheme (e.g., resolving a GS1 GTIN leads to the credential).
 
 Publishing requires the primary entity to have:
-- A primary identifier with a configured [identifier scheme](./identifiers#identifier-schemes)
+- A primary identifier with a configured [identifier scheme](./identifiers#what-is-an-identifier-scheme)
 - The scheme must have a registrar with a namespace
 - An IDR service instance (configured on the scheme, or the tenant/system default)
 

--- a/documentation/versioned_docs/version-0.3.0/reference-implementation/api/data-models.md
+++ b/documentation/versioned_docs/version-0.3.0/reference-implementation/api/data-models.md
@@ -17,9 +17,9 @@ But the credential structures that *reference* those entities do change. A produ
 
 This is what [**data model bridges**](#data-model-bridges) solve. Each UNTP core data model type and version has a corresponding bridge that maps between the evolving UNTP credential structure and the Reference Implementation's stable internal entity models. This enables the system to:
 
-- [**Extract**](#extraction) entity references from issued credentials and link them to database records
-- [**Populate**](#population) credential payloads from existing entity data, so users don't re-enter information for each credential
-- [**Validate**](#validation) credential content against expected requirements
+- [**Extract**](../data-models/index.md#extraction) entity references from issued credentials and link them to database records
+- [**Populate**](../data-models/index.md#population) credential payloads from existing entity data, so users don't re-enter information for each credential
+- [**Validate**](../data-models/index.md#validation) credential content against expected requirements
 
 Beyond UNTP core data models, tenants can create [extensions](#untp-core-data-models-and-extensions) for industry-specific or regional variants. Each data model — whether core or extension — also has associated [render templates](./render-templates) that control how credentials of that type and version are visually presented.
 


### PR DESCRIPTION
This PR retargets six broken anchor links so readers land on the section each link describes instead of the top of the page. Three links on the credentials API page pointed at heading slugs that were reworded on the identifiers and data-models pages, and three links on the data-models API page pointed at sections that live on the Data Model Bridges page (they were once headings on the API page and moved). The same fixes are applied to the version-0.3.0 snapshot, which serves as the default docs version. The docs build now reports zero broken anchors.
