### PR TITLE
test(ri): cover scheme validation edges against a deployed stack

### DIFF
--- a/packages/reference-implementation/e2e/cypress/e2e/api/scheme_api/scheme-management.cy.ts
+++ b/packages/reference-implementation/e2e/cypress/e2e/api/scheme_api/scheme-management.cy.ts
@@ -227,6 +227,41 @@ describe('Scheme API', { testIsolation: false }, () => {
   });
 
   describe('Validation errors', () => {
+    // Each case owns its fixture: the shared scheme is deleted by the CRUD
+    // block that created it, well before this block runs. Ids are removed in
+    // afterEach rather than inline, so a failing assertion still cleans up.
+    // Cypress abandons the remaining command queue on failure, and a retry
+    // would otherwise re-POST the same primaryKey and hit the uniqueness
+    // constraint, reporting a 409 in place of the original failure.
+    const createdIds: string[] = [];
+
+    afterEach(() => {
+      while (createdIds.length > 0) {
+        const id = createdIds.pop();
+        cy.request({ method: 'DELETE', url: `/api/v1/schemes/${id}`, failOnStatusCode: false });
+      }
+    });
+
+    const createTempScheme = (slug: string, overrides: Record<string, unknown> = {}) =>
+      cy
+        .request({
+          method: 'POST',
+          url: '/api/v1/schemes',
+          body: {
+            registrarId,
+            name: `Temp Scheme ${slug} ${RUN_ID}`,
+            primaryKey: `temp-${slug}-${RUN_ID}`,
+            validationPattern: '.*',
+            linkTemplate: '/{primaryKey}/{value}',
+            ...overrides,
+          },
+        })
+        .then((response) => {
+          expect(response.status).to.eq(201);
+          createdIds.push(response.body.id);
+          return response.body.id as string;
+        });
+
     it('returns 400 when registrarId is missing', () => {
       cy.request({
         method: 'POST',
@@ -326,20 +361,7 @@ describe('Scheme API', { testIsolation: false }, () => {
     });
 
     it('returns 400 when PATCH body is empty', () => {
-      // Create a temp scheme to test PATCH validation
-      cy.request({
-        method: 'POST',
-        url: '/api/v1/schemes',
-        body: {
-          registrarId,
-          name: `Temp Scheme ${RUN_ID}`,
-          primaryKey: `temp-pk-${RUN_ID}`,
-          validationPattern: '.*',
-          linkTemplate: '/{primaryKey}/{value}',
-        },
-      }).then((createResponse) => {
-        const tempId = createResponse.body.id;
-
+      createTempScheme('empty-patch').then((tempId) => {
         cy.request({
           method: 'PATCH',
           url: `/api/v1/schemes/${tempId}`,
@@ -349,8 +371,6 @@ describe('Scheme API', { testIsolation: false }, () => {
           expect(response.status).to.eq(400);
           expect(response.body.error).to.be.a('string');
         });
-
-        cy.request({ method: 'DELETE', url: `/api/v1/schemes/${tempId}` });
       });
     });
 
@@ -407,6 +427,145 @@ describe('Scheme API', { testIsolation: false }, () => {
       }).then((response) => {
         expect(response.status).to.eq(400);
         expect(response.body.error).to.be.a('string');
+      });
+    });
+
+    // The maximum is resolved at startup from API_MAX_PAGE_LIMIT and defaults
+    // to 100; the e2e stack leaves the variable unset, so the default applies.
+    it('returns 400 when limit exceeds the maximum page size', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/schemes?limit=101',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('limit');
+        expect(response.body.error).to.contain('100');
+      });
+    });
+
+    // The value is deliberately within the permitted range once parsed (1e1 is
+    // 10), so only the strict decimal-integer check can reject it. An
+    // out-of-range value such as 1e3 would also be rejected by the maximum
+    // bound, leaving the test green even if scientific notation became
+    // acceptable.
+    it('returns 400 for a limit in scientific notation', () => {
+      cy.request({
+        method: 'GET',
+        url: '/api/v1/schemes?limit=1e1',
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('limit');
+        expect(response.body.error).to.contain('positive integer');
+      });
+    });
+
+    it('returns 400 when a PATCH body carries only unrecognised keys', () => {
+      createTempScheme('unknown-keys').then((tempId) => {
+        cy.request({
+          method: 'PATCH',
+          url: `/api/v1/schemes/${tempId}`,
+          body: { nmae: 'typo', unknownField: true },
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(400);
+          expect(response.body.error).to.contain('At least one field is required');
+        });
+      });
+    });
+
+    it('returns 400 for a non-integer qualifier order', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId,
+          name: `Fractional Order ${RUN_ID}`,
+          primaryKey: `frac-order-${RUN_ID}`,
+          validationPattern: '.*',
+          linkTemplate: '/{primaryKey}/{value}',
+          qualifiers: [{ key: 'lot', description: 'Lot', validationPattern: '.*', order: 1.5 }],
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('qualifiers.0.order');
+      });
+    });
+
+    // The column is a Postgres int4, so a value above its range is rejected at
+    // the boundary rather than reaching the database as a 500.
+    it('returns 400 for a qualifier order beyond the 32-bit range', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId,
+          name: `Overflow Order ${RUN_ID}`,
+          primaryKey: `overflow-order-${RUN_ID}`,
+          validationPattern: '.*',
+          linkTemplate: '/{primaryKey}/{value}',
+          qualifiers: [{ key: 'lot', description: 'Lot', validationPattern: '.*', order: 2147483648 }],
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('qualifiers.0.order');
+      });
+    });
+
+    // Zero is the first resolution position, so it must survive the lower bound
+    // on order. This proves zero is accepted and read back; it cannot prove the
+    // stored value came from the request, because the column defaults to zero
+    // too. That distinction is asserted where it is observable, in the route's
+    // own test against the repository call.
+    it('accepts a qualifier order of zero and reads it back', () => {
+      const qualifiers = [{ key: 'lot', description: 'Lot', validationPattern: '.*', order: 0 }];
+
+      createTempScheme('zero-order', { qualifiers }).then((tempId) => {
+        cy.request(`/api/v1/schemes/${tempId}`).then((response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.qualifiers).to.have.length(1);
+          expect(response.body.qualifiers[0].order).to.eq(0);
+        });
+      });
+    });
+
+    it('returns 400 for a negative qualifier order', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId,
+          name: `Negative Order ${RUN_ID}`,
+          primaryKey: `negative-order-${RUN_ID}`,
+          validationPattern: '.*',
+          linkTemplate: '/{primaryKey}/{value}',
+          qualifiers: [{ key: 'lot', description: 'Lot', validationPattern: '.*', order: -1 }],
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('qualifiers.0.order');
+      });
+    });
+
+    it('returns 400 for a validationPattern that is not a valid regular expression', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/schemes',
+        body: {
+          registrarId,
+          name: `Bad Pattern ${RUN_ID}`,
+          primaryKey: `bad-pattern-${RUN_ID}`,
+          validationPattern: '[unclosed',
+          linkTemplate: '/{primaryKey}/{value}',
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.error).to.contain('validationPattern');
       });
     });
   });

--- a/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/identifier-scheme.repository.test.ts
@@ -127,6 +127,37 @@ describe('identifier-scheme.repository', () => {
       expect(result).toEqual(SCHEME_RECORD);
     });
 
+    // `order` is optional and the column defaults to 0, so a caller asking for
+    // 0 explicitly and a caller omitting it are indistinguishable in the
+    // stored row. The distinction lives in the payload, and a truthiness test
+    // in place of the undefined check would drop the explicit 0 silently.
+    it.each([
+      ['zero', 0],
+      ['a positive order', 2],
+    ])('forwards a qualifier order of %s to the nested create', async (_label, order) => {
+      mockIdentifierScheme.create.mockResolvedValue(SCHEME_RECORD);
+
+      await createIdentifierScheme({
+        tenantId: TENANT_ID,
+        registrarId: REGISTRAR_ID,
+        name: 'GTIN',
+        primaryKey: 'gtin',
+        validationPattern: '^\\d{13,14}$',
+        linkTemplate: '/{primaryKey}/{value}',
+        qualifiers: [{ key: 'batch', description: 'Batch number', validationPattern: '^[A-Za-z0-9]{1,20}$', order }],
+      });
+
+      expect(mockIdentifierScheme.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            qualifiers: {
+              create: [{ key: 'batch', description: 'Batch number', validationPattern: '^[A-Za-z0-9]{1,20}$', order }],
+            },
+          }),
+        }),
+      );
+    });
+
     it('creates a scheme without qualifiers', async () => {
       const recordWithoutQualifiers = { ...SCHEME_RECORD, qualifiers: [] };
       mockIdentifierScheme.create.mockResolvedValue(recordWithoutQualifiers);
@@ -413,6 +444,32 @@ describe('identifier-scheme.repository', () => {
           qualifiers: true,
           registrar: true,
         },
+      });
+    });
+
+    it.each([
+      ['zero', 0],
+      ['a positive order', 2],
+    ])('forwards a qualifier order of %s to the replacement createMany', async (_label, order) => {
+      mockTx.identifierScheme.findFirst.mockResolvedValue(SCHEME_RECORD);
+      mockTx.schemeQualifier.deleteMany.mockResolvedValue({ count: 1 });
+      mockTx.schemeQualifier.createMany.mockResolvedValue({ count: 1 });
+      mockTx.identifierScheme.update.mockResolvedValue(SCHEME_RECORD);
+
+      await updateIdentifierScheme('scheme-1', TENANT_ID, {
+        qualifiers: [{ key: 'serial', description: 'Serial number', validationPattern: '^[A-Z0-9]+$', order }],
+      });
+
+      expect(mockTx.schemeQualifier.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            schemeId: 'scheme-1',
+            key: 'serial',
+            description: 'Serial number',
+            validationPattern: '^[A-Z0-9]+$',
+            order,
+          },
+        ],
       });
     });
 


### PR DESCRIPTION
The scheme API E2E suite asserted the pre-#791 contract. This PR adds the edges #791 introduced, so the deployed stack is checked to honour the same contract the route-level Jest suites already assert against mocked repositories.

Eight cases: a `limit` above the maximum rejected rather than clamped, a `limit` in scientific notation rejected, a PATCH body of only unrecognised keys rejected rather than applied as a silent no-op, a fractional qualifier `order` rejected, one beyond the 32-bit range rejected, a negative one rejected, `order: 0` accepted and read back, and a `validationPattern` that does not compile rejected.

Closes #854

Three choices worth a reviewer's attention.

The scientific-notation case uses `limit=1e1` rather than `1e3`. `1e3` parses to 1000, which is over the maximum, so it would be rejected by the bound even if the strict decimal check were removed, and the test would stay green while the thing it guards was broken. `1e1` parses to 10, inside the range, so only the strict check can reject it.

The `order: 0` case proves zero is accepted and read back. It cannot prove the stored zero came from the request, because the column defaults to zero as well. That distinction is asserted a layer down: the route's test proves the route hands `order: 0` to the repository, and the repository's tests prove it survives into the Prisma payload on both the create and the qualifier-replacement path. Those repository tests are new here. The guard is an `!== undefined` check on both sites and nothing exercised it, so rewriting it as a truthiness test would have dropped an explicit zero with every suite still green.

Cleanup moved into an `afterEach` draining the ids each test created. Cypress abandons the remaining command queue when an assertion fails, so an inline delete is skipped exactly when it is needed, and the retry then hits the `primaryKey` uniqueness constraint and reports a 409 in place of the original failure. The block's pre-existing fixture moved onto the same helper so there is one cleanup path rather than two.

These run in the RI E2E matrix in CI, in both open and closed modes.

