### PR TITLE
docs(ri): document the conformity vocabulary catalogue and its browse API

### DIFF
--- a/documentation/docs/reference-implementation/api/conformity-vocabulary-catalogue.md
+++ b/documentation/docs/reference-implementation/api/conformity-vocabulary-catalogue.md
@@ -1,0 +1,163 @@
+---
+sidebar_position: 12
+title: Conformity Vocabulary Catalogue
+---
+
+# Conformity Vocabulary Catalogue API
+
+This API lets an issuer browse the conformity schemes registered in this Reference Implementation, drilling from a **scheme** to the **profiles** it publishes, and from a profile to the **criteria** it defines. The URIs these endpoints return are the ones you put in a credential's conformity claim.
+
+Everything here is read-only and answered from the local catalogue. Where those schemes come from, and which of them a tenant can see, is described in [Conformity Vocabulary Catalogue](../data-models/conformity-vocabulary-catalogue).
+
+:::tip[Interactive API documentation]
+The Reference Implementation includes a Swagger UI at [`/api-docs`](http://localhost:3003/api-docs) with full request/response schemas you can try directly from the browser. The endpoint descriptions below focus on behaviour and internal logic — refer to Swagger for exact payload shapes. All endpoints require authentication — see [Authentication](../authentication#obtaining-a-token) for how to obtain a Bearer token.
+:::
+
+## Concepts
+
+### Scheme, profile, criterion
+
+A conformity scheme is published by whoever owns it, and inlines the profiles it offers; each profile inlines the criteria it requires.
+
+| Level | What it is | Example |
+|-------|------------|---------|
+| **Scheme** | The programme a claim is made under | "Copper Mark" |
+| **Profile** | A versioned assessment profile within that scheme | "Responsible Risk Assessment v3.0" |
+| **Criterion** | A single requirement within a profile | "Forced labour" |
+
+### Every `id` is a canonical URI
+
+The `id` on every entry these endpoints return is the entry's **canonical URI**, not an internal database identifier. That URI is what a conformity claim carries, so a client can take an `id` from a response and put it straight into a credential.
+
+Profile and criterion URIs are versioned; a scheme URI is not. Two profiles of the same scheme are different URIs, and the same criterion can differ between profile versions, so a claim is always specific about which revision it was assessed against.
+
+### Visibility
+
+Each request returns the schemes visible to the authenticated tenant: the system catalogue plus that tenant's own entries. Where the same canonical URI exists in both, the system entry takes precedence, so a tenant sees one entry per URI rather than two.
+
+### Drilling down
+
+The three endpoints are meant to be used in sequence, each taking the previous response's `id`.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant RI as Reference Implementation
+    Client->>RI: GET /cvc/schemes
+    RI-->>Client: schemes, each with a canonical id
+    Client->>RI: GET /cvc/profiles?schemeId=<scheme id>
+    RI-->>Client: versioned profiles for that scheme
+    Client->>RI: GET /cvc/criteria?profileId=<profile id>
+    RI-->>Client: criteria, each with its conformity topics
+    Note over Client: The ids collected here go into the conformity claim
+```
+
+### Pagination and validation
+
+Results are paginated. All three endpoints take `limit` and `offset`, and reject a malformed value rather than ignoring it.
+
+| Parameter | Behaviour |
+|-----------|-----------|
+| `limit` | Number of entries per page. Defaults to 20, or the [configured maximum](../operations/api-pagination#maximum-page-size) where that is lower. A value above the maximum is rejected with a 400 naming the maximum, rather than being quietly reduced. |
+| `offset` | Number of entries to skip. Defaults to 0. |
+
+A non-integer, negative, or otherwise malformed `limit` or `offset` is a 400 naming the parameter. Repeating a query parameter is also a 400, rather than one of the values being picked silently.
+
+Entries are returned sorted by name.
+
+### Response shape
+
+All three endpoints return the same envelope: the page of entries under `data`, and the counts under `pagination`.
+
+| Field | Description |
+|-------|-------------|
+| `data` | The entries on this page |
+| `pagination.total` | How many entries the tenant can see in total, before paging |
+| `pagination.limit` | The page size actually applied |
+| `pagination.offset` | The offset actually applied |
+| `pagination.hasMore` | Whether another page follows |
+
+A filter value is a URI, so URL-encode it when building the query string.
+
+---
+
+## Endpoints
+
+### List Schemes
+
+```
+GET /api/v1/cvc/schemes
+```
+
+Returns the conformity schemes registered in this Reference Implementation and visible to the authenticated tenant. There is no filter; this is the entry point for the drill-down.
+
+An empty list is the expected response on a deployment that has not had any schemes seeded, rather than a sign the endpoint is misconfigured. See [Conformity Vocabulary Catalogue](../data-models/conformity-vocabulary-catalogue) for how schemes get there.
+
+| Field | Description |
+|-------|-------------|
+| `id` | The scheme's canonical URI |
+| `name` | Human-readable scheme name |
+| `specVersion` | The CVC specification version the scheme document conforms to, for example `0.7.0`. Not a version of the scheme itself |
+| `owner` | Present where the scheme document names one, as `{ canonicalId, name }`; either part may be absent |
+
+---
+
+### List Profiles
+
+```
+GET /api/v1/cvc/profiles?schemeId=<canonical scheme URI>
+```
+
+Returns the versioned profiles the given scheme publishes.
+
+| Parameter | Description |
+|-----------|-------------|
+| `schemeId` | **Required.** The canonical URI of the scheme, as returned by List Schemes. A missing or blank value is a 400. |
+
+A scheme that is not registered here returns an empty list rather than a 404, because the endpoint answers "what do I hold for this URI", and holding nothing is a valid answer rather than an error.
+
+| Field | Description |
+|-------|-------------|
+| `id` | The profile's canonical, versioned URI |
+| `name` | Human-readable profile name |
+| `version` | The profile version, also encoded in the `id` |
+| `status` | Lifecycle status, for example `active` |
+| `validFrom` | Present where the scheme document states one |
+
+---
+
+### List Criteria
+
+```
+GET /api/v1/cvc/criteria?profileId=<canonical profile URI>
+```
+
+Returns the criteria the given profile defines, each with the conformity topics that criterion addresses.
+
+| Parameter | Description |
+|-----------|-------------|
+| `profileId` | **Required.** The canonical URI of the profile, as returned by List Profiles. A missing or blank value is a 400. |
+
+As with profiles, a profile that is not registered here returns an empty list.
+
+| Field | Description |
+|-------|-------------|
+| `id` | The criterion's canonical, versioned URI |
+| `name` | Human-readable criterion name |
+| `version` | The criterion version, also encoded in the `id` |
+| `status` | Lifecycle status, for example `active` |
+| `topics` | The conformity topics this criterion addresses, each `{ canonicalId, name?, definition? }` |
+| `tags` | Free-form tags the scheme document attached |
+
+The topics matter when a claim classifies its criteria: a mismatch between what a credential declares and what the criterion defines produces an advisory warning when a UNTP v0.7.0 Digital Conformity Credential is issued. [CVC compliance](./credentials#cvc-compliance-conformity-credentials-only) lists the warning codes and what each one means.
+
+---
+
+## Errors
+
+| Status | When |
+|--------|------|
+| `400` | A required filter is missing or blank, a pagination parameter is malformed or above the maximum, or a query parameter is repeated |
+| `401` | No valid session or bearer token |
+| `403` | The authenticated principal has no resolvable tenant |
+| `500` | Server error |

--- a/documentation/docs/reference-implementation/api/credentials.md
+++ b/documentation/docs/reference-implementation/api/credentials.md
@@ -77,7 +77,7 @@ Publishing is optional and requires the credential's primary entity (product, fa
 
 ### CVC Compliance (Conformity Credentials Only)
 
-For [Digital Conformity Credentials](./data-models), the issuance pipeline performs an extra advisory check: it compares the conformity scheme, profile, and criteria referenced in the credential against the locally known [Conformity Vocabulary Catalogue (CVC)](https://untp.unece.org/docs/specification/ConformityVocabularyCatalog) schemes. This helps catch mistakes like referencing a non-existent scheme or omitting a required criterion.
+For UNTP v0.7.0 [Digital Conformity Credentials](./data-models), the issuance pipeline performs an extra advisory check: it compares the conformity scheme, profile, and criteria referenced in the credential against the locally known [Conformity Vocabulary Catalogue (CVC)](https://untp.unece.org/docs/specification/ConformityVocabularyCatalog) schemes. Earlier DCC versions are issued without this check. This helps catch mistakes like referencing a non-existent scheme or omitting a required criterion. See [Conformity Vocabulary Catalogue](../data-models/conformity-vocabulary-catalogue) for where those schemes come from, and the [Conformity Vocabulary Catalogue API](./conformity-vocabulary-catalogue) for browsing them.
 
 CVC validation is **advisory only** — it never blocks issuance. If issues are found, the credential is still issued but the response includes warnings.
 
@@ -99,7 +99,7 @@ sequenceDiagram
     RI->>DB: 2. Resolve data model + bridge
     DB-->>RI: Data model config + schema URLs
     RI->>RI: 3. Validate payload (JSON Schema + JSON-LD)
-    RI->>RI: 3.5. CVC validation (advisory, DCC only)
+    RI->>RI: 3.5. CVC validation (advisory, DCC v0.7.0 only)
     RI->>DB: 4. Validate issuer DID ownership
     DB-->>RI: DID record (tenant-owned or system default)
     RI->>RI: 5. Validate DID has service association

--- a/documentation/docs/reference-implementation/data-models/adding-a-bridge.md
+++ b/documentation/docs/reference-implementation/data-models/adding-a-bridge.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: Adding a Bridge
 ---
 

--- a/documentation/docs/reference-implementation/data-models/bridge-architecture.md
+++ b/documentation/docs/reference-implementation/data-models/bridge-architecture.md
@@ -77,7 +77,7 @@ sequenceDiagram
 
     API->>Bridge: Extract refs from credential subject
     Bridge-->>API: Entity + conformity refs
-    API->>API: CVC validation (advisory, DCC only)
+    API->>API: CVC validation (advisory, DCC v0.7.0 only)
 
     API->>VC: Sign credential
     VC-->>API: Signed credential

--- a/documentation/docs/reference-implementation/data-models/conformity-handling.md
+++ b/documentation/docs/reference-implementation/data-models/conformity-handling.md
@@ -13,12 +13,11 @@ The Reference Implementation maintains a conformity vocabulary catalogue (CVC) w
 
 | Level | Description | Example |
 |-------|-------------|---------|
-| **Catalogue** | Top-level grouping of related schemes, standards, and regulations | "Australian Agriculture Standards" |
 | **Scheme / Standard / Regulation** | A conformity assessment programme, standard, or regulation | "Organic Certification Scheme", "ISO 14001", "EU Deforestation Regulation" |
 | **Profile** | A specific assessment profile within a scheme, standard, or regulation | "Organic Crop Production v2.1" |
 | **Criteria** | Individual assessment requirements within a profile | "No synthetic pesticides used" |
 
-Conformity schemes reach the catalogue from three sources: operator-seeded into the system tenant (live in this release), UNTP-discovered from the Conformity Vocabulary Catalogue register (not yet operational, pending the register settling), and tenant-imported (scoped to a tenant, on the roadmap for a future release). Each tenant browses the schemes visible to it through the CVC API endpoints (`/api/v1/cvc/schemes`, `/api/v1/cvc/profiles?schemeId=`, `/api/v1/cvc/criteria?profileId=`); where the same canonical URI exists in both the system tenant and a tenant's own lane, the system-provisioned entry takes precedence.
+Where those schemes come from, how they are kept current, and which of them a tenant can see are described in [Conformity Vocabulary Catalogue](./conformity-vocabulary-catalogue). Issuers browse them through the [Conformity Vocabulary Catalogue API](../api/conformity-vocabulary-catalogue).
 
 ## Supported credential types
 
@@ -46,7 +45,7 @@ The cascading conformity picker UI is not yet implemented. The form-config endpo
 
 After extraction, the conformity references can be validated against the locally known conformity schemes (operator-seeded in this release). This validation checks whether the credential's attestations cover all the criteria defined by a given profile.
 
-Currently, CVC validation is implemented for **Digital Conformity Credentials only**. The extracted criteria are compared against the criteria defined in the matching profile — if any required criteria are missing from the credential, an advisory warning is produced. These warnings are informational; they never prevent the credential from being issued.
+Currently, CVC validation is implemented for **UNTP v0.7.0 Digital Conformity Credentials only**; earlier DCC versions, and the other credential types above, are issued without it. The extracted criteria are compared against the criteria defined in the matching profile — if any required criteria are missing from the credential, an advisory warning is produced. These warnings are informational; they never prevent the credential from being issued.
 
 For DPP and DFR credentials, conformity data is extracted but not yet validated against CVC profiles. This is planned for future work — the extraction infrastructure is already in place, so validation can be added without changes to the bridge layer.
 

--- a/documentation/docs/reference-implementation/data-models/conformity-vocabulary-catalogue.md
+++ b/documentation/docs/reference-implementation/data-models/conformity-vocabulary-catalogue.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 4
+title: Conformity Vocabulary Catalogue
+---
+
+# Conformity Vocabulary Catalogue
+
+A conformity claim in a credential records what was assessed and what the assessment found, but it does not carry the definitions it is assessing against. Instead it points at them: a **conformity scheme** published by whoever owns it, usually a versioned **profile** within that scheme, and the **criteria** the assessment covered. Those pointers are URIs, and a claim may name fewer of them than you expect, since a profile is not required.
+
+For those URIs to mean anything to the Reference Implementation, it needs the scheme documents they refer to. This page describes where those documents come from, how they are kept current, and which tenant sees which of them.
+
+## The UNTP v0.7 model
+
+Under [UNTP v0.7](https://untp.unece.org/docs/specification/ConformityVocabularyCatalog), UNECE does not publish the schemes themselves. The catalogue is to be a **register of pointer URIs**: a list saying "a conformity scheme lives over there". Each scheme owner publishes their own scheme document at their own stable URI, and that document inlines its profiles, and each profile inlines its criteria.
+
+Two consequences shape everything below. Scheme content is owned and changed by other people, so a copy held here can go stale. And profile and criterion URIs are independently versioned while a scheme URI is not, so a claim naming `.../criterion/forced-labour/1.0.0` is naming one exact revision of that criterion.
+
+The Reference Implementation keeps its own **local catalogue** of scheme documents it has resolved. Every check it performs, and everything its API returns, is answered from that local catalogue rather than from the network.
+
+## Where schemes come from
+
+A fresh deployment holds no schemes at all. The core seed does not insert any, so an issuer browsing the catalogue on an untouched install gets an empty list rather than a starter set. Schemes arrive only through one of the sources below.
+
+Three sources can feed the local catalogue. They are at different stages, and the difference matters if you are deciding what to rely on today.
+
+```mermaid
+flowchart LR
+    Manifest["Custom seed manifest<br/>(operator)"] -->|live| Catalogue[("Local catalogue")]
+    Register["UNTP register<br/>(CVC_REGISTRY_URL)"] -.->|not operational| Catalogue
+    Tenant["Tenant import<br/>(per tenant)"] -.->|not built| Catalogue
+    Catalogue --> API["CVC browse API"]
+    Catalogue --> Validation["Conformity claim validation<br/>issuing a v0.7.0 DCC"]
+```
+
+### Operator seeding, live
+
+An operator lists scheme documents in the [custom seed manifest](../operations/custom-seed), either as a URL to fetch or as a file mounted into the container. These land in the system tenant and are visible to every tenant.
+
+The manifest is the source of truth for the schemes it owns. An entry with no matching row is inserted, a changed entry is updated in place, and a scheme whose entry has been removed from the manifest is deleted along with its profiles. Only operator-seeded schemes are ever removed this way, and when a file entry cannot be resolved the removal pass is skipped entirely rather than deleting schemes on the strength of an incomplete manifest. [Custom seed](../operations/custom-seed) covers the manifest format and this behaviour in full.
+
+Seeded schemes also refresh their **content** from source, not just their membership. At boot every manifest entry is re-ingested; URL entries go through a conditional fetch and file entries are compared by digest, so an unchanged document is detected cheaply and skips parsing and persistence. Between boots, an interval re-fetches the URL-seeded schemes on the nominal cadence set by `CVC_REFRESH_INTERVAL_HOURS`, spread by a small jitter so instances do not all wake together (see [Startup](../operations/startup)). The periodic refresher handles URL-seeded schemes only; schemes seeded from a mounted file are re-read at boot instead.
+
+### Discovery from the UNTP register, not operational
+
+The intent is that the Reference Implementation reads the UNECE register named by `CVC_REGISTRY_URL`, follows each pointer URI, and ingests the schemes it finds.
+
+This is not running. The resolution and ingest machinery exists, but nothing triggers it and no startup path reads that variable, so setting it has no effect today. UNTP's current published artefact is a scheme owners registration page rather than the machine-readable register this would read, which is promised before the first stable release. Wiring the trigger is tracked in [#690](https://github.com/uncefact/tests-untp/issues/690), and the wider discovery capability in [#543](https://github.com/uncefact/tests-untp/issues/543).
+
+### Tenant-level import, not built
+
+The intent is that a tenant supplies a scheme URI and gets that scheme resolved into its own lane, without an operator changing the deployment's manifest. This is useful when a scheme matters to one tenant and not to the platform.
+
+No endpoint exists for this yet, and nothing in the product writes a tenant-owned scheme row. The design is recorded in ADR-033.
+
+## Keeping the catalogue current
+
+Because scheme owners can change a document after it is published, a copy here is only as good as its last successful fetch. A successful re-ingest replaces the stored scheme, its profiles, and its criteria with what the document now says. Within a tenant's lane a canonical URI appears once, so a changed document updates what is already there rather than accumulating copies of the same URI beside it.
+
+A failed fetch leaves the previous content in place rather than emptying the catalogue. That is the safe behaviour, but it means a stale entry and a current one look identical through the browse API, which returns only the catalogue content and no fetch metadata. An operator checking whether refresh is actually working should look at the startup and interval logs, where each pass records what it fetched and what failed.
+
+What is implemented today is the seeded-scheme refresh described above. Refresh driven by register discovery waits on the discovery trigger, and an endpoint to force a refresh on demand rather than waiting for the interval is tracked in [#666](https://github.com/uncefact/tests-untp/issues/666).
+
+## What each tenant sees
+
+A tenant browsing the catalogue sees the system catalogue plus anything in its own lane. Where the same canonical URI exists in both, the system-tenant entry wins, so a tenant cannot shadow a platform-provisioned scheme with a private copy of the same URI. The same precedence applies when a credential is validated during issuance, so what a tenant browses and what its claims are checked against agree.
+
+Since tenant import is not built, every tenant sees the same system catalogue today. How a tenant's own entry should behave once its URI is also registered upstream is tracked in [#664](https://github.com/uncefact/tests-untp/issues/664).
+
+## Using the catalogue
+
+Issuers browse the catalogue through the [Conformity Vocabulary Catalogue API](../api/conformity-vocabulary-catalogue), drilling from scheme to profile to criteria and taking the canonical URIs to put in a claim.
+
+Conformity claims in a **UNTP v0.7.0** Digital Conformity Credential are checked against the catalogue as it is issued. Earlier DCC versions are still supported for issuance and are seeded by default, but they carry no claim extraction, so a v0.6.0 or v0.6.1 credential is issued without this check and without CVC warnings.
+
+The check is advisory and never blocks a credential: see [CVC compliance](../api/credentials#cvc-compliance-conformity-credentials-only) on the Credentials API page for the warnings it produces, and [Conformity Handling](./conformity-handling) for how conformity data is modelled across the credential types that carry it.

--- a/documentation/docs/reference-implementation/data-models/index.md
+++ b/documentation/docs/reference-implementation/data-models/index.md
@@ -54,4 +54,5 @@ This means an extension automatically gets population, extraction, and validatio
 
 - [Bridge Architecture](./bridge-architecture) — the technical implementation: interfaces, the delta pattern, version composition, and the registry
 - [Conformity Handling](./conformity-handling) — how conformity data flows through different credential types and how CVC validation works
+- [Conformity Vocabulary Catalogue](./conformity-vocabulary-catalogue) — where conformity schemes come from, how they refresh, and what a tenant can see
 - [Adding a Bridge](./adding-a-bridge) — step-by-step guide for adding support for a new UNTP version or credential type


### PR DESCRIPTION
The conformity vocabulary catalogue had one paragraph of documentation and no API reference, so a reader could not find out where conformity schemes come from, which of the ways of getting them actually work today, or how to browse them. This PR adds a page for each.

**Where schemes come from** now has a page of its own, and it is explicit about what is real. Operator seeding through the custom seed manifest is live, reconciles manifest membership, and refreshes scheme content from source. Discovery from the UNTP register is not operational: the machinery exists but nothing triggers it, so setting `CVC_REGISTRY_URL` has no effect today. Tenant-level import is not built at all. The page also says a fresh deployment holds no schemes, since an empty catalogue otherwise reads as a broken endpoint.

**The browse endpoints** get a reference page following the existing `api/*.md` convention: what a scheme, profile and criterion are, that every `id` is the canonical URI a conformity claim carries, the response envelope and per-entry fields, the validation behaviour, and the errors.

Two corrections came out of writing this. Conformity validation at issuance applies only to UNTP v0.7.0 Digital Conformity Credentials, because only that version registers a claim extractor, while the seed also registers v0.6.0 and v0.6.1. Several existing passages and two diagrams said "Digital Conformity Credentials" unqualified, so a reader could expect a check that never runs; those are now qualified. And the hierarchy table in Conformity Handling still taught a `Catalogue` level above scheme that the reference implementation does not store, which contradicted the new page; that row is gone.

The three-source paragraph that lived in Conformity Handling is replaced by a pointer, so the model has one home rather than two copies to drift apart.

Closes #730

## Test plan
- [x] Docusaurus production build passes with no broken-link warnings, checked explicitly since `onBrokenMarkdownLinks` is set to warn rather than throw
- [x] Every status claim traced to code: the seeding, refresh and discovery paths, the absence of a tenant-import or manual-refresh route, and system-tenant precedence on both browsing and issuance
- [x] Every endpoint claim traced to the routes: required filters, the 400 cases, default and maximum page size, empty-list rather than 404, and the response fields for scheme, profile and criterion
- [x] Sidebar ordering checked for collisions across `data-models/` and `api/`