### PR TITLE
feat(ri): publish credentials from their identifier and name why a publish did not happen

### DIFF
--- a/docs/adrs/043-requested-publishing-fails-loudly-and-resolves-from-the-identifier.md
+++ b/docs/adrs/043-requested-publishing-fails-loudly-and-resolves-from-the-identifier.md
@@ -1,0 +1,76 @@
+# ADR-043: A requested publish fails loudly and resolves from the identifier
+
+- **Date:** 2026-08-16
+- **Status:** accepted
+
+## Context
+
+Issue #738 is the trigger. A user with a correct registrar, scheme, identifier and organisation set up a proof of concept, asked for publishing, and got back a credential with one warning: "Publishing was requested but the entity has no identity scheme configuration". They spent days auditing configuration that was never the problem. The real cause was a bridge defect, and the message could not say so because that one string covers several unrelated situations.
+
+When a caller sets `publishingOptions.publish: true` on `POST /api/v1/credentials`, the route signs and stores the credential, then takes an identifier value from the payload, finds a master-data record (product, then facility, then organisation) whose **primary** identifier matches that value, and walks that record's relations for the scheme's primary key, the registrar's namespace, and the IDR service instance. What the caller sees when that fails is inconsistent:
+
+- Both "no entity matched" and "the matched entity's scheme is incomplete" produce the same `PUBLISH_SKIPPED` code and the same message.
+- A third `PUBLISH_SKIPPED` message, "no primary identifier could be resolved", is unreachable: the resolver sets the identifier whenever it sets the scheme fields.
+- A failed reference extraction produces its own `REFS_EXTRACTION_FAILED`.
+- A missing or broken IDR service instance is not a warning at all: that resolution sits outside the try/catch and throws, **after** the credential has been signed, stored and inserted, so the caller never receives the id of a credential that now exists.
+- A matched entity that vanishes between lookup and insert fails the credential's foreign-key write, again after the credential has been stored.
+
+None of the warnings populate the `remediation` field the warning schema already defines, so a caller gets a code and free text and no stated next step.
+
+The entity is not load-bearing for publishing. The scheme, registrar and IDR instance all hang off `Identifier`; the entity contributes only a description (`description || name`). Entity links themselves are returned by both credential reads and documented as existing so credentials can be queried by entity, though that query API has never been built.
+
+An earlier draft of this decision also covered publishing a credential after issuance. That is deferred: the Identity Resolver is append-only and rejects a duplicate link variant with a conflict, including against historical registrations, so a trustworthy retry needs recorded intent and a reconciliation read that this decision does not attempt. Because there is no republish action in this release, a warning's remediation tells the caller to issue again rather than to publish again, and a publish whose outcome is unknown (the resolver unreachable rather than refusing) says so with its own code instead of inviting a retry the resolver would reject as a duplicate.
+
+## Decision
+
+**1. A requested publish that cannot happen returns the credential and a warning that names the specific unmet prerequisite.** Issuance genuinely succeeded, and the credential is signed, stored and real; failing the request would discard it and deny the caller its id, which is worse than an honest partial outcome. So the status stays 201, and each cause gets its own code with the `remediation` field filled: `PUBLISH_REFERENCE_MISSING`, `PUBLISH_SCHEME_INCOMPLETE`, `PUBLISH_IDENTIFIER_UNKNOWN`, `PUBLISH_IDENTIFIER_AMBIGUOUS`, `PUBLISH_IDR_UNAVAILABLE`, `PUBLISH_TARGET_UNRESOLVED`, `PUBLISH_LINKS_UNBUILDABLE` and `IDR_PUBLISH_UNCONFIRMED`, alongside the existing `REFS_EXTRACTION_FAILED`, `IDR_PUBLISH_FAILED` and `DB_STATUS_UPDATE_FAILED`. A publish whose outcome is unknown (the resolver unreachable, or answering 5xx) is reported as unconfirmed rather than failed, because the call may have committed and the resolver rejects a duplicate. `PUBLISH_SKIPPED` is retired, which is a contract change for any caller matching on it.
+
+**2. Publishing must not destroy the response after the credential exists.** (Issuance itself still has fatal paths before the credential row is written, and unrelated database and tenancy failures stay fatal throughout; the guarantee is about the publishing stage, which runs after the credential is durable.) Because a credential that has been signed and stored is a real resource the caller must be told about, the two paths that currently throw after that point are brought onto the warning path: an unresolvable IDR service instance becomes `PUBLISH_IDR_UNAVAILABLE`, and a vanished matched entity is caught on its own foreign key so the credential is created without the link rather than failing. Unrelated database and tenancy failures stay fatal, and the entity-link failure gets its own advisory code, `ENTITY_LINK_FAILED`, because it is not a publishing outcome.
+
+This amends ADR-042 for this case. ADR-042 rules that a server-selected dependency vanishing follows the sanitised server-failure path; that remains right where the dependency is required, and this decision carves out optional enrichment, where a race must not invalidate work that has already succeeded.
+
+**3. Publishing resolves its target from the identifier, not from a matched entity.** Everything a publish needs hangs off `Identifier`, so gating on entity matching makes an enrichment concern decide whether a credential is discoverable, and produces exactly the misdirection #738 hit. The credential's identifier value is looked up per tenant, and publishing proceeds when exactly one identifier matches. When the value matches more than one scheme, the outcome is `PUBLISH_IDENTIFIER_AMBIGUOUS` naming the colliding schemes rather than a guess, since identifier values are unique only within a scheme; the caller disambiguates with `publishingOptions.identifierSchemeId`.
+
+An earlier draft resolved the scheme from the payload's `idScheme` instead, so no caller would have to supply anything. Implementation showed that does not work yet: builders write `idScheme.id` as a scheme URI (for example `https://id.gs1.org/01/`) when the payload is authored externally, and as this system's scheme id when the payload is built here, so the reference cannot select a scheme record without a mapping rule between the two forms. That rule is a decision in its own right and is not made here. Using the payload hint remains the better long-term answer, and would remove the need for the explicit option.
+
+The residual this leaves is real and is accepted for now: because the assertion is not read, a credential whose payload names scheme A can be published under scheme B when B is the only local scheme holding that value, and the caller's `identifierSchemeId` can likewise select a scheme the payload does not name. Refusing to publish whenever an unmappable assertion is present was considered and rejected: it would block publishing for exactly the externally authored credentials this decision exists to unblock, leaving them no better off than #738. Entity linking and the published description still come from the earlier scheme-blind entity match rather than the identifier the publish selected, so those can disagree with the publish target; that incoherence predates this decision and is not closed by it.
+
+Identifier values are not made unique per tenant. The schema scopes uniqueness to `(schemeId, value, tenantId)` deliberately, and a value may legitimately exist under two schemes (a GTIN and an internal code that coincide).
+
+**4. Entity linking continues as best-effort enrichment and never gates publishing.** The link columns have a documented purpose and are part of the published response schema, so they stay; what changes is that a linking failure is advisory only.
+
+**5. The publish target is chosen without silent fall-through across entity types.** Where the payload yields references of several types, the existing product-then-facility-then-organisation priority stands, and a miss on the chosen type is reported rather than quietly retried against another type: publishing a credential under a different subject than the caller's payload leads with is a surprise no warning would make safe.
+
+**6. The IDR service instance resolves scheme, then registrar, then tenant or system default**, matching `POST /identifiers/{id}/links`. Today the credentials route passes only the scheme-level override, so the same identifier can publish to different resolvers depending on which route was used, which is an inconsistency rather than a decision.
+
+## Consequences
+
+Easier: a caller can act on a failed publish, because the code names the prerequisite and the remediation says what to do; a credential whose identifier exists without a master-data record, or whose identifier is a secondary one, now publishes where it previously could not; and no caller loses a credential id for a credential that exists.
+
+Harder: `PUBLISH_SKIPPED` disappears from responses, so anyone matching it must move to the new codes; publishing behaviour changes for identifiers whose registrar (not scheme) carries the IDR instance; and a caller whose identifier value exists under two schemes must now name the scheme, where previously the entity match picked one silently. Entity-less publishing also needs a description the resolver will accept, since it requires a non-empty value and the entity is no longer there to supply one; the link title fills that role, itself defaulting to the data model's name.
+
+Also in this change, an unrelated caller-visible correction: a stored decryption key that cannot be read no longer echoes the operator's encryption-key diagnostic and the failing row's id to the caller, returning the sanitised 500 that every other unhandled failure returns.
+
+Deferred: publishing a credential after issuance, and reconciling with an append-only resolver that rejects duplicate variants. Tracked separately. Also deferred: reading the payload's scheme assertion, and driving entity linking and the published description from the identifier the publish selected.
+
+## Alternatives considered
+
+**Fail the whole issuance when a requested publish cannot happen.** Rejected: the credential has already been signed and stored by the time publishing is attempted, so a non-2xx would either strand a stored credential whose id the caller never learns, or demand a rollback across an external storage service that the system cannot perform. An opt-in strictness flag remains available later, and would still have to return the credential id.
+
+**Keep one skip code and improve only its message text.** Rejected: free text is not machine-readable, and the failure classes differ in what the caller must do (fix scheme configuration, disambiguate an identifier, fix operator configuration, retry later). A caller cannot branch on prose.
+
+**Require identifier values to be unique per tenant, so a bare value always resolves.** Rejected: the schema's uniqueness scope was chosen deliberately, the migration would break tenants that legitimately reuse a string under two identifier systems, and the resolver's own model treats namespace and key type as part of the identity.
+
+**Resolve the scheme from the payload's `idScheme` so no caller has to supply anything.** Rejected for now, and revisited above under decision 3: the reference is a scheme URI in externally authored payloads and this system's scheme id in ones it built, and mapping between those forms is an undecided rule. Callers therefore name the scheme only in the ambiguous case, via `publishingOptions.identifierSchemeId`.
+
+**Publish under any entity type that resolves, falling through when the first misses.** Rejected: a credential published under a facility because its product reference missed is a silent substitution of subject, and the resulting link would be wrong in a way no warning corrects.
+
+**Drop entity linking entirely, since no query API consumes it.** Rejected: the columns are part of the published credential schema and both read responses, and the master-data documentation states they exist to support entity-scoped credential queries. Removing them is an API deprecation with external consumers unknown, which is a different decision from the one this ADR needs.
+
+## References
+
+- Issue #740, and the field report #738 that motivated it
+- Issue #894 (a local write failing after an upstream side effect succeeded; owns `DB_STATUS_UPDATE_FAILED`'s general shape)
+- ADR-042 (vanished-reference races), amended by decision 2 for optional enrichment
+- ADR-036 (database error translation), unchanged: unrelated database failures stay sanitised and fatal
+- RFC 9110 section 15.3.2 (201 Created), on why the created resource must still be reported

--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -191,7 +191,7 @@ The **storage service** and **IDR service** follow the standard [resolution chai
 |---------|---------|-------------|
 | **VC Service** | Signs the credential payload | From the issuer DID's associated service instance |
 | **Storage Service** | Stores the signed credential | `storageOptions.serviceInstanceId`, or tenant primary, or system default |
-| **IDR Service** | Publishes links (only when `publish: true`) | From the entity's scheme configuration |
+| **IDR Service** | Publishes links (only when `publish: true`) | From the resolved identifier's scheme, then its registrar, then the tenant/system default |
 
 #### Stage 7: Sign, Store, and Record
 
@@ -199,20 +199,35 @@ The credential payload is signed by the VC service, producing an [Enveloped Veri
 
 **Encryption**: By default, the stored credential is encrypted with AES-GCM. The decryption key is returned in the credential record and must be provided when [verifying](#verify-a-credential) encrypted credentials. Set `storageOptions.encrypt` to `false` to store the credential unencrypted.
 
-**Entity linking**: The data model bridge extracts entity references (organisations, facilities, products) from the credential payload. The primary entity (priority: product > facility > organisation) is linked to the credential record in the database. This link enables the optional publishing step.
+**Entity linking**: The data model bridge extracts entity references (organisations, facilities, products) from the credential payload. The primary entity (priority: product > facility > organisation) is linked to the credential record in the database. This link is best-effort enrichment; it never gates the optional publishing step, and a match that fails to link (for example the entity was deleted between extraction and insert) is reported as an advisory `ENTITY_LINK_FAILED` warning rather than affecting the credential or the publish.
 
 #### Stage 8: IDR Publishing (Optional)
 
-When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#what-are-links) for the primary entity's identifier. This makes the credential discoverable via the entity's identifier scheme (e.g., resolving a GS1 GTIN leads to the credential).
+When `publishingOptions.publish` is `true`, the Reference Implementation publishes a link to the stored credential on the [Identity Resolver](./identifiers#what-are-links) for the credential's own identifier. This makes the credential discoverable via that identifier's scheme (e.g., resolving a GS1 GTIN leads to the credential).
 
-Publishing requires the primary entity to have:
-- A primary identifier with a configured [identifier scheme](./identifiers#what-is-an-identifier-scheme)
-- The scheme must have a registrar with a namespace
-- An IDR service instance (configured on the scheme, or the tenant/system default)
+Publishing resolves its target from the same reference used for entity linking (priority: product > facility > organisation), looked up against the tenant's identifiers rather than against master data. Publishing requires that lookup to resolve to exactly one identifier with:
+- An [identifier scheme](./identifiers#what-is-an-identifier-scheme) that has a primary key
+- A registrar with a namespace
+- An IDR service instance (configured on the scheme, the registrar, or the tenant/system default)
 
-If any of these are missing, publishing is silently skipped and a `PUBLISH_SKIPPED` warning is included in the response. Three further publishing-related warnings can appear on a 201: `REFS_EXTRACTION_FAILED` (the payload's entity references could not be extracted, so publishing was skipped), `IDR_PUBLISH_FAILED` (the Identity Resolver rejected or failed the publish; the credential is stored but not discoverable), and `DB_STATUS_UPDATE_FAILED` (the publish succeeded but recording the published status failed, so the credential record may show unpublished).
+When publishing cannot complete, the credential is still issued and returned, and a warning names the unmet prerequisite along with what to do about it:
 
-The IDR entry's `description` field is taken from the primary entity's `description`, falling back to the entity's `name` if no description is set.
+| Code | Meaning | What to do |
+|------|---------|------------|
+| `REFS_EXTRACTION_FAILED` | No identifier could be read from the credential payload. | Check the subject carries the identifier fields its data model defines, such as a `registeredId`. |
+| `PUBLISH_REFERENCE_MISSING` | The payload carries no identifier to publish under. | Check the subject carries the identifier fields its data model defines. |
+| `PUBLISH_SCHEME_INCOMPLETE` | The identifier resolved to a scheme without a primary key, or a registrar without a namespace. | Complete the scheme and registrar configuration, then issue again. |
+| `PUBLISH_IDENTIFIER_UNKNOWN` | No identifier matching the value is registered for the tenant, or the scheme named in `identifierSchemeId` does not hold that value. | Register the identifier under a scheme, or correct `identifierSchemeId`. |
+| `PUBLISH_IDENTIFIER_AMBIGUOUS` | The value exists under more than one scheme, so the target is not decidable. | Set `publishingOptions.identifierSchemeId` to the scheme you want to publish under. |
+| `PUBLISH_IDR_UNAVAILABLE` | No Identity Resolver service is configured for the scheme, registrar, or tenant. | Ask your operator to configure an IDR service instance. |
+| `PUBLISH_TARGET_UNRESOLVED` | The identifier lookup itself failed, so no publish was attempted. | The credential was issued; ask your operator to check the service. |
+| `PUBLISH_LINKS_UNBUILDABLE` | The credential links could not be built from the stored credential. | The credential was issued and stored; ask your operator to check the storage response. |
+| `IDR_PUBLISH_FAILED` | The Identity Resolver rejected the links. | Check the scheme is registered with the resolver, then issue again once it is. |
+| `IDR_PUBLISH_UNCONFIRMED` | The resolver could not be reached or did not answer, so whether the links were registered is unknown. | Ask your operator to check the resolver before issuing again: a second publish of the same links is rejected as a duplicate. |
+| `DB_STATUS_UPDATE_FAILED` | The links are live on the resolver, but the stored published status could not be saved. | The credential is discoverable; only the local status is stale. |
+| `ENTITY_LINK_FAILED` | The credential could not be linked to its master-data record, which no longer exists. | Optional enrichment only; publishing and the credential itself are unaffected. |
+
+The IDR entry's `description` field is taken from the linked primary entity's `description`, falling back to the entity's `name`, and then to the link title (`publishingOptions.linkTitle`, or the data model's name) when no entity is linked, since the resolver requires a non-empty description.
 
 **Human verification link**: When publishing without an explicit `humanVerificationUrl`, the published link set includes a link to this Reference Implementation's own verify page. The base is derived from the `RI_APP_URL` environment variable, which is parsed as a URL with `/verify` appended to its path (any query or fragment is dropped, a base path is preserved, and a trailing slash is trimmed); for the default `http://localhost:3003` the link is `http://localhost:3003/verify`. `RI_APP_URL` is configured in the RI's environment (the shipped `.env.example` and Docker Compose files default it to `http://localhost:3003`) and is the same base URL that backs the OIDC post-logout redirect (see [Identity provider requirements](../authentication/idp-requirements)). Supplying `humanVerificationUrl` overrides the default, for deployments that host verification elsewhere.
 
@@ -255,6 +270,7 @@ Validates, signs, stores, and optionally publishes a verifiable credential. Retu
 | `publishingOptions.publish` | boolean | No | Whether to publish to IDR |
 | `publishingOptions.linkType` | string | No | Link relation type |
 | `publishingOptions.linkTitle` | string | No | Link title (defaults to data model name) |
+| `publishingOptions.identifierSchemeId` | string | No | Scheme to publish under, needed only when the credential's identifier value exists under more than one scheme |
 | `publishingOptions.qualifierPath` | string | No | Qualifier path (default: `/`) |
 | `publishingOptions.machineVerificationUrl` | string | No | Machine verification URL |
 | `publishingOptions.humanVerificationUrl` | string | No | Human verification URL (defaults to `${RI_APP_URL}/verify` when publishing) |

--- a/packages/reference-implementation/e2e/cypress/e2e/api/credential_api/credential-publishing.cy.ts
+++ b/packages/reference-implementation/e2e/cypress/e2e/api/credential_api/credential-publishing.cy.ts
@@ -197,6 +197,46 @@ describe('Credential publishing to the Identity Resolver', { testIsolation: fals
     });
   });
 
+  // A publish that cannot happen must still return the credential, with a
+  // warning naming the unmet prerequisite (ADR-043).
+  it('returns the credential with a named publish warning when the identifier is not registered', () => {
+    cy.request({
+      method: 'POST',
+      url: '/api/v1/credentials',
+      body: {
+        credentialPayload: {
+          '@context': ['https://www.w3.org/ns/credentials/v2', 'https://test.uncefact.org/vocabulary/untp/dpp/0.6.1/'],
+          id: `urn:uuid:e2e-pub-unknown-${RUN_ID}`,
+          type: ['DigitalProductPassport', 'VerifiableCredential'],
+          issuer: { type: ['CredentialIssuer'], id: defaultDidValue, name: `E2E Issuer ${RUN_ID}` },
+          credentialSubject: {
+            type: ['ProductPassport'],
+            id: `https://example.com/products/e2e-pub-unknown-${RUN_ID}`,
+            product: {
+              type: ['Product'],
+              id: `https://example.com/products/e2e-pub-unknown-${RUN_ID}`,
+              registeredId: `unregistered-${RUN_ID}`,
+              name: `E2E Unregistered Product ${RUN_ID}`,
+            },
+          },
+        },
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.1',
+        publishingOptions: { publish: true },
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      expect(response.body.credentialId).to.be.a('string');
+
+      const warnings = response.body.warnings as Array<{ code: string; remediation?: string }>;
+      expect(warnings, JSON.stringify(warnings)).to.be.an('array');
+      const publishWarning = warnings.find((w) => w.code.startsWith('PUBLISH_') || w.code === 'REFS_EXTRACTION_FAILED');
+      expect(publishWarning, JSON.stringify(warnings)).to.exist;
+      expect(publishWarning?.code).to.not.eq('PUBLISH_SKIPPED');
+      expect(publishWarning?.remediation).to.be.a('string').and.not.be.empty;
+    });
+  });
+
   it('registers all three links on the IDR with the roles on the credential and human links', () => {
     cy.request({
       method: 'GET',

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -32,7 +32,10 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
             return jsonResponse({ error: (e as Error).message }, { status: 404 });
           }
           if (e instanceof ServiceRegistryError) {
-            return jsonResponse({ error: (e as Error).message }, { status: 500 });
+            // Mirrors handleRouteError: a named missing instance is a 404,
+            // every other registry failure is a 500.
+            const status = (e as Error).name === 'ServiceInstanceNotFoundError' ? 404 : 500;
+            return jsonResponse({ error: (e as Error).message }, { status });
           }
           if (e instanceof ServiceError) {
             const serviceErr = e as Error & { code?: string; statusCode?: number };
@@ -91,6 +94,11 @@ jest.mock('@/lib/services/resolve-storage-service', () => ({
 }));
 jest.mock('@/lib/services/resolve-idr-service', () => ({
   resolveIdrService: (...args: unknown[]) => mockResolveIdrService(...args),
+}));
+
+const mockResolvePublishTarget = jest.fn();
+jest.mock('@/lib/credentials/resolve-publish-target', () => ({
+  resolvePublishTarget: (...args: unknown[]) => mockResolvePublishTarget(...args),
 }));
 
 // Services package mocks
@@ -856,6 +864,19 @@ describe('POST /api/v1/credentials', () => {
       };
       const primaryEntity = { ...defaults, ...overrides };
 
+      // Publishing resolves its target from the identifier now, not the
+      // entity; the entity remains only as the description source.
+      mockResolvePublishTarget.mockResolvedValue({
+        outcome: 'resolved',
+        target: {
+          identifierValue: '09506000134352',
+          schemePrimaryKey: 'gtin',
+          schemeNamespace: 'gs1',
+          schemeIdrServiceInstanceId: 'idr-scheme-1',
+          registrarIdrServiceInstanceId: null,
+        },
+      });
+
       mockIssueCredential.mockResolvedValue({
         credentialId: 'cred-1',
         storageResponse: STORAGE_RESPONSE,
@@ -896,7 +917,252 @@ describe('POST /api/v1/credentials', () => {
       expect(linkOptions.hreflang).toEqual(['EN-au', 'x-default', 'sl-rozaj-biske']);
     });
 
-    it('does not add PUBLISH_SKIPPED when refs extraction already failed', async () => {
+    it.each([
+      [
+        'the payload carries no identifier',
+        { outcome: 'no-reference' },
+        'PUBLISH_REFERENCE_MISSING',
+        'identifier fields',
+      ],
+      [
+        'the identifier scheme is incomplete',
+        { outcome: 'incomplete', value: '09506000134352' },
+        'PUBLISH_SCHEME_INCOMPLETE',
+        'primary key',
+      ],
+    ])(
+      'warns with its own code and a remediation when %s',
+      async (_label, resolution, expectedCode, remediationFragment) => {
+        setupPublishingHappyPath();
+        mockResolvePublishTarget.mockResolvedValue(resolution);
+
+        const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+        const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+        const json = await res.json();
+
+        expect(res.status).toBe(201);
+        expect(json.credentialId).toBe('cred-1');
+        const warning = (json.warnings as Array<{ code: string; remediation?: string }>).find(
+          (w) => w.code === expectedCode,
+        );
+        expect(warning).toBeDefined();
+        expect(warning?.remediation).toContain(remediationFragment);
+        expect(mockPublishLinks).not.toHaveBeenCalled();
+      },
+    );
+
+    it('warns PUBLISH_IDENTIFIER_AMBIGUOUS naming the colliding schemes rather than guessing', async () => {
+      setupPublishingHappyPath();
+      mockResolvePublishTarget.mockResolvedValue({
+        outcome: 'ambiguous',
+        value: '09506000134352',
+        candidates: [
+          { schemeId: 'scheme-1', schemeName: 'GS1 GTIN' },
+          { schemeId: 'scheme-2', schemeName: 'Internal SKU' },
+        ],
+      });
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      const warning = (json.warnings as Array<{ code: string; message: string; remediation?: string }>).find(
+        (w) => w.code === 'PUBLISH_IDENTIFIER_AMBIGUOUS',
+      );
+      // The caller needs the scheme id the option takes, not just its name.
+      expect(warning?.remediation).toContain('identifierSchemeId');
+      expect(warning?.remediation).toContain('scheme-1');
+      expect(warning?.remediation).toContain('GS1 GTIN');
+      expect(mockPublishLinks).not.toHaveBeenCalled();
+    });
+
+    it('warns PUBLISH_IDENTIFIER_UNKNOWN when no identifier is registered for the value', async () => {
+      setupPublishingHappyPath();
+      mockResolvePublishTarget.mockResolvedValue({ outcome: 'not-found', value: '09506000134352' });
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      const warning = (json.warnings as Array<{ code: string; remediation?: string }>).find(
+        (w) => w.code === 'PUBLISH_IDENTIFIER_UNKNOWN',
+      );
+      expect(warning?.remediation).toContain('Register the identifier');
+      expect(mockPublishLinks).not.toHaveBeenCalled();
+    });
+
+    it('warns ENTITY_LINK_FAILED when the credential was stored without its entity links', async () => {
+      setupPublishingHappyPath();
+      mockIssueCredential.mockResolvedValue({
+        credentialId: 'cred-1',
+        storageResponse: STORAGE_RESPONSE,
+        primaryEntity: {
+          primaryIdentifier: '09506000134352',
+          schemePrimaryKey: 'gtin',
+          schemeNamespace: 'gs1',
+          schemeIdrServiceInstanceId: 'idr-scheme-1',
+          entityName: 'Test Product',
+        },
+        entityLinkFailed: true,
+      });
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.credentialId).toBe('cred-1');
+      const warning = (json.warnings as Array<{ code: string; remediation?: string }>).find(
+        (w) => w.code === 'ENTITY_LINK_FAILED',
+      );
+      expect(warning).toBeDefined();
+      expect(warning?.remediation).toContain('master-data');
+      // Linking is enrichment: its failure must not stop the publish.
+      expect(mockPublishLinks).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns ENTITY_LINK_FAILED even when publishing was not requested', async () => {
+      // Entity linking is enrichment in its own right (ADR-043 decision 4), so
+      // the warning does not belong to the publish branch.
+      setupPublishingHappyPath();
+      mockIssueCredential.mockResolvedValue({
+        credentialId: 'cred-1',
+        storageResponse: STORAGE_RESPONSE,
+        primaryEntity: {},
+        entityLinkFailed: true,
+      });
+
+      const req = createFakeRequest(validBody());
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect((json.warnings as Array<{ code: string }>).map((w) => w.code)).toContain('ENTITY_LINK_FAILED');
+      expect(mockPublishLinks).not.toHaveBeenCalled();
+    });
+
+    it('warns PUBLISH_TARGET_UNRESOLVED instead of losing the credential when the lookup itself fails', async () => {
+      setupPublishingHappyPath();
+      mockResolvePublishTarget.mockRejectedValue(new Error('connection lost'));
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.credentialId).toBe('cred-1');
+      expect((json.warnings as Array<{ code: string }>).map((w) => w.code)).toContain('PUBLISH_TARGET_UNRESOLVED');
+    });
+
+    it('distinguishes a resolver rejection from an unconfirmed publish, and never leaks the upstream body', async () => {
+      setupPublishingHappyPath();
+      const rejection = Object.assign(new Error('HTTP 409: {"detail":"duplicate response for /gtin/095"}'), {
+        name: 'IdrPublishError',
+        details: { httpStatus: 409 },
+      });
+      mockPublishLinks.mockRejectedValueOnce(rejection);
+
+      let res = await POST(
+        createFakeRequest(validBody({ publishingOptions: { publish: true } })),
+        AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+      );
+      let json = await res.json();
+      let warning = (json.warnings as Array<{ code: string; message: string }>).find((w) =>
+        w.code.startsWith('IDR_PUBLISH'),
+      );
+      expect(warning?.code).toBe('IDR_PUBLISH_FAILED');
+      expect(warning?.message).not.toContain('duplicate response');
+      expect(warning?.message).not.toContain('409');
+
+      // A transport failure may have committed upstream, so it must not be
+      // reported as a confirmed rejection nor invite a blind retry.
+      mockPublishLinks.mockRejectedValueOnce(new Error('socket hang up'));
+      res = await POST(
+        createFakeRequest(validBody({ publishingOptions: { publish: true } })),
+        AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+      );
+      json = await res.json();
+      warning = (json.warnings as Array<{ code: string; message: string; remediation?: string }>).find((w) =>
+        w.code.startsWith('IDR_PUBLISH'),
+      );
+      expect(warning?.code).toBe('IDR_PUBLISH_UNCONFIRMED');
+      expect((warning as { remediation?: string }).remediation).toContain('duplicate');
+
+      // A resolver 5xx may still have committed, so it is unknown, not refused.
+      mockPublishLinks.mockRejectedValueOnce(
+        Object.assign(new Error('HTTP 503: upstream unavailable'), {
+          name: 'IdrPublishError',
+          details: { httpStatus: 503 },
+        }),
+      );
+      res = await POST(
+        createFakeRequest(validBody({ publishingOptions: { publish: true } })),
+        AUTH_CONTEXT as unknown as Parameters<typeof POST>[1],
+      );
+      json = await res.json();
+      warning = (json.warnings as Array<{ code: string; message: string }>).find((w) =>
+        w.code.startsWith('IDR_PUBLISH'),
+      );
+      expect(warning?.code).toBe('IDR_PUBLISH_UNCONFIRMED');
+    });
+
+    it('warns PUBLISH_IDR_UNAVAILABLE and still returns the credential when no IDR service resolves', async () => {
+      setupPublishingHappyPath();
+      // Previously this threw and destroyed the response for a credential that
+      // had already been signed and stored (ADR-043 decision 2).
+      mockResolveIdrService.mockRejectedValue(new Error('No service instance available for IDR'));
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(json.credentialId).toBe('cred-1');
+      const warning = (json.warnings as Array<{ code: string; remediation?: string }>).find(
+        (w) => w.code === 'PUBLISH_IDR_UNAVAILABLE',
+      );
+      expect(warning).toBeDefined();
+      expect(warning?.remediation).toContain('identity resolver');
+      expect(mockPublishLinks).not.toHaveBeenCalled();
+    });
+
+    it('warns DB_STATUS_UPDATE_FAILED with a remediation when the status write fails after a successful publish', async () => {
+      setupPublishingHappyPath();
+      mockUpdateCredentialPublished.mockRejectedValue(new Error('connection lost'));
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(mockPublishLinks).toHaveBeenCalledTimes(1);
+      const warning = (json.warnings as Array<{ code: string; remediation?: string }>).find(
+        (w) => w.code === 'DB_STATUS_UPDATE_FAILED',
+      );
+      expect(warning).toBeDefined();
+      expect(warning?.remediation).toContain('discoverable');
+    });
+
+    it('every publish warning carries a remediation the caller can act on', async () => {
+      setupPublishingHappyPath();
+      mockResolvePublishTarget.mockResolvedValue({ outcome: 'incomplete', value: '09506000134352' });
+
+      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const json = await res.json();
+
+      const publishWarnings = (json.warnings as Array<{ code: string; remediation?: string }>).filter((w) =>
+        w.code.startsWith('PUBLISH_'),
+      );
+      expect(publishWarnings.length).toBeGreaterThan(0);
+      for (const warning of publishWarnings) {
+        expect(warning.remediation).toEqual(expect.any(String));
+      }
+    });
+
+    it('does not add a publish-prerequisite warning when refs extraction already failed', async () => {
       setupPublishingHappyPath();
       const failingBridge = {
         buildSubject: jest.fn().mockReturnValue({}),
@@ -917,7 +1183,7 @@ describe('POST /api/v1/credentials', () => {
       expect(res.status).toBe(201);
       const codes = ((json.warnings ?? []) as Array<{ code: string }>).map((w) => w.code);
       expect(codes).toContain('REFS_EXTRACTION_FAILED');
-      expect(codes).not.toContain('PUBLISH_SKIPPED');
+      expect(codes).not.toContain('PUBLISH_SCHEME_INCOMPLETE');
     });
 
     it('publishes to IDR when publish=true and entity has scheme config', async () => {
@@ -926,8 +1192,9 @@ describe('POST /api/v1/credentials', () => {
       const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
-      // resolveIdrService called with scheme IDR only
-      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1');
+      // Scheme, then registrar, then tenant/system default, matching the
+      // identifier-links route (ADR-043).
+      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1', null);
 
       // buildPublishLinks called with storage response, link title, and options.
       // humanVerificationUrl defaults to `${RI_APP_URL}/verify` (RI_APP_URL is
@@ -957,7 +1224,7 @@ describe('POST /api/v1/credentials', () => {
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
       // serviceInstanceId should be ignored — resolveIdrService called with scheme IDR only
-      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1');
+      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', 'idr-scheme-1', null);
     });
 
     it('uses publishingOptions.linkTitle override when provided', async () => {
@@ -1307,24 +1574,27 @@ describe('POST /api/v1/credentials', () => {
       expect(mockUpdateCredentialPublished).not.toHaveBeenCalled();
     });
 
-    it('skips publishing when primaryEntity has no schemePrimaryKey', async () => {
-      setupPublishingHappyPath({ schemePrimaryKey: undefined });
+    it('publishes from the identifier even when no master-data entity matched', async () => {
+      // The decoupling this ADR makes: an identifier with no entity record
+      // used to skip publishing entirely (#738's misdirection).
+      setupPublishingHappyPath();
+      mockIssueCredential.mockResolvedValue({
+        credentialId: 'cred-1',
+        storageResponse: STORAGE_RESPONSE,
+        primaryEntity: {},
+        entityLinkFailed: false,
+      });
 
       const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
-      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
-      expect(mockResolveIdrService).not.toHaveBeenCalled();
-      expect(mockUpdateCredentialPublished).not.toHaveBeenCalled();
-    });
-
-    it('skips publishing when primaryEntity has no schemeNamespace', async () => {
-      setupPublishingHappyPath({ schemeNamespace: undefined });
-
-      const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
-      await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
-
-      expect(mockResolveIdrService).not.toHaveBeenCalled();
-      expect(mockUpdateCredentialPublished).not.toHaveBeenCalled();
+      expect(res.status).toBe(201);
+      expect(mockPublishLinks).toHaveBeenCalledTimes(1);
+      expect(mockUpdateCredentialPublished).toHaveBeenCalledTimes(1);
+      // With no entity to describe it, the link title is the description.
+      expect(mockPublishLinks.mock.calls[0][4]).toEqual(
+        expect.objectContaining({ description: 'Digital Product Passport' }),
+      );
     });
 
     it('issues credential with IDR_PUBLISH_FAILED warning when publishLinks throws', async () => {
@@ -1337,14 +1607,12 @@ describe('POST /api/v1/credentials', () => {
 
       expect(res.status).toBe(201);
       expect(json.credentialId).toBe('cred-1');
+      // A plain Error is not a stated resolver rejection, so the outcome is
+      // unconfirmed rather than failed, and the upstream text stays in the log.
       expect(json.warnings).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            code: 'IDR_PUBLISH_FAILED',
-            message: expect.stringContaining('scheme not registered'),
-          }),
-        ]),
+        expect.arrayContaining([expect.objectContaining({ code: 'IDR_PUBLISH_UNCONFIRMED' })]),
       );
+      expect(JSON.stringify(json.warnings)).not.toContain('scheme not registered');
     });
 
     it('does not mark credential as published when publishLinks throws', async () => {
@@ -1357,25 +1625,39 @@ describe('POST /api/v1/credentials', () => {
       expect(mockUpdateCredentialPublished).not.toHaveBeenCalled();
     });
 
-    it('skips publishing when primaryEntity is empty (no scheme info)', async () => {
-      // primaryEntity returned from issueCredential has no scheme fields
-      mockIssueCredential.mockResolvedValue({
-        credentialId: 'cred-1',
-        storageResponse: STORAGE_RESPONSE,
-        primaryEntity: {},
+    it('uses the registrar IDR instance when the scheme carries none', async () => {
+      setupPublishingHappyPath();
+      mockResolvePublishTarget.mockResolvedValue({
+        outcome: 'resolved',
+        target: {
+          identifierValue: '09506000134352',
+          schemePrimaryKey: 'gtin',
+          schemeNamespace: 'gs1',
+          schemeIdrServiceInstanceId: null,
+          registrarIdrServiceInstanceId: 'idr-registrar-1',
+        },
       });
 
       const req = createFakeRequest(validBody({ publishingOptions: { publish: true } }));
       await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
 
-      expect(mockResolveIdrService).not.toHaveBeenCalled();
-      expect(mockUpdateCredentialPublished).not.toHaveBeenCalled();
+      expect(mockResolveIdrService).toHaveBeenCalledWith('tenant-1', null, 'idr-registrar-1');
     });
   });
 
   // ── Error propagation ─────────────────────────────────────────────────
 
   describe('error propagation', () => {
+    it('returns 404 when an explicitly requested service instance no longer exists', async () => {
+      const { ServiceInstanceNotFoundError } = jest.requireActual('@/lib/api/errors');
+      mockResolveStorageService.mockRejectedValue(new ServiceInstanceNotFoundError('STORAGE', 'missing-instance'));
+
+      const req = createFakeRequest(validBody({ storageOptions: { serviceInstanceId: 'missing-instance' } }));
+      const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+      expect(res.status).toBe(404);
+    });
+
     it('returns 500 when issueCredential throws', async () => {
       mockIssueCredential.mockRejectedValue(new Error('Signing service unavailable'));
 
@@ -1608,8 +1890,11 @@ describe('GET /api/v1/credentials', () => {
     const json = await res.json();
 
     expect(res.status).toBe(500);
-    // The failing row is named so an operator can find it without trawling logs.
-    expect(json.error).toContain('cred-1');
+    // The underlying message names the operator's encryption key and the
+    // failing row, so neither reaches the caller; both go to the log.
+    expect(json.error).not.toContain('cred-1');
+    expect(json.error).not.toContain('DATA_ENCRYPTION_KEY');
+    expect(json.error).not.toContain('decrypt the stored credential');
   });
 
   it('reveals stored decryption keys in the listed credentials', async () => {

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -8,7 +8,6 @@ import {
 } from '@/lib/api/validation';
 import { credentialIssueRequestSchema, listCredentialsQuerySchema } from '@/lib/api/request-schemas/credential';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { errorMessage } from '@/lib/api/errors';
 import { resolveAppUrl, buildVerifyUrl } from '@/lib/config/app-url.config';
 import { apiLogger } from '@/lib/api/logger';
 import { resolveDataModel } from '@/lib/credentials/resolve-data-model';
@@ -21,6 +20,7 @@ import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { resolveVcService } from '@/lib/services/resolve-vc-service';
 import { resolveStorageService } from '@/lib/services/resolve-storage-service';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
+import { resolvePublishTarget } from '@/lib/credentials/resolve-publish-target';
 import { getDidByDid, findConformitySchemeByCanonicalId } from '@/lib/prisma/repositories';
 import { buildPublishLinks } from '@uncefact/untp-ri-services';
 import type { CredentialPayload, ExtractedRefs } from '@uncefact/untp-ri-services';
@@ -71,7 +71,11 @@ function defaultHumanVerificationUrl(): string {
  *             $ref: '#/components/schemas/CredentialIssueRequest'
  *     responses:
  *       201:
- *         description: Credential issued
+ *         description: >-
+ *           Credential issued. When publishing was requested and could not
+ *           complete, the credential is still returned and a warning names the
+ *           unmet prerequisite with a remediation; publishing never fails
+ *           issuance.
  *         content:
  *           application/json:
  *             schema:
@@ -200,7 +204,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     if (publishingOptions.publish) {
       warnings.push({
         code: 'REFS_EXTRACTION_FAILED',
-        message: 'Failed to extract references from credential payload — publishing will be skipped',
+        message: 'Publishing was requested but no identifier could be extracted from the credential payload.',
+        remediation:
+          "Check that the credential's subject carries the identifier fields its data model defines, such as a registeredId on the party or product.",
       });
     }
   }
@@ -271,7 +277,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
   // ── Step 7: Issue credential ────────────────────────────────────────────
 
   logger.info({ credentialType }, 'Issuing credential');
-  const { credentialId, storageResponse, primaryEntity } = await issueCredential({
+  const { credentialId, storageResponse, primaryEntity, entityLinkFailed } = await issueCredential({
     tenantId,
     credentialPayload,
     credentialType,
@@ -281,76 +287,194 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
     storageOptions,
   });
 
+  if (entityLinkFailed) {
+    warnings.push({
+      code: 'ENTITY_LINK_FAILED' as const,
+      message: 'The credential was issued but could not be linked to its master-data record, which no longer exists.',
+      remediation:
+        'Re-create the master-data record if the link matters to you. The credential itself is unaffected, and publishing does not depend on the link.',
+    });
+  }
+
   // ── Step 8: Publish to IDR ──────────────────────────────────────────────
 
   if (publishingOptions.publish === true && refs) {
-    if (!primaryEntity.schemePrimaryKey || !primaryEntity.schemeNamespace) {
-      logger.warn({ credentialId }, 'Publishing requested but entity has no scheme configuration — skipping');
+    // Publishing resolves its target from the credential's own identifier
+    // (ADR-043): the scheme, registrar and IDR instance all hang off
+    // Identifier, so a missing master-data record no longer decides whether a
+    // credential is discoverable. Every failure below names the unmet
+    // prerequisite and what the caller does about it, and nothing throws: the
+    // credential exists by this point, so a caller who loses the response
+    // loses the id of a credential that was signed and stored.
+    let resolution: Awaited<ReturnType<typeof resolvePublishTarget>>;
+    try {
+      resolution = await resolvePublishTarget(refs, tenantId, publishingOptions.identifierSchemeId);
+    } catch (error) {
+      logger.error({ err: error, credentialId }, 'Could not resolve the publish target');
+      resolution = { outcome: 'unavailable' };
+    }
+
+    if (resolution.outcome === 'ambiguous') {
       warnings.push({
-        code: 'PUBLISH_SKIPPED' as const,
-        message: 'Publishing was requested but the entity has no identity scheme configuration',
+        code: 'PUBLISH_IDENTIFIER_AMBIGUOUS' as const,
+        message: `Publishing was requested but the identifier "${resolution.value}" exists under more than one scheme.`,
+        remediation: `Set publishingOptions.identifierSchemeId to the scheme you want to publish under. Candidates: ${resolution.candidates
+          .map((candidate) => `${candidate.schemeName} (${candidate.schemeId})`)
+          .join(', ')}.`,
       });
-    } else if (!primaryEntity.primaryIdentifier) {
-      logger.warn({ credentialId }, 'Publishing requested but no primary identifier resolved — skipping');
+    } else if (resolution.outcome === 'not-found') {
       warnings.push({
-        code: 'PUBLISH_SKIPPED' as const,
-        message: 'Publishing was requested but no primary identifier could be resolved from the credential payload',
+        code: 'PUBLISH_IDENTIFIER_UNKNOWN' as const,
+        message: `Publishing was requested but no identifier matching "${resolution.value}" is registered for this tenant.`,
+        remediation: 'Register the identifier under an identifier scheme, then issue the credential again.',
+      });
+    } else if (resolution.outcome === 'no-reference') {
+      warnings.push({
+        code: 'PUBLISH_REFERENCE_MISSING' as const,
+        message: 'Publishing was requested but the credential payload carries no identifier to publish under.',
+        remediation:
+          "Check that the credential's subject carries the identifier fields its data model defines, such as a registeredId on the party or product.",
+      });
+    } else if (resolution.outcome === 'unavailable') {
+      warnings.push({
+        code: 'PUBLISH_TARGET_UNRESOLVED' as const,
+        message: "Publishing was requested but the credential's identifier could not be looked up.",
+        remediation:
+          'The credential was issued. Ask your operator to check the service, then issue again if you need it published.',
+      });
+    } else if (resolution.outcome === 'incomplete') {
+      warnings.push({
+        code: 'PUBLISH_SCHEME_INCOMPLETE' as const,
+        message: `Publishing was requested but the identifier "${resolution.value}" belongs to a scheme without both a primary key and a registrar namespace.`,
+        remediation:
+          'Give the identifier scheme a primary key, and its registrar a namespace, then issue the credential again.',
       });
     } else {
-      // Resolve IDR service outside try-catch — config failures should be fatal
-      const idrService = await resolveIdrService(tenantId, primaryEntity.schemeIdrServiceInstanceId);
-
-      const linkTitle = publishingOptions.linkTitle || dataModel.name;
-      const links = buildPublishLinks(storageResponse, linkTitle, {
-        linkType: publishingOptions.linkType ?? idrService.service.defaultLinkType,
-        machineVerificationUrl,
-        humanVerificationUrl: effectiveHumanVerificationUrl,
-        ...(publishingOptions.hreflang !== undefined ? { hreflang: publishingOptions.hreflang } : {}),
-        ...(publishingOptions.additionalRels !== undefined ? { additionalRels: publishingOptions.additionalRels } : {}),
-        ...(publishingOptions.public !== undefined ? { public: publishingOptions.public } : {}),
-        ...(publishingOptions.accessRole !== undefined ? { accessRole: publishingOptions.accessRole } : {}),
-      });
-
-      logger.info(
-        { idrInstanceId: idrService.instanceId, primaryIdentifier: primaryEntity.primaryIdentifier },
-        'Publishing credential to IDR',
-      );
-
+      const { target } = resolution;
+      let idrService: Awaited<ReturnType<typeof resolveIdrService>> | undefined;
       try {
-        await idrService.service.publishLinks(
-          primaryEntity.schemePrimaryKey,
-          primaryEntity.primaryIdentifier,
-          links,
-          publishingOptions.qualifierPath || '/',
-          {
-            namespace: primaryEntity.schemeNamespace,
-            description: primaryEntity.entityDescription || primaryEntity.entityName,
-          },
+        // Scheme, then registrar, then tenant or system default, matching how
+        // POST /identifiers/{id}/links resolves the same chain.
+        idrService = await resolveIdrService(
+          tenantId,
+          target.schemeIdrServiceInstanceId,
+          target.registrarIdrServiceInstanceId,
         );
       } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        logger.error(
-          { err: error, credentialId, scheme: primaryEntity.schemePrimaryKey },
-          'Failed to publish credential to IDR',
-        );
+        logger.error({ err: error, credentialId }, 'Publishing requested but no IDR service could be resolved');
         warnings.push({
-          code: 'IDR_PUBLISH_FAILED',
-          message: `Failed to publish credential to identity resolver: ${detail}. Ensure the identifier scheme is registered with the IDR service. Contact your IDR operator if this persists.`,
+          code: 'PUBLISH_IDR_UNAVAILABLE' as const,
+          message: 'Publishing was requested but no identity resolver service is available for this credential.',
+          remediation:
+            'Ask your operator to configure an identity resolver service instance for the scheme, the registrar, or the tenant.',
         });
       }
 
-      if (!warnings.some((w) => w.code === 'IDR_PUBLISH_FAILED')) {
+      if (idrService) {
+        const linkTitle = publishingOptions.linkTitle || dataModel.name;
+        let links: ReturnType<typeof buildPublishLinks> | undefined;
         try {
-          await updateCredentialPublished(credentialId, tenantId, true);
-        } catch (error) {
-          logger.error(
-            { err: error, credentialId },
-            'Failed to update published status — credential was published to IDR but DB record is stale',
-          );
-          warnings.push({
-            code: 'DB_STATUS_UPDATE_FAILED' as const,
-            message: 'Credential was published to IDR but the published status could not be saved',
+          links = buildPublishLinks(storageResponse, linkTitle, {
+            linkType: publishingOptions.linkType ?? idrService.service.defaultLinkType,
+            machineVerificationUrl,
+            humanVerificationUrl: effectiveHumanVerificationUrl,
+            ...(publishingOptions.hreflang !== undefined ? { hreflang: publishingOptions.hreflang } : {}),
+            ...(publishingOptions.additionalRels !== undefined
+              ? { additionalRels: publishingOptions.additionalRels }
+              : {}),
+            ...(publishingOptions.public !== undefined ? { public: publishingOptions.public } : {}),
+            ...(publishingOptions.accessRole !== undefined ? { accessRole: publishingOptions.accessRole } : {}),
           });
+        } catch (error) {
+          logger.error({ err: error, credentialId }, 'Could not build the publish links');
+          warnings.push({
+            code: 'PUBLISH_LINKS_UNBUILDABLE' as const,
+            message: 'Publishing was requested but the credential links could not be built.',
+            remediation:
+              'The credential was issued and stored. Ask your operator to check the storage response, then issue again if you need it published.',
+          });
+        }
+
+        let published = false;
+        if (links) {
+          logger.info(
+            { idrInstanceId: idrService.instanceId, primaryIdentifier: target.identifierValue },
+            'Publishing credential to IDR',
+          );
+          try {
+            await idrService.service.publishLinks(
+              target.schemePrimaryKey,
+              target.identifierValue,
+              links,
+              publishingOptions.qualifierPath || '/',
+              {
+                namespace: target.schemeNamespace,
+                // The resolver requires a non-empty description. The entity
+                // supplied it before publishing was decoupled from entity
+                // matching; with no entity the link title is the stable
+                // fallback, itself defaulting to the data model's name.
+                description: primaryEntity.entityDescription || primaryEntity.entityName || linkTitle,
+              },
+            );
+            published = true;
+          } catch (error) {
+            // The upstream error carries the resolver's raw response body, which
+            // is operator detail: it goes to the log, not to the caller.
+            logger.error(
+              { err: error, credentialId, scheme: target.schemePrimaryKey },
+              'Failed to publish credential to IDR',
+            );
+            // A rejection the resolver stated is distinguishable from one where
+            // the call itself failed: the second may have committed upstream, so
+            // it must not invite a blind retry (the resolver is append-only).
+            // A 4xx is the resolver stating it did not accept the links. A 5xx,
+            // or a failure of the call itself, may still have committed upstream,
+            // so it is reported as unknown rather than as a refusal.
+            // The upstream status is in details.httpStatus; the error's own
+            // statusCode is this service's 502 for any upstream failure.
+            const status = (error as { details?: { httpStatus?: number } })?.details?.httpStatus;
+            const rejected =
+              error instanceof Error &&
+              error.name === 'IdrPublishError' &&
+              typeof status === 'number' &&
+              status >= 400 &&
+              status < 500;
+            warnings.push(
+              rejected
+                ? {
+                    code: 'IDR_PUBLISH_FAILED' as const,
+                    message:
+                      'The identity resolver rejected the credential links, so the credential is not discoverable.',
+                    remediation:
+                      'Check that the identifier scheme is registered with the identity resolver, then issue the credential again once it is.',
+                  }
+                : {
+                    code: 'IDR_PUBLISH_UNCONFIRMED' as const,
+                    message:
+                      'The identity resolver could not be reached or did not answer, so whether the credential links were registered is unknown.',
+                    remediation:
+                      'Ask your operator to check the resolver for these links before issuing again: a second publish of the same links is rejected as a duplicate.',
+                  },
+            );
+          }
+
+          if (published) {
+            try {
+              await updateCredentialPublished(credentialId, tenantId, true);
+            } catch (error) {
+              logger.error(
+                { err: error, credentialId },
+                'Failed to update published status — credential was published to IDR but DB record is stale',
+              );
+              warnings.push({
+                code: 'DB_STATUS_UPDATE_FAILED' as const,
+                message:
+                  'The credential was published to the identity resolver but its published status could not be saved.',
+                remediation:
+                  'The credential is discoverable; only its stored status is stale. No action is needed unless you rely on that flag.',
+              });
+            }
+          }
         }
       }
     }
@@ -463,8 +587,11 @@ export const GET = withTenantAuth(async (req, { tenantId }) => {
     try {
       return { ...credential, decryptionKey: revealDecryptionKey(credential.decryptionKey) };
     } catch (error) {
+      // The underlying message names the operator's encryption key, so it
+      // stays in the log; the caller gets the sanitised 500 every other
+      // unhandled failure returns (ADR-036).
       logger.error({ err: error, credentialId: credential.id }, 'Failed to reveal a stored decryption key');
-      throw new Error(`${errorMessage(error)} (credential ${credential.id})`, { cause: error });
+      throw new Error('Failed to read a stored credential', { cause: error });
     }
   });
   return NextResponse.json(buildPaginatedResponse(credentials, total, limit, offset));

--- a/packages/reference-implementation/src/lib/api/request-schemas/credential.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/credential.ts
@@ -34,6 +34,11 @@ export const publishingOptionsSchema = z.object({
     .optional()
     .describe("UNTP link relation type (defaults to the IDR service's configured default link type)"),
   linkTitle: z.string().optional().describe('Title for the published link (defaults to data model name)'),
+  identifierSchemeId: idSchema
+    .optional()
+    .describe(
+      "Identifier scheme to publish under, required only when the credential's identifier value exists under more than one scheme",
+    ),
   qualifierPath: z
     .string()
     .optional()

--- a/packages/reference-implementation/src/lib/credentials/issue-credential.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/issue-credential.test.ts
@@ -86,7 +86,7 @@ function buildInput(overrides: Partial<IssueCredentialInput> = {}): IssueCredent
 
 function setupHappyPath() {
   mockResolvePrimaryEntity.mockResolvedValue(PRIMARY_ENTITY);
-  mockCreateCredential.mockResolvedValue({ id: 'cred-1' });
+  mockCreateCredential.mockResolvedValue({ credential: { id: 'cred-1' }, entityLinkFailed: false });
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -160,11 +160,21 @@ describe('issueCredential', () => {
     expect(saved.decryptionKey).toBeUndefined();
   });
 
+  it('reports entityLinkFailed when the repository stored the credential without its entity links', async () => {
+    mockCreateCredential.mockResolvedValue({ credential: { id: 'cred-1' }, entityLinkFailed: true });
+
+    const result = await issueCredential(buildInput());
+
+    expect(result.credentialId).toBe('cred-1');
+    expect(result.entityLinkFailed).toBe(true);
+  });
+
   it('returns storage response and primary entity for publishing', async () => {
     const result = await issueCredential(buildInput());
 
     expect(result).toEqual({
       credentialId: 'cred-1',
+      entityLinkFailed: false,
       storageResponse: STORAGE_RESPONSE,
       primaryEntity: PRIMARY_ENTITY,
     });

--- a/packages/reference-implementation/src/lib/credentials/issue-credential.ts
+++ b/packages/reference-implementation/src/lib/credentials/issue-credential.ts
@@ -30,6 +30,12 @@ export type IssueCredentialResult = {
   credentialId: string;
   storageResponse: StorageRecord;
   primaryEntity: PrimaryEntityResult;
+  /**
+   * True when the matched entity vanished before the credential row was
+   * written, so the credential was stored without its entity links. Advisory
+   * enrichment only (ADR-043): the caller is told, and issuance still succeeds.
+   */
+  entityLinkFailed: boolean;
 };
 
 export async function issueCredential(input: IssueCredentialInput): Promise<IssueCredentialResult> {
@@ -47,7 +53,7 @@ export async function issueCredential(input: IssueCredentialInput): Promise<Issu
 
   const decryptionKey = protectDecryptionKey(storageResponse.decryptionKey);
 
-  const credentialRecord = await createCredential({
+  const { credential: credentialRecord, entityLinkFailed } = await createCredential({
     tenantId,
     storageUri: storageResponse.uri,
     digestMultibase: storageResponse.digestMultibase,
@@ -61,9 +67,17 @@ export async function issueCredential(input: IssueCredentialInput): Promise<Issu
 
   logger.info({ tenantId, credentialId: credentialRecord.id }, 'Credential issued and stored');
 
+  if (entityLinkFailed) {
+    logger.warn(
+      { tenantId, credentialId: credentialRecord.id },
+      'Credential stored without entity links: the matched entity no longer exists',
+    );
+  }
+
   return {
     credentialId: credentialRecord.id,
     storageResponse,
     primaryEntity,
+    entityLinkFailed,
   };
 }

--- a/packages/reference-implementation/src/lib/credentials/resolve-publish-target.test.ts
+++ b/packages/reference-implementation/src/lib/credentials/resolve-publish-target.test.ts
@@ -1,0 +1,142 @@
+const mockFindIdentifiersByValue = jest.fn();
+jest.mock('@/lib/prisma/repositories', () => ({
+  findIdentifiersByValue: (...args: unknown[]) => mockFindIdentifiersByValue(...args),
+}));
+
+jest.mock('@/lib/api/logger', () => ({
+  apiLogger: { child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }) },
+}));
+
+import { resolvePublishTarget } from './resolve-publish-target';
+
+const TENANT = 'tenant-1';
+
+function identifier(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ident-1',
+    value: '09506000134352',
+    scheme: {
+      name: 'GS1 GTIN',
+      primaryKey: 'gtin',
+      idrServiceInstanceId: 'idr-scheme-1',
+      registrar: { namespace: 'gs1', idrServiceInstanceId: 'idr-registrar-1' },
+    },
+    ...overrides,
+  };
+}
+
+function refs(overrides: Record<string, unknown> = {}) {
+  return { organisations: [], facilities: [], products: [], ...overrides };
+}
+
+describe('resolvePublishTarget', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('resolves the scheme, namespace and both IDR instances from the identifier', async () => {
+    mockFindIdentifiersByValue.mockResolvedValue([identifier()]);
+
+    const result = await resolvePublishTarget(refs({ products: [{ id: '09506000134352' }] }), TENANT);
+
+    expect(result).toEqual({
+      outcome: 'resolved',
+      target: {
+        identifierValue: '09506000134352',
+        schemePrimaryKey: 'gtin',
+        schemeNamespace: 'gs1',
+        schemeIdrServiceInstanceId: 'idr-scheme-1',
+        registrarIdrServiceInstanceId: 'idr-registrar-1',
+      },
+    });
+  });
+
+  it('narrows the lookup to the scheme the caller named, so a shared value resolves', async () => {
+    mockFindIdentifiersByValue.mockResolvedValue([identifier()]);
+
+    const result = await resolvePublishTarget(refs({ products: [{ id: '09506000134352' }] }), TENANT, 'scheme-1');
+
+    expect(mockFindIdentifiersByValue).toHaveBeenCalledWith('09506000134352', TENANT, 'scheme-1');
+    expect(result).toMatchObject({ outcome: 'resolved' });
+  });
+
+  it('reports ambiguity naming every colliding scheme rather than guessing', async () => {
+    mockFindIdentifiersByValue.mockResolvedValue([
+      { ...identifier(), schemeId: 'scheme-a' },
+      {
+        ...identifier({ id: 'ident-2' }),
+        schemeId: 'scheme-b',
+        scheme: { ...identifier().scheme, name: 'Internal SKU' },
+      },
+    ]);
+
+    const result = await resolvePublishTarget(refs({ products: [{ id: '09506000134352' }] }), TENANT);
+
+    expect(result).toEqual({
+      outcome: 'ambiguous',
+      value: '09506000134352',
+      candidates: [
+        { schemeId: 'scheme-a', schemeName: 'GS1 GTIN' },
+        { schemeId: 'scheme-b', schemeName: 'Internal SKU' },
+      ],
+    });
+  });
+
+  it('reports a value no identifier is registered for', async () => {
+    mockFindIdentifiersByValue.mockResolvedValue([]);
+
+    const result = await resolvePublishTarget(refs({ products: [{ id: 'unknown' }] }), TENANT);
+
+    expect(result).toEqual({ outcome: 'not-found', value: 'unknown' });
+  });
+
+  it.each([
+    ['a scheme without a primary key', { ...identifier().scheme, primaryKey: '' }],
+    ['a registrar without a namespace', { ...identifier().scheme, registrar: { namespace: '' } }],
+  ])('reports %s as incomplete rather than publishing under a partial scheme', async (_label, scheme) => {
+    mockFindIdentifiersByValue.mockResolvedValue([identifier({ scheme })]);
+
+    const result = await resolvePublishTarget(refs({ products: [{ id: '09506000134352' }] }), TENANT);
+
+    expect(result).toEqual({ outcome: 'incomplete', value: '09506000134352' });
+  });
+
+  it('reports no reference when the payload yields none', async () => {
+    const result = await resolvePublishTarget(refs(), TENANT);
+
+    expect(result).toEqual({ outcome: 'no-reference' });
+    expect(mockFindIdentifiersByValue).not.toHaveBeenCalled();
+  });
+
+  it('prefers the product reference, then facility, then organisation', async () => {
+    mockFindIdentifiersByValue.mockResolvedValue([identifier()]);
+
+    await resolvePublishTarget(
+      refs({
+        products: [{ id: 'product-value' }],
+        facilities: [{ id: 'facility-value' }],
+        organisations: [{ id: 'org-value' }],
+      }),
+      TENANT,
+    );
+    expect(mockFindIdentifiersByValue).toHaveBeenLastCalledWith('product-value', TENANT, undefined);
+
+    await resolvePublishTarget(
+      refs({ facilities: [{ id: 'facility-value' }], organisations: [{ id: 'org-value' }] }),
+      TENANT,
+    );
+    expect(mockFindIdentifiersByValue).toHaveBeenLastCalledWith('facility-value', TENANT, undefined);
+  });
+
+  it('does not fall through to another entity type when the chosen reference does not resolve', async () => {
+    // Publishing under a facility because the product reference missed would
+    // be a silent substitution of subject (ADR-043).
+    mockFindIdentifiersByValue.mockResolvedValue([]);
+
+    const result = await resolvePublishTarget(
+      refs({ products: [{ id: 'product-value' }], facilities: [{ id: 'facility-value' }] }),
+      TENANT,
+    );
+
+    expect(result).toEqual({ outcome: 'not-found', value: 'product-value' });
+    expect(mockFindIdentifiersByValue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/reference-implementation/src/lib/credentials/resolve-publish-target.ts
+++ b/packages/reference-implementation/src/lib/credentials/resolve-publish-target.ts
@@ -1,0 +1,87 @@
+import type { ExtractedRefs } from '@uncefact/untp-ri-services';
+import { findIdentifiersByValue } from '@/lib/prisma/repositories';
+import { apiLogger } from '@/lib/api/logger';
+
+const logger = apiLogger.child({ module: 'resolve-publish-target' });
+
+/**
+ * Everything the IDR publish call needs, read from the identifier rather than
+ * from a matched master-data record (ADR-043). The scheme, registrar and IDR
+ * service instance all hang off `Identifier`, so an entity is not required for
+ * a credential to be discoverable.
+ */
+export type PublishTarget = {
+  identifierValue: string;
+  schemePrimaryKey: string;
+  schemeNamespace: string;
+  schemeIdrServiceInstanceId: string | null;
+  registrarIdrServiceInstanceId: string | null;
+};
+
+export type ResolvePublishTargetResult =
+  | { outcome: 'resolved'; target: PublishTarget }
+  | { outcome: 'no-reference' }
+  | { outcome: 'not-found'; value: string }
+  | { outcome: 'incomplete'; value: string }
+  | { outcome: 'ambiguous'; value: string; candidates: { schemeId: string; schemeName: string }[] }
+  | { outcome: 'unavailable' };
+
+/**
+ * Chooses the reference the credential is published under: product, then
+ * facility, then organisation, without falling through to another type when
+ * the chosen one does not resolve. Publishing a credential under a different
+ * subject than the payload leads with would be a silent substitution, and no
+ * warning makes that safe (ADR-043).
+ */
+function chooseReference(refs: ExtractedRefs): { id: string } | undefined {
+  return refs.products[0] ?? refs.facilities[0] ?? refs.organisations[0];
+}
+
+/**
+ * Resolves the publish target from the credential's own references.
+ *
+ * The value is looked up across the tenant's schemes, and a value matching
+ * more than one scheme is reported rather than guessed: identifier values are
+ * unique only within a scheme. A caller disambiguates by naming the scheme in
+ * `publishingOptions.identifierSchemeId`.
+ */
+export async function resolvePublishTarget(
+  refs: ExtractedRefs,
+  tenantId: string,
+  identifierSchemeId?: string,
+): Promise<ResolvePublishTargetResult> {
+  const reference = chooseReference(refs);
+  if (!reference?.id) return { outcome: 'no-reference' };
+
+  const matches = await findIdentifiersByValue(reference.id, tenantId, identifierSchemeId);
+
+  if (matches.length === 0) {
+    logger.warn({ tenantId, value: reference.id }, 'No identifier matches the credential reference');
+    return { outcome: 'not-found', value: reference.id };
+  }
+
+  if (matches.length > 1) {
+    // The caller needs the scheme ids, not just their names: naming the option
+    // without its value leaves them unable to act on the warning.
+    const candidates = matches.map((match) => ({ schemeId: match.schemeId, schemeName: match.scheme.name }));
+    logger.warn({ tenantId, value: reference.id, candidates }, 'Credential reference matches more than one scheme');
+    return { outcome: 'ambiguous', value: reference.id, candidates };
+  }
+
+  const [identifier] = matches;
+  const namespace = identifier.scheme.registrar?.namespace;
+  if (!identifier.scheme.primaryKey || !namespace) {
+    return { outcome: 'incomplete', value: reference.id };
+  }
+
+  return {
+    outcome: 'resolved',
+    target: {
+      identifierValue: identifier.value,
+      schemePrimaryKey: identifier.scheme.primaryKey,
+      schemeNamespace: namespace,
+      schemeIdrServiceInstanceId: identifier.scheme.idrServiceInstanceId ?? null,
+      registrarIdrServiceInstanceId: identifier.scheme.registrar?.idrServiceInstanceId ?? null,
+    },
+  };
+}

--- a/packages/reference-implementation/src/lib/prisma/repositories/credential.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/credential.repository.test.ts
@@ -75,11 +75,40 @@ describe('credential.repository', () => {
   });
 
   describe('createCredential', () => {
-    it('rethrows a foreign-key violation unchanged', async () => {
-      // The entity links (organisationId, facilityId, productId) are resolved
-      // server-side, so a violation is a server-side race with no honest 4xx;
-      // this pins the deliberate absence of a mapping.
-      const fkError = prismaError('P2003', 'Foreign key constraint failed on the field: `organisationId`');
+    it.each(['organisationId', 'facilityId', 'productId'])(
+      'retries without entity links when %s vanished, so a stored credential is never lost',
+      async (column) => {
+        // ADR-043: the credential is already signed and stored externally by
+        // this point, so an entity that disappeared mid-request must not fail
+        // the write. The retry drops only the links and says so.
+        const created = { ...SEED_CREDENTIALS[0], organisationId: null, facilityId: null, productId: null };
+        mockCredential.create
+          .mockRejectedValueOnce(prismaError('P2003', `Foreign key constraint failed on the field: \`${column}\``))
+          .mockResolvedValueOnce(created);
+
+        const result = await createCredential({
+          tenantId: TENANT_ID,
+          storageUri: 'https://storage.example/credential-new',
+          digestMultibase: 'zNew',
+          credentialType: 'DigitalProductPassport',
+          organisationId: 'org-1',
+          facilityId: 'fac-1',
+          productId: 'prod-1',
+        });
+
+        expect(result).toEqual({ credential: created, entityLinkFailed: true });
+        expect(mockCredential.create).toHaveBeenCalledTimes(2);
+        const retryData = mockCredential.create.mock.calls[1][0].data;
+        expect(retryData).not.toHaveProperty('organisationId');
+        expect(retryData).not.toHaveProperty('facilityId');
+        expect(retryData).not.toHaveProperty('productId');
+      },
+    );
+
+    it('rethrows a foreign-key violation on a column that is not an entity link', async () => {
+      // Only the optional enrichment columns are retried; a tenant that
+      // vanished is a real failure and stays fatal under ADR-036.
+      const fkError = prismaError('P2003', 'Foreign key constraint failed on the field: `tenantId`');
       mockCredential.create.mockRejectedValue(fkError);
 
       await expect(
@@ -91,6 +120,22 @@ describe('credential.repository', () => {
           organisationId: 'org-1',
         }),
       ).rejects.toBe(fkError);
+      expect(mockCredential.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows an unrelated database failure without retrying', async () => {
+      const other = prismaError('P2002', 'Unique constraint failed');
+      mockCredential.create.mockRejectedValue(other);
+
+      await expect(
+        createCredential({
+          tenantId: TENANT_ID,
+          storageUri: 'https://storage.example/credential-new',
+          digestMultibase: 'zNew',
+          credentialType: 'DigitalProductPassport',
+        }),
+      ).rejects.toBe(other);
+      expect(mockCredential.create).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/reference-implementation/src/lib/prisma/repositories/credential.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/credential.repository.ts
@@ -1,3 +1,4 @@
+import { isForeignKeyViolationOn } from '@/lib/prisma/db-errors';
 import { Credential, Prisma } from '../generated';
 import { prisma } from '../prisma';
 import { mapDatabaseError } from '@/lib/prisma/db-errors';
@@ -30,24 +31,50 @@ export type ListCredentialsOptions = {
 };
 
 /**
- * Creates a new credential record. The entity links are resolved server-side,
- * so a foreign-key failure here is a race, not a caller error; #740 owns what
- * it should mean for issuance.
+ * Creates a new credential record.
+ *
+ * Entity links are optional enrichment (ADR-043): the server picks the entity
+ * on the caller's behalf, and by the time this runs the credential has already
+ * been signed and stored externally, so an entity that vanished between the
+ * lookup and this write must not destroy work that succeeded. A foreign-key
+ * violation on one of the three entity columns is retried once without any of
+ * them and reported through `entityLinkFailed` (a credential carries at most
+ * one entity link, since the publish target is a single chosen reference); every other database failure,
+ * including a violation on `tenantId`, stays fatal and is translated by
+ * ADR-036's mapping. This is the carve-out ADR-043 makes to ADR-042, which
+ * otherwise routes a vanished server-selected dependency to the sanitised
+ * server-failure path.
  */
-export async function createCredential(input: CreateCredentialInput): Promise<Credential> {
-  return prisma.credential.create({
-    data: {
-      tenantId: input.tenantId,
-      storageUri: input.storageUri,
-      digestMultibase: input.digestMultibase,
-      decryptionKey: input.decryptionKey,
-      credentialType: input.credentialType,
-      isPublished: input.isPublished ?? false,
-      organisationId: input.organisationId,
-      facilityId: input.facilityId,
-      productId: input.productId,
-    },
-  });
+export async function createCredential(
+  input: CreateCredentialInput,
+): Promise<{ credential: Credential; entityLinkFailed: boolean }> {
+  const data = {
+    tenantId: input.tenantId,
+    storageUri: input.storageUri,
+    digestMultibase: input.digestMultibase,
+    decryptionKey: input.decryptionKey,
+    credentialType: input.credentialType,
+    isPublished: input.isPublished ?? false,
+  };
+
+  try {
+    const credential = await prisma.credential.create({
+      data: {
+        ...data,
+        organisationId: input.organisationId,
+        facilityId: input.facilityId,
+        productId: input.productId,
+      },
+    });
+    return { credential, entityLinkFailed: false };
+  } catch (error) {
+    const onEntityColumn = ['organisationId', 'facilityId', 'productId'].some((column) =>
+      isForeignKeyViolationOn(error, column),
+    );
+    if (!onEntityColumn) throw error;
+    const credential = await prisma.credential.create({ data });
+    return { credential, entityLinkFailed: true };
+  }
 }
 
 /**

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.test.ts
@@ -1,4 +1,5 @@
 import {
+  findIdentifiersByValue,
   createIdentifier,
   getIdentifierById,
   listIdentifiers,
@@ -367,5 +368,30 @@ describe('identifier.repository', () => {
 
       await expect(deleteIdentifier('ident-1', 'other-tenant')).rejects.toThrow('Identifier not found');
     });
+  });
+});
+
+describe('findIdentifiersByValue', () => {
+  it('queries by value and tenant with the scheme, registrar and qualifiers included', async () => {
+    mockIdentifier.findMany.mockResolvedValue([]);
+
+    await findIdentifiersByValue('09506000134352', 'tenant-1');
+
+    expect(mockIdentifier.findMany).toHaveBeenCalledWith({
+      where: { value: '09506000134352', tenantId: 'tenant-1' },
+      include: { scheme: { include: { registrar: true, qualifiers: true } } },
+    });
+  });
+
+  it('narrows to a scheme when one is given, so a shared value resolves to one identifier', async () => {
+    mockIdentifier.findMany.mockResolvedValue([]);
+
+    await findIdentifiersByValue('09506000134352', 'tenant-1', 'scheme-1');
+
+    expect(mockIdentifier.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { value: '09506000134352', tenantId: 'tenant-1', schemeId: 'scheme-1' },
+      }),
+    );
   });
 });

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier.repository.ts
@@ -110,6 +110,39 @@ export async function createIdentifier(input: CreateIdentifierInput): Promise<Id
 }
 
 /**
+ * Finds the identifiers matching a value for a tenant, with their scheme,
+ * registrar and qualifiers.
+ *
+ * Returns every match rather than the first: `Identifier` is unique on
+ * (schemeId, value, tenantId), so one value can legitimately exist under two
+ * schemes (a GTIN and an internal code that coincide). Publishing must not
+ * guess between them, so the caller decides what an ambiguous result means
+ * (ADR-043). Passing `schemeId` narrows to the exact identifier when the
+ * caller named the scheme to publish under.
+ */
+export async function findIdentifiersByValue(
+  value: string,
+  tenantId: string,
+  schemeId?: string,
+): Promise<IdentifierWithScheme[]> {
+  return prisma.identifier.findMany({
+    where: {
+      value,
+      tenantId,
+      ...(schemeId ? { schemeId } : {}),
+    },
+    include: {
+      scheme: {
+        include: {
+          registrar: true,
+          qualifiers: true,
+        },
+      },
+    },
+  });
+}
+
+/**
  * Retrieves an identifier by ID, scoped to an organisation.
  * Identifiers belong to a single tenant — no system default sharing.
  * Includes the full scheme with registrar and qualifiers.

--- a/packages/reference-implementation/src/lib/services/resolve-idr-service.ts
+++ b/packages/reference-implementation/src/lib/services/resolve-idr-service.ts
@@ -13,8 +13,8 @@ export type ResolvedIdrService = ResolvedService<IIdentityResolverService>;
  * 2. Registrar-level: `Registrar.idrServiceInstanceId`
  * 3. System default: tenant's primary IDR service instance (or system-wide default)
  *
- * The credentials route uses a two-tier chain (scheme → system default),
- * while the identifier links route uses the full three-tier chain.
+ * Both the credentials route and the identifier links route pass the full
+ * chain (scheme, then registrar, then tenant or system default); see ADR-043.
  */
 export async function resolveIdrService(
   tenantId: string,

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -52,7 +52,11 @@ function stripAdditionalPropertiesFalse(node: unknown): void {
 
 /** Advisory warning that may accompany a credential-issue response. */
 export const credentialWarningSchema = z.object({
-  code: z.string().describe('Warning code'),
+  code: z
+    .string()
+    .describe(
+      'Warning code. Publishing codes: `REFS_EXTRACTION_FAILED` (no identifier could be read from the payload), `PUBLISH_REFERENCE_MISSING` (the payload carries no identifier to publish under), `PUBLISH_SCHEME_INCOMPLETE` (the identifier resolved to a scheme missing a primary key or registrar namespace), `PUBLISH_IDENTIFIER_UNKNOWN` (no identifier registered for the value), `PUBLISH_IDENTIFIER_AMBIGUOUS` (the value exists under more than one scheme; set publishingOptions.identifierSchemeId), `PUBLISH_IDR_UNAVAILABLE` (no identity resolver service is configured), `PUBLISH_TARGET_UNRESOLVED` (the identifier lookup itself failed), `IDR_PUBLISH_FAILED` (the resolver rejected the links), `IDR_PUBLISH_UNCONFIRMED` (the resolver could not be reached, so whether the links were registered is unknown), `DB_STATUS_UPDATE_FAILED` (the links are live but the stored status was not saved). `ENTITY_LINK_FAILED` reports that the credential could not be linked to a master-data record, which does not affect publishing.',
+    ),
   message: z.string().describe('Human-readable warning message'),
   received: z.unknown().optional().describe('The value that triggered the warning, where one applies'),
   expected: z.unknown().optional().describe('The value or shape that was expected, where one applies'),


### PR DESCRIPTION
When a caller asks to publish a credential to the Identity Resolver and it does not happen, they currently get one warning that reads "the entity has no identity scheme configuration", and that single sentence covers several unrelated causes. Issue #738 is what that costs: a user with a correct registrar, scheme and identifier spent days auditing configuration that was never the problem. This PR makes each cause say what it actually is, and stops publishing depending on something it never needed.

Publishing now resolves its target from the credential's own identifier rather than from a matched master-data record. Everything the resolver call needs (the scheme's primary key, the registrar's namespace, the IDR instance) hangs off the identifier, and the entity only ever supplied a description. So a credential whose identifier is registered now publishes even when no product, facility or organisation record matches it, which previously failed silently. Master-data linking continues as enrichment, and its failure no longer stops anything, including the case where the matched entity is deleted mid-request, which used to fail the whole write after the credential had already been signed and stored.

Every way a requested publish can fall over now has its own code and a remediation the caller can act on: no identifier in the payload, an identifier that is not registered, one that exists under two schemes (with the scheme ids they need to disambiguate), an incomplete scheme, no resolver configured, and the resolver refusing the links. Two of those matter more than the rest. A publish whose outcome is unknown, because the resolver could not be reached or answered 5xx, is reported as unconfirmed rather than failed, since the call may have committed and this resolver rejects a duplicate; and nothing in the publishing stage can now throw, because a caller who loses the response loses the id of a credential that exists.

The decisions behind all of this, including what was deliberately not done, are in ADR-043.

Closes #740

## Test plan
- [x] Each publish failure returns 201 with its own code and a remediation, and never attempts the publish
- [x] A credential publishes from a registered identifier with no master-data record, using the link title as the resolver description
- [x] A vanished entity stores the credential without links and warns, rather than failing issuance
- [x] A resolver refusal, an unreachable resolver, and a 5xx are distinguished, and the resolver's response body stays in the log
- [x] The IDR instance resolves scheme, then registrar, then default, matching the identifier-links route
- [x] Full RI suite green (138 suites, 2,425 tests), typecheck and lint clean
