### PR TITLE
fix(ri): return the documented error envelope for auth pipeline failures

### DIFF
--- a/packages/reference-implementation/src/lib/api/errors.ts
+++ b/packages/reference-implementation/src/lib/api/errors.ts
@@ -1,7 +1,26 @@
 /**
+ * The body text returned when an error has no deliberate mapping, so nothing
+ * of the underlying failure reaches the client. Shared by the route-error
+ * mapper's database branch and the auth pipeline's boundary.
+ */
+export const UNEXPECTED_ERROR_MESSAGE = 'An unexpected error has occurred.';
+
+/**
+ * The same message with the request's correlation id appended, so a caller
+ * who cannot act on the failure themselves has the one identifier that ties
+ * their request to its server-side logs. Falls back to the bare message when
+ * called outside a request context, where no id exists to quote.
+ */
+export function unexpectedErrorMessage(correlationId: string | undefined): string {
+  return correlationId
+    ? `${UNEXPECTED_ERROR_MESSAGE} If the issue persists, please contact support and quote correlation id "${correlationId}".`
+    : UNEXPECTED_ERROR_MESSAGE;
+}
+
+/**
  * Extract a human-readable message from an unknown caught value.
  */
-export function errorMessage(e: unknown, fallback = 'An unexpected error has occurred.'): string {
+export function errorMessage(e: unknown, fallback: string = UNEXPECTED_ERROR_MESSAGE): string {
   return e instanceof Error ? e.message : fallback;
 }
 

--- a/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.test.ts
@@ -169,6 +169,71 @@ describe('handleRouteError', () => {
 
   // --- Database errors (sanitised backstop) ---
 
+  it('quotes the correlation id so the caller has something to give support', async () => {
+    const { handlePipelineError } = await import('./handle-route-error');
+    const { runWithRequestContext } = await import('@uncefact/untp-ri-services/logging');
+
+    const res = await runWithRequestContext('corr-abc-123', async () =>
+      handlePipelineError(new Error('session decode failed')),
+    );
+    const body = (await res.json()) as { error: string };
+
+    expect(res.status).toBe(500);
+    expect(body.error).toContain('An unexpected error has occurred.');
+    expect(body.error).toContain('contact support');
+    // Quoted so the id is unambiguous when pasted into a support ticket.
+    expect(body.error).toContain('"corr-abc-123"');
+    // Still nothing of the underlying failure.
+    expect(body.error).not.toContain('session decode failed');
+  });
+
+  it('quotes the correlation id on a sanitised database failure too', async () => {
+    const { handleRouteError } = await import('./handle-route-error');
+    const { runWithRequestContext } = await import('@uncefact/untp-ri-services/logging');
+    const prismaError = Object.assign(new Error('Invalid `prisma.tenant.findUnique()` invocation'), {
+      code: 'P2021',
+      clientVersion: '5.0.0',
+      name: 'PrismaClientKnownRequestError',
+    });
+
+    const res = await runWithRequestContext('corr-db-9', async () => handleRouteError(prismaError));
+    const body = (await res.json()) as { error: string };
+
+    expect(body.error).toContain('"corr-db-9"');
+    expect(body.error).not.toContain('prisma.tenant.findUnique');
+  });
+
+  it('omits the support guidance when there is no request context to quote', async () => {
+    const { handlePipelineError } = await import('./handle-route-error');
+
+    const res = handlePipelineError(new Error('boom'));
+    const body = (await res.json()) as { error: string };
+
+    expect(body.error).toBe('An unexpected error has occurred.');
+    expect(body.error).not.toContain('contact support');
+  });
+
+  it('redacts an unmapped error through the pipeline entry point, leaving the default contract alone', async () => {
+    const { handleRouteError, handlePipelineError } = await import('./handle-route-error');
+
+    const redacted = handlePipelineError(new Error('session decode failed for issuer https://idp.internal'));
+    expect(redacted.status).toBe(500);
+    expect(await redacted.json()).toEqual({ error: 'An unexpected error has occurred.' });
+
+    const defaulted = handleRouteError(new Error('session decode failed for issuer https://idp.internal'));
+    expect(await defaulted.json()).toEqual({ error: 'session decode failed for issuer https://idp.internal' });
+  });
+
+  it('still maps a typed error normally through the pipeline entry point', async () => {
+    const { handlePipelineError } = await import('./handle-route-error');
+    const { NotFoundError } = await import('./errors');
+
+    const res = handlePipelineError(new NotFoundError('Scheme not found'));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Scheme not found' });
+  });
+
   it('sanitises an unhandled Prisma known request error to a generic 500', async () => {
     const dbError = new Error('Unique constraint failed on the fields: (`schemeId`,`value`,`tenantId`)');
     dbError.name = 'PrismaClientKnownRequestError';

--- a/packages/reference-implementation/src/lib/api/handle-route-error.ts
+++ b/packages/reference-implementation/src/lib/api/handle-route-error.ts
@@ -6,11 +6,13 @@ import {
   UnprocessableError,
   errorMessage,
   ServiceRegistryError,
+  unexpectedErrorMessage,
 } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { isDatabaseError } from '@/lib/prisma/db-errors';
 import { ServiceError } from '@uncefact/untp-ri-services';
 import { apiLogger } from '@/lib/api/logger';
+import { getRequestContext } from '@uncefact/untp-ri-services/logging';
 
 const logger = apiLogger.child({ handler: 'error' });
 
@@ -25,7 +27,26 @@ const logger = apiLogger.child({ handler: 'error' });
  *   - ServiceInstanceNotFoundError (name check) returns 404
  *   - All other registry errors return 500
  */
-export function handleRouteError(e: unknown): Response {
+type HandleRouteErrorOptions = {
+  /**
+   * Return the canned message instead of the thrown text when no branch
+   * below claims the error. Deliberately not part of the exported surface:
+   * `handlePipelineError` is the only way to ask for it, so a route caller
+   * cannot redact a handler failure whose contract is to echo its message.
+   */
+  redactUnmapped?: boolean;
+};
+
+/**
+ * Maps an error raised outside a route handler, where an unmapped message
+ * must not reach the client. Typed and database errors map exactly as they
+ * do for handlers; anything else becomes the canned message.
+ */
+export function handlePipelineError(e: unknown): Response {
+  return handleRouteError(e, { redactUnmapped: true });
+}
+
+export function handleRouteError(e: unknown, options: HandleRouteErrorOptions = {}): Response {
   if (e instanceof ValidationError) {
     // The default err serialiser concatenates the messages and stacks of the
     // native cause chain (not the causes' typed fields), so a ValidationError
@@ -65,8 +86,13 @@ export function handleRouteError(e: unknown): Response {
     // fallback below, this branch never echoes error text. The distinct log message
     // is the signal that a repository is missing a mapping.
     logger.error({ err: e }, 'Unhandled database error');
-    return NextResponse.json({ error: 'An unexpected error has occurred.' }, { status: 500 });
+    return NextResponse.json({ error: unexpectedErrorMessage(getRequestContext()?.correlationId) }, { status: 500 });
   }
   logger.error({ err: e }, 'Unexpected error');
-  return NextResponse.json({ error: errorMessage(e) }, { status: 500 });
+  return NextResponse.json(
+    {
+      error: options.redactUnmapped ? unexpectedErrorMessage(getRequestContext()?.correlationId) : errorMessage(e),
+    },
+    { status: 500 },
+  );
 }

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
@@ -31,6 +31,19 @@ jest.mock('@uncefact/untp-ri-services/logging', () => ({
   createLogger: () => mockLogger(),
 }));
 
+const mockApiLoggerInfo = jest.fn();
+const mockApiLoggerWarn = jest.fn();
+const mockApiLoggerError = jest.fn();
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: {
+    info: (...args: unknown[]) => mockApiLoggerInfo(...args),
+    warn: (...args: unknown[]) => mockApiLoggerWarn(...args),
+    error: (...args: unknown[]) => mockApiLoggerError(...args),
+    debug: jest.fn(),
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  },
+}));
+
 jest.mock('next/server', () => ({
   NextResponse: {
     json: (body: unknown, init?: { status?: number }) => ({
@@ -54,9 +67,13 @@ jest.mock('@/lib/api/service-account-user', () => ({
 }));
 
 // Tenant config mock — controlled by mockTenantMode
-let mockTenantMode: 'open' | 'closed' = 'open';
+let mockTenantMode: 'open' | 'closed' | 'invalid' = 'open';
 jest.mock('@/lib/auth/tenant-config', () => ({
   getTenantConfig: () => {
+    if (mockTenantMode === 'invalid') {
+      // Mirrors the real thrown shape, which names the rejected value.
+      throw new Error('Invalid TENANT_MODE: "sideways". Must be one of: open, closed');
+    }
     if (mockTenantMode === 'closed') {
       return { mode: 'closed', claimName: 'groups', claimFormat: 'array_first' };
     }
@@ -754,6 +771,272 @@ describe('withTenantAuth — request context propagation', () => {
 // ========================================================
 // handleRouteError tests (unchanged)
 // ========================================================
+
+// ========================================================
+// Pre-handler pipeline failures (#850)
+// ========================================================
+
+describe('withTenantAuth — unexpected failures before the handler runs', () => {
+  const SENTINEL = 'tenant lookup exploded with connection string postgres://user:pw@host/db';
+
+  it('returns the documented envelope with a canned message when open-mode tenant resolution throws', async () => {
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockRejectedValue(new Error(SENTINEL));
+    const handler = jest.fn();
+
+    const res = (await withTenantAuth(handler)(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+    // The thrown text must not reach the client: Next's own uncaught path
+    // returns a plain fallback carrying no message, so this boundary must not
+    // become a new disclosure channel.
+    expect(JSON.stringify(body)).not.toContain('postgres://');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('returns the canned envelope when the session read itself throws in closed mode', async () => {
+    mockTenantMode = 'closed';
+    mockAuth.mockRejectedValue(new Error(SENTINEL));
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  it('returns the canned envelope when the closed-mode tenant lookup throws', async () => {
+    mockTenantMode = 'closed';
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' }, group_claim: 'group-1' });
+    mockPrismaTenant.findUnique.mockRejectedValue(new Error(SENTINEL));
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  it('routes a service-account resolution failure through the same central boundary', async () => {
+    mockGetSessionUserId.mockResolvedValue(null);
+    mockResolveServiceAccountUser.mockRejectedValue(new Error(SENTINEL));
+
+    const res = (await withTenantAuth(jest.fn())(
+      fakeRequest('GET', { 'x-auth-sub': 'sub-1' }),
+      emptyRouteContext,
+    )) as unknown as MockResponse & { status: number };
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    // The same canned body as every other pre-handler failure, rather than a
+    // second wording produced by a catch local to this path.
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  it('attributes a service-account failure by putting the subject on the request context', async () => {
+    mockGetSessionUserId.mockResolvedValue(null);
+    mockResolveServiceAccountUser.mockRejectedValue(new Error(SENTINEL));
+
+    await withTenantAuth(jest.fn())(fakeRequest('GET', { 'x-auth-sub': 'sub-1' }), emptyRouteContext);
+
+    // Without this the central boundary's log could not say which service
+    // account the failure belonged to, which the removed local catch did.
+    expect(mockUpdateRequestContext).toHaveBeenCalledWith(expect.objectContaining({ serviceAccountSub: 'sub-1' }));
+  });
+
+  it('keeps the sanitised database mapping for a Prisma failure thrown before the handler', async () => {
+    const prismaError = Object.assign(new Error('Invalid `prisma.tenant.findUnique()` invocation: table missing'), {
+      code: 'P2021',
+      clientVersion: '5.0.0',
+      name: 'PrismaClientKnownRequestError',
+    });
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockRejectedValue(prismaError);
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    // The database branch already sanitises, so this proves the pipeline
+    // reaches the mapper's typed branches rather than short-circuiting them.
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+    expect(JSON.stringify(body)).not.toContain('prisma.tenant.findUnique');
+  });
+
+  it('logs a typed pre-handler failure at its status level rather than as an error', async () => {
+    const { NotFoundError } = await import('@/lib/api/errors');
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockRejectedValue(new NotFoundError('Tenant not found'));
+
+    await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext);
+
+    // A 404 is not an error-level event; executeHandler already picks its
+    // level from the mapped status and this boundary must match.
+    expect(mockApiLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 404 }),
+      'Request failed before the handler ran',
+    );
+  });
+
+  it('keeps the deliberate mapping for a typed error thrown before the handler', async () => {
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockRejectedValue(new NotFoundError('Tenant not found'));
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body).toEqual({ error: 'Tenant not found' });
+  });
+
+  it('leaves the explicit 401 and 403 returns untouched', async () => {
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockResolvedValue(null);
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'No tenant found for user' });
+  });
+
+  it('returns the canned envelope when bearer token validation throws', async () => {
+    mockTenantMode = 'closed';
+    mockAuth.mockResolvedValue(null);
+    mockExtractBearerToken.mockReturnValue('token-1');
+    mockValidateServiceAccountToken.mockRejectedValue(new Error(SENTINEL));
+
+    const res = (await withTenantAuth(jest.fn())(
+      fakeRequest('GET', { authorization: 'Bearer token-1' }),
+      emptyRouteContext,
+    )) as unknown as MockResponse & { status: number };
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  it('returns the canned envelope when closed-mode tenant resolution throws on the bearer path', async () => {
+    mockTenantMode = 'closed';
+    mockAuth.mockResolvedValue(null);
+    mockExtractBearerToken.mockReturnValue('token-1');
+    mockValidateServiceAccountToken.mockResolvedValue({ valid: true, payload: { sub: 'sub-1' } });
+    mockExtractGroupClaim.mockReturnValue('group-1');
+    mockResolveClosedModeTenant.mockRejectedValue(new Error(SENTINEL));
+
+    const res = (await withTenantAuth(jest.fn())(
+      fakeRequest('GET', { authorization: 'Bearer token-1' }),
+      emptyRouteContext,
+    )) as unknown as MockResponse & { status: number };
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  it('returns the canned envelope when re-linking the user to a changed tenant throws', async () => {
+    mockTenantMode = 'closed';
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' }, group_claim: 'group-1' });
+    mockPrismaTenant.findUnique.mockResolvedValue({ id: 'tenant-2' });
+    mockPrismaUser.findUnique.mockResolvedValue({ tenantId: 'tenant-1' });
+    mockPrismaUser.update.mockRejectedValue(new Error(SENTINEL));
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'An unexpected error has occurred.' });
+    expect(mockPrismaUser.update).toHaveBeenCalled();
+  });
+
+  it('answers rather than escaping when the tenant-config read throws, redacting the offending value', async () => {
+    // Invalid configuration fails at module import in production (auth.config.ts
+    // reads it at module scope), so this pins the boundary's handling of a
+    // throw from that position rather than a reachable TENANT_MODE failure.
+    mockTenantMode = 'invalid';
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+    expect(JSON.stringify(body)).not.toContain('TENANT_MODE');
+  });
+
+  it('answers rather than escaping when the request URL cannot be parsed', async () => {
+    const malformed = {
+      method: 'GET',
+      url: 'not a url',
+      headers: { get: () => null },
+    } as unknown as Request;
+
+    const res = (await withTenantAuth(jest.fn())(malformed, emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'An unexpected error has occurred.' });
+  });
+
+  it('answers rather than escaping when establishing the request context itself throws', async () => {
+    mockRunWithRequestContext.mockImplementation(() => {
+      throw new Error(SENTINEL);
+    });
+
+    const res = (await withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)) as unknown as MockResponse & {
+      status: number;
+    };
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: 'An unexpected error has occurred.' });
+    // No correlation id exists at this point, so the outer boundary logs
+    // directly rather than relying on the request context.
+    expect(JSON.stringify(body)).not.toContain('postgres://');
+  });
+
+  it('lets a Next control-flow throw escape the outer boundary too', async () => {
+    const redirectError = Object.assign(new Error('NEXT_REDIRECT'), { digest: 'NEXT_REDIRECT;replace;/login;307;' });
+    mockRunWithRequestContext.mockImplementation(() => {
+      throw redirectError;
+    });
+
+    await expect(withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)).rejects.toBe(redirectError);
+  });
+
+  it('lets Next control-flow throws propagate rather than mapping them to a 500', async () => {
+    // NEXT_REDIRECT is how Next signals redirect(); unstable_rethrow must let it pass.
+    const redirectError = Object.assign(new Error('NEXT_REDIRECT'), { digest: 'NEXT_REDIRECT;replace;/login;307;' });
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockRejectedValue(redirectError);
+
+    await expect(withTenantAuth(jest.fn())(fakeRequest(), emptyRouteContext)).rejects.toBe(redirectError);
+  });
+
+  it('lets a Next control-flow throw from inside the handler propagate too', async () => {
+    const redirectError = Object.assign(new Error('NEXT_REDIRECT'), { digest: 'NEXT_REDIRECT;replace;/login;307;' });
+    mockGetSessionUserId.mockResolvedValue('user-1');
+    mockGetTenantId.mockResolvedValue('tenant-1');
+
+    await expect(
+      withTenantAuth(jest.fn().mockRejectedValue(redirectError))(fakeRequest(), emptyRouteContext),
+    ).rejects.toBe(redirectError);
+  });
+});
 
 describe('handleRouteError', () => {
   it('maps ValidationError to 400', async () => {

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
+import { unstable_rethrow } from 'next/navigation';
 import { getSessionUserId, getTenantId } from '@/lib/api/helpers';
-import { handleRouteError } from '@/lib/api/handle-route-error';
+import { handlePipelineError, handleRouteError } from '@/lib/api/handle-route-error';
+import { unexpectedErrorMessage } from '@/lib/api/errors';
 import { apiLogger } from '@/lib/api/logger';
 import { resolveServiceAccountUser } from '@/lib/api/service-account-user';
 import { getTenantConfig } from '@/lib/auth/tenant-config';
@@ -33,39 +35,75 @@ type RouteHandler = (req: Request, context: TenantAuthContext) => Promise<Respon
 
 export function withTenantAuth(handler: RouteHandler) {
   return async (req: Request, routeContext: { params: Promise<Record<string, string>> }) => {
-    // Zero trust at the boundary (#654): an inbound ID outside the shared
-    // length/charset rule is replaced, never echoed into logs or responses.
-    const raw = req.headers.get('x-correlation-id');
-    const correlationId = raw && isValidCorrelationId(raw) ? raw : crypto.randomUUID();
-    if (raw && correlationId !== raw) {
-      apiLogger.warn(
-        { inboundLength: raw.length, replacedWith: correlationId },
-        'Rejected invalid x-correlation-id header; minted a fresh id',
-      );
-    }
+    const start = Date.now();
 
-    return runWithRequestContext(correlationId, async () => {
-      const method = req.method;
-      const url = new URL(req.url);
-      const path = url.pathname;
-      const start = Date.now();
-      const tenantConfig = getTenantConfig();
-
-      // Carry the request method and path in the request context so every
-      // downstream log entry, including a centrally-handled error, is
-      // attributable to its route without each handler restating them. The
-      // `request`-prefixed keys avoid colliding with per-log `method` fields
-      // that some handlers already use for a domain concept (e.g. a DID method).
-      updateRequestContext({ requestMethod: method, requestPath: path });
-
-      apiLogger.info({ method, path }, 'Request received');
-
-      if (tenantConfig.mode === 'closed') {
-        return handleClosedMode(handler, req, routeContext, method, path, start, tenantConfig);
+    // Nothing may escape this wrapper: every route documents a 500 as an
+    // ErrorResponse, and an uncaught throw would instead reach Next's
+    // plain-text fallback. The inner boundary handles everything once the
+    // request context exists, so a failure there is logged with its
+    // correlation id; this outer one is the last resort for the context
+    // establishment itself, which has no context to log against.
+    try {
+      // Zero trust at the boundary (#654): an inbound ID outside the shared
+      // length/charset rule is replaced, never echoed into logs or responses.
+      const raw = req.headers.get('x-correlation-id');
+      const correlationId = raw && isValidCorrelationId(raw) ? raw : crypto.randomUUID();
+      if (raw && correlationId !== raw) {
+        apiLogger.warn(
+          { inboundLength: raw.length, replacedWith: correlationId },
+          'Rejected invalid x-correlation-id header; minted a fresh id',
+        );
       }
 
-      return handleOpenMode(handler, req, routeContext, method, path, start);
-    });
+      return await runWithRequestContext(correlationId, async () => {
+        // Established before the try so the catch can still attribute a
+        // failure that happens while working them out.
+        let method = 'UNKNOWN';
+        let path = 'unknown';
+
+        try {
+          method = req.method;
+          path = new URL(req.url).pathname;
+
+          // Carry the request method and path in the request context so every
+          // downstream log entry, including a centrally-handled error, is
+          // attributable to its route without each handler restating them. The
+          // `request`-prefixed keys avoid colliding with per-log `method` fields
+          // that some handlers already use for a domain concept (e.g. a DID method).
+          updateRequestContext({ requestMethod: method, requestPath: path });
+
+          apiLogger.info({ method, path }, 'Request received');
+
+          // Read inside the boundary so a throw here is answered rather than
+          // escaping. Note that invalid tenant configuration does not reach
+          // this point in practice: auth.config.ts calls getTenantConfig() at
+          // module scope, so a bad TENANT_MODE fails the route module's import
+          // and never runs a request. That fail-fast behaviour is deliberate
+          // and outside this boundary.
+          const tenantConfig = getTenantConfig();
+
+          // Awaited rather than returned: an unawaited promise's rejection
+          // would not land in this catch.
+          if (tenantConfig.mode === 'closed') {
+            return await handleClosedMode(handler, req, routeContext, method, path, start, tenantConfig);
+          }
+
+          return await handleOpenMode(handler, req, routeContext, method, path, start);
+        } catch (error: unknown) {
+          return respondToPipelineFailure(error, method, path, start);
+        }
+      });
+    } catch (error: unknown) {
+      unstable_rethrow(error);
+
+      apiLogger.error(
+        { err: error, durationMs: Date.now() - start },
+        'Request failed before the request context was established',
+      );
+      // Outside the request context by definition, so there is no correlation
+      // id to quote; the log line above is the only record of this failure.
+      return NextResponse.json({ error: unexpectedErrorMessage(undefined) }, { status: 500 });
+    }
   };
 }
 
@@ -242,16 +280,13 @@ async function handleOpenMode(
     const email = req.headers.get('x-auth-email') ?? undefined;
     const azp = req.headers.get('x-auth-azp') ?? undefined;
 
-    let resolved: { userId: string; tenantId: string } | null;
-    try {
-      resolved = await resolveServiceAccountUser({ sub, name, email });
-    } catch (error) {
-      apiLogger.error(
-        { method, path, sub, error, durationMs: Date.now() - start },
-        'Service account user resolution failed unexpectedly',
-      );
-      return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    }
+    // No local catch: an unexpected failure here joins the wrapper's central
+    // boundary, so it is logged and answered like every other pre-handler
+    // failure rather than through a second, differently-worded 500. The
+    // subject goes on the request context first, so a failure is still
+    // attributable to a service account without that catch's own log line.
+    updateRequestContext({ serviceAccountSub: sub });
+    const resolved = await resolveServiceAccountUser({ sub, name, email });
 
     if (!resolved) {
       apiLogger.warn(
@@ -281,6 +316,35 @@ async function handleOpenMode(
   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 }
 
+/**
+ * Maps an unexpected failure from the auth-and-tenant-resolution pipeline to
+ * the documented ErrorResponse body.
+ *
+ * Typed API errors and database errors keep their existing mapping; an
+ * unmapped error is redacted to the canned message, because echoing it here
+ * would newly disclose session, cookie and auth-provider detail that Next's
+ * own uncaught path never returns. Redaction is scoped to this pipeline: a
+ * handler that throws an unmapped error still echoes its message, which is
+ * the established route contract and is deliberately left alone here.
+ */
+function respondToPipelineFailure(error: unknown, method: string, path: string, start: number): Response {
+  // Next signals redirects and similar framework control flow by throwing;
+  // those must pass through untouched rather than becoming a 500.
+  unstable_rethrow(error);
+
+  const response = handlePipelineError(error);
+
+  // The error itself is already logged by the mapper; this line is the
+  // completion record, matching what executeHandler emits for handler
+  // failures, including its status-derived level.
+  const level = response.status >= 500 ? 'error' : 'warn';
+  apiLogger[level](
+    { method, path, status: response.status, durationMs: Date.now() - start },
+    'Request failed before the handler ran',
+  );
+  return response;
+}
+
 async function executeHandler(
   handler: RouteHandler,
   req: Request,
@@ -301,6 +365,7 @@ async function executeHandler(
     );
     return response;
   } catch (e: unknown) {
+    unstable_rethrow(e);
     const errorResponse = handleRouteError(e);
     const logLevel = errorResponse.status >= 500 ? 'error' : 'warn';
     apiLogger[logLevel](


### PR DESCRIPTION
Every route documents its 500 as an `ErrorResponse`, but only the handler ran inside anything that produced one. The authentication and tenant-resolution work that happens first sat outside any catch, so a failure there escaped the wrapper entirely and Next answered with its own fallback: a plain-text body in production, and an HTML page carrying a full stack trace in development. This PR makes that promise true for the whole pipeline.

`withTenantAuth` now has two boundaries. The inner one runs inside the request context and covers everything from the URL parse through both auth paths, so a failure is answered with the documented envelope and logged against its correlation id. The outer one covers establishing that context itself, which is the only region with no context to log against. Both call `unstable_rethrow` first, so Next's redirect and not-found signals still propagate rather than being swallowed.

An unmapped failure in that pipeline is redacted to a canned message rather than echoing its text, because an authentication or configuration error can name a provider, an issuer or an environment variable that Next's own fallback never disclosed. Typed and database errors keep the mapping they already had, and the handler contract is untouched: a route that throws still echoes its message exactly as before. `handlePipelineError` is the only entry point that redacts, so a route caller cannot reach for it by accident.

That canned message now also carries the correlation id, quoted, with a line telling the caller to contact support and quote it. The same id is on the log record for that request, so someone who cannot act on the failure themselves still leaves with the one thing that ties their report to the server's account of it. Requests that supply their own `x-correlation-id` see it echoed back after the existing validation; everything else gets the server-minted one.

Verified against a running instance, not only in tests: an authenticated request returns 200, an unauthenticated one returns the wrapper's 401, and a database failure mid-request returns

```json
{"error":"An unexpected error has occurred. If the issue persists, please contact support and quote correlation id \"final-check-7\"."}
```

with the underlying cause and that same id in the logs.

Two behaviours are deliberately left as they are, and worth knowing when reading this. Invalid tenant configuration fails at module import rather than per request, because `auth.config.ts` reads it at module scope, so it is fail-fast by design and outside this boundary. And a handler that throws an unmapped error still returns its message, which is the established route contract that 42 tests pin; changing it fleet-wide is a separate decision, not a drive-by.

Closes #850
