### PR TITLE
refactor(ri): share the auth response definitions across every guarded route

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/credentials/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/[id]/route.ts
@@ -30,17 +30,9 @@ const logger = apiLogger.child({ route: '/api/v1/credentials/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/Credential'
  *       401:
- *         description: Unauthorised — missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Credential not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -98,17 +98,9 @@ function defaultHumanVerificationUrl(): string {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Service instance not found
  *         content:
@@ -425,17 +417,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/cvc/criteria/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/criteria/route.ts
@@ -63,17 +63,9 @@ const logger = apiLogger.child({ route: '/api/v1/cvc/criteria' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: No tenant found for user
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/cvc/profiles/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/profiles/route.ts
@@ -63,17 +63,9 @@ const logger = apiLogger.child({ route: '/api/v1/cvc/profiles' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: No tenant found for user
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/cvc/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/cvc/schemes/route.ts
@@ -58,17 +58,9 @@ const logger = apiLogger.child({ route: '/api/v1/cvc/schemes' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: No tenant found for user
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/form-config/route.ts
@@ -136,11 +136,9 @@ const ENTITY_REQUIREMENTS: Record<string, Array<FormSection>> = {
  *                             type: string
  *                             description: The entityType this section depends on. If set, this section is only active when the referenced section has a value.
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Data model not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.ts
@@ -32,11 +32,9 @@ const UPDATABLE_FIELDS = ['name', 'schemaUrl', 'contextUrl', 'websiteUrl'] as co
  *             schema:
  *               $ref: '#/components/schemas/DataModel'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Data model not found
  *         content:
@@ -110,11 +108,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Data model not found
  *         content:
@@ -203,11 +199,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Data model deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Data model not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.ts
@@ -74,11 +74,9 @@ const logger = apiLogger.child({ route: '/api/v1/data-models' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:
@@ -174,11 +172,9 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Parent data model configuration not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/document/route.ts
@@ -30,17 +30,9 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/document' });
  *             schema:
  *               $ref: '#/components/schemas/DidDocument'
  *       401:
- *         description: Unauthorized - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: DID or service instance not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/route.ts
@@ -32,17 +32,9 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/Did'
  *       401:
- *         description: Unauthorized - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: DID not found
  *         content:
@@ -121,17 +113,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorized - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: DID not found
  *         content:
@@ -188,17 +172,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorized - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: DID not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
@@ -52,17 +52,9 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorized - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: DID or service instance not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/import/route.ts
@@ -66,17 +66,9 @@ const logger = apiLogger.child({ route: '/api/v1/dids/import' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Service instance not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -93,11 +93,7 @@ function assertSupported<T extends string>(field: string, value: T, supported: r
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorized - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
  *         description: |
  *           Forbidden. Either of:
@@ -304,17 +300,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorized - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/[id]/route.ts
@@ -31,17 +31,9 @@ const logger = apiLogger.child({ route: '/api/v1/facilities/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/Facility'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Facility not found
  *         content:
@@ -138,17 +130,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Facility not found, or a referenced organisation or identifier not found
  *         content:
@@ -201,17 +185,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Facility deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Facility not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/facilities/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/facilities/route.ts
@@ -70,17 +70,9 @@ const logger = apiLogger.child({ route: '/api/v1/facilities' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Referenced organisation or identifier not found
  *         content:
@@ -163,17 +155,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/[linkId]/route.ts
@@ -54,11 +54,9 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links/[linkId]
  *                 warning:
  *                   type: string
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Link not found
  *         content:
@@ -213,11 +211,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Link not found
  *         content:
@@ -339,11 +335,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Link deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Link not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/links/route.ts
@@ -135,11 +135,9 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]/links' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Identifier not found
  *         content:
@@ -268,11 +266,9 @@ export const POST = withTenantAuth(async (req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Identifier not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.ts
@@ -31,11 +31,9 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/Identifier'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Identifier not found
  *         content:
@@ -103,11 +101,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Identifier not found
  *         content:
@@ -161,11 +157,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Identifier deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Identifier not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.ts
@@ -49,11 +49,9 @@ const logger = apiLogger.child({ route: '/api/v1/identifiers' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Scheme not found
  *         content:
@@ -136,11 +134,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/[id]/route.ts
@@ -31,17 +31,9 @@ const logger = apiLogger.child({ route: '/api/v1/organisations/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/Organisation'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Organisation not found
  *         content:
@@ -132,17 +124,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Organisation not found, or a referenced primary or secondary identifier does not exist
  *         content:
@@ -195,17 +179,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Organisation deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Organisation not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/organisations/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/organisations/route.ts
@@ -66,17 +66,9 @@ const logger = apiLogger.child({ route: '/api/v1/organisations' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Referenced entity not found
  *         content:
@@ -154,17 +146,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -41,11 +41,9 @@ const UPDATABLE_FIELDS = [
  *             schema:
  *               $ref: '#/components/schemas/Product'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Product not found
  *         content:
@@ -132,11 +130,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Product not found
  *         content:
@@ -218,11 +214,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Product not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/products/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.ts
@@ -78,11 +78,9 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Referenced entity not found
  *         content:
@@ -211,11 +209,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/[id]/route.ts
@@ -32,17 +32,9 @@ const logger = apiLogger.child({ route: '/api/v1/registrars/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/Registrar'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Registrar not found
  *         content:
@@ -126,17 +118,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Registrar or IDR service instance not found
  *         content:
@@ -214,17 +198,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Registrar deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Registrar not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/registrars/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/registrars/route.ts
@@ -60,17 +60,9 @@ const logger = apiLogger.child({ route: '/api/v1/registrars' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: IDR service instance not found
  *         content:
@@ -184,17 +176,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/[id]/route.ts
@@ -39,11 +39,9 @@ const PATCHABLE_FIELDS = ['name', 'template', 'isDefault', 'inline', 'mediaType'
  *             schema:
  *               $ref: '#/components/schemas/RenderTemplate'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Render template not found
  *         content:
@@ -133,11 +131,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Render template not found
  *         content:
@@ -236,11 +232,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Render template deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Render template not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/render-templates/route.ts
@@ -63,11 +63,9 @@ const logger = apiLogger.child({ route: '/api/v1/render-templates' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:
@@ -160,11 +158,9 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Data model not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -37,17 +37,9 @@ const logger = apiLogger.child({ route: '/api/v1/schemes/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/IdentifierScheme'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Scheme not found
  *         content:
@@ -163,17 +155,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Scheme or IDR service instance not found
  *         content:
@@ -243,17 +227,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Scheme deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Scheme not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.ts
@@ -101,17 +101,9 @@ const logger = apiLogger.child({ route: '/api/v1/schemes' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Registrar or IDR service instance not found
  *         content:
@@ -227,17 +219,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         description: Forbidden - authenticated principal has no resolvable tenant assignment
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
@@ -42,11 +42,9 @@ const logger = apiLogger.child({ route: '/api/v1/services/[id]' });
  *             schema:
  *               $ref: '#/components/schemas/ServiceInstance'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Service instance not found
  *         content:
@@ -126,11 +124,9 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Service instance not found
  *         content:
@@ -276,11 +272,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       204:
  *         description: Service instance deleted successfully
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
  *         description: Service instance not found
  *         content:

--- a/packages/reference-implementation/src/app/api/v1/services/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/route.ts
@@ -81,11 +81,9 @@ const logger = apiLogger.child({ route: '/api/v1/services' });
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:
@@ -245,11 +243,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       401:
- *         description: Unauthorised - missing or invalid authentication
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *         $ref: '#/components/responses/UnauthorisedResponse'
+ *       403:
+ *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       500:
  *         description: Server error
  *         content:

--- a/packages/reference-implementation/src/lib/swagger/auth-responses.test.ts
+++ b/packages/reference-implementation/src/lib/swagger/auth-responses.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Congruence checks for the shared auth responses (#852).
+ *
+ * `withTenantAuth` answers 401 when a caller is unauthenticated and 403 when
+ * an authenticated principal has no resolvable tenant, so every operation it
+ * wraps owes the reader both. Hand-written blocks had already drifted into
+ * four wordings, so these tests guard the referenced form rather than the
+ * prose: an operation that documents its own auth block, or omits one, fails
+ * here rather than reaching the published specification.
+ */
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { getApiDocs } from './swagger';
+
+const UNAUTHORISED_REF = '#/components/responses/UnauthorisedResponse';
+const FORBIDDEN_REF = '#/components/responses/TenantAssignmentForbiddenResponse';
+
+/**
+ * `POST /dids` documents a combined 403: the tenant-assignment case shared
+ * with every route, plus a business rule the handler itself enforces
+ * (a tenant may not claim the system VC service's root DID). Referencing the
+ * shared component alone would delete half of that contract, so this
+ * operation keeps an inline response and is checked for both causes instead.
+ */
+const COMBINED_FORBIDDEN_OPERATIONS = new Set(['post /dids']);
+
+// This exemption can only go stale in the safe direction: an entry for a route
+// that changed simply stops matching. Nothing detects that an operation has
+// become (or stopped being) exceptional, so revisit it when the DID routes
+// change what they enforce.
+
+type Response = {
+  $ref?: string;
+  description?: string;
+  content?: Record<string, { schema?: { $ref?: string } }>;
+};
+type Operation = { responses?: Record<string, Response> };
+type Spec = {
+  paths?: Record<string, Record<string, Operation>>;
+  components?: { responses?: Record<string, unknown>; schemas?: Record<string, unknown> };
+};
+
+/**
+ * Which wrapper guards each exported handler, read from source rather than
+ * inferred from the specification: the generated document records what an
+ * operation says, not what enforces it, and that gap is exactly what lets an
+ * operation advertise auth it does not apply.
+ *
+ * Keyed by operation rather than by file, because one route file can export a
+ * guarded POST beside a public GET; a file-level answer would call both
+ * guarded and wave the public one through.
+ */
+export type HandlerExport = { route: string; method: string; wrapper: string };
+
+const HANDLER_EXPORT = /^export const (GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*=\s*([A-Za-z_][\w]*)\s*\(/gm;
+
+export function exportedHandlers(): HandlerExport[] {
+  const apiRoot = path.join(process.cwd(), 'src/app/api/v1');
+  const handlers: HandlerExport[] = [];
+
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (entry.name !== 'route.ts') continue;
+
+      // src/app/api/v1/schemes/[id]/route.ts -> /schemes/{id}
+      const relative = path.relative(apiRoot, path.dirname(full));
+      const route = relative === '' ? '/' : '/' + relative.replace(/\[([^\]]+)\]/g, '{$1}');
+
+      for (const [, method, wrapper] of readFileSync(full, 'utf8').matchAll(HANDLER_EXPORT)) {
+        handlers.push({ route, method: method.toLowerCase(), wrapper });
+      }
+    }
+  };
+
+  walk(apiRoot);
+  return handlers;
+}
+
+/** Walks every $ref in the document, whatever its depth, and resolves it. */
+function unresolvedReferences(spec: Spec): string[] {
+  const components = (spec.components ?? {}) as Record<string, Record<string, unknown> | undefined>;
+  const unresolved: string[] = [];
+
+  const visit = (node: unknown, where: string) => {
+    if (Array.isArray(node)) {
+      node.forEach((item, index) => visit(item, `${where}[${index}]`));
+      return;
+    }
+    if (node === null || typeof node !== 'object') return;
+
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === '$ref' && typeof value === 'string') {
+        const match = /^#\/components\/([^/]+)\/(.+)$/.exec(value);
+        if (match === null || components[match[1]]?.[match[2]] === undefined) {
+          unresolved.push(`${where} -> ${value}`);
+        }
+        continue;
+      }
+      visit(value, `${where}.${key}`);
+    }
+  };
+
+  visit(spec.paths, 'paths');
+  visit(spec.components, 'components');
+  return unresolved;
+}
+
+describe('shared auth responses', () => {
+  let spec: Spec;
+
+  beforeAll(async () => {
+    spec = (await getApiDocs()) as Spec;
+  });
+
+  it('declares both auth response components', () => {
+    expect(spec.components?.responses).toHaveProperty('UnauthorisedResponse');
+    expect(spec.components?.responses).toHaveProperty('TenantAssignmentForbiddenResponse');
+  });
+
+  it.each([
+    ['UnauthorisedResponse', 'Unauthorised - missing or invalid authentication'],
+    ['TenantAssignmentForbiddenResponse', 'Forbidden - authenticated principal has no resolvable tenant assignment'],
+  ])('states exactly what %s means, since every route now inherits that wording', (name, expected) => {
+    const response = spec.components?.responses?.[name] as { description?: string } | undefined;
+
+    // Exact, not contained: the drift this sweep removed included an American
+    // spelling and an em-dash variant, both of which contain the fragment.
+    expect(response?.description).toBe(expected);
+  });
+
+  it.each(['UnauthorisedResponse', 'TenantAssignmentForbiddenResponse'])(
+    'resolves the schema %s carries, so the body shape is not a dangling reference',
+    (name) => {
+      const response = spec.components?.responses?.[name] as
+        | { content?: Record<string, { schema?: { $ref?: string } }> }
+        | undefined;
+      const ref = response?.content?.['application/json']?.schema?.$ref;
+
+      expect(ref).toBe('#/components/schemas/ErrorResponse');
+      expect(spec.components?.schemas).toHaveProperty('ErrorResponse');
+    },
+  );
+
+  it('resolves every reference in the document, at any depth', () => {
+    expect(unresolvedReferences(spec)).toEqual([]);
+  });
+
+  it('documents exactly the operations the routes export', () => {
+    const documented = new Set<string>();
+    for (const [route, operations] of Object.entries(spec.paths ?? {})) {
+      for (const method of Object.keys(operations)) documented.add(`${method} ${route}`);
+    }
+    const exported = new Set(exportedHandlers().map((h) => `${h.method} ${h.route}`));
+
+    // A handler with no annotation is invisible to consumers; an annotation
+    // with no handler promises an endpoint that does not answer. Neither can
+    // be caught by walking only the specification, which is why the census is
+    // compared in both directions.
+    expect({
+      undocumented: [...exported].filter((id) => !documented.has(id)).sort(),
+      unimplemented: [...documented].filter((id) => !exported.has(id)).sort(),
+    }).toEqual({ undocumented: [], unimplemented: [] });
+  });
+
+  it('documents both auth responses on every guarded operation, by reference', () => {
+    const guarded = exportedHandlers().filter((h) => h.wrapper === 'withTenantAuth');
+    expect(guarded.length).toBeGreaterThan(0);
+
+    const missing: string[] = [];
+    const inlined: string[] = [];
+
+    for (const { route, method } of guarded) {
+      const id = `${method} ${route}`;
+      const responses = spec.paths?.[route]?.[method]?.responses;
+
+      const unauthorised = responses?.['401'];
+      if (unauthorised?.$ref !== UNAUTHORISED_REF) {
+        (unauthorised === undefined ? missing : inlined).push(`${id} 401`);
+      }
+
+      const forbidden = responses?.['403'];
+      if (COMBINED_FORBIDDEN_OPERATIONS.has(id)) {
+        // Both causes must survive: the shared wording plus its own rule.
+        expect(forbidden?.description).toContain('no resolvable tenant assignment');
+        expect(forbidden?.description).toContain('root DID');
+        // Staying inline costs this operation the component's body shape, so
+        // the schema it carries is asserted here instead.
+        expect(forbidden?.content?.['application/json']?.schema?.$ref).toBe('#/components/schemas/ErrorResponse');
+        continue;
+      }
+      if (forbidden?.$ref !== FORBIDDEN_REF) {
+        (forbidden === undefined ? missing : inlined).push(`${id} 403`);
+      }
+    }
+
+    expect({ missing, inlined }).toEqual({ missing: [], inlined: [] });
+  });
+
+  it('never advertises auth responses on an operation no auth wrapper guards', () => {
+    const ungated = exportedHandlers().filter((h) => h.wrapper !== 'withTenantAuth');
+    expect(ungated.length).toBeGreaterThan(0);
+
+    const falselyAdvertised = ungated
+      .filter(({ route, method }) => {
+        const responses = spec.paths?.[route]?.[method]?.responses;
+        return [responses?.['401']?.$ref, responses?.['403']?.$ref].some(
+          (ref) => ref === UNAUTHORISED_REF || ref === FORBIDDEN_REF,
+        );
+      })
+      .map(({ route, method }) => `${method} ${route}`);
+
+    expect(falselyAdvertised).toEqual([]);
+  });
+
+  it("reads each handler's own wrapper, including nested dynamic segments", () => {
+    const handlers = exportedHandlers();
+    const wrapperFor = (id: string) => handlers.find((h) => `${h.method} ${h.route}` === id)?.wrapper;
+
+    // Pins the source-to-specification mapping independently of spec content,
+    // so a discovery bug surfaces as itself rather than as a coverage failure.
+    expect(wrapperFor('get /dids/{id}')).toBe('withTenantAuth');
+    expect(wrapperFor('delete /identifiers/{id}/links/{linkId}')).toBe('withTenantAuth');
+    expect(wrapperFor('post /credentials/verify')).toBe('withPublicRoute');
+  });
+
+  it('leaves the public verification operation without auth responses', () => {
+    const verify = spec.paths?.['/credentials/verify']?.post;
+
+    expect(verify).toBeDefined();
+    expect(verify?.responses?.['401']).toBeUndefined();
+    expect(verify?.responses?.['403']).toBeUndefined();
+  });
+});

--- a/packages/reference-implementation/src/lib/swagger/swagger.ts
+++ b/packages/reference-implementation/src/lib/swagger/swagger.ts
@@ -21,6 +21,28 @@ export const getApiDocs = async (): Promise<Record<string, unknown>> => {
         },
       ],
       components: {
+        // The auth responses every withTenantAuth route shares. Declared once
+        // and referenced, because hand-copied blocks have already drifted into
+        // four wordings across the fleet, including an em-dash and American
+        // spellings the repository's own conventions rule out.
+        responses: {
+          UnauthorisedResponse: {
+            description: 'Unauthorised - missing or invalid authentication',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+              },
+            },
+          },
+          TenantAssignmentForbiddenResponse: {
+            description: 'Forbidden - authenticated principal has no resolvable tenant assignment',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+              },
+            },
+          },
+        },
         securitySchemes: {
           BearerAuth: {
             type: 'http',


### PR DESCRIPTION
`withTenantAuth` answers 401 when a caller is unauthenticated and 403 when an authenticated principal has no tenant it can act for. Every route it guards owes a reader both, but 31 of the 65 guarded operations never documented the 403 at all, and the 34 that did had each been written by hand.

Hand-copying had done what hand-copying does. Across the 401 descriptions alone there were four wordings: the intended one, an em-dash variant, seven American "Unauthorized" spellings, and five bare "Unauthorised". Three 403s said "No tenant found for user" instead of describing the tenant-assignment rule. None of that was wrong enough to notice, which is why it accumulated.

This PR declares both responses once as OpenAPI components and points every guarded operation at them. The 31 operations that were silent about the 403 now document it, and the wording is no longer something a future route can get subtly wrong, because there is only one copy of it.

Two operations stay as they are, deliberately. `POST /dids` documents a 403 covering both the shared tenant rule and a rule of its own (a tenant may not claim the system VC service's root DID); referencing the shared component would have deleted half of that contract, so it keeps an inline response and the test asserts both causes survive. `POST /credentials/verify` is public and carries neither response.

A contract test ships with the sweep, because a convention that lives only in reviewers' heads is one PR away from being reintroduced. It reads each handler's own wrapper from source rather than trusting the generated document, then checks that the documented operations and the exported handlers match in both directions, that every guarded operation references both components, that no unguarded operation advertises auth it does not apply, that the components say exactly what they should, and that no reference anywhere in the document dangles. Nine deliberate regressions were introduced while developing it and all nine fail the suite, including subtler ones such as an operation losing its annotation while keeping its handler, and a public route advertising authentication it never enforces.

Reviewers regenerating a client will see the newly documented 403 outcomes and no wire-schema change.

Closes #852
