### PR TITLE
test(ri): add Postgres-backed integration rig and seed reconcile suites

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -141,6 +141,55 @@ jobs:
       - name: Test ${{ matrix.package }} (changed files only)
         run: pnpm exec turbo run test --filter='${{ matrix.package }}...[origin/next]' -- --changedSince=origin/next
 
+  # Postgres-backed integration suites (ADR-029 integration layer). The rig's
+  # jest globalSetup starts its own ephemeral postgres:17-alpine container on
+  # the runner's docker daemon and applies migrations, so the job needs no
+  # services block. Package-affected via the same turbo filter as `qa`; jest's
+  # --changedSince is deliberately not used here, because a source change must
+  # run every integration suite, not only the suites whose own files changed.
+  qa-integration:
+    name: QA integration (reference implementation)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Restore node_modules cache
+        id: cache-modules
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            packages/*/e2e/node_modules
+            ~/.cache/Cypress
+          key: node-modules-v4-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies (fallback if cache restore missed)
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Integration tests (when the reference implementation is affected)
+        # The placeholder URL only satisfies prisma.config.ts's boot check for
+        # `prisma generate`; the rig's globalSetup overwrites RI_DATABASE_URL
+        # with the ephemeral container's URL before anything connects.
+        env:
+          RI_DATABASE_URL: postgresql://placeholder:placeholder@localhost:9/placeholder
+        run: pnpm exec turbo run test:integration --filter='untp-reference-implementation...[origin/next]'
+
   # Per-app image build jobs run in parallel after qa. Each downstream E2E
   # job depends only on its own image-build job so the playground E2E starts
   # as soon as the playground image is ready (not blocked on the RI image),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,13 @@ pnpm test:services                  # Services package only
 pnpm test:reference-implementation  # Reference implementation only
 pnpm test:components                # Components only
 
+# Postgres-backed integration tests (reference implementation only; needs a running Docker daemon)
+# By default the rig starts and tears down its own ephemeral postgres:17-alpine container.
+# To point it at an existing database instead, set TEST_DATABASE_URL; the rig refuses a URL
+# naming a real environment's database (ri, vckit) unless TEST_DATABASE_ACCEPT_DESTRUCTIVE=true
+# is also set, because the suites truncate tables between tests.
+cd packages/reference-implementation && pnpm test:integration
+
 # E2E Testing (per-app suites; see packages/<app>/e2e/README.md for details)
 
 # RI open mode

--- a/docs/adrs/029-test-layer-taxonomy-and-decision-rules.md
+++ b/docs/adrs/029-test-layer-taxonomy-and-decision-rules.md
@@ -2,6 +2,7 @@
 
 - **Date:** 2026-05-12
 - **Status:** proposed
+- **Update (2026-08-16):** the reference implementation's integration rig (`packages/reference-implementation/__tests__/integration/`, #900) implements this layer's "real DB" requirement with the `docker` CLI managing an ephemeral `postgres:17-alpine` container directly, rather than the testcontainers library named below. The rig also accepts an operator-supplied `TEST_DATABASE_URL` as an alternative to the ephemeral container. The layer's decision (real Postgres, per-package `__tests__/integration/`, `*.integration.test.ts`) is unchanged.
 
 ## Context
 

--- a/packages/reference-implementation/__tests__/integration/conformity-eviction.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/conformity-eviction.integration.test.ts
@@ -1,0 +1,146 @@
+import { createRigClient, truncateApplicationTables } from './rig/db';
+import { startFixtureServer, type FixtureServer } from './rig/fixture-server';
+import { seedSystemTenant, seedCvcDataModel, schemeDoc, bootManifest, CVC_SPEC_VERSION } from './fixtures';
+
+const prisma = createRigClient();
+let fixtures: FixtureServer;
+
+const SCHEME_A = 'https://schemes.example/a';
+const SCHEME_B = 'https://schemes.example/b';
+const CRITERION_SHARED = 'https://criteria.example/shared/1.0.0';
+const CRITERION_A_ONLY = 'https://criteria.example/a-only/1.0.0';
+
+/** Boots a manifest listing each entry as a `file:` conformity-scheme source. */
+async function bootWithFiles(entries: { file: string; doc?: Record<string, unknown> }[]): Promise<void> {
+  const yaml =
+    `conformitySchemes:\n` + entries.map((e) => `  - file: ${e.file}\n    version: "${CVC_SPEC_VERSION}"\n`).join('');
+  const files = Object.fromEntries(entries.filter((e) => e.doc).map((e) => [e.file, JSON.stringify(e.doc)]));
+  await bootManifest(prisma, yaml, files);
+}
+
+beforeAll(async () => {
+  fixtures = await startFixtureServer();
+});
+
+beforeEach(async () => {
+  await truncateApplicationTables(prisma);
+  await seedSystemTenant(prisma);
+  await seedCvcDataModel(prisma, fixtures);
+});
+
+afterAll(async () => {
+  await fixtures.close();
+  await prisma.$disconnect();
+});
+
+describe('seeded conformity scheme eviction and orphan-criterion sweep', () => {
+  it('evicts a scheme dropped from the manifest and sweeps its now-orphaned criteria', async () => {
+    const docA = schemeDoc(fixtures, SCHEME_A, {
+      name: 'Scheme A',
+      profiles: [
+        {
+          id: `${SCHEME_A}/full/1.0.0`,
+          name: 'Full',
+          criteria: [
+            { id: CRITERION_A_ONLY, name: 'A Only' },
+            { id: CRITERION_SHARED, name: 'Shared' },
+          ],
+        },
+      ],
+    });
+    const docB = schemeDoc(fixtures, SCHEME_B, {
+      name: 'Scheme B',
+      profiles: [{ id: `${SCHEME_B}/full/1.0.0`, name: 'Full', criteria: [{ id: CRITERION_SHARED, name: 'Shared' }] }],
+    });
+
+    await bootWithFiles([
+      { file: 'schemes/a.json', doc: docA },
+      { file: 'schemes/b.json', doc: docB },
+    ]);
+    expect(await prisma.conformityScheme.count()).toBe(2);
+    expect(await prisma.conformityCriterion.count()).toBe(2);
+
+    // Second boot drops scheme A. Its profiles cascade; the A-only criterion
+    // is swept, while the criterion scheme B still references survives.
+    await bootWithFiles([{ file: 'schemes/b.json', doc: docB }]);
+
+    const schemes = await prisma.conformityScheme.findMany();
+    expect(schemes).toHaveLength(1);
+    expect(schemes[0].canonicalId).toBe(SCHEME_B);
+
+    const criteria = await prisma.conformityCriterion.findMany();
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0].canonicalId).toBe(CRITERION_SHARED);
+    expect(await prisma.conformityProfileCriterion.count()).toBe(1);
+  });
+
+  it('an explicit empty conformitySchemes array removes every seeded scheme and all orphaned criteria', async () => {
+    const docA = schemeDoc(fixtures, SCHEME_A, {
+      name: 'Scheme A',
+      profiles: [{ id: `${SCHEME_A}/full/1.0.0`, name: 'Full', criteria: [{ id: CRITERION_A_ONLY, name: 'A Only' }] }],
+    });
+    await bootWithFiles([{ file: 'schemes/a.json', doc: docA }]);
+    expect(await prisma.conformityScheme.count()).toBe(1);
+
+    await bootManifest(prisma, `conformitySchemes: []\n`);
+
+    expect(await prisma.conformityScheme.count()).toBe(0);
+    expect(await prisma.conformityProfile.count()).toBe(0);
+    expect(await prisma.conformityCriterion.count()).toBe(0);
+  });
+
+  it('a FILE entry that fails to resolve suppresses eviction for the boot', async () => {
+    const docA = schemeDoc(fixtures, SCHEME_A, { name: 'Scheme A', profiles: [] });
+    await bootWithFiles([{ file: 'schemes/a.json', doc: docA }]);
+    expect(await prisma.conformityScheme.count()).toBe(1);
+
+    // The next manifest omits scheme A and carries one FILE entry whose file
+    // is missing: identity resolution fails, so nothing may be evicted, and
+    // the previously seeded row must survive the boot.
+    await bootWithFiles([{ file: 'schemes/missing.json' }]);
+
+    expect(await prisma.conformityScheme.count()).toBe(1);
+  });
+
+  it('a document that moved URL with a stable canonical id converges to one row at the new URL', async () => {
+    const doc = schemeDoc(fixtures, SCHEME_A, { name: 'Scheme A', profiles: [] });
+    fixtures.set('/schemes/old-location.json', { body: JSON.stringify(doc) });
+    fixtures.set('/schemes/new-location.json', { body: JSON.stringify(doc) });
+
+    const bootWithUrl = (path: string) =>
+      bootManifest(
+        prisma,
+        `conformitySchemes:\n  - url: ${fixtures.baseUrl}${path}\n    version: "${CVC_SPEC_VERSION}"\n`,
+      );
+
+    await bootWithUrl('/schemes/old-location.json');
+    expect(await prisma.conformityScheme.count()).toBe(1);
+
+    await bootWithUrl('/schemes/new-location.json');
+
+    const schemes = await prisma.conformityScheme.findMany();
+    expect(schemes).toHaveLength(1);
+    expect(schemes[0].canonicalId).toBe(SCHEME_A);
+    expect(schemes[0].sourceUrl).toBe(`${fixtures.baseUrl}/schemes/new-location.json`);
+  });
+});
+
+describe('top-level conformitySchemes presence semantics', () => {
+  it('an absent conformitySchemes key leaves previously seeded schemes and their graph untouched', async () => {
+    const doc = schemeDoc(fixtures, SCHEME_A, {
+      name: 'Scheme A',
+      profiles: [{ id: `${SCHEME_A}/full/1.0.0`, name: 'Full', criteria: [{ id: CRITERION_A_ONLY, name: 'A Only' }] }],
+    });
+    await bootWithFiles([{ file: 'schemes/a.json', doc }]);
+    expect(await prisma.conformityScheme.count()).toBe(1);
+
+    // A later boot managing a different section only: conformity schemes are
+    // unmanaged this boot, so nothing is evicted and the graph survives.
+    await bootManifest(prisma, `dataModels: []\n`);
+
+    expect(await prisma.conformityScheme.count()).toBe(1);
+    expect(await prisma.conformityProfile.count()).toBe(1);
+    expect(await prisma.conformityCriterion.count()).toBe(1);
+    expect(await prisma.conformityProfileCriterion.count()).toBe(1);
+  });
+});

--- a/packages/reference-implementation/__tests__/integration/fixtures.ts
+++ b/packages/reference-implementation/__tests__/integration/fixtures.ts
@@ -1,0 +1,177 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { LoggerService as Logger } from '@uncefact/untp-ri-services';
+import type { PrismaClient } from '../../src/lib/prisma/generated/index.js';
+import { RecordSource } from '../../src/lib/prisma/generated/index.js';
+import { SYSTEM_TENANT_ID } from '../../src/lib/prisma/constants';
+import { runCustomSeed, type CustomSeedDependencies } from '../../prisma/custom-seed';
+import type { FixtureServer } from './rig/fixture-server';
+
+export { SYSTEM_TENANT_ID };
+
+/**
+ * Structured-logger stub satisfying the seed's LoggerService surface.
+ * Error-level output always reaches the console: several production paths
+ * log-and-continue rather than throw, and swallowing those would leave an
+ * error-logged regression invisible in CI. Suites that deliberately drive a
+ * failure path will print that failure's log line; that noise is the
+ * visibility working as intended.
+ */
+export function quietLogger(): Logger {
+  const logger = {
+    info: () => undefined,
+    warn: () => undefined,
+    error: (...args: unknown[]) => console.error('[seed error]', ...args),
+    debug: () => undefined,
+    child: () => logger,
+  };
+  return logger as unknown as Logger;
+}
+
+/** Creates a temp custom-seed directory containing the given seed.yaml body. */
+export function writeManifestDir(yaml: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ri-integration-seed-'));
+  fs.writeFileSync(path.join(dir, 'seed.yaml'), yaml);
+  return dir;
+}
+
+export function writeSeedFile(dir: string, relative: string, content: string): void {
+  const target = path.join(dir, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+}
+
+/**
+ * Logger that records every log call so a suite can assert on the seed's
+ * structured output (e.g. the final summary) and on the absence of
+ * error-level logs. `error` also reaches the console, as in quietLogger.
+ */
+export interface CapturedLog {
+  level: 'info' | 'warn' | 'error' | 'debug';
+  args: unknown[];
+}
+
+export function capturingLogger(sink: CapturedLog[]): Logger {
+  const push = (level: CapturedLog['level']) => {
+    return (...args: unknown[]) => {
+      sink.push({ level, args });
+      if (level === 'error') console.error('[seed error]', ...args);
+    };
+  };
+  const logger = {
+    info: push('info'),
+    warn: push('warn'),
+    error: push('error'),
+    debug: push('debug'),
+    child: () => logger,
+  };
+  return logger as unknown as Logger;
+}
+
+/** Builds the `runCustomSeed` dependency bag shared by every seed-boot suite. */
+export function seedDeps(prisma: PrismaClient, customSeedDir: string, logger?: Logger): CustomSeedDependencies {
+  return {
+    logger: logger ?? quietLogger(),
+    prisma,
+    systemTenantId: SYSTEM_TENANT_ID,
+    customSeedDir,
+    storageService: null,
+    storageServiceInstanceId: null,
+  };
+}
+
+/**
+ * Writes a manifest (and any accompanying seed files) to a temp directory,
+ * runs the custom seed against it, and removes the directory afterwards.
+ */
+export async function bootManifest(
+  prisma: PrismaClient,
+  yaml: string,
+  files: Record<string, string> = {},
+  logger?: Logger,
+): Promise<void> {
+  const dir = writeManifestDir(yaml);
+  for (const [relative, content] of Object.entries(files)) {
+    writeSeedFile(dir, relative, content);
+  }
+  try {
+    await runCustomSeed(seedDeps(prisma, dir, logger));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export async function seedSystemTenant(prisma: PrismaClient): Promise<void> {
+  await prisma.tenant.create({ data: { id: SYSTEM_TENANT_ID, name: 'System' } });
+}
+
+export const CVC_DATA_MODEL_ID = 'ctestcvcdatamodel00000001';
+export const CVC_SPEC_VERSION = '0.7.0';
+
+/**
+ * Seeds the core `ConformityScheme` data-model row ingest resolves its
+ * schema URL from, pointing at the fixture server so no test fetches a
+ * remote schema.
+ */
+export async function seedCvcDataModel(prisma: PrismaClient, fixtures: FixtureServer): Promise<void> {
+  fixtures.set('/cvc/schema.json', { body: JSON.stringify({ type: 'object' }) });
+  fixtures.set('/cvc/context.jsonld', {
+    body: JSON.stringify({ '@context': { '@vocab': 'https://test.example/vocab#', id: '@id', type: '@type' } }),
+    contentType: 'application/ld+json',
+  });
+  await prisma.dataModel.create({
+    data: {
+      id: CVC_DATA_MODEL_ID,
+      tenantId: SYSTEM_TENANT_ID,
+      name: `ConformityScheme v${CVC_SPEC_VERSION}`,
+      credentialType: 'ConformityScheme',
+      version: CVC_SPEC_VERSION,
+      isExtension: false,
+      schemaUrl: `${fixtures.baseUrl}/cvc/schema.json`,
+      contextUrl: `${fixtures.baseUrl}/cvc/context.jsonld`,
+      source: RecordSource.CORE_SEED,
+    },
+  });
+}
+
+export interface FixtureCriterion {
+  id: string;
+  name: string;
+  version?: string;
+}
+
+export interface FixtureProfile {
+  id: string;
+  name: string;
+  version?: string;
+  criteria?: FixtureCriterion[];
+}
+
+/** Builds a parseable v0.7.0 conformity scheme JSON-LD document. */
+export function schemeDoc(
+  fixtures: FixtureServer,
+  canonicalId: string,
+  options: { name: string; profiles?: FixtureProfile[] },
+): Record<string, unknown> {
+  return {
+    '@context': [`${fixtures.baseUrl}/cvc/context.jsonld`],
+    type: ['ConformityScheme'],
+    id: canonicalId,
+    name: options.name,
+    includedProfile: (options.profiles ?? []).map((profile) => ({
+      id: profile.id,
+      name: profile.name,
+      version: profile.version ?? '1.0.0',
+      status: 'active',
+      criterion: (profile.criteria ?? []).map((criterion) => ({
+        type: ['Criterion'],
+        id: criterion.id,
+        name: criterion.name,
+        version: criterion.version ?? '1.0.0',
+        status: 'active',
+        conformityTopic: 'environment.energy',
+      })),
+    })),
+  };
+}

--- a/packages/reference-implementation/__tests__/integration/generation-evolution.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/generation-evolution.integration.test.ts
@@ -1,0 +1,132 @@
+import { createRigClient, truncateApplicationTables } from './rig/db';
+import { startFixtureServer, type FixtureServer } from './rig/fixture-server';
+import { seedSystemTenant, seedCvcDataModel, schemeDoc, bootManifest, CVC_SPEC_VERSION } from './fixtures';
+
+const prisma = createRigClient();
+let fixtures: FixtureServer;
+
+const SCHEME_S = 'https://schemes.example/s';
+const SCHEME_T = 'https://schemes.example/t';
+const PROFILE_P1 = 'https://schemes.example/s/basic/1.0.0';
+const PROFILE_P2 = 'https://schemes.example/s/advanced/1.0.0';
+const CRITERION_C1 = 'https://criteria.example/c1/1.0.0';
+const CRITERION_C2 = 'https://criteria.example/c2/1.0.0';
+const CRITERION_C3 = 'https://criteria.example/c3/1.0.0';
+
+/** Boots a manifest listing each entry as a `file:` conformity-scheme source. */
+function boot(docs: { file: string; doc: Record<string, unknown> }[]): Promise<void> {
+  const yaml =
+    `conformitySchemes:\n` + docs.map((d) => `  - file: ${d.file}\n    version: "${CVC_SPEC_VERSION}"\n`).join('');
+  const files = Object.fromEntries(docs.map((d) => [d.file, JSON.stringify(d.doc)]));
+  return bootManifest(prisma, yaml, files);
+}
+
+beforeAll(async () => {
+  fixtures = await startFixtureServer();
+});
+
+beforeEach(async () => {
+  await truncateApplicationTables(prisma);
+  await seedSystemTenant(prisma);
+  await seedCvcDataModel(prisma, fixtures);
+});
+
+afterAll(async () => {
+  await fixtures.close();
+  await prisma.$disconnect();
+});
+
+describe('two-generation document evolution converges on re-ingest', () => {
+  it('applies rename-in-place, profile addition, and criterion drop-with-sweep; shared criteria survive', async () => {
+    // Generation 1: scheme S has profile P1 with criteria C1 + C2; a second
+    // scheme T also references C1, making it tenant-shared.
+    const gen1S = schemeDoc(fixtures, SCHEME_S, {
+      name: 'Scheme S',
+      profiles: [
+        {
+          id: PROFILE_P1,
+          name: 'Basic',
+          criteria: [
+            { id: CRITERION_C1, name: 'C1' },
+            { id: CRITERION_C2, name: 'C2' },
+          ],
+        },
+      ],
+    });
+    const docT = schemeDoc(fixtures, SCHEME_T, {
+      name: 'Scheme T',
+      profiles: [{ id: `${SCHEME_T}/full/1.0.0`, name: 'Full', criteria: [{ id: CRITERION_C1, name: 'C1' }] }],
+    });
+
+    await boot([
+      { file: 'schemes/s.json', doc: gen1S },
+      { file: 'schemes/t.json', doc: docT },
+    ]);
+
+    const schemeRowGen1 = await prisma.conformityScheme.findFirstOrThrow({ where: { canonicalId: SCHEME_S } });
+    expect(await prisma.conformityProfile.count()).toBe(2);
+    expect(await prisma.conformityCriterion.count()).toBe(2);
+    const c1RowGen1 = await prisma.conformityCriterion.findFirstOrThrow({ where: { canonicalId: CRITERION_C1 } });
+
+    // Generation 2 of S: P1 renamed at the same canonical id, P2 added with
+    // new criterion C3, and C2 dropped from the document entirely.
+    const gen2S = schemeDoc(fixtures, SCHEME_S, {
+      name: 'Scheme S (2nd edition)',
+      profiles: [
+        { id: PROFILE_P1, name: 'Basic (renamed)', criteria: [{ id: CRITERION_C1, name: 'C1' }] },
+        { id: PROFILE_P2, name: 'Advanced', criteria: [{ id: CRITERION_C3, name: 'C3' }] },
+      ],
+    });
+
+    await boot([
+      { file: 'schemes/s.json', doc: gen2S },
+      { file: 'schemes/t.json', doc: docT },
+    ]);
+
+    // The scheme row is updated in place (stable row id, new name).
+    const schemeRowGen2 = await prisma.conformityScheme.findFirstOrThrow({ where: { canonicalId: SCHEME_S } });
+    expect(schemeRowGen2.id).toBe(schemeRowGen1.id);
+    expect(schemeRowGen2.name).toBe('Scheme S (2nd edition)');
+
+    // Profile convergence is canonical-identity based: one profile at P1's
+    // canonical id carrying the new name, and P2 present. (Profile row ids
+    // are deliberately not asserted: ingest delete-and-recreates them.)
+    const profiles = await prisma.conformityProfile.findMany({ where: { schemeId: schemeRowGen2.id } });
+    expect(profiles.map((p) => [p.canonicalId, p.name]).sort()).toEqual([
+      [PROFILE_P2, 'Advanced'],
+      [PROFILE_P1, 'Basic (renamed)'],
+    ]);
+
+    // C2 is referenced by nothing and swept; C1 survives because scheme T
+    // still references it; C3 was added. Criterion rows keep their identity
+    // for unchanged canonical ids.
+    const criteria = await prisma.conformityCriterion.findMany();
+    expect(criteria.map((c) => c.canonicalId).sort()).toEqual([CRITERION_C1, CRITERION_C3]);
+
+    const c1 = criteria.find((c) => c.canonicalId === CRITERION_C1)!;
+    // Criterion rows are upserted on (canonicalId, tenantId), so an
+    // unchanged canonical id must keep its ROW identity across generations
+    // (unlike profiles, which are delete-and-recreated by design).
+    expect(c1.id).toBe(c1RowGen1.id);
+    const c1Joins = await prisma.conformityProfileCriterion.count({ where: { criterionId: c1.id } });
+    expect(c1Joins).toBe(2); // S's renamed P1 and T's Full profile.
+  });
+
+  it('dropping the last scheme referencing a criterion sweeps it once unreferenced', async () => {
+    const doc = schemeDoc(fixtures, SCHEME_S, {
+      name: 'Scheme S',
+      profiles: [{ id: PROFILE_P1, name: 'Basic', criteria: [{ id: CRITERION_C1, name: 'C1' }] }],
+    });
+    await boot([{ file: 'schemes/s.json', doc }]);
+    expect(await prisma.conformityCriterion.count()).toBe(1);
+
+    const gen2 = schemeDoc(fixtures, SCHEME_S, {
+      name: 'Scheme S',
+      profiles: [{ id: PROFILE_P1, name: 'Basic', criteria: [] }],
+    });
+    await boot([{ file: 'schemes/s.json', doc: gen2 }]);
+
+    expect(await prisma.conformityCriterion.count()).toBe(0);
+    expect(await prisma.conformityProfile.count()).toBe(1);
+  });
+});

--- a/packages/reference-implementation/__tests__/integration/reconcile-data-loss.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/reconcile-data-loss.integration.test.ts
@@ -1,0 +1,388 @@
+import { createRigClient, truncateApplicationTables } from './rig/db';
+import { seedSystemTenant, bootManifest, SYSTEM_TENANT_ID } from './fixtures';
+import { ReconcileBlockedError } from '../../prisma/custom-seed-reconcile';
+import { convergeCoreProvenance } from '../../prisma/core-seed-provenance';
+import { RecordSource } from '../../src/lib/prisma/generated/index.js';
+
+const REGISTRAR_ID = 'ctestregistrar00000000001';
+const SCHEME_ID = 'ctestscheme00000000000001';
+const QUALIFIER_ID = 'ctestqualifier00000000001';
+const OTHER_TENANT_ID = 'ctestothertenant000000001';
+
+const prisma = createRigClient();
+
+const FULL_MANIFEST = `
+registrars:
+  - id: ${REGISTRAR_ID}
+    name: Test Registrar
+    namespace: testreg
+    identifierSchemes:
+      - id: ${SCHEME_ID}
+        name: Test Scheme
+        primaryKey: "01"
+        validationPattern: "^\\\\d{13}$"
+        linkTemplate: "/{primaryKey}/{value}"
+        qualifiers:
+          - id: ${QUALIFIER_ID}
+            key: "10"
+            description: Batch number
+            validationPattern: ".*"
+`;
+
+function runManifest(yaml: string): Promise<void> {
+  return bootManifest(prisma, yaml);
+}
+
+beforeEach(async () => {
+  await truncateApplicationTables(prisma);
+  await seedSystemTenant(prisma);
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('custom-seed reconcile against real Postgres', () => {
+  it('seeds registrar, scheme, and qualifier, all stamped CUSTOM_SEED', async () => {
+    await runManifest(FULL_MANIFEST);
+
+    const registrar = await prisma.registrar.findUniqueOrThrow({ where: { id: REGISTRAR_ID } });
+    expect(registrar.source).toBe(RecordSource.CUSTOM_SEED);
+    expect(await prisma.identifierScheme.count()).toBe(1);
+    expect(await prisma.schemeQualifier.count()).toBe(1);
+  });
+
+  it('absent registrars key leaves previously seeded rows unmanaged', async () => {
+    await runManifest(FULL_MANIFEST);
+    await runManifest(`
+dataModels: []
+`);
+    expect(await prisma.registrar.count()).toBe(1);
+    expect(await prisma.identifierScheme.count()).toBe(1);
+  });
+
+  it('explicit empty registrars array removes all manifest-owned rows of that type', async () => {
+    await runManifest(FULL_MANIFEST);
+    await runManifest(`
+registrars: []
+`);
+    expect(await prisma.registrar.count()).toBe(0);
+    expect(await prisma.identifierScheme.count()).toBe(0);
+    expect(await prisma.schemeQualifier.count()).toBe(0);
+  });
+
+  it('a whole-empty manifest (no section keys) is a no-op guard, not a wipe', async () => {
+    await runManifest(FULL_MANIFEST);
+    await runManifest(`{}\n`);
+    expect(await prisma.registrar.count()).toBe(1);
+  });
+
+  it("removal cascading into another tenant's scheme is refused and the transaction rolls back", async () => {
+    await runManifest(FULL_MANIFEST);
+    await prisma.tenant.create({ data: { id: OTHER_TENANT_ID, name: 'Other' } });
+    await prisma.identifierScheme.create({
+      data: {
+        id: 'ctestforeignscheme0000001',
+        tenantId: OTHER_TENANT_ID,
+        registrarId: REGISTRAR_ID,
+        name: 'Foreign Scheme',
+        primaryKey: '02',
+        validationPattern: '.*',
+        linkTemplate: '/{primaryKey}/{value}',
+        source: RecordSource.USER,
+      },
+    });
+
+    await expect(runManifest(`\nregistrars: []\n`)).rejects.toThrow(ReconcileBlockedError);
+
+    // Rollback: the manifest-owned rows are still present, nothing was deleted.
+    expect(await prisma.registrar.count()).toBe(1);
+    expect(await prisma.identifierScheme.count()).toBe(2);
+  });
+
+  it('registered identifiers block scheme removal with the identifier count named', async () => {
+    await runManifest(FULL_MANIFEST);
+    await prisma.identifier.create({
+      data: { tenantId: SYSTEM_TENANT_ID, schemeId: SCHEME_ID, value: '9506000134352' },
+    });
+
+    let caught: ReconcileBlockedError | undefined;
+    await runManifest(`\nregistrars: []\n`).catch((err) => {
+      caught = err as ReconcileBlockedError;
+    });
+    expect(caught).toBeInstanceOf(ReconcileBlockedError);
+    expect(caught!.problems.join('\n')).toContain('1 registered identifier');
+    expect(await prisma.identifierScheme.count()).toBe(1);
+    expect(await prisma.identifier.count()).toBe(1);
+  });
+
+  it('a non-owned render template blocks data-model removal', async () => {
+    // A manifest-owned data model (created directly: the manifest schema only
+    // expresses extensions, and provenance is what the reconcile keys on).
+    const parent = await prisma.dataModel.create({
+      data: {
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'Core Parent',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        isExtension: false,
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        source: RecordSource.CORE_SEED,
+      },
+    });
+    const owned = await prisma.dataModel.create({
+      data: {
+        id: 'ctestowneddatamodel000001',
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'Owned Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        isExtension: true,
+        parentConfigId: parent.id,
+        schemaUrl: 'https://example.com/ext.json',
+        contextUrl: 'https://example.com/ext-context.jsonld',
+        source: RecordSource.CUSTOM_SEED,
+      },
+    });
+    await prisma.renderTemplate.create({
+      data: {
+        tenantId: SYSTEM_TENANT_ID,
+        dataModelId: owned.id,
+        name: 'User Template',
+        storageUrl: 'https://example.com/template',
+        digestMultibase: 'zTESTdigest',
+        renderMethodType: 'RenderTemplate2024',
+        source: RecordSource.USER,
+      },
+    });
+
+    await expect(runManifest(`\ndataModels: []\n`)).rejects.toThrow(ReconcileBlockedError);
+    expect(await prisma.dataModel.count()).toBe(2);
+    expect(await prisma.renderTemplate.count()).toBe(1);
+  });
+
+  it('reparenting a scheme and removing its old registrar in one boot keeps the child', async () => {
+    await runManifest(FULL_MANIFEST);
+    const NEW_REGISTRAR_ID = 'ctestregistrar00000000002';
+    await runManifest(`
+registrars:
+  - id: ${NEW_REGISTRAR_ID}
+    name: New Registrar
+    namespace: newreg
+    identifierSchemes:
+      - id: ${SCHEME_ID}
+        name: Test Scheme
+        primaryKey: "01"
+        validationPattern: "^\\\\d{13}$"
+        linkTemplate: "/{primaryKey}/{value}"
+`);
+
+    const scheme = await prisma.identifierScheme.findUniqueOrThrow({ where: { id: SCHEME_ID } });
+    expect(scheme.registrarId).toBe(NEW_REGISTRAR_ID);
+    expect(await prisma.registrar.count()).toBe(1);
+    expect((await prisma.registrar.findFirstOrThrow()).id).toBe(NEW_REGISTRAR_ID);
+  });
+
+  it('a manifest id colliding with a CORE_SEED row fails validation without touching the row', async () => {
+    await prisma.registrar.create({
+      data: {
+        id: REGISTRAR_ID,
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'Core Registrar',
+        namespace: 'core',
+        source: RecordSource.CORE_SEED,
+      },
+    });
+
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    try {
+      await expect(runManifest(FULL_MANIFEST)).rejects.toThrow('process.exit(1)');
+    } finally {
+      exitSpy.mockRestore();
+    }
+    const registrar = await prisma.registrar.findUniqueOrThrow({ where: { id: REGISTRAR_ID } });
+    expect(registrar.source).toBe(RecordSource.CORE_SEED);
+    expect(registrar.name).toBe('Core Registrar');
+  });
+
+  it('adopts a system-tenant USER row with a matching id (legacy pre-provenance row)', async () => {
+    await prisma.registrar.create({
+      data: {
+        id: REGISTRAR_ID,
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'Legacy Registrar',
+        namespace: 'testreg',
+        source: RecordSource.USER,
+      },
+    });
+
+    await runManifest(FULL_MANIFEST);
+
+    const registrar = await prisma.registrar.findUniqueOrThrow({ where: { id: REGISTRAR_ID } });
+    expect(registrar.source).toBe(RecordSource.CUSTOM_SEED);
+    expect(registrar.name).toBe('Test Registrar');
+  });
+});
+
+describe('nested-key presence semantics against real Postgres', () => {
+  it('a retained registrar omitting the identifierSchemes key leaves its schemes unmanaged', async () => {
+    await runManifest(FULL_MANIFEST);
+    await runManifest(`
+registrars:
+  - id: ${REGISTRAR_ID}
+    name: Test Registrar
+    namespace: testreg
+`);
+    expect(await prisma.identifierScheme.count()).toBe(1);
+    expect(await prisma.schemeQualifier.count()).toBe(1);
+  });
+
+  it('a retained registrar with an explicit empty identifierSchemes array removes its owned schemes', async () => {
+    await runManifest(FULL_MANIFEST);
+    await runManifest(`
+registrars:
+  - id: ${REGISTRAR_ID}
+    name: Test Registrar
+    namespace: testreg
+    identifierSchemes: []
+`);
+    expect(await prisma.registrar.count()).toBe(1);
+    expect(await prisma.identifierScheme.count()).toBe(0);
+    expect(await prisma.schemeQualifier.count()).toBe(0);
+  });
+
+  it('a retained scheme omitting the qualifiers key leaves its qualifiers unmanaged, while an explicit empty array removes them', async () => {
+    await runManifest(FULL_MANIFEST);
+    const withoutQualifiersKey = `
+registrars:
+  - id: ${REGISTRAR_ID}
+    name: Test Registrar
+    namespace: testreg
+    identifierSchemes:
+      - id: ${SCHEME_ID}
+        name: Test Scheme
+        primaryKey: "01"
+        validationPattern: "^\\\\d{13}$"
+        linkTemplate: "/{primaryKey}/{value}"
+`;
+    await runManifest(withoutQualifiersKey);
+    expect(await prisma.schemeQualifier.count()).toBe(1);
+
+    await runManifest(
+      withoutQualifiersKey.replace(
+        'linkTemplate: "/{primaryKey}/{value}"',
+        'linkTemplate: "/{primaryKey}/{value}"\n        qualifiers: []',
+      ),
+    );
+    expect(await prisma.schemeQualifier.count()).toBe(0);
+    expect(await prisma.identifierScheme.count()).toBe(1);
+  });
+});
+
+describe('CORE_SEED provenance convergence against real Postgres', () => {
+  it('stamps a pre-provenance USER row at a real core id, after which a manifest reusing the id is refused', async () => {
+    // Production stamps DataModel (and RenderTemplate) rows only, so the
+    // scenario uses the real ConformityScheme data-model core id from
+    // seed.ts and the matching delegate. First, a pre-provenance database:
+    // the core row exists but is still labelled USER (created before the
+    // source column existed).
+    const CORE_DATA_MODEL_ID = 'c4fxk5o3sqrm6n0u7c7akm0sb';
+    await prisma.dataModel.create({
+      data: {
+        id: CORE_DATA_MODEL_ID,
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'ConformityScheme',
+        credentialType: 'ConformityScheme',
+        version: '0.7.0',
+        isExtension: false,
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        source: RecordSource.USER,
+      },
+    });
+
+    const converged = await convergeCoreProvenance(prisma.dataModel, CORE_DATA_MODEL_ID, RecordSource.USER);
+    expect(converged).toBe(true);
+    const row = await prisma.dataModel.findUniqueOrThrow({ where: { id: CORE_DATA_MODEL_ID } });
+    expect(row.source).toBe(RecordSource.CORE_SEED);
+
+    // Without the stamp this manifest would have adopted the row (the
+    // legacy-adoption rule); with it, the reuse is refused loudly and the
+    // row is untouched.
+    const manifest = `
+dataModels:
+  - id: ${CORE_DATA_MODEL_ID}
+    name: Hijacked Extension
+    credentialType: ConformityScheme
+    version: "0.7.0"
+    parentConfigId: ${CORE_DATA_MODEL_ID}
+    schemaUrl: https://example.com/hijack.json
+    contextUrl: https://example.com/hijack-context.jsonld
+`;
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    try {
+      await expect(runManifest(manifest)).rejects.toThrow('process.exit(1)');
+    } finally {
+      exitSpy.mockRestore();
+    }
+    const after = await prisma.dataModel.findUniqueOrThrow({ where: { id: CORE_DATA_MODEL_ID } });
+    expect(after.name).toBe('ConformityScheme');
+    expect(after.source).toBe(RecordSource.CORE_SEED);
+  });
+});
+
+describe('top-level dataModels presence semantics', () => {
+  const coreParent = () =>
+    prisma.dataModel.create({
+      data: {
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'Core Parent',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        isExtension: false,
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        source: RecordSource.CORE_SEED,
+      },
+    });
+  const ownedExtension = (parentId: string) =>
+    prisma.dataModel.create({
+      data: {
+        id: 'ctestowneddatamodel000002',
+        tenantId: SYSTEM_TENANT_ID,
+        name: 'Owned Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        isExtension: true,
+        parentConfigId: parentId,
+        schemaUrl: 'https://example.com/ext.json',
+        contextUrl: 'https://example.com/ext-context.jsonld',
+        source: RecordSource.CUSTOM_SEED,
+      },
+    });
+
+  it('an absent dataModels key leaves a manifest-owned extension untouched', async () => {
+    const parent = await coreParent();
+    await ownedExtension(parent.id);
+
+    await runManifest(`\nregistrars: []\n`);
+
+    expect(await prisma.dataModel.count()).toBe(2);
+  });
+
+  it('an explicit empty dataModels array removes an unblocked manifest-owned extension, core rows untouched', async () => {
+    const parent = await coreParent();
+    await ownedExtension(parent.id);
+
+    await runManifest(`\ndataModels: []\n`);
+
+    const remaining = await prisma.dataModel.findMany();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].source).toBe(RecordSource.CORE_SEED);
+  });
+});

--- a/packages/reference-implementation/__tests__/integration/reconcile-row-locks.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/reconcile-row-locks.integration.test.ts
@@ -1,0 +1,291 @@
+import { createRigClient, truncateApplicationTables } from './rig/db';
+import { startFixtureServer, type FixtureServer } from './rig/fixture-server';
+import { seedSystemTenant, seedCvcDataModel, schemeDoc, SYSTEM_TENANT_ID, CVC_SPEC_VERSION } from './fixtures';
+import { reconcileRemovals } from '../../prisma/custom-seed-reconcile';
+import { acquireCvcStructuralLock } from '../../src/lib/cvc/cvc-structural-lock';
+import { ingestConformityScheme } from '../../src/lib/cvc/ingest-conformity-scheme';
+import { schemaLoader } from '../../src/lib/credentials/schema-loader';
+import type { CustomSeedManifest, ManifestSectionPresence } from '../../prisma/custom-seed-schema';
+import type { Prisma } from '../../src/lib/prisma/generated/index.js';
+import { ConformitySchemeSource, RecordSource } from '../../src/lib/prisma/generated/index.js';
+
+const REGISTRAR_ID = 'ctestlockedregistrar00001';
+
+const writer = createRigClient();
+const attacker = createRigClient();
+let fixtures: FixtureServer;
+
+const EMPTY_MANIFEST: CustomSeedManifest = {
+  registrars: [],
+  dataModels: [],
+  renderTemplates: [],
+  conformitySchemes: [],
+};
+
+const REGISTRARS_PRESENT: ManifestSectionPresence = {
+  registrars: true,
+  dataModels: false,
+  renderTemplates: false,
+  conformitySchemes: false,
+  identifierSchemesByRegistrar: new Map(),
+  qualifiersByScheme: new Map(),
+};
+
+/**
+ * Wraps a transaction client so `registrar.deleteMany` pauses at a barrier
+ * before executing. For this fixture (victim registrar with no children)
+ * that pause point is exactly #900's discovery-to-delete gap: after
+ * `lockRows` has taken FOR UPDATE on the victim and the descendant checks
+ * have passed, before any delete has run. Every other property and method
+ * is returned bound to the real client, untouched (Prisma's tx is itself a
+ * proxy, so receivers must be preserved).
+ *
+ * The mutation this makes detectable: with `lockRows` removed from
+ * `reconcileRemovals`, the attacker's INSERT at the pause sees an unlocked,
+ * still-live parent, commits into the gap, and is silently cascade-deleted
+ * when the barrier lifts, which fails this suite's assertions.
+ */
+function pauseBeforeRegistrarDelete(
+  tx: Prisma.TransactionClient,
+  onReachedDelete: () => void,
+  release: Promise<void>,
+): Prisma.TransactionClient {
+  const registrarDelegate = new Proxy(tx.registrar, {
+    get(target, prop, receiver) {
+      if (prop === 'deleteMany') {
+        return async (...args: unknown[]) => {
+          onReachedDelete();
+          await release;
+          return (target.deleteMany as (...a: unknown[]) => Promise<unknown>).apply(target, args);
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+  return new Proxy(tx, {
+    get(target, prop, receiver) {
+      if (prop === 'registrar') return registrarDelegate;
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+/** Runs reconcileRemovals paused at the gap, invokes `attack` there, then releases. */
+async function withGapOpen(attack: () => Promise<void>): Promise<{ registrarsRemoved: number }> {
+  let releaseDelete!: () => void;
+  const release = new Promise<void>((resolve) => {
+    releaseDelete = resolve;
+  });
+  let signalReached!: () => void;
+  const reachedDelete = new Promise<void>((resolve) => {
+    signalReached = resolve;
+  });
+
+  const reconcile = writer.$transaction(
+    async (tx) => {
+      const paused = pauseBeforeRegistrarDelete(tx, signalReached, release);
+      return reconcileRemovals(paused, EMPTY_MANIFEST, REGISTRARS_PRESENT, SYSTEM_TENANT_ID);
+    },
+    { timeout: 30_000 },
+  );
+
+  await reachedDelete;
+  try {
+    await attack();
+  } finally {
+    releaseDelete();
+  }
+  const summary = await reconcile;
+  return { registrarsRemoved: summary.registrars };
+}
+
+beforeAll(async () => {
+  fixtures = await startFixtureServer();
+});
+
+beforeEach(async () => {
+  await truncateApplicationTables(writer);
+  await seedSystemTenant(writer);
+  await writer.registrar.create({
+    data: {
+      id: REGISTRAR_ID,
+      tenantId: SYSTEM_TENANT_ID,
+      name: 'Victim Registrar',
+      namespace: 'victim',
+      source: RecordSource.CUSTOM_SEED,
+    },
+  });
+});
+
+afterAll(async () => {
+  await fixtures.close();
+  await writer.$disconnect();
+  await attacker.$disconnect();
+});
+
+describe('reconcile FOR UPDATE victim locks (the #900 discovery-to-delete race)', () => {
+  it('a child INSERT inside the gap times out on the FOR UPDATE lock instead of committing and being cascade-deleted', async () => {
+    const { registrarsRemoved } = await withGapOpen(async () => {
+      // Inside the gap: the victim is locked FOR UPDATE but NOT yet deleted.
+      // The insert's FK check takes FOR KEY SHARE on the parent row, which
+      // conflicts with FOR UPDATE, so with a bounded lock_timeout it fails
+      // loudly here rather than waiting or slipping through.
+      await expect(
+        attacker.$transaction(async (tx) => {
+          await tx.$executeRawUnsafe(`SET LOCAL lock_timeout = '1s'`);
+          await tx.identifierScheme.create({
+            data: {
+              id: 'ctestlateattach0000000001',
+              tenantId: SYSTEM_TENANT_ID,
+              registrarId: REGISTRAR_ID,
+              name: 'Late Attach',
+              primaryKey: '01',
+              validationPattern: '.*',
+              linkTemplate: '/{primaryKey}/{value}',
+              source: RecordSource.USER,
+            },
+          });
+        }),
+      ).rejects.toMatchObject({ message: expect.stringContaining('lock timeout') });
+    });
+
+    expect(registrarsRemoved).toBe(1);
+    // Nothing slipped into the gap: no child row exists, silently deleted or otherwise.
+    expect(await writer.identifierScheme.count()).toBe(0);
+    expect(await writer.registrar.count()).toBe(0);
+  });
+
+  it('after the gap closes (transaction committed), a late attach fails its FK check loudly', async () => {
+    await withGapOpen(async () => {
+      /* no attack inside the gap; this case pins the post-commit behaviour */
+    });
+
+    await expect(
+      attacker.identifierScheme.create({
+        data: {
+          id: 'ctestlateattach0000000002',
+          tenantId: SYSTEM_TENANT_ID,
+          registrarId: REGISTRAR_ID,
+          name: 'Too Late',
+          primaryKey: '01',
+          validationPattern: '.*',
+          linkTemplate: '/{primaryKey}/{value}',
+          source: RecordSource.USER,
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'P2003' });
+  });
+});
+
+describe('CVC structural advisory lock', () => {
+  it('serialises a second helper acquisition until the holder commits (key + lock semantics)', async () => {
+    let releaseHold!: () => void;
+    const hold = new Promise<void>((resolve) => {
+      releaseHold = resolve;
+    });
+    let signalAcquired!: () => void;
+    const acquired = new Promise<void>((resolve) => {
+      signalAcquired = resolve;
+    });
+
+    const holder = writer.$transaction(
+      async (tx) => {
+        await acquireCvcStructuralLock(tx, SYSTEM_TENANT_ID);
+        signalAcquired();
+        await hold;
+      },
+      { timeout: 20_000 },
+    );
+    await acquired;
+
+    await expect(
+      attacker.$transaction(async (tx) => {
+        await tx.$executeRawUnsafe(`SET LOCAL lock_timeout = '500ms'`);
+        await acquireCvcStructuralLock(tx, SYSTEM_TENANT_ID);
+      }),
+    ).rejects.toMatchObject({ message: expect.stringContaining('lock timeout') });
+
+    releaseHold();
+    await holder;
+
+    await attacker.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe(`SET LOCAL lock_timeout = '500ms'`);
+      await acquireCvcStructuralLock(tx, SYSTEM_TENANT_ID);
+    });
+  });
+
+  it('blocks a REAL production writer (ingest persist) until the holder releases', async () => {
+    await seedCvcDataModel(writer, fixtures);
+    fixtures.set('/schemes/lock-probe.json', {
+      body: JSON.stringify(schemeDoc(fixtures, 'https://schemes.example/lock-probe', { name: 'Probe', profiles: [] })),
+    });
+    const dataModel = await writer.dataModel.findFirstOrThrow({ where: { credentialType: 'ConformityScheme' } });
+
+    let releaseHold!: () => void;
+    const hold = new Promise<void>((resolve) => {
+      releaseHold = resolve;
+    });
+    let signalAcquired!: (identity: { classid: number; objid: number; objsubid: number }) => void;
+    const acquired = new Promise<{ classid: number; objid: number; objsubid: number }>((resolve) => {
+      signalAcquired = resolve;
+    });
+    const holder = writer.$transaction(
+      async (tx) => {
+        await acquireCvcStructuralLock(tx, SYSTEM_TENANT_ID);
+        // Capture THIS transaction's granted advisory-lock identity so the
+        // wait signal below matches this exact lock key, not any advisory
+        // waiter that happens to exist on a shared external database.
+        const granted = await tx.$queryRaw<{ classid: number; objid: number; objsubid: number }[]>`
+          SELECT classid::int, objid::int, objsubid::int FROM pg_locks
+          WHERE locktype = 'advisory' AND granted AND pid = pg_backend_pid()
+        `;
+        signalAcquired(granted[0]);
+        await hold;
+      },
+      { timeout: 30_000 },
+    );
+    const lockIdentity = await acquired;
+
+    try {
+      let holderReleasedAt = 0;
+      const ingest = ingestConformityScheme({
+        sourceUrl: `${fixtures.baseUrl}/schemes/lock-probe.json`,
+        source: ConformitySchemeSource.SYSTEM_SEED,
+        tenantId: SYSTEM_TENANT_ID,
+        conformitySchemaUrl: dataModel.schemaUrl,
+        schemaLoader,
+        conformityVocabularySpecVersion: CVC_SPEC_VERSION,
+      }).then((result) => ({ result, settledAfterRelease: holderReleasedAt !== 0 }));
+
+      // Wait signal, not a sleep: the ingest's persist transaction must show
+      // up in pg_locks as an UNGRANTED waiter on the holder's exact lock key
+      // before the holder releases. Removing acquireCvcStructuralLock from
+      // the persist path makes this wait never appear and the assertion fail.
+      const deadline = Date.now() + 15_000;
+      let waiting = false;
+      while (Date.now() < deadline && !waiting) {
+        const rows = await attacker.$queryRaw<{ count: bigint }[]>`
+          SELECT count(*)::bigint AS count FROM pg_locks
+          WHERE locktype = 'advisory' AND NOT granted
+            AND classid = ${lockIdentity.classid} AND objid = ${lockIdentity.objid}
+            AND objsubid = ${lockIdentity.objsubid}
+        `;
+        waiting = Number(rows[0].count) > 0;
+        if (!waiting) await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      expect(waiting).toBe(true);
+
+      holderReleasedAt = Date.now();
+      releaseHold();
+      await holder;
+
+      const { result, settledAfterRelease } = await ingest;
+      expect(result.kind).toBe('success');
+      expect(settledAfterRelease).toBe(true);
+    } finally {
+      // A failed wait must still release the holder, or the open transaction
+      // and pending ingest sit on their timeouts and bury the real failure.
+      releaseHold();
+    }
+  });
+});

--- a/packages/reference-implementation/__tests__/integration/refresh-and-second-boot.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/refresh-and-second-boot.integration.test.ts
@@ -1,0 +1,211 @@
+import { createRigClient, truncateApplicationTables } from './rig/db';
+import { startFixtureServer, type FixtureServer } from './rig/fixture-server';
+import {
+  quietLogger,
+  capturingLogger,
+  seedSystemTenant,
+  seedCvcDataModel,
+  schemeDoc,
+  bootManifest,
+  SYSTEM_TENANT_ID,
+  CVC_SPEC_VERSION,
+  type CapturedLog,
+} from './fixtures';
+import { ingestConformityScheme } from '../../src/lib/cvc/ingest-conformity-scheme';
+import { refreshSeededSchemes } from '../../src/lib/cvc/refresh-seeded-schemes';
+import { schemaLoader } from '../../src/lib/credentials/schema-loader';
+import { ConformitySchemeSource, SeedEntryKind } from '../../src/lib/prisma/generated/index.js';
+
+const prisma = createRigClient();
+let fixtures: FixtureServer;
+
+const SCHEME_URL_PATH = '/schemes/live.json';
+const SCHEME_CANONICAL = 'https://schemes.example/live';
+const REGISTRAR_ID = 'ctestbootregistrar0000001';
+
+beforeAll(async () => {
+  fixtures = await startFixtureServer();
+});
+
+beforeEach(async () => {
+  await truncateApplicationTables(prisma);
+  await seedSystemTenant(prisma);
+  await seedCvcDataModel(prisma, fixtures);
+});
+
+afterAll(async () => {
+  await fixtures.close();
+  await prisma.$disconnect();
+});
+
+describe('seeded-scheme refresh against real rows', () => {
+  it('picks up a changed URL document and persists the update', async () => {
+    fixtures.set(SCHEME_URL_PATH, {
+      body: JSON.stringify(schemeDoc(fixtures, SCHEME_CANONICAL, { name: 'Original', profiles: [] })),
+    });
+    await bootManifest(
+      prisma,
+      `conformitySchemes:\n  - url: ${fixtures.baseUrl}${SCHEME_URL_PATH}\n    version: "${CVC_SPEC_VERSION}"\n`,
+    );
+    const row = await prisma.conformityScheme.findFirstOrThrow();
+    expect(row.name).toBe('Original');
+    expect(row.seedEntryKind).toBe(SeedEntryKind.URL);
+
+    fixtures.set(SCHEME_URL_PATH, {
+      body: JSON.stringify(schemeDoc(fixtures, SCHEME_CANONICAL, { name: 'Publisher Updated', profiles: [] })),
+    });
+
+    const summary = await refreshSeededSchemes(quietLogger());
+
+    expect(summary.refreshed).toBe(1);
+    expect(summary.failed).toBe(0);
+    const updated = await prisma.conformityScheme.findFirstOrThrow();
+    expect(updated.id).toBe(row.id);
+    expect(updated.name).toBe('Publisher Updated');
+  });
+
+  it('an unchanged document is a digest no-op that keeps profile row identity', async () => {
+    const doc = JSON.stringify(
+      schemeDoc(fixtures, SCHEME_CANONICAL, {
+        name: 'Stable',
+        profiles: [{ id: `${SCHEME_CANONICAL}/basic/1.0.0`, name: 'Basic' }],
+      }),
+    );
+    fixtures.set(SCHEME_URL_PATH, { body: doc });
+    await bootManifest(
+      prisma,
+      `conformitySchemes:\n  - url: ${fixtures.baseUrl}${SCHEME_URL_PATH}\n    version: "${CVC_SPEC_VERSION}"\n`,
+    );
+    const profileBefore = await prisma.conformityProfile.findFirstOrThrow();
+
+    const summary = await refreshSeededSchemes(quietLogger());
+
+    expect(summary.unchanged).toBe(1);
+    expect(summary.refreshed).toBe(0);
+    // The unchanged path never rewrites the profile graph, so the row
+    // identity survives (a re-persist would delete-and-recreate it).
+    const profileAfter = await prisma.conformityProfile.findFirstOrThrow();
+    expect(profileAfter.id).toBe(profileBefore.id);
+  });
+
+  it('requireExistingRow returns stale (and creates nothing) when the row was evicted mid-refresh', async () => {
+    fixtures.set(SCHEME_URL_PATH, {
+      body: JSON.stringify(schemeDoc(fixtures, SCHEME_CANONICAL, { name: 'Original', profiles: [] })),
+    });
+    await bootManifest(
+      prisma,
+      `conformitySchemes:\n  - url: ${fixtures.baseUrl}${SCHEME_URL_PATH}\n    version: "${CVC_SPEC_VERSION}"\n`,
+    );
+    const dataModel = await prisma.dataModel.findFirstOrThrow({ where: { credentialType: 'ConformityScheme' } });
+
+    // The eviction that raced the refresh: the row disappears after the
+    // refresh listed it but before its persist.
+    await prisma.conformityScheme.deleteMany();
+    // A changed body forces the persist path (an unchanged digest would
+    // short-circuit before the requireExistingRow check matters).
+    fixtures.set(SCHEME_URL_PATH, {
+      body: JSON.stringify(schemeDoc(fixtures, SCHEME_CANONICAL, { name: 'Newer', profiles: [] })),
+    });
+
+    const result = await ingestConformityScheme({
+      sourceUrl: `${fixtures.baseUrl}${SCHEME_URL_PATH}`,
+      source: ConformitySchemeSource.SYSTEM_SEED,
+      tenantId: SYSTEM_TENANT_ID,
+      conformitySchemaUrl: dataModel.schemaUrl,
+      schemaLoader,
+      conformityVocabularySpecVersion: CVC_SPEC_VERSION,
+      requireExistingRow: true,
+    });
+
+    expect(result.kind).toBe('stale');
+    // A timer must never recreate membership the manifest removed.
+    expect(await prisma.conformityScheme.count()).toBe(0);
+  });
+});
+
+describe('second boot with an unchanged manifest', () => {
+  it('performs no deletions and keeps every row identity', async () => {
+    const schemeFile = JSON.stringify(
+      schemeDoc(fixtures, SCHEME_CANONICAL, {
+        name: 'Stable',
+        profiles: [
+          {
+            id: `${SCHEME_CANONICAL}/basic/1.0.0`,
+            name: 'Basic',
+            criteria: [{ id: 'https://criteria.example/boot/1.0.0', name: 'Boot Criterion' }],
+          },
+        ],
+      }),
+    );
+    const manifest = `
+registrars:
+  - id: ${REGISTRAR_ID}
+    name: Boot Registrar
+    namespace: bootreg
+    identifierSchemes:
+      - id: ctestbootscheme0000000001
+        name: Boot Scheme
+        primaryKey: "01"
+        validationPattern: ".*"
+        linkTemplate: "/{primaryKey}/{value}"
+        qualifiers:
+          - id: ctestbootqualifier0000001
+            key: "10"
+            description: Batch number
+            validationPattern: ".*"
+conformitySchemes:
+  - file: schemes/live.json
+    version: "${CVC_SPEC_VERSION}"
+`;
+
+    await bootManifest(prisma, manifest, { 'schemes/live.json': schemeFile });
+
+    // Snapshot identity as (id, createdAt) pairs: manifest-specified ids
+    // (registrar, scheme, qualifier) would survive a delete-and-recreate
+    // regression, but createdAt would not. Joins are included so a second
+    // boot silently dropping graph edges cannot pass.
+    const snapshot = async () => ({
+      registrars: (await prisma.registrar.findMany()).map((r) => [r.id, r.createdAt.toISOString()]).sort(),
+      schemes: (await prisma.identifierScheme.findMany()).map((r) => [r.id, r.createdAt.toISOString()]).sort(),
+      qualifiers: (await prisma.schemeQualifier.findMany()).map((r) => [r.id, r.createdAt.toISOString()]).sort(),
+      conformitySchemes: (await prisma.conformityScheme.findMany()).map((r) => r.id).sort(),
+      profiles: (await prisma.conformityProfile.findMany()).map((r) => r.id).sort(),
+      criteria: (await prisma.conformityCriterion.findMany()).map((r) => r.id).sort(),
+      // Join ROW ids, not endpoints: a delete-and-recreate under the same
+      // (profileId, criterionId) pair would keep the endpoints but not the ids.
+      joins: (await prisma.conformityProfileCriterion.findMany()).map((j) => j.id).sort(),
+    });
+    const before = await snapshot();
+    expect(before.qualifiers).toHaveLength(1);
+    expect(before.joins).toHaveLength(1);
+
+    const logs: CapturedLog[] = [];
+    await bootManifest(prisma, manifest, { 'schemes/live.json': schemeFile }, capturingLogger(logs));
+
+    // Identity, not timestamps: upsert update-arms legitimately bump
+    // updatedAt, so the no-op contract is "same rows, nothing deleted,
+    // nothing recreated under a new id or a new createdAt".
+    expect(await snapshot()).toEqual(before);
+
+    // A silently failed second ingest (log-and-continue) would retain the
+    // old rows and pass the identity checks; the fetch status and the
+    // captured summary pin that the second boot actually succeeded and
+    // deleted nothing.
+    const conformityRow = await prisma.conformityScheme.findFirstOrThrow();
+    expect(conformityRow.lastFetchStatus).toBe('SUCCESS');
+
+    expect(logs.filter((l) => l.level === 'error')).toEqual([]);
+    const summaryLog = logs.find(
+      (l) => l.level === 'info' && typeof l.args[1] === 'string' && l.args[1].includes('Custom seed completed'),
+    );
+    expect(summaryLog).toBeDefined();
+    const summary = summaryLog!.args[0] as {
+      removed: Record<string, number>;
+      conformitySchemes: { failed: number; evicted: number; criteriaSwept: number };
+    };
+    expect(Object.values(summary.removed).every((count) => count === 0)).toBe(true);
+    expect(summary.conformitySchemes.failed).toBe(0);
+    expect(summary.conformitySchemes.evicted).toBe(0);
+    expect(summary.conformitySchemes.criteriaSwept).toBe(0);
+  });
+});

--- a/packages/reference-implementation/__tests__/integration/rig-smoke.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/rig-smoke.integration.test.ts
@@ -1,0 +1,27 @@
+import { createRigClient, truncateApplicationTables } from './rig/db';
+
+/**
+ * Rig self-check: the resolved database is migrated, writable, and the
+ * truncate helper clears application tables while preserving migrations.
+ */
+describe('integration rig', () => {
+  const prisma = createRigClient();
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('runs against a migrated, writable database and truncates between tests', async () => {
+    await truncateApplicationTables(prisma);
+    await prisma.tenant.create({ data: { id: 'rig-smoke-tenant', name: 'Rig Smoke' } });
+    expect(await prisma.tenant.count()).toBe(1);
+
+    await truncateApplicationTables(prisma);
+    expect(await prisma.tenant.count()).toBe(0);
+
+    const migrations = await prisma.$queryRaw<{ count: bigint }[]>`
+      SELECT count(*)::bigint AS count FROM _prisma_migrations
+    `;
+    expect(Number(migrations[0].count)).toBeGreaterThan(0);
+  });
+});

--- a/packages/reference-implementation/__tests__/integration/rig/db.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/db.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '../../../src/lib/prisma/generated/index.js';
+
+/**
+ * Test-side database helpers. Every client constructed here reads
+ * `RI_DATABASE_URL`, which globalSetup has already pointed at the rig's
+ * owned database; suites must construct clients through this module (or the
+ * application's own singleton) rather than hand-building URLs.
+ */
+
+/** A dedicated client, e.g. the second connection in a concurrency test. */
+export function createRigClient(): PrismaClient {
+  return new PrismaClient();
+}
+
+/**
+ * Truncates all application tables, preserving `_prisma_migrations` so the
+ * schema stays migrated for the whole run. CASCADE keeps the statement
+ * order-independent; identity is cuid-based so sequences are not a concern.
+ */
+export async function truncateApplicationTables(client: PrismaClient): Promise<void> {
+  const rows = await client.$queryRaw<{ tablename: string }[]>`
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public' AND tablename <> '_prisma_migrations'
+  `;
+  if (rows.length === 0) return;
+  const tables = rows.map((r) => `"${r.tablename}"`).join(', ');
+  await client.$executeRawUnsafe(`TRUNCATE TABLE ${tables} CASCADE`);
+}

--- a/packages/reference-implementation/__tests__/integration/rig/docker.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/docker.ts
@@ -1,0 +1,154 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Ephemeral Postgres lifecycle for the integration rig, via the docker CLI.
+ *
+ * One container per jest run: `postgres:17-alpine` (the same pin as the
+ * repository's `ri-db` and `e2e-ri-db` services) on a docker-assigned
+ * loopback port. Containers carry a label so an orphan left by a crashed
+ * run is identified and removed by the next run rather than accumulating.
+ */
+
+const IMAGE = 'postgres:17-alpine';
+const LABEL = 'untp-ri-integration-rig=true';
+export const EPHEMERAL_DB_NAME = 'ri_integration';
+const DB_USER = 'test';
+const DB_PASSWORD = 'test';
+const READINESS_TIMEOUT_MS = 60_000;
+const READINESS_POLL_MS = 250;
+
+function docker(args: string[]): string {
+  try {
+    return execFileSync('docker', args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  } catch (err) {
+    const stderr = (err as { stderr?: Buffer | string }).stderr?.toString().trim();
+    throw new Error(`docker ${args.slice(0, 2).join(' ')} failed${stderr ? `: ${stderr}` : ''}`, { cause: err });
+  }
+}
+
+function assertDockerAvailable(): void {
+  try {
+    execFileSync('docker', ['info'], { stdio: 'ignore' });
+  } catch {
+    throw new Error(
+      'The integration rig needs a running docker daemon to start its ephemeral Postgres container ' +
+        '(or set TEST_DATABASE_URL to an existing dedicated test database). Docker is not reachable.',
+    );
+  }
+}
+
+/**
+ * Removes containers left behind by a previous crashed run. The label is
+ * shared by every rig container, so this assumes one rig per docker daemon:
+ * two simultaneous local `test:integration` runs would remove each other's
+ * database. CI runners are isolated; locally, run one at a time.
+ */
+function removeOrphans(): void {
+  const orphans = docker(['ps', '-aq', '--filter', `label=${LABEL}`]);
+  for (const id of orphans.split('\n').filter(Boolean)) {
+    docker(['rm', '-f', id]);
+  }
+}
+
+function mappedHostPort(containerId: string): string {
+  // `docker port` may print IPv4 and IPv6 mappings; take the IPv4 line.
+  const lines = docker(['port', containerId, '5432/tcp']).split('\n');
+  const ipv4 = lines.find((l) => l.startsWith('127.0.0.1:')) ?? lines[0];
+  const port = ipv4?.split(':').pop();
+  if (!port || !/^\d+$/.test(port)) {
+    throw new Error(
+      `Could not determine the ephemeral container's mapped port (docker port said: "${lines.join(' | ')}")`,
+    );
+  }
+  return port;
+}
+
+function waitForReadiness(containerId: string): void {
+  const deadline = Date.now() + READINESS_TIMEOUT_MS;
+  // The official postgres image restarts the server once during first-boot
+  // init, and pg_isready can succeed against the throwaway init server, so
+  // readiness requires two consecutive successful probes.
+  let consecutive = 0;
+  while (Date.now() < deadline) {
+    try {
+      execFileSync('docker', ['exec', containerId, 'pg_isready', '-U', DB_USER, '-d', EPHEMERAL_DB_NAME], {
+        stdio: 'ignore',
+      });
+      consecutive += 1;
+      if (consecutive >= 2) return;
+    } catch {
+      consecutive = 0;
+      // "Not ready yet" and "the container died" both land here; only the
+      // former is worth waiting out, so a non-running container fails now
+      // with its logs rather than burning the timeout on a lost cause.
+      let state = 'unknown';
+      try {
+        state = docker(['inspect', '-f', '{{.State.Status}}', containerId]);
+      } catch {
+        throw new Error(
+          `Ephemeral Postgres container disappeared (or the docker daemon stopped) while waiting for readiness.`,
+        );
+      }
+      if (state !== 'running' && state !== 'created') {
+        const logs = docker(['logs', '--tail', '20', containerId]);
+        docker(['rm', '-f', containerId]);
+        throw new Error(`Ephemeral Postgres container is "${state}" instead of running. Last container logs:\n${logs}`);
+      }
+    }
+    execFileSync('sleep', [String(READINESS_POLL_MS / 1000)]);
+  }
+  const logs = docker(['logs', '--tail', '20', containerId]);
+  docker(['rm', '-f', containerId]);
+  throw new Error(
+    `Ephemeral Postgres did not become ready within ${READINESS_TIMEOUT_MS / 1000}s. Last container logs:\n${logs}`,
+  );
+}
+
+export interface EphemeralPostgres {
+  containerId: string;
+  url: string;
+}
+
+export function startEphemeralPostgres(): EphemeralPostgres {
+  assertDockerAvailable();
+  removeOrphans();
+  const containerId = docker([
+    'run',
+    '-d',
+    '--label',
+    LABEL,
+    '-e',
+    `POSTGRES_USER=${DB_USER}`,
+    '-e',
+    `POSTGRES_PASSWORD=${DB_PASSWORD}`,
+    '-e',
+    `POSTGRES_DB=${EPHEMERAL_DB_NAME}`,
+    '-p',
+    // Port 0 lets docker pick a free host port atomically (no preselect race).
+    '127.0.0.1:0:5432',
+    IMAGE,
+  ]);
+  try {
+    const port = mappedHostPort(containerId);
+    waitForReadiness(containerId);
+    return {
+      containerId,
+      url: `postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${port}/${EPHEMERAL_DB_NAME}`,
+    };
+  } catch (err) {
+    // Best-effort cleanup for the paths that have not already removed the
+    // container (waitForReadiness removes it itself). A failing `rm -f` is
+    // swallowed so the original startup error surfaces; a leaked container
+    // is picked up by the next run's label-based orphan removal.
+    try {
+      docker(['rm', '-f', containerId]);
+    } catch {
+      /* orphan removal on the next run is the backstop */
+    }
+    throw err;
+  }
+}
+
+export function removeContainer(containerId: string): void {
+  docker(['rm', '-f', containerId]);
+}

--- a/packages/reference-implementation/__tests__/integration/rig/fixture-server.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/fixture-server.ts
@@ -1,0 +1,45 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface Fixture {
+  body: string;
+  contentType?: string;
+  status?: number;
+}
+
+export interface FixtureServer {
+  baseUrl: string;
+  /** Registers or replaces the fixture served at `path` (leading slash). */
+  set(path: string, fixture: Fixture): void;
+  remove(path: string): void;
+  close(): Promise<void>;
+}
+
+/**
+ * Loopback HTTP server for schema documents, JSON-LD contexts, and
+ * URL-entry scheme documents, so no integration test depends on a remote
+ * host (ADR-029: mock external services at the HTTP boundary, keep internal
+ * I/O real).
+ */
+export async function startFixtureServer(): Promise<FixtureServer> {
+  const fixtures = new Map<string, Fixture>();
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const fixture = fixtures.get(url.pathname);
+    if (!fixture) {
+      res.writeHead(404, { 'content-type': 'text/plain' });
+      res.end(`no fixture registered for ${url.pathname}`);
+      return;
+    }
+    res.writeHead(fixture.status ?? 200, { 'content-type': fixture.contentType ?? 'application/json' });
+    res.end(fixture.body);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    set: (path, fixture) => void fixtures.set(path, fixture),
+    remove: (path) => void fixtures.delete(path),
+    close: () => new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}

--- a/packages/reference-implementation/__tests__/integration/rig/global-setup.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/global-setup.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { guardExternalUrl } from './target';
+import { startEphemeralPostgres, removeContainer } from './docker';
+
+interface RigState {
+  containerId: string | null;
+}
+
+/**
+ * Jest globalSetup for the integration rig (#900; ADR-029 integration layer).
+ *
+ * Resolves exactly one owned database target, forces it onto
+ * `RI_DATABASE_URL`, and applies migrations, all before any worker forks or
+ * any module constructs a `PrismaClient`. Jest runs this in the parent
+ * process and forks workers with a copy of `process.env`, so the assignment
+ * is visible to every suite. Every downstream consumer of the database URL
+ * (the generated client, `prisma.config.ts`, `seed.ts`) honours a pre-set
+ * `RI_DATABASE_URL` and dotenv never overrides an existing value, so the
+ * repository `.env`'s developer database cannot leak in.
+ */
+export default async function globalSetup(): Promise<void> {
+  const external = process.env.TEST_DATABASE_URL;
+  const state: RigState = { containerId: null };
+
+  let url: string;
+  if (external) {
+    url = guardExternalUrl(external, process.env.TEST_DATABASE_ACCEPT_DESTRUCTIVE === 'true');
+  } else {
+    const ephemeral = startEphemeralPostgres();
+    state.containerId = ephemeral.containerId;
+    url = ephemeral.url;
+  }
+
+  process.env.RI_DATABASE_URL = url;
+  (globalThis as Record<string, unknown>).__RI_INTEGRATION_RIG__ = state;
+
+  // Jest 29 loads globalSetup through its script transformer (ts-jest here)
+  // with static ESM disabled, so the module runs as CJS and __dirname exists.
+  const packageRoot = path.resolve(__dirname, '../../..');
+  try {
+    execFileSync('pnpm', ['exec', 'prisma', 'migrate', 'deploy', '--config', 'prisma/prisma.config.ts'], {
+      cwd: packageRoot,
+      env: { ...process.env, RI_DATABASE_URL: url },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const stderr = (err as { stderr?: Buffer | string }).stderr?.toString().trim();
+    if (state.containerId) {
+      removeContainer(state.containerId);
+      state.containerId = null;
+    }
+    throw new Error(`prisma migrate deploy failed against the rig database${stderr ? `:\n${stderr}` : ''}`, {
+      cause: err,
+    });
+  }
+}

--- a/packages/reference-implementation/__tests__/integration/rig/global-teardown.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/global-teardown.ts
@@ -1,0 +1,17 @@
+import { removeContainer } from './docker';
+
+/**
+ * Jest globalTeardown: removes the ephemeral container this run started.
+ * Runs in the same parent process as globalSetup, so the state handoff is a
+ * plain global. An externally supplied database is left as-is (the operator
+ * owns it); a crashed run's orphaned container is removed by the next run's
+ * setup via the container label.
+ */
+export default async function globalTeardown(): Promise<void> {
+  const state = (globalThis as Record<string, unknown>).__RI_INTEGRATION_RIG__ as
+    | { containerId: string | null }
+    | undefined;
+  if (state?.containerId) {
+    removeContainer(state.containerId);
+  }
+}

--- a/packages/reference-implementation/__tests__/integration/rig/multibase-digest-stub.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/multibase-digest-stub.ts
@@ -1,0 +1,65 @@
+/**
+ * Full-payload deterministic stub for `@uncefact/untp-utils/multibase-digest`,
+ * wired via `moduleNameMapper` in `jest.integration.config.mjs`.
+ *
+ * The real package ships as ESM through `multiformats` subpath exports the
+ * RI's Jest resolver cannot unpack (same constraint as the unit stub). The
+ * unit stub is unusable here for a different reason: it digests only the
+ * first 8 payload bytes, so two JSON-LD documents sharing an opening
+ * collide and re-ingest takes the `unchanged` path, false-passing the
+ * convergence suites. This stub hashes the full payload with sha-256, so
+ * changed-versus-unchanged detection carries the same information as the
+ * real digest. Multibase encoding correctness lives in `@uncefact/untp-utils`.
+ */
+
+import { createHash } from 'node:crypto';
+import { Buffer } from 'node:buffer';
+
+type HashAlgorithm = 'sha2-256' | 'sha2-512';
+type MultibaseEncoding = 'base58btc' | 'base64';
+
+export class MultibaseDigest {
+  constructor(public readonly encoded: string) {}
+
+  static fromDigest(digest: Uint8Array, _opts: { algorithm: HashAlgorithm; base: MultibaseEncoding }): MultibaseDigest {
+    return new MultibaseDigest(`zINTEG${Buffer.from(digest).toString('hex')}`);
+  }
+
+  static fromHex(hex: string, opts: { algorithm: HashAlgorithm; base: MultibaseEncoding }): MultibaseDigest {
+    if (typeof hex !== 'string' || hex.length === 0 || hex.length % 2 !== 0 || !/^[a-fA-F0-9]+$/.test(hex)) {
+      throw new Error(`Invalid hex digest: "${hex}"`);
+    }
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i += 1) bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    return MultibaseDigest.fromDigest(bytes, opts);
+  }
+
+  static async fromData(
+    data: Uint8Array,
+    _opts: { algorithm: HashAlgorithm; base: MultibaseEncoding },
+  ): Promise<MultibaseDigest> {
+    return new MultibaseDigest(`zINTEG${createHash('sha256').update(data).digest('hex')}`);
+  }
+
+  static async fromText(
+    text: string,
+    opts: { algorithm: HashAlgorithm; base: MultibaseEncoding },
+  ): Promise<MultibaseDigest> {
+    return MultibaseDigest.fromData(new TextEncoder().encode(text), opts);
+  }
+
+  static fromString(encoded: string): MultibaseDigest {
+    if (typeof encoded !== 'string' || encoded.length < 2 || !/^[zm]/.test(encoded)) {
+      throw new Error(`Invalid multibase-encoded multihash: "${encoded}"`);
+    }
+    return new MultibaseDigest(encoded);
+  }
+
+  toString(): string {
+    return this.encoded;
+  }
+
+  async verify(data: Uint8Array): Promise<boolean> {
+    return this.encoded === `zINTEG${createHash('sha256').update(data).digest('hex')}`;
+  }
+}

--- a/packages/reference-implementation/__tests__/integration/rig/target.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/target.ts
@@ -1,0 +1,82 @@
+/**
+ * Database-target resolution for the integration rig.
+ *
+ * The rig operates under one safety contract (ADR-029 integration layer;
+ * #900): the only database a suite may touch is the one this module
+ * resolves, either a guarded external `TEST_DATABASE_URL` or the ephemeral
+ * container the rig itself started. The resolved URL is forced onto
+ * `RI_DATABASE_URL` before any Prisma command or client construction, so the
+ * repository `.env`'s developer database can never be inherited. The suites
+ * truncate tables between tests, which is why an external URL is refused
+ * when its database name matches a real environment.
+ */
+
+/**
+ * Database names used by the real environments in this repository's compose
+ * files: `ri` (`ri-db` and `e2e-ri-db`) and `vckit` (the VCKit `db`
+ * service). An external target with one of these names is refused unless
+ * the operator explicitly accepts destruction.
+ */
+const GUARDED_DATABASE_NAMES = new Set(['ri', 'vckit']);
+
+export interface ResolvedTarget {
+  url: string;
+  source: 'external' | 'ephemeral';
+}
+
+/** Redacted description safe for error messages (never the raw URL, which carries credentials). */
+function describeTarget(parsed: URL | null, raw: string): string {
+  if (!parsed) return `a malformed URL (${raw.length} characters, not echoed in case it carries credentials)`;
+  return `host "${parsed.hostname}:${parsed.port || '5432'}", path "${parsed.pathname}"`;
+}
+
+/**
+ * Validates an operator-supplied external database URL. Throws when the URL
+ * is malformed, names no single unambiguous database, selects a non-public
+ * Prisma schema (cleanup truncates `public` only), or names a database that
+ * looks like a real environment, unless `acceptDestructive` (from
+ * `TEST_DATABASE_ACCEPT_DESTRUCTIVE=true`) is set. The database name is
+ * percent-decoded and trailing-slash-normalised before comparison, so
+ * encodings of a guarded name cannot slip past.
+ */
+export function guardExternalUrl(raw: string, acceptDestructive: boolean): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`TEST_DATABASE_URL is not a valid URL: ${describeTarget(null, raw)}`);
+  }
+  if (parsed.protocol !== 'postgresql:' && parsed.protocol !== 'postgres:') {
+    throw new Error(`TEST_DATABASE_URL must be a postgresql:// URL, got "${parsed.protocol}//"`);
+  }
+
+  const segments = parsed.pathname
+    .split('/')
+    .slice(1)
+    .filter((s) => s.length > 0);
+  if (segments.length !== 1) {
+    throw new Error(`TEST_DATABASE_URL must name exactly one database in its path; got ${describeTarget(parsed, raw)}`);
+  }
+  let databaseName: string;
+  try {
+    databaseName = decodeURIComponent(segments[0]);
+  } catch {
+    throw new Error(`TEST_DATABASE_URL has an undecodable database name; got ${describeTarget(parsed, raw)}`);
+  }
+
+  const schemaParams = parsed.searchParams.getAll('schema');
+  if (schemaParams.length > 1 || (schemaParams.length === 1 && schemaParams[0] !== 'public')) {
+    throw new Error(
+      `TEST_DATABASE_URL selects a non-public (or ambiguous) Prisma schema, but the rig's between-test cleanup truncates the "public" schema only. Use a dedicated database on the public schema.`,
+    );
+  }
+
+  if (!acceptDestructive && GUARDED_DATABASE_NAMES.has(databaseName)) {
+    throw new Error(
+      `TEST_DATABASE_URL points at database "${databaseName}", which matches a real environment's database name. ` +
+        `The integration suites TRUNCATE tables between tests. Point TEST_DATABASE_URL at a dedicated test database, ` +
+        `or set TEST_DATABASE_ACCEPT_DESTRUCTIVE=true if this database really is disposable.`,
+    );
+  }
+  return raw;
+}

--- a/packages/reference-implementation/__tests__/integration/rig/untp-utils-node-stub.ts
+++ b/packages/reference-implementation/__tests__/integration/rig/untp-utils-node-stub.ts
@@ -1,0 +1,36 @@
+/**
+ * Integration stand-in for `@uncefact/untp-utils`'s node module, wired via
+ * `moduleNameMapper` in `jest.integration.config.mjs`.
+ *
+ * Everything is the real build except `validatePublicUrl`: the production
+ * SSRF guard (correctly) refuses loopback addresses, and the integration
+ * suites serve every document, schema, and context from a loopback fixture
+ * server (ADR-029: mock external services at the HTTP boundary, keep
+ * internal I/O real). This override validates URL shape and scheme like the
+ * real one but permits private addresses, so the resolver's fetch, redirect,
+ * and size handling still run for real against the fixture server.
+ */
+
+import { isIP } from 'node:net';
+
+export * from '../../../../untp-utils/build/node/index.js';
+
+interface ResolvedAddress {
+  address: string;
+  family: number;
+}
+
+export async function validatePublicUrl(
+  url: string,
+  options?: { allowedSchemes?: readonly string[] },
+): Promise<ResolvedAddress> {
+  const parsed = new URL(url);
+  const scheme = parsed.protocol.toLowerCase().replace(/:$/, '');
+  const allowed = options?.allowedSchemes ?? ['http', 'https'];
+  if (!allowed.some((s) => s.toLowerCase() === scheme)) {
+    throw new Error(`Unsupported scheme "${scheme}"`);
+  }
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  const family = isIP(hostname);
+  return { address: hostname, family: family === 0 ? 4 : family };
+}

--- a/packages/reference-implementation/__tests__/integration/target-guard.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/target-guard.integration.test.ts
@@ -1,0 +1,59 @@
+import { guardExternalUrl } from './rig/target';
+
+/**
+ * Pure-function tests for the external-URL guard. They live in the
+ * integration tree because the guard is rig code the unit run must not
+ * collect, so they run under the integration job (docker and all) even
+ * though the assertions themselves never touch a database. The guard is
+ * the only thing between an operator's stale shell variable and a
+ * truncated real database, so every bypass shape found in review is
+ * pinned here.
+ */
+describe('guardExternalUrl', () => {
+  const ok = 'postgresql://test:test@localhost:5544/ri_test';
+
+  it('accepts a dedicated test database', () => {
+    expect(guardExternalUrl(ok, false)).toBe(ok);
+  });
+
+  it.each([
+    ['plain', 'postgresql://u:p@localhost:5433/ri'],
+    ['percent-encoded', 'postgresql://u:p@localhost:5433/%72i'],
+    ['trailing slash', 'postgresql://u:p@localhost:5433/ri/'],
+    ['vckit compose database', 'postgresql://u:p@localhost:5432/vckit'],
+  ])('refuses a guarded database name (%s)', (_label, url) => {
+    expect(() => guardExternalUrl(url, false)).toThrow(/matches a real environment|exactly one database/);
+  });
+
+  it('a trailing slash normalises rather than changing the compared name', () => {
+    // The bypass shape was "/ri/" reading as "ri/" and missing the guard;
+    // normalisation must strip the empty segment on safe names too.
+    expect(guardExternalUrl('postgresql://u:p@localhost:5433/ri_test/', false)).toBeTruthy();
+  });
+
+  it('allows a guarded name only with the explicit destructive acknowledgement', () => {
+    expect(guardExternalUrl('postgresql://u:p@localhost:5433/ri', true)).toBeTruthy();
+  });
+
+  it('refuses a non-postgres scheme, an empty path, and a multi-segment path', () => {
+    expect(() => guardExternalUrl('mysql://u:p@localhost/db', false)).toThrow(/postgresql/);
+    expect(() => guardExternalUrl('postgresql://u:p@localhost:5433/', false)).toThrow(/exactly one database/);
+    expect(() => guardExternalUrl('postgresql://u:p@localhost:5433/a/b', false)).toThrow(/exactly one database/);
+  });
+
+  it('refuses a non-public Prisma schema (cleanup truncates public only)', () => {
+    expect(() => guardExternalUrl('postgresql://u:p@localhost:5433/ri_test?schema=other', false)).toThrow(/public/);
+  });
+
+  it('never echoes credentials in its errors', () => {
+    const secret = 'postgresql://user:sup3rs3cret@localhost:5433';
+    let message = '';
+    try {
+      guardExternalUrl(`${secret}/`, false);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).not.toContain('sup3rs3cret');
+    expect(message).toContain('localhost');
+  });
+});

--- a/packages/reference-implementation/jest.config.mjs
+++ b/packages/reference-implementation/jest.config.mjs
@@ -4,14 +4,11 @@ const jestConfig = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  testMatch: [
-    '**/src/**/*.test.{ts,tsx}',
-    '**/prisma/__tests__/**/*.test.{ts,tsx}',
-  ],
-  testPathIgnorePatterns: ['<rootDir>/node_modules/'],
-  transformIgnorePatterns: [
-    'node_modules/(?!@reference-implementation|uuid)',
-  ],
+  testMatch: ['**/src/**/*.test.{ts,tsx}', '**/prisma/__tests__/**/*.test.{ts,tsx}'],
+  // Integration-layer files run only via jest.integration.config.mjs; the
+  // unit run must never collect them (they expect the rig's database).
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '\\.integration\\.test\\.'],
+  transformIgnorePatterns: ['node_modules/(?!@reference-implementation|uuid)'],
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
@@ -32,7 +29,8 @@ const jestConfig = {
     '^@uncefact/untp-utils/cache$': '<rootDir>/../untp-utils/build/cache/index.js',
     '^@uncefact/untp-utils/conformity-vocabulary$': '<rootDir>/../untp-utils/build/conformity-vocabulary/index.js',
     '^@uncefact/untp-utils$': '<rootDir>/../untp-utils/build/index.js',
-    '^@reference-implementation/components$': '<rootDir>/node_modules/@reference-implementation/components/build/index.js',
+    '^@reference-implementation/components$':
+      '<rootDir>/node_modules/@reference-implementation/components/build/index.js',
   },
   transform: {
     '^.+\\.m?[tj]sx?$': [

--- a/packages/reference-implementation/jest.integration.config.mjs
+++ b/packages/reference-implementation/jest.integration.config.mjs
@@ -1,0 +1,80 @@
+import base from '../../jest.config.base.js';
+
+/**
+ * Integration-layer jest config (ADR-029; #900): real Postgres via the rig's
+ * globalSetup, node environment, `*.integration.test.ts` only. Deliberately
+ * NOT the unit config plus overrides: a `--testMatch` override cannot lift an
+ * inherited `testPathIgnorePatterns`, and the unit config's module doubles
+ * (jsdom setup, the truncated-digest stub) would silently weaken these
+ * suites. Only the transform and workspace build mappings are shared; the
+ * digest double here hashes the full payload (see rig/multibase-digest-stub.ts).
+ */
+const jestConfig = {
+  ...base,
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  testMatch: ['**/__tests__/integration/**/*.integration.test.ts'],
+  testPathIgnorePatterns: ['<rootDir>/node_modules/'],
+  globalSetup: '<rootDir>/__tests__/integration/rig/global-setup.ts',
+  globalTeardown: '<rootDir>/__tests__/integration/rig/global-teardown.ts',
+  // Suites share one database; truncation between tests requires serial runs.
+  maxWorkers: 1,
+  testTimeout: 30_000,
+  transformIgnorePatterns: ['node_modules/(?!@reference-implementation|uuid)'],
+  moduleNameMapper: {
+    // The untp-utils build reaches its multibase-digest module via relative
+    // imports (bypassing the bare-specifier mapping below), and that module
+    // imports `multiformats` subpath exports jest's resolver cannot unpack.
+    // Both routes land on the same full-payload stub. Listed before the
+    // generic `.js`-strip rule: first match wins.
+    '^\\.{1,2}/multibase-digest(?:/index)?(?:\\.js)?$': '<rootDir>/__tests__/integration/rig/multibase-digest-stub.ts',
+    // The resolver's SSRF guard refuses loopback; suites serve all documents
+    // from a loopback fixture server, so the guard alone is swapped (the
+    // stub re-exports the rest of the real node module untouched).
+    '^\\.{1,2}/node(?:/index)?(?:\\.js)?$': '<rootDir>/__tests__/integration/rig/untp-utils-node-stub.ts',
+    '^@uncefact/untp-utils/node$': '<rootDir>/__tests__/integration/rig/untp-utils-node-stub.ts',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@uncefact/untp-ri-services/server$': '<rootDir>/../services/build/server.js',
+    '^@uncefact/untp-ri-services/logging$': '<rootDir>/../services/build/logging/index.js',
+    '^@uncefact/untp-ri-services/encryption$': '<rootDir>/../services/build/encryption/index.js',
+    '^@uncefact/untp-ri-services/key-provider$': '<rootDir>/../services/build/key-provider/index.js',
+    '^@uncefact/untp-ri-services/cvc$': '<rootDir>/../services/build/cvc/index.js',
+    '^@uncefact/untp-ri-services$': '<rootDir>/../services/build/index.js',
+    '^@uncefact/untp-utils/multibase-digest$': '<rootDir>/__tests__/integration/rig/multibase-digest-stub.ts',
+    '^@uncefact/untp-utils/validation$': '<rootDir>/../untp-utils/build/validation/index.js',
+    '^@uncefact/untp-utils/loaders$': '<rootDir>/../untp-utils/build/loaders/index.js',
+    '^@uncefact/untp-utils/cache$': '<rootDir>/../untp-utils/build/cache/index.js',
+    '^@uncefact/untp-utils/conformity-vocabulary$': '<rootDir>/../untp-utils/build/conformity-vocabulary/index.js',
+    '^@uncefact/untp-utils$': '<rootDir>/../untp-utils/build/index.js',
+  },
+  transform: {
+    '^.+\\.m?[tj]sx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          module: 'esnext',
+          target: 'ES2022',
+          lib: ['esnext'],
+          allowJs: true,
+          skipLibCheck: true,
+          strict: true,
+          esModuleInterop: true,
+          moduleResolution: 'bundler',
+          resolveJsonModule: true,
+          isolatedModules: true,
+          baseUrl: '.',
+          paths: {
+            '@uncefact/untp-ri-services': ['../services/build/index.d.ts'],
+            '@uncefact/untp-ri-services/*': ['../services/build/*.d.ts'],
+            '@/*': ['./src/*'],
+          },
+        },
+      },
+    ],
+  },
+};
+
+export default jestConfig;

--- a/packages/reference-implementation/package.json
+++ b/packages/reference-implementation/package.json
@@ -41,7 +41,8 @@
     "test:coverage": "jest --coverage",
     "audit:encryption": "npx tsx scripts/audit-encryption.ts",
     "backfill:decryption-keys": "npx tsx scripts/backfill-decryption-keys.ts",
-    "rotate:encryption-key": "npx tsx scripts/rotate-encryption-key.ts"
+    "rotate:encryption-key": "npx tsx scripts/rotate-encryption-key.ts",
+    "test:integration": "prisma generate && jest --config jest.integration.config.mjs"
   },
   "browserslist": {
     "production": [

--- a/turbo.json
+++ b/turbo.json
@@ -2,11 +2,25 @@
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["build/**", ".next/**", "!.next/cache/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "build/**",
+        ".next/**",
+        "!.next/cache/**"
+      ]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [
+        "^build"
+      ],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
This PR adds the reference implementation's first Postgres-backed test layer, which means the custom seed's data-loss paths are now covered by tests that can actually fail when they break. Cascade deletes, `Restrict` refusals, unique collisions, row locks and transaction rollback are all database behaviour, and the existing unit tests mock Prisma away, so none of it was covered before.

The rig starts its own ephemeral `postgres:17-alpine` container, applies migrations, and removes it afterwards, so `pnpm test:integration` needs nothing running beforehand except Docker. A developer who would rather point it at an existing database can set `TEST_DATABASE_URL`; the rig refuses a URL naming a real environment's database unless `TEST_DATABASE_ACCEPT_DESTRUCTIVE=true` is also set, because the suites truncate tables between tests. Whichever target is resolved is forced onto `RI_DATABASE_URL` before anything connects, so the repository `.env`'s developer database can never be reached.

This is the first implementation of the integration layer ADR-029 describes. It uses the `docker` CLI directly rather than the testcontainers library that ADR names, which is recorded as a dated update line on that ADR: one container and one readiness probe did not seem worth the dependency, and the layer's decision is unchanged.

The suites cover the scenarios #900 lists. The one worth calling out is the concurrency case: while the reconcile holds its `FOR UPDATE` lock on a registrar it is about to delete, a second connection tries to attach a child to it and must block rather than committing into the gap and being silently cascade-deleted. The test pauses inside that window by wrapping the transaction client, so removing the lock from `reconcileRemovals` makes it fail.

Closes #900
Related to #727 and #770

## Test plan

- [x] 42 tests across seven suites pass against a real Postgres: reconcile presence semantics (absent key, populated, explicit empty, nested and top-level), removal refused with rollback for cross-tenant schemes, registered identifiers and non-owned templates, core-id collision refusal, `CORE_SEED` convergence, reparenting, conformity eviction and orphan sweep, two-generation document evolution, refresh paths, second boot as a no-op, and the row-lock and advisory-lock concurrency cases
- [x] The concurrency tests fail when their protection is removed, rather than passing for an unrelated reason
- [x] Pointing `TEST_DATABASE_URL` at a database named `ri` is refused, including percent-encoded and trailing-slash forms
- [x] A container left behind by a killed run is removed by the next run
- [x] The unit run no longer collects the integration files, and `pnpm format:check` and ESLint are clean
