### PR TITLE
test(ri): cover every documented conflict response at the route boundary

### DIFF
--- a/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/[id]/route.test.ts
@@ -63,7 +63,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   deleteDataModel: (id: string, tenantId: string) => mockDeleteDataModel(id, tenantId),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { GET, PATCH, DELETE } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -273,6 +273,20 @@ describe('PATCH /api/v1/data-models/:id', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toMatch(/schemaUrl.*valid URL/);
+  });
+
+  it('returns 409 when the repository reports a name clash for the credential type and version', async () => {
+    mockUpdateDataModel.mockRejectedValue(
+      new ConflictError('A data model with this name already exists for the credential type and version'),
+    );
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Updated Extension' } });
+    const res = await PATCH(req, createContext('dm-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('A data model with this name already exists for the credential type and version');
+    expect(mockUpdateDataModel).toHaveBeenCalled();
   });
 });
 

--- a/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/data-models/route.test.ts
@@ -52,7 +52,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   createDataModel: (tenantId: string, input: unknown) => mockCreateDataModel(tenantId, input),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { GET, POST } from './route';
 
@@ -715,5 +715,28 @@ describe('POST /api/v1/data-models', () => {
 
     expect(res.status).toBe(400);
     expect(json.error).toMatch(/schemaUrl.*valid URL/);
+  });
+
+  it('returns 409 when the repository reports a name clash for the credential type and version', async () => {
+    mockCreateDataModel.mockRejectedValue(
+      new ConflictError('A data model with this name already exists for the credential type and version'),
+    );
+
+    const req = createFakeRequest({
+      body: {
+        name: 'Custom DPP Extension',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        schemaUrl: 'https://example.com/schema.json',
+        contextUrl: 'https://example.com/context.jsonld',
+        parentConfigId: 'cfg-parent',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('A data model with this name already exists for the credential type and version');
+    expect(mockCreateDataModel).toHaveBeenCalled();
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.test.ts
@@ -52,7 +52,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
     mockFindDidByAliasAndService(alias, serviceInstanceId),
 }));
 
-import { ServiceResolutionError, ServiceInstanceNotFoundError } from '@/lib/api/errors';
+import { ConflictError, ServiceInstanceNotFoundError, ServiceResolutionError } from '@/lib/api/errors';
 import { DidType, DidMethod, DidStatus, DidCreateError, DidDocumentFetchError } from '@uncefact/untp-ri-services';
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { prismaError } from '@/lib/prisma/db-errors.fixtures';
@@ -571,6 +571,30 @@ describe('POST /api/v1/dids', () => {
     expect(mockFindDidByAliasAndService).toHaveBeenCalledWith('existing-alias', 'inst-1');
     expect(mockDidService.create).not.toHaveBeenCalled();
     expect(mockCreateDid).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the DID record itself already exists', async () => {
+    // The third documented cause: the pre-check passes and the provider
+    // succeeds, then the insert hits the unique constraint that createDid
+    // maps to a conflict.
+    mockDidService.normaliseAlias.mockReturnValue('fresh-alias');
+    mockFindDidByAliasAndService.mockResolvedValue(false);
+    mockDidService.create.mockResolvedValue({
+      did: 'did:web:example.com:org:123',
+      keyId: 'key-1',
+      document: { '@context': 'https://www.w3.org/ns/did/v1', id: 'did:web:example.com:org:123' },
+    });
+    mockCreateDid.mockRejectedValueOnce(new ConflictError('A DID record with this DID already exists'));
+
+    const req = createFakeRequest({
+      body: { type: DidType.MANAGED, method: DidMethod.DID_WEB, alias: 'fresh-alias' },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('A DID record with this DID already exists');
+    expect(mockDidService.create).toHaveBeenCalled();
   });
 
   it('returns 409 when upstream provider reports DID already exists', async () => {

--- a/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/[id]/route.test.ts
@@ -59,7 +59,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   deleteIdentifier: (id: string, tenantId: string) => mockDeleteIdentifier(id, tenantId),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { GET, PATCH, DELETE } from './route';
 
@@ -229,6 +229,20 @@ describe('PATCH /api/v1/identifiers/:id', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('Database error');
+  });
+
+  it('returns 409 when the repository reports a duplicate value for the scheme', async () => {
+    mockUpdateIdentifier.mockRejectedValue(
+      new ConflictError('An identifier with this value already exists for the scheme'),
+    );
+
+    const req = createFakeRequest({ method: 'PATCH', body: { value: '09520123456799' } });
+    const res = await PATCH(req, createContext('id-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('An identifier with this value already exists for the scheme');
+    expect(mockUpdateIdentifier).toHaveBeenCalled();
   });
 });
 

--- a/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/identifiers/route.test.ts
@@ -57,7 +57,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   listIdentifiers: (tenantId: string, opts: unknown) => mockListIdentifiers(tenantId, opts),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { DEFAULT_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
@@ -237,6 +237,20 @@ describe('POST /api/v1/identifiers', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('Database error');
+  });
+
+  it('returns 409 when the repository reports a duplicate value for the scheme', async () => {
+    mockCreateIdentifier.mockRejectedValue(
+      new ConflictError('An identifier with this value already exists for the scheme'),
+    );
+
+    const req = createFakeRequest({ body: { schemeId: 'sch-1', value: '09520123456788' } });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('An identifier with this value already exists for the scheme');
+    expect(mockCreateIdentifier).toHaveBeenCalled();
   });
 });
 

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
@@ -43,7 +43,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   deleteProduct: (id: string, tenantId: string) => mockDeleteProduct(id, tenantId),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { ValidationError } from '@/lib/api/validation';
 import { GET, PATCH, DELETE } from './route';
 
@@ -192,6 +192,25 @@ describe('PATCH /api/v1/products/:id', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('Database error');
+  });
+
+  it('returns 409 when the identifier already belongs to another product', async () => {
+    mockUpdateProduct.mockRejectedValue(
+      new ConflictError('The identifier is already the primary identifier of another product'),
+    );
+
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryIdentifierId: 'ident-1' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('The identifier is already the primary identifier of another product');
+    // The identifier the conflict is about must actually reach the repository.
+    expect(mockUpdateProduct).toHaveBeenCalledWith(
+      'p-1',
+      expect.anything(),
+      expect.objectContaining({ primaryIdentifierId: 'ident-1' }),
+    );
   });
 });
 

--- a/packages/reference-implementation/src/app/api/v1/products/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.test.ts
@@ -32,7 +32,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   listProducts: (tenantId: string, opts: unknown) => mockListProducts(tenantId, opts),
 }));
 
-import { NotFoundError } from '@/lib/api/errors';
+import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -163,6 +163,26 @@ describe('POST /api/v1/products', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('Database error');
+  });
+
+  it('returns 409 when an identifier already belongs to another product', async () => {
+    mockCreateProducts.mockRejectedValue(
+      new ConflictError('An identifier in this request is already the primary identifier of another product'),
+    );
+
+    const req = createFakeRequest({
+      body: [{ name: 'Widget A', level: 'MODEL', primaryIdentifierId: 'ident-1' }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('An identifier in this request is already the primary identifier of another product');
+    // The identifier the conflict is about must actually reach the repository.
+    expect(mockCreateProducts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([expect.objectContaining({ primaryIdentifierId: 'ident-1' })]),
+    );
   });
 });
 

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.test.ts
@@ -402,6 +402,21 @@ describe('PATCH /api/v1/schemes/:id', () => {
     expect(mockUpdateIdentifierScheme).not.toHaveBeenCalled();
   });
 
+  it('returns 409 when the repository reports a primary-key clash for the registrar', async () => {
+    // The PATCH 409 documents two causes; the qualifier half is covered below.
+    mockUpdateIdentifierScheme.mockRejectedValue(
+      new ConflictError('An identifier scheme with this primary key already exists for the registrar'),
+    );
+
+    const req = createFakeRequest({ method: 'PATCH', body: { primaryKey: 'gtin' } });
+    const res = await PATCH(req, createContext('sch-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('An identifier scheme with this primary key already exists for the registrar');
+    expect(mockUpdateIdentifierScheme).toHaveBeenCalled();
+  });
+
   it('returns 409 when repository reports a qualifier key conflict', async () => {
     mockUpdateIdentifierScheme.mockRejectedValue(
       new ConflictError('A qualifier with this key already exists for the scheme'),
@@ -453,5 +468,19 @@ describe('DELETE /api/v1/schemes/:id', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('Database error');
+  });
+
+  it('returns 409 when the scheme still has identifiers', async () => {
+    mockDeleteIdentifierScheme.mockRejectedValue(
+      new ConflictError('The identifier scheme has identifiers and cannot be deleted'),
+    );
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('sch-1') as unknown as Parameters<typeof DELETE>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('The identifier scheme has identifiers and cannot be deleted');
+    expect(mockDeleteIdentifierScheme).toHaveBeenCalled();
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/route.test.ts
@@ -37,6 +37,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 }));
 
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+import { ConflictError } from '@/lib/api/errors';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -594,6 +595,28 @@ describe('POST /api/v1/schemes', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('Database error');
+  });
+
+  it('returns 409 when the repository reports a primary-key clash for the registrar', async () => {
+    mockCreateIdentifierScheme.mockRejectedValue(
+      new ConflictError('An identifier scheme with this primary key already exists for the registrar'),
+    );
+
+    const req = createFakeRequest({
+      body: {
+        registrarId: 'reg-1',
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+      },
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe('An identifier scheme with this primary key already exists for the registrar');
+    expect(mockCreateIdentifierScheme).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
A 409 is what the API returns when a request collides with data that already exists: a scheme whose primary key is taken, a product claiming an identifier another product already owns, a scheme that still has identifiers hanging off it. Two thirds of that path was already tested. The mapping from `ConflictError` to a 409 has central tests, and each repository's conflict-throwing query is covered at its own layer.

The untested third was the thin wiring in between, and it is the part that quietly breaks: a handler that catches the error, or rewrites its message, or never reaches the call at all, still returns something plausible. Ten documented conflicts had no route-level test to notice.

This PR adds one test per uncovered conflict. Seven cover route files that documented a 409 and asserted nothing. Two cover operations whose file was already partly covered: the scheme PATCH documents two causes and only the qualifier half was tested, and the scheme DELETE has-dependants case had nothing. The tenth covers the third conflict cause on `POST /dids`, where the persistence-layer unique violation was untested; that file's own comment had already named it as a gap.

Each test rejects the relevant repository call with a `ConflictError` and asserts the route answers 409 with that exact message, which pins that the handler propagates rather than rewriting it. Where the conflict is about a particular field, the request carries that field and the test asserts it reached the repository, so the fixture represents the conflict it names rather than standing in for it.

Two checks establish what the tests are worth rather than assuming it. Breaking the shared `ConflictError` mapping fails all ten plus the pre-existing one, so they are genuinely wired to the behaviour. Making a single route swallow its conflict fails only that route's test, so each guards its own path and they are not redundant with one another.

Worth stating plainly, since it would be easy to read more into them: these tests do not compare the documentation with the implementation. They mock the repository and never read the Swagger, so the message strings are an authoring-time copy of each route's documented description, not a lock on it. The repository suites own the real mappings.

Closes #853
