### PR TITLE
feat(ri): fail the seed loudly when required configuration is missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,10 @@ VERIFY_ALLOW_PRIVATE_URLS=true
 # Seed Control
 # SKIP_SEED=true           # Skip core database seed
 # SKIP_CUSTOM_SEED=true    # Skip custom seed (deployer-provided data from /app/seed/custom/)
+# A category the seed was asked to configure (service instances, the default DID, render templates) fails
+# the whole seed by default when its required environment variables are missing. Set SEED_ALLOW_PARTIAL=true
+# to seed whatever is configured and skip the rest with a warning instead.
+# SEED_ALLOW_PARTIAL=true
 
 # Logging
 # Minimum log level: debug, info, warn, error

--- a/docs/adrs/043-seed-fails-loudly-on-missing-configuration.md
+++ b/docs/adrs/043-seed-fails-loudly-on-missing-configuration.md
@@ -1,0 +1,67 @@
+# ADR: The seed fails loudly when configuration for a category it was asked to seed is missing
+
+- **Date:** 2026-08-16
+- **Status:** accepted
+- **Update (2026-08-16):** the summary decision 6 describes is also emitted on a mid-run failure (a category whose configuration resolved but whose own write then failed), not only on the default-mode preflight abort and on success. It also distinguishes a category that completed only some of its work (for example, some but not all render template files found) from one that fully seeded, reporting the former under a `categoriesPartial` bucket with the specifics named, rather than folding it into `categoriesSeeded`. The summary also now covers the system tenant, the core data models, and the custom seed, not only the categories a missing environment variable can gate.
+- **Update (2026-08-16):** decision 2 is tightened. A missing required environment variable always triggers the fail-loud posture, even when the same category also contains an invalid value or names an unrecognised adapter type: the presence of a missing variable is decided independently of any other problem in the category, so a second, unrelated mistake can never downgrade an absent variable out of the fail-loud posture. An invalid value with nothing missing keeps its original behaviour (`'other'`, not fail-loud).
+
+## Context
+
+Issue #771 asks for this because a half-configured deployment currently starts successfully and only reveals itself much later, when someone tries to issue or resolve a credential and hits a missing service instance, DID, or render template. Fixing that at seed time is what unblocks treating a green container start as evidence the deployment is usable.
+
+The seed (`prisma/seed.ts`, run from the container entrypoint) creates the system tenant, registrars, identifier schemes, data models, service instances for the IDR, storage and VC services, the default DID, and render templates. Several of those categories need environment variables: `DATA_ENCRYPTION_KEY` for any service instance, the `SYSTEM_IDR_*`, `SYSTEM_STORAGE_*` and `SYSTEM_VC_*` groups for their respective services, and `SYSTEM_DID` for the default DID. Render templates additionally need the storage service to have been seeded.
+
+Today every one of those cases is a warning and a skip. The seed exits zero, the entrypoint proceeds, and the container reports healthy. `documentation/docs/reference-implementation/operations/startup.md` documents this as the intended contract, under "Seed contents": each category is independent, and a category whose variable is missing is skipped with a warning while the rest proceed.
+
+The cost is that the signal is a log line nobody reads at the moment it matters. An operator who mistypes a variable name, or whose secret injection silently fails, gets a running system that cannot do its job, and discovers this through a downstream failure whose message points at the symptom rather than the missing variable.
+
+The custom seed, which loads an operator-supplied manifest in the same run, already takes the opposite posture: a configuration-level problem (unparseable YAML, a schema violation, render templates requested with no storage service available) exits non-zero and stops the boot. So the two halves of the same seed currently disagree about what a missing prerequisite means.
+
+A partial seed is nonetheless a real workflow. An operator may deliberately bring the system up with only some services configured and add the rest later through the application, and that use must remain available as a stated choice rather than an accident.
+
+## Decision
+
+**1. A category whose required environment variables are missing fails the seed by default.** The seed exits non-zero, and because the entrypoint runs under `set -e`, the container does not start. This inverts the current default because a container that starts without the configuration it needs is indistinguishable, from the outside, from one that started correctly, and the difference only surfaces when a user's request fails.
+
+**2. Only missing variables carry this meaning; operational failures keep the behaviour they have today.** A variable that is absent is a deployment mistake the operator can fix before the system serves traffic. A storage service that is unreachable, an unknown adapter type, an invalid value, or a database error are different failures with different remedies, and today's broad `try`/`catch` blocks label all of them "configuration not available". Widening the fail-loud posture to cover them would turn a transient dependency outage into a failed deployment, so the change narrows those catches instead of repurposing them.
+
+**3. Configuration is resolved for every category before any category executes, and a default-mode failure happens before the seed writes anything or calls any external service.** The seed's later steps create a DID in the VC service and upload template objects to storage, neither of which is covered by the database transaction. Attempting every category and failing at the end would leave those external effects behind on a boot that then failed, so the check has to precede the work rather than accumulate alongside it.
+
+**4. All missing variables are reported together, not the first one found.** An operator fixing a deployment wants the complete list in one boot cycle rather than discovering the next missing variable after each redeploy.
+
+**5. `SEED_ALLOW_PARTIAL=true` restores the skip behaviour as a chosen state.** The variable is read as the exact string `true`, and this is stated as a new contract rather than inherited from a convention: the existing `SKIP_*` flags do not parse uniformly (the entrypoint's `SKIP_MIGRATIONS`, `SKIP_BACKFILLS` and `SKIP_SEED` proceed only when the value is exactly `false`, while `SKIP_CUSTOM_SEED` skips only when the value is exactly `true`). One variable covers the whole seed rather than one per category, because the workflow it serves is a single intent, "bring this up with what is configured and add the rest later", and per-category flags would multiply deployment configuration for a distinction nobody has needed.
+
+**6. Every run ends with one structured summary naming the categories seeded, the categories skipped, and the variables responsible.** This holds on success as well as failure, so an operator confirming a good deployment reads the same record as one diagnosing a bad one, and neither has to reconstruct the outcome from scattered log lines. In default mode the aggregate error carries the same object.
+
+## Consequences
+
+An operator who misconfigures a deployment learns at deploy time, from a message naming each missing variable and the category it gates, instead of from a failed credential issuance later.
+
+A deployment that relies on today's silent partial seed across restarts will fail to start after upgrading until `SEED_ALLOW_PARTIAL=true` is set. This is a breaking change for those deployments and is why the change carries a migration note; the documented startup paths (copying `.env.example` before starting Compose, and the E2E Compose stack) populate every variable and are unaffected.
+
+The seed gains a separation between resolving configuration and executing categories. That is a structural change to a file that is currently one long procedure, and it makes the categories individually testable, but it also means the file no longer reads top to bottom as the order things happen.
+
+Making that separation testable also splits the executable from the logic. `prisma/seed.ts` exports `main` and no longer runs itself; a new `prisma/seed-cli.ts` owns the process-level concerns (catching, the exit code, disconnecting) and is what the container entrypoint and the `prisma.seed` script now invoke. Anything that invoked `seed.ts` directly must move to `seed-cli.ts`, and the seed's script-relative paths (the `.env` lookup and the render-template directory) now derive from the running script's path rather than the module's own URL.
+
+Narrowing the existing catch blocks makes the failure modes distinguishable, at the cost of more branches in code that previously handled everything the same way.
+
+The seed still leaves a partially populated database when an operational failure interrupts it mid-run, because DID creation and template upload cannot be rolled back with the database writes. The upserts are idempotent, so a corrected re-run converges; the change does not make the seed transactional and does not claim to.
+
+## Alternatives Considered
+
+**Keep warn-and-skip and rely on a health check or startup probe to detect the missing pieces.** Rejected. It defers the signal to a second mechanism that must independently know what "fully configured" means, duplicating the seed's own knowledge of which categories need which variables, and it leaves the window where the container reports healthy while being unusable.
+
+**Fail on the first missing variable rather than collecting them.** Rejected. Each redeploy would reveal one more missing variable, turning a single misconfiguration into several deploy cycles, and the information needed to list them all is available at the same moment as the first.
+
+**Attempt every category, then fail at the end if any were skipped.** Rejected. The later categories create a DID in the VC service and upload objects to storage before their database rows exist. A run that did that work and then exited non-zero would leave external state behind for a boot that failed, which is harder to reason about than refusing before any of it happens.
+
+**A per-category opt-in (for example `SEED_ALLOW_PARTIAL_DID`).** Rejected. It multiplies deployment configuration to express a distinction the supported workflow does not draw: the case being served is bringing the system up with whatever is configured, not permitting one specific category to be absent while forbidding another.
+
+**Extend the fail-loud posture to every failure the current catch blocks cover, including an unreachable storage service.** Rejected. Compose starts the storage service without waiting for it to become healthy, so the seed can legitimately run before storage accepts uploads. Treating that as fatal would make a documented startup path fail intermittently for a reason the operator cannot fix by changing configuration.
+
+## References
+
+- Issue [#771](https://github.com/uncefact/tests-untp/issues/771), which asks for this posture change, the opt-in, and the summary.
+- Issue [#762](https://github.com/uncefact/tests-untp/issues/762), which catches invalid configuration at application boot; this ADR covers missing configuration at seed time.
+- `documentation/docs/reference-implementation/operations/startup.md`, "Seed contents", whose statement that a category with a missing variable is skipped with a warning is superseded by this decision and updated alongside it.
+- ADR-033, which records the custom seed's architecture; its loader already exits non-zero on configuration-level problems, and this decision brings the core seed into line.

--- a/documentation/docs/reference-implementation/operations/startup.md
+++ b/documentation/docs/reference-implementation/operations/startup.md
@@ -48,8 +48,8 @@ Each version of the Reference Implementation may include changes to the database
 
 If the database is already up to date, this step completes immediately.
 
-| Variable | Description | Default |
-|----------|-------------|---------|
+| Variable          | Description                                | Default |
+| ----------------- | ------------------------------------------ | ------- |
 | `SKIP_MIGRATIONS` | Set to `true` to skip automatic migrations | `false` |
 
 Set `SKIP_MIGRATIONS=true` if your deployment process applies migrations separately, for example in a CI/CD pipeline. This also skips the backfills in step 2, so a deployment that applies migrations out of band runs the backfills out of band too. The [digest multibase backfill reference](./backfills/digest-multibase) gives the command for the one that runs there today.
@@ -72,33 +72,40 @@ Conversions that cannot be undone are deliberately kept out of this step and shi
 
 ## Step 3: Database Seed
 
-After migrations and backfills, the entrypoint script runs the [seed script](https://github.com/uncefact/tests-untp/blob/main/packages/reference-implementation/prisma/seed.ts) to create a set of system default records that the Reference Implementation needs to function. These are the baseline records that every instance requires — the data that makes the system usable out of the box.
+After migrations and backfills, the entrypoint script runs the [seed script](https://github.com/uncefact/tests-untp/blob/main/packages/reference-implementation/prisma/seed-cli.ts) to create a set of system default records that the Reference Implementation needs to function. These are the baseline records that every instance requires — the data that makes the system usable out of the box.
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `SKIP_SEED` | Set to `true` to skip automatic seeding | `false` |
+| Variable             | Description                                                                                                                             | Default |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `SKIP_SEED`          | Set to `true` to skip automatic seeding                                                                                                 | `false` |
+| `SEED_ALLOW_PARTIAL` | Set to `true` to seed whichever categories below are configured and skip the rest with a warning, instead of failing (see next section) | `false` |
 
 ### What gets seeded
 
-The seed creates the following defaults. Each category is independent — if a required environment variable is missing, that category is skipped with a warning and the rest still proceed.
+The seed creates the defaults listed below. Some categories need their own environment variables (service instances, the default DID, render templates); the system tenant, registrars, identifier schemes and data models need none and always seed.
 
-| What | Description | Additional Environment Variables Required |
-|------|-------------|------------------------------------------|
-| System tenant | An internal tenant that owns all system default records | None |
-| Registrars | Identifier registrars (GS1, Australian Business Register, ASIC) | None |
-| Identifier schemes | Identifier types (GTIN, GLN, ABN, ACN) with validation patterns and qualifiers | None |
-| Data models | UNTP credential types (DPP, DCC, DFR, DIA, DTE) for each supported spec version, with their schema and context URLs | None |
-| Service instances | Default [verifiable credential](../services/verifiable-credential-service), [storage](../services/storage-service), and [identity resolver](../services/identity-resolver-service) service instances — see each service's page for the required environment variables and what they do | `DATA_ENCRYPTION_KEY` and each service's `SYSTEM_*` variables |
-| Default DID | A system Decentralised Identifier (DID) created via the verifiable credential service | `SYSTEM_DID` and `SYSTEM_VC_*` variables |
-| Render templates | Default HTML render templates for each data model, uploaded to the storage service | `SYSTEM_STORAGE_*` variables (storage service must be reachable) |
+**By default, a category whose required environment variables are missing fails the whole seed before it writes anything**, and the container does not start. This surfaces a misconfigured deployment at deploy time, naming every missing variable in one boot cycle, rather than as a downstream failure once someone tries to issue or resolve a credential. Set `SEED_ALLOW_PARTIAL=true` to restore the previous behaviour instead: eligible categories seed, and categories with missing variables are skipped with a warning while the rest still proceed. This suits a deployment that is intentionally brought up with only some services configured, with the rest added later through the application.
 
-For example, if `DATA_ENCRYPTION_KEY` is not set, the service instances, default DID, and render templates are all skipped — but the system tenant, registrars, identifier schemes, and data models are still created. The skipped items must be configured before the system can issue, store, or resolve credentials — ensure all required environment variables are set.
+| What               | Description                                                                                                                                                                                                                                                                            | Additional Environment Variables Required                        |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| System tenant      | An internal tenant that owns all system default records                                                                                                                                                                                                                                | None                                                             |
+| Registrars         | Identifier registrars (GS1, Australian Business Register, ASIC)                                                                                                                                                                                                                        | None                                                             |
+| Identifier schemes | Identifier types (GTIN, GLN, ABN, ACN) with validation patterns and qualifiers                                                                                                                                                                                                         | None                                                             |
+| Data models        | UNTP credential types (DPP, DCC, DFR, DIA, DTE) for each supported spec version, with their schema and context URLs                                                                                                                                                                    | None                                                             |
+| Service instances  | Default [verifiable credential](../services/verifiable-credential-service), [storage](../services/storage-service), and [identity resolver](../services/identity-resolver-service) service instances — see each service's page for the required environment variables and what they do | `DATA_ENCRYPTION_KEY` and each service's `SYSTEM_*` variables    |
+| Default DID        | A system Decentralised Identifier (DID) created via the verifiable credential service                                                                                                                                                                                                  | `SYSTEM_DID` and `SYSTEM_VC_*` variables                         |
+| Render templates   | Default HTML render templates for each data model, uploaded to the storage service                                                                                                                                                                                                     | `SYSTEM_STORAGE_*` variables (storage service must be reachable) |
+
+For example, with `SEED_ALLOW_PARTIAL=true` and `DATA_ENCRYPTION_KEY` not set, the service instances, default DID, and render templates are all skipped — but the system tenant, registrars, identifier schemes, and data models are still created. The skipped items must be configured before the system can issue, store, or resolve credentials.
+
+Every seed run, whichever mode it ran in, ends with one structured summary naming the categories seeded, the categories skipped, and the variables responsible, so confirming a healthy deployment and diagnosing a misconfigured one both read the same record.
+
+**Migrating from the previous default:** deployments that relied on the old skip-and-continue behaviour across restarts (for example, a deployment intentionally running with only some services configured) will fail to start after upgrading until `SEED_ALLOW_PARTIAL=true` is set. The documented startup paths — copying `.env.example` before starting Compose, and the E2E Compose stack — populate every variable and are unaffected.
 
 When `DATA_ENCRYPTION_KEY` is set, the seed validates it against any existing encrypted data before it writes any service instance configuration (the system tenant and other non-encrypted records may already exist by that point): see [Encryption Key Validation](#encryption-key-validation) below for what this checks and how it fails.
 
 ### Customising seed data
 
-The seed script is located at `packages/reference-implementation/prisma/seed.ts` in the [repository](https://github.com/uncefact/tests-untp). Organisations that need additional seed data — custom registrars, identifier schemes, data models, render templates, or conformity schemes — supply it via a Docker volume mount, without modifying the source. See [Custom Seed](./custom-seed.md).
+The seed script is located at `packages/reference-implementation/prisma/seed-cli.ts` (which runs the logic in `prisma/seed.ts`) in the [repository](https://github.com/uncefact/tests-untp). Organisations that need additional seed data — custom registrars, identifier schemes, data models, render templates, or conformity schemes — supply it via a Docker volume mount, without modifying the source. See [Custom Seed](./custom-seed.md).
 
 Render templates are loaded from `packages/reference-implementation/src/templates/` and uploaded to the storage service during seeding. To customise the default templates, replace the `.hbs` files in this directory before building the Docker image, or supply additional templates through the custom seed.
 
@@ -114,12 +121,12 @@ Before the application accepts its first request, it validates `RI_APP_URL` (the
 
 Before the application accepts its first request, it validates the active `DATA_ENCRYPTION_KEY` by decrypting one existing encrypted value — a service instance configuration, or (when no service instance has a usable one, whether because none exists yet or because every existing configuration is corrupted) a protected credential decryption key. This runs once per process start, using the same check the [seed](#step-3-database-seed) already runs before it writes.
 
-| Situation | Result |
-|-----------|--------|
-| The key decrypts the sample value | Startup proceeds normally |
-| Nothing is encrypted yet (fresh deployment, `DATA_ENCRYPTION_KEY` not yet configured) | Startup proceeds normally — there is nothing to validate against |
-| The key cannot decrypt the sample value | Startup fails with a named error identifying the row that failed to decrypt |
-| `DATA_ENCRYPTION_KEY` is still the placeholder value from `.env.example` | Startup fails outside local development (`DEPLOYMENT_ENVIRONMENT` unset or `local` is treated as local development); a warning is logged and startup proceeds within it |
+| Situation                                                                             | Result                                                                                                                                                                  |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The key decrypts the sample value                                                     | Startup proceeds normally                                                                                                                                               |
+| Nothing is encrypted yet (fresh deployment, `DATA_ENCRYPTION_KEY` not yet configured) | Startup proceeds normally — there is nothing to validate against                                                                                                        |
+| The key cannot decrypt the sample value                                               | Startup fails with a named error identifying the row that failed to decrypt                                                                                             |
+| `DATA_ENCRYPTION_KEY` is still the placeholder value from `.env.example`              | Startup fails outside local development (`DEPLOYMENT_ENVIRONMENT` unset or `local` is treated as local development); a warning is logged and startup proceeds within it |
 
 Without this check, a `DATA_ENCRYPTION_KEY` that does not match the key data was encrypted under only surfaces once a real request tries to decrypt something — for example a `ConfigDecryptionError` when a service instance resolves. Validating at startup turns that into an immediate, loud failure instead of an intermittent one discovered by end users.
 

--- a/packages/reference-implementation/README.md
+++ b/packages/reference-implementation/README.md
@@ -98,7 +98,9 @@ packages/reference-implementation/
 ├── prisma/
 │   ├── prisma.config.ts       # Database connection configuration
 │   ├── schema.prisma          # Schema definition
-│   └── seed.ts                # System tenant and default data seeding
+│   ├── seed.ts                # System tenant and default data seeding
+│   ├── seed-cli.ts            # Seed entrypoint (invoked by Docker and `prisma.seed`)
+│   └── seed-preflight.ts      # Required-variable checks run before seeding writes anything
 └── src/lib/prisma/
     ├── generated/             # Auto-generated Prisma client
     └── prisma.ts              # Prisma client instance

--- a/packages/reference-implementation/__tests__/integration/reconcile-data-loss.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/reconcile-data-loss.integration.test.ts
@@ -195,11 +195,17 @@ registrars:
       },
     });
 
+    // A configuration-level problem (here, a manifest id colliding with a
+    // core-seeded row) is a typed CustomSeedFatalError, not a direct
+    // process.exit(1): the process is terminated exclusively by
+    // seed-cli.ts, never from inside the custom seed itself, so the
+    // failure still reaches main()'s summary (Blocker finding 1).
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);
     try {
-      await expect(runManifest(FULL_MANIFEST)).rejects.toThrow('process.exit(1)');
+      await expect(runManifest(FULL_MANIFEST)).rejects.toThrow(/belongs to a core-seeded row/);
+      expect(exitSpy).not.toHaveBeenCalled();
     } finally {
       exitSpy.mockRestore();
     }
@@ -322,11 +328,14 @@ dataModels:
     schemaUrl: https://example.com/hijack.json
     contextUrl: https://example.com/hijack-context.jsonld
 `;
+    // See the earlier collision test's comment: this is a typed
+    // CustomSeedFatalError, not a direct process.exit(1) (Blocker finding 1).
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);
     try {
-      await expect(runManifest(manifest)).rejects.toThrow('process.exit(1)');
+      await expect(runManifest(manifest)).rejects.toThrow(/belongs to a core-seeded row/);
+      expect(exitSpy).not.toHaveBeenCalled();
     } finally {
       exitSpy.mockRestore();
     }

--- a/packages/reference-implementation/__tests__/integration/seed-preflight.integration.test.ts
+++ b/packages/reference-implementation/__tests__/integration/seed-preflight.integration.test.ts
@@ -1,0 +1,663 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { createRigClient, truncateApplicationTables } from './rig/db';
+import { startFixtureServer, type FixtureServer } from './rig/fixture-server';
+import { SYSTEM_TENANT_ID } from './fixtures';
+import { main as runSeedMain, prisma as seedPrisma, logger as seedLogger } from '../../prisma/seed';
+import { SeedConfigurationError, type SeedRunSummary } from '../../prisma/seed-preflight';
+
+/**
+ * Drives the real seed's decision path (ADR-043) — `main()` from
+ * `prisma/seed.ts`, the same function the CLI entrypoint calls — directly
+ * against the rig database, with a deliberately incomplete environment.
+ *
+ * This does not go through a child process. `prisma/` is ESM-scoped (its
+ * own `package.json`) while `src/` is not, and a raw `tsx prisma/seed.ts`
+ * subprocess crossing that boundary depends on a marker the production
+ * Dockerfile writes at build time; this test environment doesn't reproduce
+ * that step, and `tsx` mis-resolves the cross-boundary named imports as a
+ * result. Jest's own module loader has no such boundary, so importing and
+ * calling `main()` exercises the identical preflight-then-execute logic
+ * without it. The process-level contract this sidesteps — a non-zero exit
+ * code from `tsx prisma/seed.ts`, and `set -e` in the entrypoint refusing
+ * to start the container — is covered by manual container validation
+ * rather than by this suite.
+ */
+const SEED_CONFIG_VARS = [
+  'DATA_ENCRYPTION_KEY',
+  'SERVICE_ENCRYPTION_KEY',
+  'SYSTEM_IDR_ADAPTER_TYPE',
+  'SYSTEM_IDR_BASE_URL',
+  'SYSTEM_IDR_API_KEY',
+  'SYSTEM_IDR_API_VERSION',
+  'SYSTEM_IDR_DEFAULT_LINK_TYPE',
+  'SYSTEM_IDR_DEFAULT_MIME_TYPE',
+  'SYSTEM_IDR_DEFAULT_LANGUAGE',
+  'SYSTEM_IDR_DEFAULT_CONTEXT',
+  'SYSTEM_IDR_DEFAULT_FWQS',
+  'SYSTEM_STORAGE_ADAPTER_TYPE',
+  'SYSTEM_STORAGE_BASE_URL',
+  'SYSTEM_STORAGE_API_KEY',
+  'SYSTEM_STORAGE_API_VERSION',
+  'SYSTEM_STORAGE_PUBLIC_BUCKET',
+  'SYSTEM_STORAGE_PRIVATE_BUCKET',
+  'SYSTEM_VC_ADAPTER_TYPE',
+  'SYSTEM_VC_BASE_URL',
+  'SYSTEM_VC_API_KEY',
+  'SYSTEM_VC_API_VERSION',
+  'SYSTEM_DID',
+  'SYSTEM_DID_KEY_ID',
+  'SEED_ALLOW_PARTIAL',
+  'DEPLOYMENT_ENVIRONMENT',
+];
+
+/**
+ * Runs `fn` with `process.env` set to exactly the seed-relevant variables
+ * this test controls (everything else the outer process already has stays
+ * put), then restores every touched variable afterwards, so one test's
+ * environment can never leak into the next.
+ */
+async function withSeedEnv<T>(overrides: Record<string, string>, fn: () => Promise<T>): Promise<T> {
+  const previous = new Map(SEED_CONFIG_VARS.map((key) => [key, process.env[key]]));
+  for (const key of SEED_CONFIG_VARS) delete process.env[key];
+  process.env.SKIP_CUSTOM_SEED = 'true';
+  Object.assign(process.env, overrides);
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    delete process.env.SKIP_CUSTOM_SEED;
+  }
+}
+
+type SeedModule = typeof import('../../prisma/seed');
+
+/**
+ * `seed.ts` resolves DATA_ENCRYPTION_KEY once at module load (so a
+ * divergent DATA_ENCRYPTION_KEY / SERVICE_ENCRYPTION_KEY throws before
+ * anything else runs, not partway through), which means the encryption
+ * key `main()` actually uses cannot be changed by setting the environment
+ * variable after the module the test file imports at the top has already
+ * loaded. A scenario that needs a real encryption key therefore resets
+ * Jest's module registry and re-imports `seed.ts` fresh, inside the same
+ * environment window `withSeedEnv` opens, so this one load picks up the
+ * key. The resulting module's own `main`, `prisma` and `logger` are
+ * distinct objects from the ones imported at the top of this file (a
+ * fresh class per reset also means its errors are not `instanceof` the
+ * classes imported at the top, hence checking error identity by `.name`
+ * rather than `instanceof` in the tests that use this).
+ */
+async function withFreshSeedModule<T>(
+  overrides: Record<string, string>,
+  fn: (seedModule: SeedModule) => Promise<T>,
+): Promise<T> {
+  return withSeedEnv(overrides, async () => {
+    jest.resetModules();
+    const seedModule = await import('../../prisma/seed');
+    try {
+      return await fn(seedModule);
+    } finally {
+      await seedModule.prisma.$disconnect();
+    }
+  });
+}
+
+describe('seed.ts: fails loudly on missing configuration (ADR-043)', () => {
+  const prisma = createRigClient();
+
+  beforeEach(async () => {
+    await truncateApplicationTables(prisma);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await seedPrisma.$disconnect();
+  });
+
+  it('default mode: aborts before any write, naming every missing variable and the opt-out', async () => {
+    let caught: SeedConfigurationError | undefined;
+    try {
+      await withSeedEnv({}, runSeedMain);
+    } catch (error) {
+      caught = error as SeedConfigurationError;
+    }
+    expect(caught).toBeInstanceOf(SeedConfigurationError);
+    expect(caught!.message).toMatch(/SEED_ALLOW_PARTIAL=true/);
+    expect(caught!.summary.categoriesNotRun.sort()).toEqual(
+      ['did', 'idr', 'renderTemplates', 'storage', 'vc', 'tenant', 'dataModels', 'customSeed'].sort(),
+    );
+    expect(Object.keys(caught!.summary.missingVariables)).toEqual(
+      expect.arrayContaining(['encryption', 'idr', 'storage', 'vc', 'did', 'renderTemplates']),
+    );
+
+    // Every mention of a category the seed would otherwise have written is
+    // in the summary, but nothing actually reached the database — not even
+    // the system tenant, which carries no gated configuration itself.
+    expect(await prisma.tenant.count()).toBe(0);
+    expect(await prisma.serviceInstance.count()).toBe(0);
+    expect(await prisma.did.count()).toBe(0);
+    expect(await prisma.renderTemplate.count()).toBe(0);
+  });
+
+  it('default mode: a divergent encryption key alongside an unrelated missing variable names BOTH in the abort message (Major finding 2)', async () => {
+    // Before this fix, the preflight abort message and its `otherIssuesByCategory`
+    // dropped a divergent DATA_ENCRYPTION_KEY/SERVICE_ENCRYPTION_KEY pair
+    // entirely whenever an unrelated category (here, SYSTEM_IDR_BASE_URL)
+    // was the one that actually triggered `hasMissing`. Both problems must
+    // be visible in the same boot cycle.
+    let caught: SeedConfigurationError | undefined;
+    try {
+      await withSeedEnv(
+        {
+          DATA_ENCRYPTION_KEY: 'key-one',
+          SERVICE_ENCRYPTION_KEY: 'key-two',
+        },
+        runSeedMain,
+      );
+    } catch (error) {
+      caught = error as SeedConfigurationError;
+    }
+    expect(caught).toBeInstanceOf(SeedConfigurationError);
+    expect(caught!.message).toMatch(/idr: SYSTEM_IDR_BASE_URL/);
+    expect(caught!.message).toMatch(/encryption: DATA_ENCRYPTION_KEY and SERVICE_ENCRYPTION_KEY are both set/);
+    expect(caught!.summary.invalidSiblings.encryption).toMatch(/both set with different values/);
+    expect(await prisma.tenant.count()).toBe(0);
+  });
+
+  it('default mode: main() itself logs nothing before throwing, so the one caller who logs the caught error does not double the summary (BLOCKER 2a)', async () => {
+    // `SeedConfigurationError` already carries the summary as `.summary`,
+    // and the one real caller (seed-cli.ts) logs the caught error with
+    // pino, whose default err serializer expands every own property —
+    // including `.summary` — into the log line. If `main()` ALSO logged
+    // the summary itself before throwing, an operator would see the same
+    // summary twice for one run, which is exactly what this test guards
+    // against by asserting `main()` logs nothing on this path.
+    const errorSpy = jest.spyOn(seedLogger, 'error');
+    try {
+      await expect(withSeedEnv({}, runSeedMain)).rejects.toBeInstanceOf(SeedConfigurationError);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('a divergent DATA_ENCRYPTION_KEY / SERVICE_ENCRYPTION_KEY still emits the summary once, rather than an uncaught exception with none at all (BLOCKER 2b)', async () => {
+    // resolveDataEncryptionKey() used to run at module load, before main()
+    // (and its try/catch) existed, so this failure was an unhandled
+    // exception at import time with no summary and no structured log at
+    // all. It now runs as the first statement inside main()'s try block,
+    // so the same mid-run failure handling that covers every other
+    // interruption covers this one too.
+    let caught: unknown;
+    let errorCalls: unknown[][] = [];
+
+    await withFreshSeedModule(
+      {
+        DATA_ENCRYPTION_KEY: 'a-real-key',
+        SERVICE_ENCRYPTION_KEY: 'a-different-key',
+        SEED_ALLOW_PARTIAL: 'true',
+      },
+      async (seedModule) => {
+        const errorSpy = jest.spyOn(seedModule.logger, 'error');
+        try {
+          await seedModule.main();
+        } catch (error) {
+          caught = error;
+        } finally {
+          errorCalls = errorSpy.mock.calls as unknown[][];
+          errorSpy.mockRestore();
+        }
+      },
+    );
+
+    expect((caught as Error)?.message).toMatch(
+      /DATA_ENCRYPTION_KEY and SERVICE_ENCRYPTION_KEY are both set with different values/,
+    );
+    expect((caught as Error)?.name).not.toBe('SeedConfigurationError');
+
+    const summaryCall = errorCalls.find(
+      ([, message]) => message === 'Seed failed partway through; the summary reflects what did complete',
+    );
+    expect(summaryCall).toBeDefined();
+    const [{ summary }] = summaryCall as [{ summary: SeedRunSummary }, string];
+    // The throw happens before even the tenant upsert, so nothing ran.
+    expect(summary.categoriesSeeded).toEqual([]);
+    expect(await prisma.tenant.count()).toBe(0);
+  });
+
+  it('SEED_ALLOW_PARTIAL=true, nothing configured: tenant and data models still seed, everything gated stays absent', async () => {
+    await withSeedEnv({ SEED_ALLOW_PARTIAL: 'true' }, runSeedMain);
+
+    // The system tenant and data models carry no gated configuration, so
+    // they seed regardless of what's missing.
+    expect(await prisma.tenant.count({ where: { id: SYSTEM_TENANT_ID } })).toBe(1);
+    expect(await prisma.dataModel.count()).toBeGreaterThan(0);
+
+    // Every category gated on DATA_ENCRYPTION_KEY (unset) or SYSTEM_DID
+    // (unset) is absent.
+    expect(await prisma.serviceInstance.count()).toBe(0);
+    expect(await prisma.did.count()).toBe(0);
+    expect(await prisma.renderTemplate.count()).toBe(0);
+  });
+
+  it('SEED_ALLOW_PARTIAL=true: a category with everything IT needs configured actually seeds, proving the encryption gate genuinely responds to DATA_ENCRYPTION_KEY rather than passing for an unrelated reason', async () => {
+    // DATA_ENCRYPTION_KEY is resolved once at module load (see
+    // `withFreshSeedModule`'s doc comment), so this scenario needs the
+    // fresh-module path: only that guarantees the real key this test sets
+    // is the one `main()` actually uses, rather than whatever was resolved
+    // before this test file's top-level import ran (typically nothing).
+    await withFreshSeedModule(
+      {
+        SEED_ALLOW_PARTIAL: 'true',
+        DATA_ENCRYPTION_KEY: crypto.randomBytes(32).toString('hex'),
+        SYSTEM_IDR_BASE_URL: 'https://idr.example.com',
+        SYSTEM_IDR_API_KEY: 'idr-key',
+        SYSTEM_IDR_DEFAULT_LINK_TYPE: 'untp:dpp',
+        SYSTEM_IDR_DEFAULT_MIME_TYPE: 'text/html',
+        SYSTEM_IDR_DEFAULT_LANGUAGE: 'en',
+        SYSTEM_IDR_DEFAULT_CONTEXT: 'au',
+      },
+      (seedModule) => seedModule.main(),
+    );
+
+    // IDR is both eligible (its own variables are fully configured) and
+    // ungated (a real key was resolved), so it seeds. This is the half of
+    // "executes the eligible categories" the previous version of this test
+    // never actually exercised: with DATA_ENCRYPTION_KEY frozen at import
+    // time, IDR was skipped by its own missing variables regardless of
+    // what the encryption gate did, so the assertion held for the wrong
+    // reason and would not have caught the gate always resolving 'ok'.
+    expect(await prisma.serviceInstance.count({ where: { serviceType: 'IDR' } })).toBe(1);
+
+    // VC, storage, and DID are still gated by their own missing variables.
+    expect(await prisma.serviceInstance.count({ where: { serviceType: { not: 'IDR' } } })).toBe(0);
+    expect(await prisma.did.count()).toBe(0);
+    expect(await prisma.renderTemplate.count()).toBe(0);
+  });
+
+  it('SEED_ALLOW_PARTIAL=true: a fully configured category still does not seed when DATA_ENCRYPTION_KEY itself is missing (the gate, not its own variables)', async () => {
+    // The mirror image of the previous test: IDR's own variables are
+    // complete, but DATA_ENCRYPTION_KEY is absent. If the encryption gate
+    // were broken (for example `if (ENCRYPTION_KEY)` mutated to always
+    // true), IDR would seed here despite no key ever being configured;
+    // this is what makes the gate itself, not just IDR's own schema, the
+    // thing under test.
+    await withFreshSeedModule(
+      {
+        SEED_ALLOW_PARTIAL: 'true',
+        SYSTEM_IDR_BASE_URL: 'https://idr.example.com',
+        SYSTEM_IDR_API_KEY: 'idr-key',
+        SYSTEM_IDR_DEFAULT_LINK_TYPE: 'untp:dpp',
+        SYSTEM_IDR_DEFAULT_MIME_TYPE: 'text/html',
+        SYSTEM_IDR_DEFAULT_LANGUAGE: 'en',
+        SYSTEM_IDR_DEFAULT_CONTEXT: 'au',
+      },
+      (seedModule) => seedModule.main(),
+    );
+
+    expect(await prisma.serviceInstance.count()).toBe(0);
+  });
+
+  it('a mid-run failure after preflight passed still emits the summary once and propagates the original error', async () => {
+    // A placeholder DATA_ENCRYPTION_KEY outside local development is an
+    // operational failure the preflight does not check for (it only checks
+    // the variable is present), so it throws from inside main() itself,
+    // after the tenant has already been upserted. ADR-043 decision 2 keeps
+    // this failure's own behaviour unchanged; this test only checks that
+    // the summary the seed builds around it is honest and that the
+    // original error is not swallowed.
+    let caught: unknown;
+    let errorCalls: unknown[][] = [];
+
+    await withFreshSeedModule(
+      {
+        SEED_ALLOW_PARTIAL: 'true',
+        DATA_ENCRYPTION_KEY: '0'.repeat(64),
+        DEPLOYMENT_ENVIRONMENT: 'production',
+      },
+      async (seedModule) => {
+        const errorSpy = jest.spyOn(seedModule.logger, 'error');
+        try {
+          await seedModule.main();
+        } catch (error) {
+          caught = error;
+        } finally {
+          errorCalls = errorSpy.mock.calls as unknown[][];
+          errorSpy.mockRestore();
+        }
+      },
+    );
+
+    // The original error propagates unmodified, not wrapped or replaced,
+    // so seed-cli.ts's `.catch()` still exits non-zero for the real cause.
+    // (Checked by name, not `instanceof`: this scenario needs a fresh
+    // module import per `withFreshSeedModule`'s own doc comment, so the
+    // error class here is not the one imported at the top of this file.)
+    expect((caught as Error)?.name).toBe('PlaceholderEncryptionKeyError');
+    expect((caught as Error)?.name).not.toBe('SeedConfigurationError');
+
+    // The summary is built and logged from whatever state existed at the
+    // moment of failure: nothing under `preflight.hasMissing` blocked this
+    // run (SEED_ALLOW_PARTIAL=true), and the tenant upsert (the very first
+    // statement in the try block) already completed before the throw, so
+    // it correctly reads 'seeded' — a real side effect already happened.
+    // The throw happens before the run reaches any later category's own
+    // gate check, so every one of them is 'notRun' rather than 'skipped'
+    // (Moderate finding 6: 'skipped' is reserved for a category the run
+    // actually reached and decided not to run).
+    const summaryCall = errorCalls.find(
+      ([, message]) => message === 'Seed failed partway through; the summary reflects what did complete',
+    );
+    expect(summaryCall).toBeDefined();
+    const [{ summary }] = summaryCall as [{ summary: SeedRunSummary }, string];
+    expect(summary.categoriesSeeded).toEqual(['tenant']);
+    expect(summary.categoriesSkipped).toEqual([]);
+    expect(summary.categoriesNotRun.sort()).toEqual(
+      ['did', 'idr', 'renderTemplates', 'storage', 'vc', 'dataModels', 'customSeed'].sort(),
+    );
+
+    // The tenant upsert ran before the throw and is not rolled back (the
+    // seed is not transactional; ADR-043's consequences section says so).
+    expect(await prisma.tenant.count({ where: { id: SYSTEM_TENANT_ID } })).toBe(1);
+    expect(await prisma.serviceInstance.count()).toBe(0);
+  });
+
+  it('renderTemplates reports partial when every template file is missing (the category ran, but produced nothing)', async () => {
+    // TEMPLATES_BASE resolves relative to `scriptDir`, which under a test
+    // runner is not prisma/'s real directory (see seed.ts's own comment on
+    // `scriptDir`), so every core data model's template file reads as
+    // missing here without any file-system manipulation.
+    let warnCalls: unknown[][] = [];
+
+    await withFreshSeedModule(
+      {
+        SEED_ALLOW_PARTIAL: 'true',
+        DATA_ENCRYPTION_KEY: crypto.randomBytes(32).toString('hex'),
+        SYSTEM_STORAGE_BASE_URL: 'http://127.0.0.1:1',
+        SYSTEM_STORAGE_PUBLIC_BUCKET: 'public',
+        SYSTEM_STORAGE_PRIVATE_BUCKET: 'private',
+      },
+      async (seedModule) => {
+        const warnSpy = jest.spyOn(seedModule.logger, 'warn');
+        try {
+          await seedModule.main();
+        } finally {
+          warnCalls = warnSpy.mock.calls as unknown[][];
+          warnSpy.mockRestore();
+        }
+      },
+    );
+
+    // Every template file read as missing, so none were uploaded — the
+    // category ran (the service instance seeded) but produced nothing.
+    expect(await prisma.serviceInstance.count()).toBe(1);
+    expect(await prisma.renderTemplate.count()).toBe(0);
+
+    const summaryCall = warnCalls.find(
+      ([, message]) => message === 'Seed complete with categories skipped or incomplete',
+    );
+    expect(summaryCall).toBeDefined();
+    const [{ summary }] = summaryCall as [{ summary: SeedRunSummary }, string];
+
+    // The honest claim: renderTemplates is partial, named with what was
+    // skipped, and it must NOT also appear as fully seeded.
+    expect(summary.categoriesPartial).toContain('renderTemplates');
+    expect(summary.categoriesSeeded).not.toContain('renderTemplates');
+    expect(summary.partialDetails.renderTemplates.length).toBeGreaterThan(0);
+  });
+
+  it('renderTemplates reports partial when one template genuinely uploads and a later one is missing (the real mixed case)', async () => {
+    // Drives the actual mixed outcome rather than the all-missing edge
+    // case above: a real storage round-trip against a loopback fixture
+    // server for exactly one data model's template, with every other
+    // template's file read still reporting missing (the same `scriptDir`
+    // mismatch as above). `fs.existsSync`/`readFileSync` are mocked only
+    // for that one path; every other call falls through to the real `fs`.
+    const fixtures: FixtureServer = await startFixtureServer();
+    const targetCredentialType = 'DigitalProductPassport';
+    const targetVersion = '0.6.0';
+    // Captured before `spyOn` replaces the shared `fs` object's own methods:
+    // `jest.requireActual('node:fs')` for a Node core module returns that
+    // same mutated object, not an independent unmocked copy, so calling it
+    // from inside the mock implementation would recurse into itself.
+    const realExistsSync = fs.existsSync.bind(fs);
+    const realReadFileSync = fs.readFileSync.bind(fs);
+    const existsSyncSpy = jest.spyOn(fs, 'existsSync');
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+    try {
+      fixtures.set('/api/v4/public', {
+        contentType: 'application/json',
+        body: JSON.stringify({ uri: 'https://fixture.example/blob', digestMultibase: 'zFIXTUREDIGEST' }),
+      });
+
+      const isTargetTemplatePath = (templatePath: unknown): boolean =>
+        typeof templatePath === 'string' &&
+        templatePath.includes('digital_product_passport') &&
+        templatePath.includes(`v${targetVersion}`);
+
+      existsSyncSpy.mockImplementation((templatePath: fs.PathLike) => {
+        if (isTargetTemplatePath(templatePath)) return true;
+        return realExistsSync(templatePath);
+      });
+      readFileSyncSpy.mockImplementation(((templatePath: fs.PathLike, options?: BufferEncoding) => {
+        if (isTargetTemplatePath(templatePath)) return '<html>fixture template</html>';
+        return realReadFileSync(templatePath, options);
+      }) as typeof fs.readFileSync);
+
+      let warnCalls: unknown[][] = [];
+      await withFreshSeedModule(
+        {
+          SEED_ALLOW_PARTIAL: 'true',
+          DATA_ENCRYPTION_KEY: crypto.randomBytes(32).toString('hex'),
+          SYSTEM_STORAGE_BASE_URL: fixtures.baseUrl,
+          SYSTEM_STORAGE_PUBLIC_BUCKET: 'public',
+          SYSTEM_STORAGE_PRIVATE_BUCKET: 'private',
+        },
+        async (seedModule) => {
+          const warnSpy = jest.spyOn(seedModule.logger, 'warn');
+          try {
+            await seedModule.main();
+          } finally {
+            warnCalls = warnSpy.mock.calls as unknown[][];
+            warnSpy.mockRestore();
+          }
+        },
+      );
+
+      // Exactly one template genuinely uploaded via the fixture server.
+      expect(await prisma.renderTemplate.count()).toBe(1);
+      const created = await prisma.renderTemplate.findFirstOrThrow();
+      expect(created.storageUrl).toBe('https://fixture.example/blob');
+
+      const summaryCall = warnCalls.find(
+        ([, message]) => message === 'Seed complete with categories skipped or incomplete',
+      );
+      expect(summaryCall).toBeDefined();
+      const [{ summary }] = summaryCall as [{ summary: SeedRunSummary }, string];
+
+      expect(summary.categoriesPartial).toContain('renderTemplates');
+      expect(summary.categoriesSeeded).not.toContain('renderTemplates');
+      // 14 of the 15 core data models' templates are still missing; only
+      // the one this test made "exist" is absent from the skipped list.
+      expect(summary.partialDetails.renderTemplates.length).toBe(14);
+      expect(
+        summary.partialDetails.renderTemplates.some(
+          (detail) => detail.includes(targetCredentialType) && detail.includes(targetVersion),
+        ),
+      ).toBe(false);
+    } finally {
+      existsSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
+      await fixtures.close();
+    }
+  });
+
+  it('renderTemplates reports partial, not skipped, when the storage upload succeeds but the database write then fails (Major finding 4)', async () => {
+    // The upload is a real external side effect the storage service
+    // cannot roll back; if the database `create` that follows throws, the
+    // uploaded object is orphaned. Before this fix, `templatesCreatedCount`
+    // was only incremented after the database write, so this exact
+    // scenario was misreported as `renderTemplates: skipped` (as if
+    // nothing had happened) instead of `partial`.
+    const fixtures: FixtureServer = await startFixtureServer();
+    const realExistsSync = fs.existsSync.bind(fs);
+    const realReadFileSync = fs.readFileSync.bind(fs);
+    const existsSyncSpy = jest.spyOn(fs, 'existsSync');
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+    const isTargetTemplatePath = (templatePath: unknown): boolean =>
+      typeof templatePath === 'string' &&
+      templatePath.includes('digital_product_passport') &&
+      templatePath.includes('v0.6.0');
+
+    existsSyncSpy.mockImplementation((templatePath: fs.PathLike) => {
+      if (isTargetTemplatePath(templatePath)) return true;
+      return realExistsSync(templatePath);
+    });
+    readFileSyncSpy.mockImplementation(((templatePath: fs.PathLike, options?: BufferEncoding) => {
+      if (isTargetTemplatePath(templatePath)) return '<html>fixture template</html>';
+      return realReadFileSync(templatePath, options);
+    }) as typeof fs.readFileSync);
+
+    try {
+      fixtures.set('/api/v4/public', {
+        contentType: 'application/json',
+        body: JSON.stringify({ uri: 'https://fixture.example/blob', digestMultibase: 'zFIXTUREDIGEST' }),
+      });
+
+      let warnCalls: unknown[][] = [];
+      let errorCalls: unknown[][] = [];
+      let caught: unknown;
+
+      await withFreshSeedModule(
+        {
+          SEED_ALLOW_PARTIAL: 'true',
+          DATA_ENCRYPTION_KEY: crypto.randomBytes(32).toString('hex'),
+          SYSTEM_STORAGE_BASE_URL: fixtures.baseUrl,
+          SYSTEM_STORAGE_PUBLIC_BUCKET: 'public',
+          SYSTEM_STORAGE_PRIVATE_BUCKET: 'private',
+        },
+        async (seedModule) => {
+          const dbFailure = new Error('simulated database write failure after upload');
+          const createSpy = jest.spyOn(seedModule.prisma.renderTemplate, 'create').mockRejectedValue(dbFailure);
+          const warnSpy = jest.spyOn(seedModule.logger, 'warn');
+          const errorSpy = jest.spyOn(seedModule.logger, 'error');
+          try {
+            await seedModule.main();
+          } catch (error) {
+            caught = error;
+          } finally {
+            warnCalls = warnSpy.mock.calls as unknown[][];
+            errorCalls = errorSpy.mock.calls as unknown[][];
+            createSpy.mockRestore();
+            warnSpy.mockRestore();
+            errorSpy.mockRestore();
+          }
+        },
+      );
+
+      // The upload happened (the fixture recorded a request) but the row
+      // never landed, so nothing exists in the database — yet the summary
+      // must still say 'partial', never 'skipped', for renderTemplates.
+      expect(await prisma.renderTemplate.count()).toBe(0);
+      expect(caught).toBeUndefined();
+
+      const summaryCall =
+        warnCalls.find(([, message]) => message === 'Seed complete with categories skipped or incomplete') ??
+        errorCalls.find(
+          ([, message]) => message === 'Seed failed partway through; the summary reflects what did complete',
+        );
+      expect(summaryCall).toBeDefined();
+      const [{ summary }] = summaryCall as [{ summary: SeedRunSummary }, string];
+
+      expect(summary.categoriesPartial).toContain('renderTemplates');
+      expect(summary.categoriesSkipped).not.toContain('renderTemplates');
+    } finally {
+      existsSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
+      await fixtures.close();
+    }
+  });
+
+  it('renderTemplates never disagrees with itself: partialDetails and the outcome agree even when the very first upload throws', async () => {
+    // Grok's remaining finding on the panel follow-up: before this fix,
+    // `renderTemplateInterruptedItem` was set right before the upload
+    // call, but only `templatesCreatedCount` (incremented after a
+    // successful upload) and `templatesSkippedFiles` fed the outcome. If
+    // the first item's own `storeBinary` call is what throws, neither of
+    // those is non-empty, so the catch reported `renderTemplates: skipped`
+    // while `partialDetails.renderTemplates` still named the interrupted
+    // item — the outcome and its own detail disagreeing about whether the
+    // category did anything. The storage base URL here points at a
+    // fixture server with no upload endpoint registered, so the very
+    // first `storeBinary` call fails with a 404 before anything succeeds.
+    const fixtures: FixtureServer = await startFixtureServer();
+    const realReadFileSync = fs.readFileSync.bind(fs);
+    const existsSyncSpy = jest.spyOn(fs, 'existsSync');
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+    existsSyncSpy.mockImplementation(() => true);
+    readFileSyncSpy.mockImplementation(((templatePath: fs.PathLike, options?: BufferEncoding) => {
+      if (typeof templatePath === 'string' && templatePath.includes('template.hbs')) {
+        return '<html>fixture template</html>';
+      }
+      return realReadFileSync(templatePath, options);
+    }) as typeof fs.readFileSync);
+
+    try {
+      let warnCalls: unknown[][] = [];
+      let errorCalls: unknown[][] = [];
+
+      await withFreshSeedModule(
+        {
+          SEED_ALLOW_PARTIAL: 'true',
+          DATA_ENCRYPTION_KEY: crypto.randomBytes(32).toString('hex'),
+          // No fixture registered at this base URL for any path, so the
+          // very first upload attempt gets a 404 and the adapter throws
+          // before any template is ever created.
+          SYSTEM_STORAGE_BASE_URL: fixtures.baseUrl,
+          SYSTEM_STORAGE_PUBLIC_BUCKET: 'public',
+          SYSTEM_STORAGE_PRIVATE_BUCKET: 'private',
+        },
+        async (seedModule) => {
+          const warnSpy = jest.spyOn(seedModule.logger, 'warn');
+          const errorSpy = jest.spyOn(seedModule.logger, 'error');
+          try {
+            await seedModule.main();
+          } finally {
+            warnCalls = warnSpy.mock.calls as unknown[][];
+            errorCalls = errorSpy.mock.calls as unknown[][];
+            warnSpy.mockRestore();
+            errorSpy.mockRestore();
+          }
+        },
+      );
+
+      expect(await prisma.renderTemplate.count()).toBe(0);
+
+      const summaryCall =
+        warnCalls.find(([, message]) => message === 'Seed complete with categories skipped or incomplete') ??
+        errorCalls.find(
+          ([, message]) => message === 'Seed failed partway through; the summary reflects what did complete',
+        );
+      expect(summaryCall).toBeDefined();
+      const [{ summary }] = summaryCall as [{ summary: SeedRunSummary }, string];
+
+      // The core assertion: whenever renderTemplates has a detail entry,
+      // it must be in categoriesPartial, never categoriesSkipped — the two
+      // must never disagree about whether the category did anything.
+      const hasDetail = (summary.partialDetails.renderTemplates ?? []).length > 0;
+      expect(hasDetail).toBe(true);
+      expect(summary.categoriesPartial).toContain('renderTemplates');
+      expect(summary.categoriesSkipped).not.toContain('renderTemplates');
+    } finally {
+      existsSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
+      await fixtures.close();
+    }
+  });
+});

--- a/packages/reference-implementation/docker-entrypoint.sh
+++ b/packages/reference-implementation/docker-entrypoint.sh
@@ -51,7 +51,7 @@ if [ "${SKIP_SEED:-false}" = "false" ]; then
     # prefixing with `node` (as the previous yarn-1 invocation did)
     # makes node try to parse the shell script as JavaScript and
     # fail with "SyntaxError: missing ) after argument list".
-    /app/node_modules/.bin/tsx seed.ts
+    /app/node_modules/.bin/tsx seed-cli.ts
     echo "Database seed completed"
 else
     echo "Skipping database seed (SKIP_SEED is set)"

--- a/packages/reference-implementation/package.json
+++ b/packages/reference-implementation/package.json
@@ -25,7 +25,7 @@
     "postcss": "^8.5.14",
     "prisma": "6.19.2",
     "tailwind-merge": "^3.3.1",
-    "tsx": "^4.21.0",
+    "tsx": "^4.23.12",
     "yaml": "^2.8.2",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.1"
@@ -57,7 +57,7 @@
     ]
   },
   "prisma": {
-    "seed": "npx tsx prisma/seed.ts"
+    "seed": "npx tsx prisma/seed-cli.ts"
   },
   "devDependencies": {
     "@auth/prisma-adapter": "^2.11.1",

--- a/packages/reference-implementation/prisma/__tests__/custom-seed.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/custom-seed.test.ts
@@ -35,7 +35,7 @@ const mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {
 
 import fs from 'fs';
 import { parse as parseYaml } from 'yaml';
-import { runCustomSeed } from '../custom-seed';
+import { runCustomSeed, CustomSeedFatalError, CustomSeedPartialProgressError } from '../custom-seed';
 import { ingestConformityScheme } from '../../src/lib/cvc/index.js';
 
 const ingestMockFn = ingestConformityScheme as jest.Mock;
@@ -167,8 +167,9 @@ describe('runCustomSeed', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(false);
       const deps = createDeps();
 
-      await runCustomSeed(deps);
+      const result = await runCustomSeed(deps);
 
+      expect(result).toEqual({ ran: false, conformityFailed: 0 });
       expect(deps.logger.info).toHaveBeenCalledWith(
         expect.objectContaining({ manifestPath: path.join(CUSTOM_SEED_DIR, 'seed.yaml') }),
         expect.stringContaining('No custom seed manifest found'),
@@ -185,8 +186,9 @@ describe('runCustomSeed', () => {
 
       const deps = createDeps();
 
-      await runCustomSeed(deps);
+      const result = await runCustomSeed(deps);
 
+      expect(result).toEqual({ ran: false, conformityFailed: 0 });
       expect(deps.logger.info).toHaveBeenCalledWith(expect.stringContaining('empty'));
       expect(deps.prisma.$transaction).not.toHaveBeenCalled();
       expect(mockExit).not.toHaveBeenCalled();
@@ -203,16 +205,22 @@ describe('runCustomSeed', () => {
 
       const deps = createDeps();
 
-      await runCustomSeed(deps);
+      const result = await runCustomSeed(deps);
 
       // Present-but-empty keys are a remove-all instruction, not an empty file.
       expect(deps.prisma.$transaction).toHaveBeenCalled();
+      expect(result).toEqual({ ran: true, conformityFailed: 0 });
       expect(mockExit).not.toHaveBeenCalled();
     });
   });
 
   describe('when YAML syntax is invalid', () => {
-    it('exits with code 1', async () => {
+    it('throws CustomSeedFatalError instead of terminating the process directly', async () => {
+      // Regression guard for the round-two review finding: runCustomSeed()
+      // must never call process.exit() itself, because a real exit would
+      // abandon main() before its summary-and-rethrow catch (and, in the
+      // real CLI, seed-cli.ts's disconnect) ever run. Throwing lets the
+      // caller decide, the same as every other mid-run failure.
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.readFileSync as jest.Mock).mockReturnValue('bad yaml');
       (parseYaml as jest.Mock).mockImplementation(() => {
@@ -222,10 +230,16 @@ describe('runCustomSeed', () => {
       });
 
       const deps = createDeps();
+      let caught: unknown;
+      try {
+        await runCustomSeed(deps);
+      } catch (error) {
+        caught = error;
+      }
 
-      await expect(runCustomSeed(deps)).rejects.toThrow('process.exit');
-
-      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(caught).toBeInstanceOf(CustomSeedFatalError);
+      expect((caught as Error).message).toMatch(/Failed to parse custom seed YAML/);
+      expect(mockExit).not.toHaveBeenCalled();
       expect(deps.logger.error).toHaveBeenCalledWith(
         expect.objectContaining({ line: 3, col: 5 }),
         expect.stringContaining('Failed to parse'),
@@ -234,7 +248,7 @@ describe('runCustomSeed', () => {
   });
 
   describe('when Phase 1 validation fails (invalid CUID)', () => {
-    it('exits with code 1', async () => {
+    it('throws CustomSeedFatalError instead of terminating the process directly', async () => {
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.readFileSync as jest.Mock).mockReturnValue('');
       (parseYaml as jest.Mock).mockReturnValue({
@@ -248,10 +262,16 @@ describe('runCustomSeed', () => {
       });
 
       const deps = createDeps();
+      let caught: unknown;
+      try {
+        await runCustomSeed(deps);
+      } catch (error) {
+        caught = error;
+      }
 
-      await expect(runCustomSeed(deps)).rejects.toThrow('process.exit');
-
-      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(caught).toBeInstanceOf(CustomSeedFatalError);
+      expect((caught as Error).message).toMatch(/failed schema validation/);
+      expect(mockExit).not.toHaveBeenCalled();
       expect(deps.logger.error).toHaveBeenCalled();
     });
   });
@@ -301,10 +321,64 @@ describe('runCustomSeed', () => {
         storageService: null, // No storage service!
       });
 
-      await expect(runCustomSeed(deps)).rejects.toThrow('process.exit');
-
-      expect(mockExit).toHaveBeenCalledWith(1);
+      await expect(runCustomSeed(deps)).rejects.toBeInstanceOf(CustomSeedFatalError);
+      expect(mockExit).not.toHaveBeenCalled();
       expect(deps.logger.error).toHaveBeenCalledWith(expect.stringContaining('storage service'));
+    });
+  });
+
+  describe('when the database transaction fails after a template was already uploaded to storage', () => {
+    it('throws CustomSeedPartialProgressError, not a plain error implying nothing happened', async () => {
+      // The orphaned storage object is a real side effect the caller's
+      // outcome tracking must see; a plain rethrow here would report
+      // customSeed as 'skipped' despite that upload having happened.
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.readFileSync as jest.Mock).mockReturnValue('');
+
+      const manifestData = {
+        registrars: [],
+        dataModels: [],
+        renderTemplates: [
+          {
+            id: IDS.renderTemplate1,
+            name: 'Test Template',
+            file: 'template.hbs',
+            dataModelId: IDS.dataModel1,
+            renderMethodType: 'RenderTemplate2024',
+            isDefault: false,
+            inline: null,
+            mediaType: null,
+            mediaQuery: null,
+          },
+        ],
+      };
+      (parseYaml as jest.Mock).mockReturnValue(manifestData);
+
+      const mockPrisma = createMockPrisma();
+      (mockPrisma.dataModel.findMany as jest.Mock).mockImplementation((query: Record<string, unknown>) => {
+        const where = query?.where as Record<string, unknown> | undefined;
+        if (where?.isExtension === false || where?.source !== undefined) return Promise.resolve([]);
+        return Promise.resolve([{ id: IDS.dataModel1 }]);
+      });
+      const transactionFailure = new Error('connection reset');
+      (mockPrisma.$transaction as jest.Mock).mockRejectedValue(transactionFailure);
+
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.realpathSync as unknown as jest.Mock).mockImplementation((p: string) => p);
+
+      const storeBinary = jest.fn().mockResolvedValue({ uri: 'https://storage.example/blob', digestMultibase: 'z1' });
+      const deps = createDeps({ prisma: mockPrisma, storageService: { storeBinary } });
+
+      let caught: unknown;
+      try {
+        await runCustomSeed(deps);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(storeBinary).toHaveBeenCalledTimes(1);
+      expect(caught).toBeInstanceOf(CustomSeedPartialProgressError);
+      expect((caught as Error).cause).toBe(transactionFailure);
     });
   });
 
@@ -389,14 +463,18 @@ describe('runCustomSeed', () => {
       );
     });
 
-    it('skips an entry whose version has no ConformityScheme DataModel row', async () => {
+    it('skips an entry whose version has no ConformityScheme DataModel row, and reports it via the return value rather than throwing', async () => {
       setupManifest([{ url: 'https://example.com/scheme', version: '9.9.9' }]);
       const deps = createDeps();
       const ingestMock = ingestMockFn;
       (deps.prisma.dataModel.findFirst as jest.Mock).mockResolvedValue(null);
 
-      await runCustomSeed(deps);
+      // processConformitySchemes() acknowledges this failure and counts it
+      // rather than throwing (a real, if partial, completion — the caller
+      // must not treat this the same as a fully successful run).
+      const result = await runCustomSeed(deps);
 
+      expect(result).toEqual({ ran: true, conformityFailed: 1 });
       expect(ingestMock).not.toHaveBeenCalled();
       expect(deps.logger.error).toHaveBeenCalledWith(
         expect.objectContaining({ version: '9.9.9' }),
@@ -572,7 +650,7 @@ describe('runCustomSeed', () => {
       });
     }
 
-    it('exits when a manifest id collides with a core-seeded row', async () => {
+    it('throws CustomSeedFatalError when a manifest id collides with a core-seeded row', async () => {
       setupRegistrarManifest();
       const deps = createDeps();
       (deps.prisma.registrar.findMany as jest.Mock).mockImplementation((query: Record<string, unknown>) => {
@@ -581,9 +659,8 @@ describe('runCustomSeed', () => {
         return Promise.resolve([]);
       });
 
-      await expect(runCustomSeed(deps)).rejects.toThrow('process.exit');
-
-      expect(mockExit).toHaveBeenCalledWith(1);
+      await expect(runCustomSeed(deps)).rejects.toBeInstanceOf(CustomSeedFatalError);
+      expect(mockExit).not.toHaveBeenCalled();
       expect(deps.logger.error).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('core-seeded'));
     });
 

--- a/packages/reference-implementation/prisma/__tests__/seed-cli.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/seed-cli.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `seed-cli.ts` runs its whole body at import time (it is the CLI
+ * entrypoint), so these tests replace `./seed.js` with a controllable
+ * double before importing it, and stub `process.exit` so the test process
+ * survives the call. What each test actually checks is ordering: that
+ * `prisma.$disconnect()` completes before `process.exit()` runs, on both
+ * the success and the failure path, and that the failure path's exit code
+ * is non-zero.
+ */
+
+async function flushMicrotasks(): Promise<void> {
+  // Two hops: one for `main()`'s own promise chain, one for the `.then()`
+  // that awaits `prisma.$disconnect()` before calling `process.exit()`.
+  // `setTimeout`, not `setImmediate`: this suite runs under a jsdom
+  // environment, which does not provide `setImmediate`.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('seed-cli.ts: disconnect always precedes exit', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  it('on success: disconnects, then exits 0', async () => {
+    const callOrder: string[] = [];
+    const disconnect = jest.fn(async () => {
+      callOrder.push('disconnect');
+    });
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => callOrder.push(`exit:${code}`)) as never);
+
+    jest.doMock('../seed', () => ({
+      main: jest.fn(async () => undefined),
+      prisma: { $disconnect: disconnect },
+      logger: { error: jest.fn() },
+    }));
+
+    await import('../seed-cli');
+    await flushMicrotasks();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    // The regression this guards against: `process.exit()` runs inside a
+    // `.catch()` that a chained `.finally()` follows, so exit happens
+    // first and the disconnect never gets the chance to run at all.
+    expect(callOrder).toEqual(['disconnect', 'exit:0']);
+  });
+
+  it('on failure: still disconnects, then exits non-zero, and logs the error', async () => {
+    const callOrder: string[] = [];
+    const disconnect = jest.fn(async () => {
+      callOrder.push('disconnect');
+    });
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => callOrder.push(`exit:${code}`)) as never);
+    const failure = new Error('seed failed for this test');
+    const errorLog = jest.fn();
+
+    jest.doMock('../seed', () => ({
+      main: jest.fn(async () => {
+        throw failure;
+      }),
+      prisma: { $disconnect: disconnect },
+      logger: { error: errorLog },
+    }));
+
+    await import('../seed-cli');
+    await flushMicrotasks();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['disconnect', 'exit:1']);
+    expect(errorLog).toHaveBeenCalledWith({ err: failure }, 'Seed failed');
+  });
+});

--- a/packages/reference-implementation/prisma/__tests__/seed-preflight-field-coverage.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/seed-preflight-field-coverage.test.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { adapterRegistry, ServiceType } from '@uncefact/untp-ri-services';
+import { IDR_FIELD_TO_ENV, STORAGE_FIELD_TO_ENV, VC_FIELD_TO_ENV } from '../seed-preflight';
+
+/**
+ * The preflight's field-to-env maps are hand-maintained, with nothing
+ * binding them to the adapter schemas they describe. A required field
+ * added upstream without a matching map entry would silently reclassify
+ * its category from 'missing' to 'other' (see `classifyParse` in
+ * `seed-preflight.ts`): the field's own `invalid_type` issue still fires,
+ * but with no env var to attribute it to, the whole category falls back
+ * to the non-fail-loud bucket. This derives each adapter's required
+ * fields directly from its own zod schema, so that drift fails here
+ * rather than silently at boot.
+ */
+function requiredFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
+  return Object.entries(schema.shape)
+    .filter(([, field]) => !field.isOptional())
+    .map(([key]) => key);
+}
+
+describe('seed-preflight field-to-env maps cover every required adapter field', () => {
+  it('IDR (Pyx) adapter', () => {
+    const schema = adapterRegistry[ServiceType.IDR].PYX_IDR.configSchema;
+    const required = requiredFields(schema);
+
+    expect(required.length).toBeGreaterThan(0);
+    for (const field of required) {
+      expect(IDR_FIELD_TO_ENV).toHaveProperty(field);
+    }
+  });
+
+  it('storage (UNCEFACT) adapter', () => {
+    const schema = adapterRegistry[ServiceType.STORAGE].UNCEFACT_STORAGE.configSchema;
+    const required = requiredFields(schema);
+
+    expect(required.length).toBeGreaterThan(0);
+    for (const field of required) {
+      expect(STORAGE_FIELD_TO_ENV).toHaveProperty(field);
+    }
+  });
+
+  it('VC (VCKit) adapter', () => {
+    const schema = adapterRegistry[ServiceType.VC].VCKIT.configSchema;
+    const required = requiredFields(schema);
+
+    expect(required.length).toBeGreaterThan(0);
+    for (const field of required) {
+      expect(VC_FIELD_TO_ENV).toHaveProperty(field);
+    }
+  });
+});

--- a/packages/reference-implementation/prisma/__tests__/seed-preflight.test.ts
+++ b/packages/reference-implementation/prisma/__tests__/seed-preflight.test.ts
@@ -1,0 +1,559 @@
+import {
+  runSeedPreflight,
+  SeedConfigurationError,
+  EXECUTION_CATEGORIES,
+  ALWAYS_RUN_CATEGORIES,
+  buildOutcomeSummary,
+  type SeedRunSummary,
+  type SummaryCategoryName,
+  type CategoryOutcome,
+} from '../seed-preflight';
+
+/** A fully configured environment: every category resolves 'ok'. */
+function fullEnv(): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: 'test',
+    DATA_ENCRYPTION_KEY: 'a-real-key',
+    SYSTEM_IDR_BASE_URL: 'https://idr.example.com',
+    SYSTEM_IDR_API_KEY: 'idr-key',
+    SYSTEM_IDR_DEFAULT_LINK_TYPE: 'untp:dpp',
+    SYSTEM_IDR_DEFAULT_MIME_TYPE: 'text/html',
+    SYSTEM_IDR_DEFAULT_LANGUAGE: 'en',
+    SYSTEM_IDR_DEFAULT_CONTEXT: 'au',
+    SYSTEM_STORAGE_BASE_URL: 'https://storage.example.com',
+    SYSTEM_STORAGE_PUBLIC_BUCKET: 'public',
+    SYSTEM_STORAGE_PRIVATE_BUCKET: 'private',
+    SYSTEM_VC_BASE_URL: 'https://vckit.example.com',
+    SYSTEM_VC_API_KEY: 'vc-key',
+    SYSTEM_DID: 'did:web:example.com',
+  };
+}
+
+describe('runSeedPreflight', () => {
+  it('resolves every category ok against a fully configured environment', () => {
+    const result = runSeedPreflight(fullEnv());
+
+    expect(result.hasMissing).toBe(false);
+    for (const category of Object.values(result.categories)) {
+      expect(category.status).toBe('ok');
+    }
+    expect(result.missingByCategory).toEqual({});
+  });
+
+  it('reports DATA_ENCRYPTION_KEY missing, and gates idr, storage and vc on it', () => {
+    const env = fullEnv();
+    delete env.DATA_ENCRYPTION_KEY;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.hasMissing).toBe(true);
+    expect(result.categories.encryption).toMatchObject({
+      status: 'missing',
+      missingVars: ['DATA_ENCRYPTION_KEY (or the deprecated SERVICE_ENCRYPTION_KEY)'],
+    });
+    expect(result.categories.idr).toMatchObject({ status: 'missing', gatedBy: 'encryption' });
+    expect(result.categories.storage).toMatchObject({ status: 'missing', gatedBy: 'encryption' });
+    expect(result.categories.vc).toMatchObject({ status: 'missing', gatedBy: 'encryption' });
+  });
+
+  it('honours SERVICE_ENCRYPTION_KEY as the deprecated alias so encryption still resolves ok', () => {
+    const env = fullEnv();
+    delete env.DATA_ENCRYPTION_KEY;
+    env.SERVICE_ENCRYPTION_KEY = 'a-real-key';
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.encryption.status).toBe('ok');
+  });
+
+  it('reports each missing IDR variable by its actual environment variable name', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_IDR_BASE_URL;
+    delete env.SYSTEM_IDR_DEFAULT_CONTEXT;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.idr).toMatchObject({ status: 'missing' });
+    expect(result.categories.idr.missingVars).toEqual(
+      expect.arrayContaining(['SYSTEM_IDR_BASE_URL', 'SYSTEM_IDR_DEFAULT_CONTEXT']),
+    );
+  });
+
+  it('reports each missing storage variable by its actual environment variable name', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_STORAGE_PUBLIC_BUCKET;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.storage).toEqual({ status: 'missing', missingVars: ['SYSTEM_STORAGE_PUBLIC_BUCKET'] });
+  });
+
+  it('reports each missing VC variable by its actual environment variable name', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_VC_API_KEY;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.vc).toEqual({ status: 'missing', missingVars: ['SYSTEM_VC_API_KEY'] });
+  });
+
+  it('does not treat an optional storage field (apiKey) as missing when absent', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_STORAGE_API_KEY; // already absent in fullEnv(); explicit for clarity
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.storage.status).toBe('ok');
+  });
+
+  it('reports SYSTEM_DID missing, independent of whether VC is configured', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_DID;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.did).toEqual({ status: 'missing', missingVars: ['SYSTEM_DID'] });
+  });
+
+  it('gates did on vc: SYSTEM_DID present but VC not configured still reports did as missing', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_VC_BASE_URL;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.vc.status).toBe('missing');
+    expect(result.categories.did).toMatchObject({ status: 'missing', gatedBy: 'vc' });
+  });
+
+  it('gates renderTemplates on storage', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_STORAGE_BASE_URL;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.storage.status).toBe('missing');
+    expect(result.categories.renderTemplates).toMatchObject({ status: 'missing', gatedBy: 'storage' });
+  });
+
+  it('classifies an unknown IDR adapter type as other, not missing', () => {
+    const env = fullEnv();
+    env.SYSTEM_IDR_ADAPTER_TYPE = 'NOT_A_REAL_ADAPTER';
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.idr.status).toBe('other');
+    expect(result.categories.idr.reason).toMatch(/Unknown IDR adapter type/);
+    expect(result.hasMissing).toBe(false);
+  });
+
+  it('classifies an invalid (present but malformed) value as other, not missing', () => {
+    const env = fullEnv();
+    env.SYSTEM_VC_BASE_URL = 'not-a-url';
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.vc.status).toBe('other');
+    expect(result.hasMissing).toBe(false);
+  });
+
+  it('a missing required variable always wins as missing, even when another field in the same category is also invalid', () => {
+    // ADR-043 decision 2, tightened: a second, independent mistake in the
+    // same category (a mistyped SYSTEM_VC_BASE_URL) must never downgrade
+    // an absent SYSTEM_VC_API_KEY out of the fail-loud posture. Making a
+    // deployment's configuration worse (adding the typo on top of the
+    // missing key) must never make validation weaker.
+    const env = fullEnv();
+    delete env.SYSTEM_VC_API_KEY;
+    env.SYSTEM_VC_BASE_URL = 'not-a-url';
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.vc).toMatchObject({ status: 'missing', missingVars: ['SYSTEM_VC_API_KEY'] });
+    expect(result.hasMissing).toBe(true);
+  });
+
+  it('names the invalid sibling value in otherIssuesByCategory, not only the missing variable', () => {
+    const env = fullEnv();
+    delete env.SYSTEM_VC_API_KEY;
+    env.SYSTEM_VC_BASE_URL = 'not-a-url';
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.vc.reason).toMatch(/Invalid url/);
+    expect(result.otherIssuesByCategory.vc).toMatch(/Invalid url/);
+    // A category with only a missing variable and no other problem has no entry here.
+    expect(result.otherIssuesByCategory).not.toHaveProperty('encryption');
+  });
+
+  it('surfaces a divergent encryption key reason even when the category itself is not "missing"', () => {
+    // resolveEncryptionCategory reports divergent DATA_ENCRYPTION_KEY /
+    // SERVICE_ENCRYPTION_KEY values as 'other', never 'missing'. An
+    // unrelated category that IS missing (here, SYSTEM_VC_API_KEY) must
+    // not make that divergence reason disappear from the run's record
+    // (Major finding 2 in the panel follow-up: previously the top-level
+    // loop only collected a category's reason when that same category was
+    // 'missing', so encryption's divergence was silently dropped whenever
+    // paired with an unrelated missing variable elsewhere).
+    const env = fullEnv();
+    env.DATA_ENCRYPTION_KEY = 'key-one';
+    env.SERVICE_ENCRYPTION_KEY = 'key-two';
+    delete env.SYSTEM_VC_API_KEY;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.encryption.status).toBe('other');
+    expect(result.categories.encryption.reason).toMatch(/both set with different values/);
+    expect(result.otherIssuesByCategory.encryption).toMatch(/both set with different values/);
+    expect(result.hasMissing).toBe(true);
+  });
+
+  it('does not abort preflight on a divergent encryption key alone (no other category missing)', () => {
+    // hasMissing stays false because 'other' is not the fail-loud status
+    // (ADR-043 decision 2); the divergence is still surfaced later, when
+    // main() calls resolveDataEncryptionKey() itself.
+    const env = fullEnv();
+    env.DATA_ENCRYPTION_KEY = 'key-one';
+    env.SERVICE_ENCRYPTION_KEY = 'key-two';
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.encryption.status).toBe('other');
+    expect(result.otherIssuesByCategory.encryption).toMatch(/both set with different values/);
+    expect(result.hasMissing).toBe(false);
+  });
+
+  it('an unknown adapter type does not mask a missing required variable underneath it', () => {
+    // The same rule extended to the early unknown-adapter-type return: a
+    // typo in SYSTEM_IDR_ADAPTER_TYPE must not hide that SYSTEM_IDR_BASE_URL
+    // was also never set.
+    const env = fullEnv();
+    env.SYSTEM_IDR_ADAPTER_TYPE = 'NOT_A_REAL_ADAPTER';
+    delete env.SYSTEM_IDR_BASE_URL;
+
+    const result = runSeedPreflight(env);
+
+    expect(result.categories.idr).toMatchObject({ status: 'missing', missingVars: ['SYSTEM_IDR_BASE_URL'] });
+  });
+
+  it('collects every missing category together in one pass', () => {
+    const env = fullEnv();
+    delete env.DATA_ENCRYPTION_KEY;
+    delete env.SYSTEM_DID;
+
+    const result = runSeedPreflight(env);
+
+    expect(Object.keys(result.missingByCategory).sort()).toEqual(
+      ['did', 'encryption', 'idr', 'renderTemplates', 'storage', 'vc'].sort(),
+    );
+  });
+
+  describe('an empty or whitespace-only value reads as missing, the same as absent', () => {
+    it('DATA_ENCRYPTION_KEY set to only whitespace', () => {
+      const env = fullEnv();
+      env.DATA_ENCRYPTION_KEY = '   ';
+
+      const result = runSeedPreflight(env);
+
+      expect(result.categories.encryption).toMatchObject({ status: 'missing' });
+    });
+
+    it('SYSTEM_IDR_BASE_URL set to an empty string', () => {
+      const env = fullEnv();
+      env.SYSTEM_IDR_BASE_URL = '';
+
+      const result = runSeedPreflight(env);
+
+      expect(result.categories.idr).toMatchObject({ status: 'missing', missingVars: ['SYSTEM_IDR_BASE_URL'] });
+    });
+
+    it('SYSTEM_STORAGE_PUBLIC_BUCKET set to whitespace only', () => {
+      const env = fullEnv();
+      env.SYSTEM_STORAGE_PUBLIC_BUCKET = '  \t ';
+
+      const result = runSeedPreflight(env);
+
+      expect(result.categories.storage).toMatchObject({
+        status: 'missing',
+        missingVars: ['SYSTEM_STORAGE_PUBLIC_BUCKET'],
+      });
+    });
+
+    it('SYSTEM_VC_API_KEY set to an empty string', () => {
+      const env = fullEnv();
+      env.SYSTEM_VC_API_KEY = '';
+
+      const result = runSeedPreflight(env);
+
+      expect(result.categories.vc).toMatchObject({ status: 'missing', missingVars: ['SYSTEM_VC_API_KEY'] });
+    });
+
+    it('SYSTEM_DID set to whitespace only', () => {
+      const env = fullEnv();
+      env.SYSTEM_DID = '   ';
+
+      const result = runSeedPreflight(env);
+
+      expect(result.categories.did).toEqual({ status: 'missing', missingVars: ['SYSTEM_DID'] });
+    });
+  });
+});
+
+describe('buildOutcomeSummary', () => {
+  const ALL_CATEGORIES = [...EXECUTION_CATEGORIES, ...ALWAYS_RUN_CATEGORIES] as SummaryCategoryName[];
+
+  /** Every category 'skipped', as a base to override per test. */
+  function skippedOutcomes(): Record<SummaryCategoryName, CategoryOutcome> {
+    const outcomes = {} as Record<SummaryCategoryName, CategoryOutcome>;
+    for (const category of ALL_CATEGORIES) outcomes[category] = 'skipped';
+    return outcomes;
+  }
+
+  it('buckets a fully successful run: every category (gated and always-run alike) seeded, nothing partial or skipped', () => {
+    const outcomes = {} as Record<SummaryCategoryName, CategoryOutcome>;
+    for (const category of ALL_CATEGORIES) outcomes[category] = 'seeded';
+
+    const summary = buildOutcomeSummary('default', {}, outcomes, {});
+
+    expect(summary).toEqual({
+      mode: 'default',
+      categoriesSeeded: ALL_CATEGORIES,
+      categoriesPartial: [],
+      categoriesSkipped: [],
+      categoriesNotRun: [],
+      missingVariables: {},
+      invalidSiblings: {},
+      partialDetails: {},
+    });
+  });
+
+  it('partial mode: SEED_ALLOW_PARTIAL=true run, eligible categories seeded and gated ones skipped with their variables named', () => {
+    const outcomes = skippedOutcomes();
+    outcomes.idr = 'seeded';
+    outcomes.tenant = 'seeded';
+    outcomes.dataModels = 'seeded';
+
+    const summary = buildOutcomeSummary(
+      'partial',
+      { storage: ['SYSTEM_STORAGE_BASE_URL'], vc: ['SYSTEM_VC_API_KEY'], did: ['SYSTEM_DID'] },
+      outcomes,
+      {},
+    );
+
+    expect(summary.mode).toBe('partial');
+    expect(summary.categoriesSeeded.sort()).toEqual(['idr', 'tenant', 'dataModels'].sort());
+    expect(summary.categoriesPartial).toEqual([]);
+    expect(summary.categoriesSkipped.sort()).toEqual(['storage', 'vc', 'did', 'renderTemplates', 'customSeed'].sort());
+    expect(summary.missingVariables).toEqual({
+      storage: ['SYSTEM_STORAGE_BASE_URL'],
+      vc: ['SYSTEM_VC_API_KEY'],
+      did: ['SYSTEM_DID'],
+    });
+  });
+
+  it('a category that completed only some of its work is reported partial, never folded into seeded, with the specifics named', () => {
+    const outcomes = skippedOutcomes();
+    outcomes.storage = 'seeded';
+    outcomes.renderTemplates = 'partial';
+
+    const summary = buildOutcomeSummary('partial', {}, outcomes, {
+      renderTemplates: ['DigitalProductPassport v0.7.0 (template.hbs missing)'],
+    });
+
+    expect(summary.categoriesSeeded).toEqual(['storage']);
+    expect(summary.categoriesSeeded).not.toContain('renderTemplates');
+    expect(summary.categoriesPartial).toEqual(['renderTemplates']);
+    expect(summary.partialDetails.renderTemplates).toEqual(['DigitalProductPassport v0.7.0 (template.hbs missing)']);
+  });
+
+  it('always-run categories (tenant, dataModels, customSeed) are covered the same way as the gated ones', () => {
+    const outcomes = skippedOutcomes();
+    outcomes.tenant = 'seeded';
+    outcomes.dataModels = 'partial';
+    // customSeed left 'skipped': SKIP_CUSTOM_SEED=true is a deliberate choice, not a failure.
+
+    const summary = buildOutcomeSummary('default', {}, outcomes, {});
+
+    expect(summary.categoriesSeeded).toContain('tenant');
+    expect(summary.categoriesPartial).toContain('dataModels');
+    expect(summary.categoriesSkipped).toContain('customSeed');
+  });
+
+  it('failure-mode shape: a mid-run failure with nothing yet completed reports every category skipped', () => {
+    const summary = buildOutcomeSummary(
+      'default',
+      {
+        encryption: ['DATA_ENCRYPTION_KEY (or the deprecated SERVICE_ENCRYPTION_KEY)'],
+      },
+      skippedOutcomes(),
+      {},
+    );
+
+    expect(summary.categoriesSeeded).toEqual([]);
+    expect(summary.categoriesPartial).toEqual([]);
+    expect(summary.categoriesSkipped.sort()).toEqual(ALL_CATEGORIES.slice().sort());
+    // `categoriesNotRun` is reserved for the default-mode preflight abort,
+    // where nothing at all executed; a mid-run failure instead reports
+    // through `categoriesSkipped`, since some of the run did happen.
+    expect(summary.categoriesNotRun).toEqual([]);
+  });
+
+  it('failure-mode shape: a mid-run failure after some categories already completed reports exactly that mix', () => {
+    const outcomes = skippedOutcomes();
+    outcomes.idr = 'seeded';
+    outcomes.storage = 'seeded';
+    outcomes.tenant = 'seeded';
+
+    const summary = buildOutcomeSummary('partial', {}, outcomes, {});
+
+    expect(summary.categoriesSeeded.sort()).toEqual(['idr', 'storage', 'tenant'].sort());
+    expect(summary.categoriesSkipped.sort()).toEqual(
+      ['vc', 'did', 'renderTemplates', 'dataModels', 'customSeed'].sort(),
+    );
+  });
+
+  it('iterates categories in a stable order regardless of the outcomes object key order', () => {
+    const outcomes = {} as Record<SummaryCategoryName, CategoryOutcome>;
+    // Deliberately reversed from ALL_CATEGORIES to prove the output order
+    // does not depend on insertion order.
+    for (const category of [...ALL_CATEGORIES].reverse()) outcomes[category] = 'seeded';
+
+    const summary = buildOutcomeSummary('default', {}, outcomes, {});
+
+    expect(summary.categoriesSeeded).toEqual(ALL_CATEGORIES);
+  });
+
+  it('a category the run never reached is reported notRun, distinct from one reached and genuinely skipped', () => {
+    // Moderate finding 6: a category still at its default 'skipped'
+    // outcome could mean either "the run reached this category and its
+    // gate was unmet" or "an earlier, unrelated failure aborted the run
+    // before control ever got here". Passing the categories the run
+    // actually reached lets the two be told apart.
+    const outcomes = skippedOutcomes();
+    outcomes.tenant = 'seeded';
+
+    const summary = buildOutcomeSummary('default', {}, outcomes, {}, {}, [
+      'vc',
+      'did',
+      'renderTemplates',
+      'dataModels',
+      'customSeed',
+    ]);
+
+    // idr and storage were reached (their gate was evaluated) but not run.
+    expect(summary.categoriesSkipped.sort()).toEqual(['idr', 'storage'].sort());
+    expect(summary.categoriesNotRun.sort()).toEqual(
+      ['vc', 'did', 'renderTemplates', 'dataModels', 'customSeed'].sort(),
+    );
+  });
+
+  it('defaults notRun to empty when omitted, so every unresolved category still reports skipped', () => {
+    const summary = buildOutcomeSummary('default', {}, skippedOutcomes(), {});
+    expect(summary.categoriesNotRun).toEqual([]);
+    expect(summary.categoriesSkipped.sort()).toEqual(ALL_CATEGORIES.slice().sort());
+  });
+
+  it('threads invalidSiblings through to the summary, defaulting to empty when omitted', () => {
+    const withSiblings = buildOutcomeSummary('default', {}, skippedOutcomes(), {}, { vc: 'Invalid url' });
+    expect(withSiblings.invalidSiblings).toEqual({ vc: 'Invalid url' });
+
+    const withoutSiblings = buildOutcomeSummary('default', {}, skippedOutcomes(), {});
+    expect(withoutSiblings.invalidSiblings).toEqual({});
+  });
+});
+
+describe('EXECUTION_CATEGORIES', () => {
+  it('names the categories the seed executes, excluding the encryption gate', () => {
+    expect(EXECUTION_CATEGORIES).toEqual(['idr', 'storage', 'vc', 'did', 'renderTemplates']);
+  });
+});
+
+describe('SeedConfigurationError', () => {
+  it('names every missing variable and its category, and the opt-out, in its message', () => {
+    const summary: SeedRunSummary = {
+      mode: 'default',
+      categoriesSeeded: [],
+      categoriesPartial: [],
+      categoriesSkipped: [],
+      categoriesNotRun: EXECUTION_CATEGORIES,
+      missingVariables: {
+        encryption: ['DATA_ENCRYPTION_KEY (or the deprecated SERVICE_ENCRYPTION_KEY)'],
+        idr: ['DATA_ENCRYPTION_KEY (or the deprecated SERVICE_ENCRYPTION_KEY)'],
+      },
+      invalidSiblings: {},
+      partialDetails: {},
+    };
+
+    const error = new SeedConfigurationError(summary);
+
+    expect(error.name).toBe('SeedConfigurationError');
+    expect(error.summary).toBe(summary);
+    expect(error.message).toMatch(/encryption: DATA_ENCRYPTION_KEY/);
+    expect(error.message).toMatch(/idr: DATA_ENCRYPTION_KEY/);
+    expect(error.message).toMatch(/SEED_ALLOW_PARTIAL=true/);
+  });
+
+  it('also names an invalid sibling value in the same line as the missing variable, not only on a later boot', () => {
+    // An operator who fixes only the missing variable, redeploys, and only
+    // then discovers a second, unrelated typo has paid for two boot
+    // cycles a single message should have covered.
+    const summary: SeedRunSummary = {
+      mode: 'default',
+      categoriesSeeded: [],
+      categoriesPartial: [],
+      categoriesSkipped: [],
+      categoriesNotRun: EXECUTION_CATEGORIES,
+      missingVariables: { vc: ['SYSTEM_VC_API_KEY'] },
+      invalidSiblings: { vc: 'Invalid url' },
+      partialDetails: {},
+    };
+
+    const error = new SeedConfigurationError(summary);
+
+    expect(error.message).toMatch(/vc: SYSTEM_VC_API_KEY.*\(also: Invalid url\)/);
+  });
+
+  it('does not append an "(also: ...)" suffix for a category with nothing but a missing variable', () => {
+    const summary: SeedRunSummary = {
+      mode: 'default',
+      categoriesSeeded: [],
+      categoriesPartial: [],
+      categoriesSkipped: [],
+      categoriesNotRun: EXECUTION_CATEGORIES,
+      missingVariables: { did: ['SYSTEM_DID'] },
+      invalidSiblings: {},
+      partialDetails: {},
+    };
+
+    const error = new SeedConfigurationError(summary);
+
+    expect(error.message).toMatch(/did: SYSTEM_DID$/m);
+    expect(error.message).not.toMatch(/also:/);
+  });
+
+  it('names a reason that has no missing variable of its own on a standalone line (Major finding 2)', () => {
+    // A divergent DATA_ENCRYPTION_KEY / SERVICE_ENCRYPTION_KEY pair
+    // classifies 'other', never 'missing', so encryption never appears in
+    // missingVariables. Before this fix, the abort message dropped that
+    // reason entirely whenever an unrelated category (here, idr) was the
+    // one that actually triggered the abort.
+    const summary: SeedRunSummary = {
+      mode: 'default',
+      categoriesSeeded: [],
+      categoriesPartial: [],
+      categoriesSkipped: [],
+      categoriesNotRun: EXECUTION_CATEGORIES,
+      missingVariables: { idr: ['SYSTEM_IDR_BASE_URL'] },
+      invalidSiblings: {
+        encryption: 'DATA_ENCRYPTION_KEY and SERVICE_ENCRYPTION_KEY are both set with different values.',
+      },
+      partialDetails: {},
+    };
+
+    const error = new SeedConfigurationError(summary);
+
+    expect(error.message).toMatch(/idr: SYSTEM_IDR_BASE_URL/);
+    expect(error.message).toMatch(/encryption: DATA_ENCRYPTION_KEY and SERVICE_ENCRYPTION_KEY are both set/);
+    // Not folded into idr's "(also: ...)" suffix — it is its own category's line.
+    expect(error.message).not.toMatch(/idr:.*also:/);
+  });
+});

--- a/packages/reference-implementation/prisma/custom-seed.ts
+++ b/packages/reference-implementation/prisma/custom-seed.ts
@@ -28,6 +28,38 @@ import { reconcileRemovals, ReconcileBlockedError, type RemovalSummary } from '.
 const TRANSACTION_TIMEOUT = 60_000;
 const TRANSACTION_MAX_WAIT = 10_000;
 
+/**
+ * Thrown for a custom-seed manifest problem the operator must fix before a
+ * retry can succeed (unparsable YAML, a schema violation, a reference
+ * validation failure, or render templates requested with no storage
+ * service configured). `runCustomSeed()` throws rather than calling
+ * `process.exit()` itself, so this reaches `main()`'s own summary-and-exit
+ * handling (ADR-043 decision 6) the same way any other mid-run failure
+ * does, instead of terminating the process before a summary is built.
+ */
+export class CustomSeedFatalError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'CustomSeedFatalError';
+  }
+}
+
+/**
+ * Thrown when custom seed fails after some of its work already committed
+ * or produced a real external side effect (registrars/data models/render
+ * templates written by the atomic transaction, or a template already
+ * uploaded to storage before the transaction that would have recorded it
+ * failed). The caller's outcome tracking needs to know this failure is not
+ * "nothing happened", unlike `CustomSeedFatalError`, which is always
+ * thrown before any write.
+ */
+export class CustomSeedPartialProgressError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'CustomSeedPartialProgressError';
+  }
+}
+
 // ── Dependencies interface ───────────────────────────────────────────────────
 
 export interface CustomSeedDependencies {
@@ -48,6 +80,18 @@ export interface CustomSeedDependencies {
     }>;
   } | null;
   storageServiceInstanceId: string | null;
+}
+
+/**
+ * What actually happened on a successful (non-throwing) run, so the caller
+ * can report an honest category outcome: `ran: false` for the two no-op
+ * cases (no manifest, or an empty one — nothing to seed, not a failure),
+ * and `conformityFailed > 0` for the per-entry conformity-scheme failures
+ * `processConformitySchemes` acknowledges and counts without throwing.
+ */
+export interface CustomSeedRunResult {
+  ran: boolean;
+  conformityFailed: number;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -326,14 +370,14 @@ async function sweepOrphanCriteria(deps: CustomSeedDependencies): Promise<number
  * identities are resolved, unseen seeded rows evicted, entries ingested, and
  * orphaned criteria swept.
  */
-export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void> {
+export async function runCustomSeed(deps: CustomSeedDependencies): Promise<CustomSeedRunResult> {
   const { logger, prisma, systemTenantId, customSeedDir } = deps;
 
   // ── 1. Check manifest exists ─────────────────────────────────────────────
   const manifestPath = path.join(customSeedDir, 'seed.yaml');
   if (!fs.existsSync(manifestPath)) {
     logger.info({ manifestPath }, 'No custom seed manifest found — skipping custom seed');
-    return;
+    return { ran: false, conformityFailed: 0 };
   }
 
   // ── 2. Parse YAML ────────────────────────────────────────────────────────
@@ -347,7 +391,12 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
     const line = linePos?.[0]?.line ?? err?.line;
     const col = linePos?.[0]?.col ?? err?.col;
     logger.error({ file: manifestPath, line, col, error: err?.message }, 'Failed to parse custom seed YAML');
-    process.exit(1);
+    throw new CustomSeedFatalError(
+      `Failed to parse custom seed YAML at ${manifestPath}${
+        line !== undefined ? ` (line ${line}${col !== undefined ? `, col ${col}` : ''})` : ''
+      }: ${err?.message ?? 'unknown parse error'}`,
+      { cause: error },
+    );
   }
 
   // Which keys the YAML actually contains — captured before Zod defaulting
@@ -365,7 +414,11 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
         `Schema validation error: ${issue.message}`,
       );
     }
-    process.exit(1);
+    throw new CustomSeedFatalError(
+      `Custom seed manifest failed schema validation:\n${parseResult.error.issues
+        .map((issue) => `  - ${issue.path.join('.')}: ${issue.message}`)
+        .join('\n')}`,
+    );
   }
 
   const manifest = parseResult.data;
@@ -381,7 +434,7 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
     presence.registrars || presence.dataModels || presence.renderTemplates || presence.conformitySchemes;
   if (entityCount === 0 && !anySectionPresent) {
     logger.info('Custom seed manifest is empty — nothing to seed');
-    return;
+    return { ran: false, conformityFailed: 0 };
   }
 
   // ── 5. Phase 2 validation (referential integrity) ────────────────────────
@@ -571,7 +624,9 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
     for (const error of validationErrors) {
       logger.error({ error }, `Validation error: ${error}`);
     }
-    process.exit(1);
+    throw new CustomSeedFatalError(
+      `Custom seed manifest failed reference validation:\n${validationErrors.map((e) => `  - ${e}`).join('\n')}`,
+    );
   }
 
   // ── 6. Build upsert operations ──────────────────────────────────────────
@@ -592,7 +647,9 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
   if (ops.renderTemplates.length > 0) {
     if (!deps.storageService) {
       logger.error('Render templates require a storage service but none is available');
-      process.exit(1);
+      throw new CustomSeedFatalError(
+        'Custom seed manifest requests render templates, but no storage service is configured or was seeded',
+      );
     }
 
     for (const template of ops.renderTemplates) {
@@ -625,179 +682,193 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
     renderTemplates: 0,
     dataModels: 0,
   };
-  await prisma.$transaction(
-    async (tx: Prisma.TransactionClient) => {
-      // Upsert registrars. Updates stamp `source: CUSTOM_SEED` so the
-      // manifest claims (or re-claims) ownership of the rows it manages;
-      // core-seed collisions were rejected during validation, so a claimed
-      // row is either already manifest-owned or a pre-provenance legacy row.
-      for (const registrar of ops.registrars) {
-        await tx.registrar.upsert({
-          where: { id: registrar.id },
-          update: {
-            name: registrar.name,
-            namespace: registrar.namespace,
-            url: registrar.url,
-            idrServiceInstanceId: registrar.idrServiceInstanceId,
-            source: RecordSource.CUSTOM_SEED,
-          },
-          create: {
-            id: registrar.id,
-            tenantId: registrar.tenantId,
-            name: registrar.name,
-            namespace: registrar.namespace,
-            url: registrar.url,
-            idrServiceInstanceId: registrar.idrServiceInstanceId,
-            source: RecordSource.CUSTOM_SEED,
-          },
-        });
-      }
-
-      // Upsert identifier schemes. `registrarId` is part of the update so a
-      // scheme moved between registrars in the manifest is re-attached rather
-      // than left behind for its old parent's cascade to delete.
-      for (const scheme of ops.identifierSchemes) {
-        await tx.identifierScheme.upsert({
-          where: { id: scheme.id },
-          update: {
-            registrarId: scheme.registrarId,
-            name: scheme.name,
-            primaryKey: scheme.primaryKey,
-            validationPattern: scheme.validationPattern,
-            linkTemplate: scheme.linkTemplate,
-            source: RecordSource.CUSTOM_SEED,
-          },
-          create: {
-            id: scheme.id,
-            tenantId: scheme.tenantId,
-            registrarId: scheme.registrarId,
-            name: scheme.name,
-            primaryKey: scheme.primaryKey,
-            validationPattern: scheme.validationPattern,
-            linkTemplate: scheme.linkTemplate,
-            source: RecordSource.CUSTOM_SEED,
-          },
-        });
-      }
-
-      // Upsert qualifiers. `schemeId` is part of the update for the same
-      // reparenting reason as identifier schemes above.
-      for (const qualifier of ops.qualifiers) {
-        await tx.schemeQualifier.upsert({
-          where: { id: qualifier.id },
-          update: {
-            schemeId: qualifier.schemeId,
-            key: qualifier.key,
-            description: qualifier.description,
-            validationPattern: qualifier.validationPattern,
-            order: qualifier.order,
-            source: RecordSource.CUSTOM_SEED,
-          },
-          create: {
-            id: qualifier.id,
-            schemeId: qualifier.schemeId,
-            key: qualifier.key,
-            description: qualifier.description,
-            validationPattern: qualifier.validationPattern,
-            order: qualifier.order,
-            source: RecordSource.CUSTOM_SEED,
-          },
-        });
-      }
-
-      // Upsert data models (as extensions)
-      for (const dataModel of ops.dataModels) {
-        await tx.dataModel.upsert({
-          where: { id: dataModel.id },
-          update: {
-            name: dataModel.name,
-            credentialType: dataModel.credentialType,
-            version: dataModel.version,
-            isExtension: true,
-            parentConfigId: dataModel.parentConfigId,
-            schemaUrl: dataModel.schemaUrl,
-            contextUrl: dataModel.contextUrl,
-            websiteUrl: dataModel.websiteUrl,
-            source: RecordSource.CUSTOM_SEED,
-          },
-          create: {
-            id: dataModel.id,
-            tenantId: dataModel.tenantId,
-            name: dataModel.name,
-            credentialType: dataModel.credentialType,
-            version: dataModel.version,
-            isExtension: true,
-            parentConfigId: dataModel.parentConfigId,
-            schemaUrl: dataModel.schemaUrl,
-            contextUrl: dataModel.contextUrl,
-            websiteUrl: dataModel.websiteUrl,
-            source: RecordSource.CUSTOM_SEED,
-          },
-        });
-      }
-
-      // Upsert render templates (with storage metadata from step 7)
-      for (const template of ops.renderTemplates) {
-        const storageResult = templateResults.find((r) => r.templateId === template.id);
-        if (!storageResult) {
-          // Every template in ops.renderTemplates was uploaded in step 7, so
-          // a missing result is a broken invariant, not a skippable entry.
-          throw new Error(`render template "${template.id}" has no storage upload result; aborting seed transaction`);
+  try {
+    await prisma.$transaction(
+      async (tx: Prisma.TransactionClient) => {
+        // Upsert registrars. Updates stamp `source: CUSTOM_SEED` so the
+        // manifest claims (or re-claims) ownership of the rows it manages;
+        // core-seed collisions were rejected during validation, so a claimed
+        // row is either already manifest-owned or a pre-provenance legacy row.
+        for (const registrar of ops.registrars) {
+          await tx.registrar.upsert({
+            where: { id: registrar.id },
+            update: {
+              name: registrar.name,
+              namespace: registrar.namespace,
+              url: registrar.url,
+              idrServiceInstanceId: registrar.idrServiceInstanceId,
+              source: RecordSource.CUSTOM_SEED,
+            },
+            create: {
+              id: registrar.id,
+              tenantId: registrar.tenantId,
+              name: registrar.name,
+              namespace: registrar.namespace,
+              url: registrar.url,
+              idrServiceInstanceId: registrar.idrServiceInstanceId,
+              source: RecordSource.CUSTOM_SEED,
+            },
+          });
         }
 
-        await tx.renderTemplate.upsert({
-          where: { id: template.id },
-          update: {
-            name: template.name,
-            dataModelId: template.dataModelId,
-            storageUrl: storageResult.storageUrl,
-            digestMultibase: storageResult.digestMultibase,
-            isDefault: template.isDefault,
-            renderMethodType: template.renderMethodType as RenderMethodType,
-            inline: template.inline,
-            mediaType: template.mediaType,
-            mediaQuery: template.mediaQuery,
-            storageServiceInstanceId: deps.storageServiceInstanceId,
-            storageExternalId: storageResult.externalId,
-            storageBucket: storageResult.bucket,
-            storageContentType: storageResult.contentType,
-            source: RecordSource.CUSTOM_SEED,
-          },
-          create: {
-            id: template.id,
-            tenantId: template.tenantId,
-            name: template.name,
-            dataModelId: template.dataModelId,
-            storageUrl: storageResult.storageUrl,
-            digestMultibase: storageResult.digestMultibase,
-            isDefault: template.isDefault,
-            renderMethodType: template.renderMethodType as RenderMethodType,
-            inline: template.inline,
-            mediaType: template.mediaType,
-            mediaQuery: template.mediaQuery,
-            storageServiceInstanceId: deps.storageServiceInstanceId,
-            storageExternalId: storageResult.externalId,
-            storageBucket: storageResult.bucket,
-            storageContentType: storageResult.contentType,
-            source: RecordSource.CUSTOM_SEED,
-          },
-        });
-      }
+        // Upsert identifier schemes. `registrarId` is part of the update so a
+        // scheme moved between registrars in the manifest is re-attached rather
+        // than left behind for its old parent's cascade to delete.
+        for (const scheme of ops.identifierSchemes) {
+          await tx.identifierScheme.upsert({
+            where: { id: scheme.id },
+            update: {
+              registrarId: scheme.registrarId,
+              name: scheme.name,
+              primaryKey: scheme.primaryKey,
+              validationPattern: scheme.validationPattern,
+              linkTemplate: scheme.linkTemplate,
+              source: RecordSource.CUSTOM_SEED,
+            },
+            create: {
+              id: scheme.id,
+              tenantId: scheme.tenantId,
+              registrarId: scheme.registrarId,
+              name: scheme.name,
+              primaryKey: scheme.primaryKey,
+              validationPattern: scheme.validationPattern,
+              linkTemplate: scheme.linkTemplate,
+              source: RecordSource.CUSTOM_SEED,
+            },
+          });
+        }
 
-      // Removal phase: delete manifest-owned rows whose entries are gone.
-      // Runs after the upserts (so reparented children are re-attached before
-      // their old parent is considered) and inside the same transaction, so a
-      // blocked removal rolls back the whole run. Throws ReconcileBlockedError
-      // when a deletion would cascade into rows the manifest does not own;
-      // the outer catch in seed.ts logs it and exits non-zero.
-      removalSummary = await reconcileRemovals(tx, manifest, presence, systemTenantId).catch((err: unknown) => {
-        if (err instanceof ReconcileBlockedError) throw err;
-        throw new Error('Custom seed removal phase failed', { cause: err });
-      });
-      logger.info({ ...removalSummary }, 'Custom seed removal phase complete');
-    },
-    { timeout: TRANSACTION_TIMEOUT, maxWait: TRANSACTION_MAX_WAIT },
-  );
+        // Upsert qualifiers. `schemeId` is part of the update for the same
+        // reparenting reason as identifier schemes above.
+        for (const qualifier of ops.qualifiers) {
+          await tx.schemeQualifier.upsert({
+            where: { id: qualifier.id },
+            update: {
+              schemeId: qualifier.schemeId,
+              key: qualifier.key,
+              description: qualifier.description,
+              validationPattern: qualifier.validationPattern,
+              order: qualifier.order,
+              source: RecordSource.CUSTOM_SEED,
+            },
+            create: {
+              id: qualifier.id,
+              schemeId: qualifier.schemeId,
+              key: qualifier.key,
+              description: qualifier.description,
+              validationPattern: qualifier.validationPattern,
+              order: qualifier.order,
+              source: RecordSource.CUSTOM_SEED,
+            },
+          });
+        }
+
+        // Upsert data models (as extensions)
+        for (const dataModel of ops.dataModels) {
+          await tx.dataModel.upsert({
+            where: { id: dataModel.id },
+            update: {
+              name: dataModel.name,
+              credentialType: dataModel.credentialType,
+              version: dataModel.version,
+              isExtension: true,
+              parentConfigId: dataModel.parentConfigId,
+              schemaUrl: dataModel.schemaUrl,
+              contextUrl: dataModel.contextUrl,
+              websiteUrl: dataModel.websiteUrl,
+              source: RecordSource.CUSTOM_SEED,
+            },
+            create: {
+              id: dataModel.id,
+              tenantId: dataModel.tenantId,
+              name: dataModel.name,
+              credentialType: dataModel.credentialType,
+              version: dataModel.version,
+              isExtension: true,
+              parentConfigId: dataModel.parentConfigId,
+              schemaUrl: dataModel.schemaUrl,
+              contextUrl: dataModel.contextUrl,
+              websiteUrl: dataModel.websiteUrl,
+              source: RecordSource.CUSTOM_SEED,
+            },
+          });
+        }
+
+        // Upsert render templates (with storage metadata from step 7)
+        for (const template of ops.renderTemplates) {
+          const storageResult = templateResults.find((r) => r.templateId === template.id);
+          if (!storageResult) {
+            // Every template in ops.renderTemplates was uploaded in step 7, so
+            // a missing result is a broken invariant, not a skippable entry.
+            throw new Error(`render template "${template.id}" has no storage upload result; aborting seed transaction`);
+          }
+
+          await tx.renderTemplate.upsert({
+            where: { id: template.id },
+            update: {
+              name: template.name,
+              dataModelId: template.dataModelId,
+              storageUrl: storageResult.storageUrl,
+              digestMultibase: storageResult.digestMultibase,
+              isDefault: template.isDefault,
+              renderMethodType: template.renderMethodType as RenderMethodType,
+              inline: template.inline,
+              mediaType: template.mediaType,
+              mediaQuery: template.mediaQuery,
+              storageServiceInstanceId: deps.storageServiceInstanceId,
+              storageExternalId: storageResult.externalId,
+              storageBucket: storageResult.bucket,
+              storageContentType: storageResult.contentType,
+              source: RecordSource.CUSTOM_SEED,
+            },
+            create: {
+              id: template.id,
+              tenantId: template.tenantId,
+              name: template.name,
+              dataModelId: template.dataModelId,
+              storageUrl: storageResult.storageUrl,
+              digestMultibase: storageResult.digestMultibase,
+              isDefault: template.isDefault,
+              renderMethodType: template.renderMethodType as RenderMethodType,
+              inline: template.inline,
+              mediaType: template.mediaType,
+              mediaQuery: template.mediaQuery,
+              storageServiceInstanceId: deps.storageServiceInstanceId,
+              storageExternalId: storageResult.externalId,
+              storageBucket: storageResult.bucket,
+              storageContentType: storageResult.contentType,
+              source: RecordSource.CUSTOM_SEED,
+            },
+          });
+        }
+
+        // Removal phase: delete manifest-owned rows whose entries are gone.
+        // Runs after the upserts (so reparented children are re-attached before
+        // their old parent is considered) and inside the same transaction, so a
+        // blocked removal rolls back the whole run. Throws ReconcileBlockedError
+        // when a deletion would cascade into rows the manifest does not own;
+        // the outer catch in seed.ts logs it and exits non-zero.
+        removalSummary = await reconcileRemovals(tx, manifest, presence, systemTenantId).catch((err: unknown) => {
+          if (err instanceof ReconcileBlockedError) throw err;
+          throw new Error('Custom seed removal phase failed', { cause: err });
+        });
+        logger.info({ ...removalSummary }, 'Custom seed removal phase complete');
+      },
+      { timeout: TRANSACTION_TIMEOUT, maxWait: TRANSACTION_MAX_WAIT },
+    );
+  } catch (error) {
+    // A template already uploaded to storage (step 7) survives a rolled-back
+    // transaction as an orphaned object with no database row pointing at it:
+    // a real, if incomplete, side effect the caller's outcome tracking needs
+    // to see, rather than the "nothing happened" a plain rethrow implies.
+    if (templateResults.length > 0) {
+      throw new CustomSeedPartialProgressError(
+        'Custom seed database transaction failed after external template upload(s) already completed',
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 
   // ── 9. Reconcile and ingest conformity schemes (post-transaction) ─────
   // Each ingest manages its own transaction internally; run after the main
@@ -817,31 +888,42 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
   };
 
   if (presence.conformitySchemes || manifest.conformitySchemes.length > 0) {
-    const resolution = resolveConformityEntries(deps, manifest);
-    conformitySummary.failed += resolution.failed;
+    try {
+      const resolution = resolveConformityEntries(deps, manifest);
+      conformitySummary.failed += resolution.failed;
 
-    if (presence.conformitySchemes) {
-      if (resolution.failed > 0) {
-        logger.error(
-          { failedEntries: resolution.failed },
-          'One or more conformity scheme file entries could not be resolved; skipping seeded-scheme eviction this boot (reconciliation incomplete)',
-        );
-      } else {
-        conformitySummary.evicted = await evictUnseenSeededSchemes(
-          deps,
-          resolution.resolved.map((entry) => entry.sourceUrl),
-        ).catch((err: unknown) => {
-          throw new Error('Seeded conformity scheme eviction failed', { cause: err });
+      if (presence.conformitySchemes) {
+        if (resolution.failed > 0) {
+          logger.error(
+            { failedEntries: resolution.failed },
+            'One or more conformity scheme file entries could not be resolved; skipping seeded-scheme eviction this boot (reconciliation incomplete)',
+          );
+        } else {
+          conformitySummary.evicted = await evictUnseenSeededSchemes(
+            deps,
+            resolution.resolved.map((entry) => entry.sourceUrl),
+          ).catch((err: unknown) => {
+            throw new Error('Seeded conformity scheme eviction failed', { cause: err });
+          });
+        }
+      }
+
+      await processConformitySchemes(deps, resolution.resolved, conformitySummary);
+
+      if (presence.conformitySchemes && resolution.failed === 0) {
+        conformitySummary.criteriaSwept = await sweepOrphanCriteria(deps).catch((err: unknown) => {
+          throw new Error('Orphan criterion sweep failed', { cause: err });
         });
       }
-    }
-
-    await processConformitySchemes(deps, resolution.resolved, conformitySummary);
-
-    if (presence.conformitySchemes && resolution.failed === 0) {
-      conformitySummary.criteriaSwept = await sweepOrphanCriteria(deps).catch((err: unknown) => {
-        throw new Error('Orphan criterion sweep failed', { cause: err });
-      });
+    } catch (error) {
+      // The transaction above already committed the registrars, data
+      // models and templates it upserted; only the post-commit conformity
+      // reconciliation failed, so this is partial progress, not "nothing
+      // happened".
+      throw new CustomSeedPartialProgressError(
+        'Custom seed failed during conformity scheme reconciliation after registrars, data models and templates were already committed',
+        { cause: error },
+      );
     }
   }
 
@@ -866,4 +948,6 @@ export async function runCustomSeed(deps: CustomSeedDependencies): Promise<void>
   } else {
     logger.info(summary, 'Custom seed completed successfully');
   }
+
+  return { ran: true, conformityFailed: conformitySummary.failed };
 }

--- a/packages/reference-implementation/prisma/prisma.config.ts
+++ b/packages/reference-implementation/prisma/prisma.config.ts
@@ -35,6 +35,6 @@ export default defineConfig({
   schema: './schema.prisma',
   migrations: {
     path: './migrations',
-    seed: 'npx tsx seed.ts',
+    seed: 'npx tsx prisma/seed-cli.ts',
   },
 });

--- a/packages/reference-implementation/prisma/seed-cli.ts
+++ b/packages/reference-implementation/prisma/seed-cli.ts
@@ -1,0 +1,28 @@
+import { main, prisma, logger } from './seed.js';
+
+/**
+ * The seed's actual CLI entrypoint (`tsx seed-cli.ts`). `seed.ts` exports
+ * `main` and `prisma` without running them, so the integration suite can
+ * import and drive the real decision path against the rig database; this
+ * file supplies the process-level behaviour (exit code, disconnect) that
+ * only makes sense when actually running as a script.
+ *
+ * `process.exit()` terminates the process immediately, abandoning any
+ * pending microtask, so it must run after `prisma.$disconnect()` settles,
+ * never inside a `.catch()` that a chained `.finally()` follows: `.finally`
+ * would never get the chance to run. Recording the exit code and exiting
+ * only once the disconnect has resolved is what keeps the connection
+ * closed on every path, success and failure alike.
+ */
+main()
+  .then(
+    () => 0,
+    (e) => {
+      logger.error({ err: e }, 'Seed failed');
+      return 1;
+    },
+  )
+  .then(async (exitCode) => {
+    await prisma.$disconnect();
+    process.exit(exitCode);
+  });

--- a/packages/reference-implementation/prisma/seed-preflight.ts
+++ b/packages/reference-implementation/prisma/seed-preflight.ts
@@ -1,0 +1,455 @@
+import type { z } from 'zod';
+import { adapterRegistry, ServiceType } from '@uncefact/untp-ri-services';
+import { resolveDataEncryptionKey } from '../src/lib/encryption/resolve-data-encryption-key.js';
+
+/**
+ * Pure, env-only resolution of what the seed can and cannot configure,
+ * decided before the seed writes anything or calls any external service
+ * (ADR-043, decision 3). This module answers one question per category:
+ * is its required configuration present? It does not attempt a category's
+ * actual work (no database writes, no HTTP calls, no adapter construction
+ * beyond a schema parse), so `seed.ts` still owns resolving and executing
+ * each category; this only decides whether the run should proceed.
+ */
+
+export type CategoryName = 'encryption' | 'idr' | 'storage' | 'vc' | 'did' | 'renderTemplates';
+
+/** Every category other than `encryption`, which is a gate rather than something the seed seeds directly. */
+export type ExecutionCategoryName = Exclude<CategoryName, 'encryption'>;
+
+/**
+ * The categories the seed actually executes. `encryption` is a gate that
+ * other categories depend on rather than something the seed seeds on its
+ * own, so it is tracked in `categories` but excluded here.
+ */
+export const EXECUTION_CATEGORIES: ExecutionCategoryName[] = ['idr', 'storage', 'vc', 'did', 'renderTemplates'];
+
+export type CategoryStatus = 'ok' | 'missing' | 'other';
+
+export interface CategoryResult {
+  status: CategoryStatus;
+  /** Environment variable names responsible, set only when status is 'missing'. */
+  missingVars?: string[];
+  /** Present when status is 'other' (unknown adapter type, invalid value): not a missing variable. */
+  reason?: string;
+  /** The category whose own unmet requirement this result was propagated from, when gated. */
+  gatedBy?: CategoryName;
+}
+
+export interface SeedPreflightResult {
+  categories: Record<CategoryName, CategoryResult>;
+  /** Missing environment variables, keyed by every category that reports them (including gated ones). */
+  missingByCategory: Record<string, string[]>;
+  /**
+   * For a category that is 'missing' AND also has an unrelated problem (an
+   * invalid value in another field, or an adapter-type typo): that other
+   * problem's description, keyed by category. Reported alongside the
+   * missing variables rather than dropped, so an operator sees both
+   * problems in the same boot cycle instead of redeploying once per fix.
+   */
+  otherIssuesByCategory: Record<string, string>;
+  hasMissing: boolean;
+}
+
+/**
+ * `SYSTEM_DID=` or `SYSTEM_IDR_API_KEY=  ` in an env file is the common
+ * shape of "not configured", not a deliberate empty value; no field this
+ * preflight resolves has a legitimate empty-string or whitespace-only
+ * value. Normalising an empty or whitespace-only value to `undefined`
+ * before it reaches zod means it fails the same `invalid_type` /
+ * `received: undefined` way an absent variable does, so it is classified
+ * 'missing' through the same path rather than needing a second check.
+ * Exported so `seed.ts`'s own execution consumes the same normalisation:
+ * without it, a whitespace-only value preflight correctly calls missing
+ * would still satisfy zod's `.min(1)` and get written to the database.
+ */
+export function normalizeEnvValue(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * Only an issue that means "this field was never supplied" counts as a
+ * missing environment variable. Every other zod failure (a value present
+ * but the wrong shape) is a configuration mistake, not an absence, and
+ * ADR-043 decision 2 keeps those in today's warn-and-skip behaviour rather
+ * than the fail-loud posture.
+ */
+function isMissingIssue(issue: z.ZodIssue): boolean {
+  return issue.code === 'invalid_type' && (issue as { received?: unknown }).received === 'undefined';
+}
+
+/**
+ * Every field this preflight resolves that has its own environment
+ * variable, independent of whether the adapter type naming it is even
+ * recognised. Checking these directly against `env` (rather than only
+ * through a recognised adapter's zod schema) is what lets a missing
+ * variable win over an unrelated problem in the same category (see
+ * `classifyCategory` below): the schema can't be parsed against an unknown
+ * adapter type at all, but whether its known fields were ever supplied is
+ * still answerable from the raw environment.
+ */
+function computeMissingVars(env: NodeJS.ProcessEnv, fieldToEnvVar: Record<string, string>): string[] {
+  const missing = new Set<string>();
+  for (const envVar of Object.values(fieldToEnvVar)) {
+    if (normalizeEnvValue(env[envVar]) === undefined) missing.add(envVar);
+  }
+  return Array.from(missing);
+}
+
+/**
+ * Splits a schema parse's failures into missing variables (a field whose
+ * env var was never supplied) and everything else (an invalid value, a
+ * malformed URL, an out-of-range enum). Kept separate rather than folded
+ * into one verdict, because whether a category counts as 'missing' must
+ * depend only on the first set, never on whether the second is also
+ * non-empty (see `classifyCategory`).
+ */
+function classifyParse(
+  result: z.SafeParseReturnType<unknown, unknown>,
+  fieldToEnvVar: Record<string, string>,
+): { missingVars: string[]; otherReasons: string[] } {
+  if (result.success) return { missingVars: [], otherReasons: [] };
+
+  const missingVars = new Set<string>();
+  const otherReasons: string[] = [];
+  for (const issue of result.error.issues) {
+    const field = String(issue.path[0]);
+    const envVar = fieldToEnvVar[field];
+    if (isMissingIssue(issue) && envVar) {
+      missingVars.add(envVar);
+    } else {
+      otherReasons.push(issue.message);
+    }
+  }
+  return { missingVars: Array.from(missingVars), otherReasons };
+}
+
+/**
+ * The single rule every adapter category is classified by: a missing
+ * required variable always makes the category 'missing', regardless of
+ * whether the category also has an unrelated problem (an invalid value in
+ * another field, or an adapter-type typo). Reversing that priority would
+ * mean a second, independent mistake in the same category (mistyping
+ * SYSTEM_VC_BASE_URL, say) downgrades an absent SYSTEM_VC_API_KEY out of
+ * the fail-loud posture, so making a deployment's configuration worse
+ * would make validation weaker.
+ *
+ * When a category is 'missing' AND also has an unrelated problem,
+ * `reason` is carried alongside `missingVars` rather than dropped: an
+ * operator who fixes only the missing variable, redeploys, and only then
+ * discovers the typo has paid for two boot cycles a single message could
+ * have covered, the same principle decision 4 already applies to reporting
+ * every missing variable together.
+ */
+function classifyCategory(missingVars: string[], otherReason: string | undefined): CategoryResult {
+  if (missingVars.length > 0) return { status: 'missing', missingVars, reason: otherReason };
+  if (otherReason) return { status: 'other', reason: otherReason };
+  return { status: 'ok' };
+}
+
+function resolveEncryptionCategory(env: NodeJS.ProcessEnv): CategoryResult {
+  try {
+    const resolved = resolveDataEncryptionKey(env);
+    // resolveDataEncryptionKey() is a shared utility (also used at app
+    // startup) that already treats an empty string as absent via `||`; a
+    // whitespace-only value is not, so it is normalised here rather than
+    // by changing that function's own semantics.
+    if (!normalizeEnvValue(resolved.key)) {
+      return { status: 'missing', missingVars: ['DATA_ENCRYPTION_KEY (or the deprecated SERVICE_ENCRYPTION_KEY)'] };
+    }
+    return { status: 'ok' };
+  } catch (error) {
+    // Divergent DATA_ENCRYPTION_KEY / SERVICE_ENCRYPTION_KEY values: not a
+    // missing variable, so it does not trigger the fail-loud posture here.
+    // The reason is still carried, and the same divergence throws again
+    // when the seed resolves the key for real, where the outer handler
+    // reports it with the run's summary.
+    return { status: 'other', reason: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Maps each of the adapter's own zod-required fields to the environment
+ * variable an operator sets it from. A field added to the adapter's schema
+ * without a matching entry here is caught by
+ * `seed-preflight-field-coverage.test.ts`, which derives the required
+ * field set from the schema itself rather than trusting this map to have
+ * kept up.
+ */
+export const IDR_FIELD_TO_ENV: Record<string, string> = {
+  baseUrl: 'SYSTEM_IDR_BASE_URL',
+  apiKey: 'SYSTEM_IDR_API_KEY',
+  defaultLinkType: 'SYSTEM_IDR_DEFAULT_LINK_TYPE',
+  defaultMimeType: 'SYSTEM_IDR_DEFAULT_MIME_TYPE',
+  defaultIanaLanguage: 'SYSTEM_IDR_DEFAULT_LANGUAGE',
+  defaultContext: 'SYSTEM_IDR_DEFAULT_CONTEXT',
+};
+
+function resolveIdrCategory(env: NodeJS.ProcessEnv): CategoryResult {
+  const idrAdapters = adapterRegistry[ServiceType.IDR];
+  const adapterType = (env.SYSTEM_IDR_ADAPTER_TYPE as keyof typeof idrAdapters) || 'PYX_IDR';
+  const entry = idrAdapters[adapterType];
+  if (!entry) {
+    return classifyCategory(computeMissingVars(env, IDR_FIELD_TO_ENV), `Unknown IDR adapter type: "${adapterType}"`);
+  }
+  const result = entry.configSchema.safeParse({
+    baseUrl: normalizeEnvValue(env.SYSTEM_IDR_BASE_URL),
+    apiKey: normalizeEnvValue(env.SYSTEM_IDR_API_KEY),
+    apiVersion: normalizeEnvValue(env.SYSTEM_IDR_API_VERSION),
+    defaultLinkType: normalizeEnvValue(env.SYSTEM_IDR_DEFAULT_LINK_TYPE),
+    defaultMimeType: normalizeEnvValue(env.SYSTEM_IDR_DEFAULT_MIME_TYPE),
+    defaultIanaLanguage: normalizeEnvValue(env.SYSTEM_IDR_DEFAULT_LANGUAGE),
+    defaultContext: normalizeEnvValue(env.SYSTEM_IDR_DEFAULT_CONTEXT),
+    defaultFwqs: env.SYSTEM_IDR_DEFAULT_FWQS === 'true',
+  });
+  const { missingVars, otherReasons } = classifyParse(result, IDR_FIELD_TO_ENV);
+  return classifyCategory(missingVars, otherReasons.length > 0 ? otherReasons.join('; ') : undefined);
+}
+
+export const STORAGE_FIELD_TO_ENV: Record<string, string> = {
+  baseUrl: 'SYSTEM_STORAGE_BASE_URL',
+  publicBucket: 'SYSTEM_STORAGE_PUBLIC_BUCKET',
+  privateBucket: 'SYSTEM_STORAGE_PRIVATE_BUCKET',
+};
+
+function resolveStorageCategory(env: NodeJS.ProcessEnv): CategoryResult {
+  const storageAdapters = adapterRegistry[ServiceType.STORAGE];
+  const adapterType = (env.SYSTEM_STORAGE_ADAPTER_TYPE as keyof typeof storageAdapters) || 'UNCEFACT_STORAGE';
+  const entry = storageAdapters[adapterType];
+  if (!entry) {
+    return classifyCategory(
+      computeMissingVars(env, STORAGE_FIELD_TO_ENV),
+      `Unknown storage adapter type: "${adapterType}"`,
+    );
+  }
+  const result = entry.configSchema.safeParse({
+    baseUrl: normalizeEnvValue(env.SYSTEM_STORAGE_BASE_URL),
+    apiKey: normalizeEnvValue(env.SYSTEM_STORAGE_API_KEY),
+    apiVersion: normalizeEnvValue(env.SYSTEM_STORAGE_API_VERSION),
+    publicBucket: normalizeEnvValue(env.SYSTEM_STORAGE_PUBLIC_BUCKET),
+    privateBucket: normalizeEnvValue(env.SYSTEM_STORAGE_PRIVATE_BUCKET),
+  });
+  const { missingVars, otherReasons } = classifyParse(result, STORAGE_FIELD_TO_ENV);
+  return classifyCategory(missingVars, otherReasons.length > 0 ? otherReasons.join('; ') : undefined);
+}
+
+export const VC_FIELD_TO_ENV: Record<string, string> = {
+  baseUrl: 'SYSTEM_VC_BASE_URL',
+  apiKey: 'SYSTEM_VC_API_KEY',
+};
+
+function resolveVcCategory(env: NodeJS.ProcessEnv): CategoryResult {
+  const vcAdapters = adapterRegistry[ServiceType.VC];
+  const adapterType = (env.SYSTEM_VC_ADAPTER_TYPE as keyof typeof vcAdapters) || 'VCKIT';
+  const entry = vcAdapters[adapterType];
+  if (!entry) {
+    return classifyCategory(computeMissingVars(env, VC_FIELD_TO_ENV), `Unknown VC adapter type: "${adapterType}"`);
+  }
+  const result = entry.configSchema.safeParse({
+    baseUrl: normalizeEnvValue(env.SYSTEM_VC_BASE_URL),
+    apiKey: normalizeEnvValue(env.SYSTEM_VC_API_KEY),
+    apiVersion: normalizeEnvValue(env.SYSTEM_VC_API_VERSION),
+  });
+  const { missingVars, otherReasons } = classifyParse(result, VC_FIELD_TO_ENV);
+  return classifyCategory(missingVars, otherReasons.length > 0 ? otherReasons.join('; ') : undefined);
+}
+
+/**
+ * Mirrors `getDidConfig`'s own requirement (SYSTEM_DID must be set) without
+ * going through its module-level cache, so preflight stays a pure function
+ * of the env it is given rather than of whichever env last populated that
+ * cache. `seed.ts` still calls `getDidConfig` itself when it actually seeds
+ * the DID.
+ */
+function resolveDidCategory(env: NodeJS.ProcessEnv): CategoryResult {
+  if (!normalizeEnvValue(env.SYSTEM_DID)) {
+    return { status: 'missing', missingVars: ['SYSTEM_DID'] };
+  }
+  return { status: 'ok' };
+}
+
+/**
+ * Applies a category's dependency on another category. A category with its
+ * own configuration in order still can't run when what it depends on
+ * can't, so an unmet gate overrides an otherwise-ok own result. A gate that
+ * failed for a non-missing reason ('other') propagates as 'other' too,
+ * rather than being reported as a missing variable it never had.
+ */
+function applyGate(own: CategoryResult, gate: CategoryResult, gateName: CategoryName): CategoryResult {
+  if (own.status !== 'ok' || gate.status === 'ok') return own;
+  if (gate.status === 'missing') {
+    return { status: 'missing', missingVars: gate.missingVars ?? [], gatedBy: gateName };
+  }
+  return { status: 'other', reason: `depends on category "${gateName}", which is not configured`, gatedBy: gateName };
+}
+
+/**
+ * Resolves every category's configuration from `env` and reports which are
+ * missing required variables. Categories are resolved independently of
+ * their gates first (so every missing variable is visible in one pass, per
+ * ADR-043 decision 4), then gating is applied (encryption gates idr,
+ * storage and vc; vc gates did; storage gates renderTemplates).
+ */
+export function runSeedPreflight(env: NodeJS.ProcessEnv = process.env): SeedPreflightResult {
+  const encryption = resolveEncryptionCategory(env);
+  const idr = applyGate(resolveIdrCategory(env), encryption, 'encryption');
+  const storage = applyGate(resolveStorageCategory(env), encryption, 'encryption');
+  const vc = applyGate(resolveVcCategory(env), encryption, 'encryption');
+  const did = applyGate(resolveDidCategory(env), vc, 'vc');
+  const renderTemplates = applyGate({ status: 'ok' }, storage, 'storage');
+
+  const categories: Record<CategoryName, CategoryResult> = { encryption, idr, storage, vc, did, renderTemplates };
+
+  const missingByCategory: Record<string, string[]> = {};
+  const otherIssuesByCategory: Record<string, string> = {};
+  let hasMissing = false;
+  for (const [name, result] of Object.entries(categories)) {
+    if (result.status === 'missing') {
+      hasMissing = true;
+      missingByCategory[name] = result.missingVars ?? [];
+    }
+    // Collected whenever a reason is present, not only when the same
+    // category is also 'missing': an 'other' category (for example,
+    // divergent DATA_ENCRYPTION_KEY/SERVICE_ENCRYPTION_KEY values) carries
+    // its own reason with no missing variable attached, and an unrelated
+    // missing variable elsewhere must not make that reason disappear from
+    // the run's record.
+    if (result.reason) otherIssuesByCategory[name] = result.reason;
+  }
+
+  return { categories, missingByCategory, otherIssuesByCategory, hasMissing };
+}
+
+/**
+ * One structured summary emitted exactly once on every seed exit path,
+ * a successful completion, a mid-run failure, or the default-mode
+ * preflight abort alike (ADR-043 decision 6). A category that completed
+ * only some of its work (for example, some but not all render templates
+ * uploaded because a template file was missing) is reported under
+ * `categoriesPartial` rather than `categoriesSeeded`, with what was
+ * skipped named in `partialDetails`, so the summary never claims a
+ * category fully seeded when it did not.
+ */
+export interface SeedRunSummary {
+  mode: 'default' | 'partial';
+  categoriesSeeded: string[];
+  categoriesPartial: string[];
+  categoriesSkipped: string[];
+  categoriesNotRun: string[];
+  missingVariables: Record<string, string[]>;
+  /**
+   * A category can be 'missing' and also have an unrelated, invalid value
+   * in another field (a malformed URL alongside an absent key). Reported
+   * here, keyed by category, so `SeedConfigurationError`'s message names
+   * both problems in the same boot cycle rather than only the missing one.
+   */
+  invalidSiblings: Record<string, string>;
+  partialDetails: Record<string, string[]>;
+}
+
+/**
+ * The parts of the run that carry no gated configuration (no required
+ * environment variable, so preflight never resolves a status for them)
+ * but that `main()` still executes and that can still complete only
+ * partially: the system tenant upsert, the core data model rows, and the
+ * deployer-provided custom seed. Tracked in the summary alongside the
+ * gated `ExecutionCategoryName`s so the record covers the whole run, not
+ * only the categories a missing variable can gate.
+ */
+export type AlwaysRunCategoryName = 'tenant' | 'dataModels' | 'customSeed';
+
+export const ALWAYS_RUN_CATEGORIES: AlwaysRunCategoryName[] = ['tenant', 'dataModels', 'customSeed'];
+
+/** Every category the summary reports on: the gated ones plus the always-run ones. */
+export type SummaryCategoryName = ExecutionCategoryName | AlwaysRunCategoryName;
+
+/** Whether a category fully completed, completed some of its work, or did not run. */
+export type CategoryOutcome = 'seeded' | 'partial' | 'skipped';
+
+/**
+ * Builds the one structured summary `seed.ts`'s `main()` emits on every
+ * exit path (ADR-043 decision 6): a successful completion, a mid-run
+ * failure, and (separately, via `SeedConfigurationError`) the default-mode
+ * preflight abort all report through this same shape. Exported and pure
+ * (no logging, no I/O) so its contents can be unit-tested directly against
+ * the outcome shapes `main()` can produce, rather than only observable by
+ * spying on a log call — the extraction the two prior review findings
+ * (the summary skipped on a mid-run failure, and a partially-completed
+ * category reported as fully seeded) point back to as the root cause.
+ */
+export function buildOutcomeSummary(
+  mode: SeedRunSummary['mode'],
+  missingVariables: Record<string, string[]>,
+  outcomes: Record<SummaryCategoryName, CategoryOutcome>,
+  partialDetails: Record<string, string[]>,
+  invalidSiblings: Record<string, string> = {},
+  notRun: SummaryCategoryName[] = [],
+): SeedRunSummary {
+  const categoriesSeeded: string[] = [];
+  const categoriesPartial: string[] = [];
+  const categoriesSkipped: string[] = [];
+  const categoriesNotRun: string[] = [];
+  const notRunSet = new Set(notRun);
+  for (const category of [...EXECUTION_CATEGORIES, ...ALWAYS_RUN_CATEGORIES] as SummaryCategoryName[]) {
+    if (outcomes[category] === 'seeded') categoriesSeeded.push(category);
+    else if (outcomes[category] === 'partial') categoriesPartial.push(category);
+    // A category still at its default 'skipped' outcome is only genuinely
+    // "skipped" when the run reached the point of deciding not to run it
+    // (a gate it depends on was unmet). One never reached at all, because
+    // an earlier, unrelated failure aborted the run first, is reported as
+    // 'notRun' instead, so a divergent-key failure before the tenant
+    // upsert does not mislabel every later category "skipped".
+    else if (notRunSet.has(category)) categoriesNotRun.push(category);
+    else categoriesSkipped.push(category);
+  }
+  return {
+    mode,
+    categoriesSeeded,
+    categoriesPartial,
+    categoriesSkipped,
+    categoriesNotRun,
+    missingVariables,
+    invalidSiblings,
+    partialDetails,
+  };
+}
+
+/**
+ * Thrown when the seed aborts in default mode because a category it was
+ * asked to seed is missing required configuration (ADR-043 decision 1 and
+ * 3). Carries the same summary the seed would otherwise have logged on
+ * success, so the aggregate failure and a healthy run report identically.
+ */
+export class SeedConfigurationError extends Error {
+  readonly summary: SeedRunSummary;
+
+  constructor(summary: SeedRunSummary) {
+    // A category's invalid sibling (a malformed value alongside its
+    // missing variable) is named in the same line: fixing only the
+    // missing variable, redeploying, and discovering the typo on the next
+    // boot is exactly the two-cycle cost decision 4 already avoids for
+    // multiple missing variables.
+    const missingLines = Object.entries(summary.missingVariables).map(([category, vars]) => {
+      const invalidSibling = summary.invalidSiblings[category];
+      const suffix = invalidSibling ? ` (also: ${invalidSibling})` : '';
+      return `  - ${category}: ${vars.join(', ')}${suffix}`;
+    });
+    // A category can carry a reason (for example, divergent
+    // DATA_ENCRYPTION_KEY/SERVICE_ENCRYPTION_KEY values) without itself
+    // having a missing variable, so it never appears in the loop above.
+    // Listed here on its own line, so an unrelated missing variable
+    // elsewhere never makes that reason vanish from the abort message.
+    const standaloneOtherLines = Object.entries(summary.invalidSiblings)
+      .filter(([category]) => !(category in summary.missingVariables))
+      .map(([category, reason]) => `  - ${category}: ${reason}`);
+    const lines = [...missingLines, ...standaloneOtherLines].join('\n');
+    super(
+      'Seed cannot run: required configuration is missing for one or more categories.\n' +
+        `${lines}\n` +
+        'Set the missing variables above, or set SEED_ALLOW_PARTIAL=true to seed the categories that are ' +
+        'configured and skip the rest.',
+    );
+    this.name = 'SeedConfigurationError';
+    this.summary = summary;
+  }
+}

--- a/packages/reference-implementation/prisma/seed.ts
+++ b/packages/reference-implementation/prisma/seed.ts
@@ -1,12 +1,21 @@
 import dotenv from 'dotenv';
 import path from 'path';
 import fs from 'fs';
-import { fileURLToPath } from 'url';
 import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
 
-// Reconstruct `__dirname` for ESM (prisma/ is scoped to `"type": "module"`
-// via prisma/package.json so the multibase digest imports resolve).
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Resolves to this file's own directory (prisma/, which is ESM-scoped via
+// prisma/package.json) without `import.meta.url`. This module is imported
+// directly by the integration suite so `main()` can be driven against the
+// rig database, and `import.meta` syntax anywhere in a file this repo's
+// ts-jest integration config type-checks is rejected outright, so the file
+// stays free of it. `process.argv[1]` resolves to the same directory in
+// every real invocation (`tsx prisma/seed-cli.ts`, the CLI entrypoint that
+// imports this module, lives alongside it in prisma/); under a test runner
+// it resolves to something else, which is fine, because no code path a
+// test exercises reads this value for anything other than the (irrelevant
+// there) render-template file lookup and the (harmless, file-not-found)
+// dotenv path below.
+const scriptDir = process.argv[1] ? path.dirname(path.resolve(process.cwd(), process.argv[1])) : process.cwd();
 import {
   DidMethod,
   DidStatus,
@@ -47,11 +56,22 @@ import {
 } from '../src/lib/prisma/constants.js';
 import { buildUntpArtefactUrls, buildSpecificationPageUrl } from '@uncefact/untp-utils/artefacts';
 import { convergeCoreProvenance } from './core-seed-provenance.js';
+import {
+  runSeedPreflight,
+  EXECUTION_CATEGORIES,
+  ALWAYS_RUN_CATEGORIES,
+  SeedConfigurationError,
+  buildOutcomeSummary,
+  normalizeEnvValue,
+  type SeedRunSummary,
+  type SummaryCategoryName,
+  type CategoryOutcome,
+} from './seed-preflight.js';
 
-const logger = createLogger().child({ module: 'prisma-seed' });
+export const logger = createLogger().child({ module: 'prisma-seed' });
 
 // Load .env before accessing config (seed runs outside Next.js)
-dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+dotenv.config({ path: path.resolve(scriptDir, '../../../.env') });
 
 // Honour a pre-set RI_DATABASE_URL; construct one from the RI_POSTGRES_*
 // variables only when it is absent (the same rule as docker-entrypoint.sh
@@ -62,746 +82,998 @@ if (!process.env.RI_DATABASE_URL && constructedDatabaseUrl) {
   process.env.RI_DATABASE_URL = constructedDatabaseUrl;
 }
 
-const prisma = new PrismaClient();
+// Exported so a test can drive the real seed's decision path (preflight,
+// aggregate abort, structured summary) directly against a rig database and
+// inspect the outcome, without going through a child process: this file's
+// prisma/ directory is ESM-scoped (see the scriptDir comment above) while
+// src/ is not, and a raw `tsx` subprocess crossing that boundary depends on
+// a Docker-build-time step this test environment doesn't reproduce.
+export const prisma = new PrismaClient();
 
-// Resolved before any write: divergent DATA_ENCRYPTION_KEY and
-// SERVICE_ENCRYPTION_KEY values throw here, so the seed cannot re-encrypt
-// service instance configurations under a key that splits the database.
-const resolvedEncryptionKey = resolveDataEncryptionKey();
-warnIfDeprecatedEncryptionKeyName(resolvedEncryptionKey, logger);
+export async function main() {
+  // Resolve every category's configuration from the environment before
+  // writing anything or calling any external service (ADR-043 decision 3).
+  // A category with missing required variables fails the whole run by
+  // default; SEED_ALLOW_PARTIAL=true opts back into seeding whatever is
+  // configured and skipping the rest (decision 5).
+  const preflight = runSeedPreflight(process.env);
+  const allowPartial = process.env.SEED_ALLOW_PARTIAL === 'true';
 
-async function main() {
-  // Upsert the system tenant (used for system-wide defaults)
-  await prisma.tenant.upsert({
-    where: { id: SYSTEM_TENANT_ID },
-    update: {},
-    create: {
-      id: SYSTEM_TENANT_ID,
-      name: 'System',
-    },
-  });
+  if (preflight.hasMissing && !allowPartial) {
+    const summary: SeedRunSummary = {
+      mode: 'default',
+      categoriesSeeded: [],
+      categoriesPartial: [],
+      categoriesSkipped: [],
+      categoriesNotRun: [...EXECUTION_CATEGORIES, ...ALWAYS_RUN_CATEGORIES],
+      missingVariables: preflight.missingByCategory,
+      invalidSiblings: preflight.otherIssuesByCategory,
+      partialDetails: {},
+    };
+    // The summary is not logged here: `SeedConfigurationError` carries it
+    // as `.summary`, and the one caller that logs a caught seed error
+    // (seed-cli.ts) already serialises the whole error, which pino's
+    // default err serializer expands to include every own property —
+    // logging it again here would print the same summary twice for one
+    // run, which is exactly what ADR-043 decision 6 rules out.
+    throw new SeedConfigurationError(summary);
+  }
 
-  // Read DID configuration (DID creation happens after VC service is available)
+  // Every category's outcome is tracked here, hoisted above the try block
+  // below, so a mid-run failure can still build an honest summary from
+  // whatever state was established before the throw (ADR-043 decision 6).
+  // Each is set at the point in the run where its real-world side effect
+  // happened (not inferred afterwards from an end-of-block boolean), so a
+  // category interrupted partway through — a DID created upstream but not
+  // yet written to the database, a render template uploaded before a
+  // later one failed — is reported 'partial' rather than 'skipped'.
   let didConfig: { defaultDid: string; defaultKeyId?: string } | null = null;
-  try {
-    didConfig = getDidConfig();
-  } catch (error) {
-    logger.warn(
-      { error: error instanceof Error ? error.message : error },
-      'DID configuration not available; skipping default DID seed',
-    );
-  }
-
-  // ── Seed service instances (requires DATA_ENCRYPTION_KEY) ───────────────────
-
-  const ENCRYPTION_KEY = resolvedEncryptionKey.key;
+  let didConfigError: string | null = null;
   let encryptionService: AesGcmEncryptionAdapter | null = null;
-  if (ENCRYPTION_KEY) {
-    // Refuse (or warn, in local development) the .env.example placeholder
-    // before touching any existing envelope, then confirm the key can
-    // actually decrypt what is already stored — same preflight the
-    // backfill:decryption-keys script runs, so a wrong key is caught here
-    // rather than after this seed re-encrypts the system service instances
-    // under it.
-    assertNotPlaceholderEncryptionKey(ENCRYPTION_KEY, { deploymentEnvironment: process.env.DEPLOYMENT_ENVIRONMENT });
-    encryptionService = new AesGcmEncryptionAdapter(ENCRYPTION_KEY, logger);
-    await validateEncryptionKeyAtStartup(prisma, encryptionService);
-  } else {
-    logger.warn(
-      'DATA_ENCRYPTION_KEY not set; skipping service instance seeds (IDR, storage, VC). ' +
-        'These can be configured later via the application UI.',
-    );
-  }
-
-  // ── Seed system Pyx IDR service instance ────────────────────────────────────
-
   let idrAdapterType: string | null = null;
   let idrConfig: unknown = null;
   let idrSeeded = false;
-  if (encryptionService) {
-    try {
-      const idrAdapters = adapterRegistry[ServiceType.IDR];
-      const permittedIdrTypes = Object.keys(idrAdapters) as Array<keyof typeof idrAdapters>;
-      const resolvedIdrAdapterType = (process.env.SYSTEM_IDR_ADAPTER_TYPE as keyof typeof idrAdapters) || 'PYX_IDR';
-      idrAdapterType = resolvedIdrAdapterType;
-      const idrRegistryEntry = idrAdapters[resolvedIdrAdapterType];
-      if (!idrRegistryEntry) {
-        throw new Error(
-          `Unknown IDR adapter type: "${idrAdapterType}". Permitted types: ${permittedIdrTypes.join(', ')}`,
-        );
-      }
-      idrConfig = idrRegistryEntry.configSchema.parse({
-        baseUrl: process.env.SYSTEM_IDR_BASE_URL,
-        apiKey: process.env.SYSTEM_IDR_API_KEY,
-        apiVersion: process.env.SYSTEM_IDR_API_VERSION || undefined,
-        defaultLinkType: process.env.SYSTEM_IDR_DEFAULT_LINK_TYPE,
-        defaultMimeType: process.env.SYSTEM_IDR_DEFAULT_MIME_TYPE,
-        defaultIanaLanguage: process.env.SYSTEM_IDR_DEFAULT_LANGUAGE,
-        defaultContext: process.env.SYSTEM_IDR_DEFAULT_CONTEXT,
-        defaultFwqs: process.env.SYSTEM_IDR_DEFAULT_FWQS === 'true',
-      });
-      const idrServiceConfig = JSON.stringify(idrConfig);
-      const encryptedIdrConfig = JSON.stringify(
-        encryptionService.encrypt(idrServiceConfig, EncryptionAlgorithm.AES_256_GCM),
-      );
-
-      await prisma.serviceInstance.upsert({
-        where: { id: SYSTEM_IDR_SERVICE_ID },
-        update: { config: encryptedIdrConfig },
-        create: {
-          id: SYSTEM_IDR_SERVICE_ID,
-          tenantId: SYSTEM_TENANT_ID,
-          serviceType: PrismaServiceType.IDR,
-          adapterType: idrAdapterType as unknown as PrismaAdapterType,
-          name: process.env.SYSTEM_IDR_SERVICE_NAME || 'System Default IDR',
-          description:
-            process.env.SYSTEM_IDR_SERVICE_DESCRIPTION || 'System-wide default Identity Resolver service instance',
-          config: encryptedIdrConfig,
-          isPrimary: true,
-        },
-      });
-      idrSeeded = true;
-    } catch (error) {
-      logger.warn(
-        { error: error instanceof Error ? error.message : error },
-        'Skipping IDR service instance seed: IDR configuration not available',
-      );
-    }
-  }
-
-  // ── Seed system UNCEFACT storage service instance ───────────────────────────
-
+  let idrOutcome: CategoryOutcome = 'skipped';
   let storageSeeded = false;
+  let storageOutcome: CategoryOutcome = 'skipped';
   let storageRegistryEntry:
     | (typeof adapterRegistry)[typeof ServiceType.STORAGE][keyof (typeof adapterRegistry)[typeof ServiceType.STORAGE]]
     | null = null;
   let storageConfig: unknown = null;
-  if (encryptionService) {
-    try {
-      const storageAdapters = adapterRegistry[ServiceType.STORAGE];
-      const permittedStorageTypes = Object.keys(storageAdapters) as Array<keyof typeof storageAdapters>;
-      const storageAdapterType =
-        (process.env.SYSTEM_STORAGE_ADAPTER_TYPE as keyof typeof storageAdapters) || 'UNCEFACT_STORAGE';
-      const resolvedStorageEntry = storageAdapters[storageAdapterType];
-      if (!resolvedStorageEntry) {
-        throw new Error(
-          `Unknown storage adapter type: "${storageAdapterType}". Permitted types: ${permittedStorageTypes.join(', ')}`,
-        );
-      }
-      const parsedStorageConfig = resolvedStorageEntry.configSchema.parse({
-        baseUrl: process.env.SYSTEM_STORAGE_BASE_URL,
-        apiKey: process.env.SYSTEM_STORAGE_API_KEY || undefined,
-        apiVersion: process.env.SYSTEM_STORAGE_API_VERSION || undefined,
-        publicBucket: process.env.SYSTEM_STORAGE_PUBLIC_BUCKET || undefined,
-        privateBucket: process.env.SYSTEM_STORAGE_PRIVATE_BUCKET || undefined,
-      });
-      storageConfig = parsedStorageConfig;
-      storageRegistryEntry = resolvedStorageEntry;
-      const storageServiceConfig = JSON.stringify(parsedStorageConfig);
-      const encryptedStorageConfig = JSON.stringify(
-        encryptionService.encrypt(storageServiceConfig, EncryptionAlgorithm.AES_256_GCM),
-      );
-
-      await prisma.serviceInstance.upsert({
-        where: { id: SYSTEM_STORAGE_SERVICE_ID },
-        update: { config: encryptedStorageConfig },
-        create: {
-          id: SYSTEM_STORAGE_SERVICE_ID,
-          tenantId: SYSTEM_TENANT_ID,
-          serviceType: PrismaServiceType.STORAGE,
-          adapterType: storageAdapterType as unknown as PrismaAdapterType,
-          name: process.env.SYSTEM_STORAGE_SERVICE_NAME || 'System Default Storage',
-          description: process.env.SYSTEM_STORAGE_SERVICE_DESCRIPTION || 'System-wide default storage service instance',
-          config: encryptedStorageConfig,
-          isPrimary: true,
-        },
-      });
-      storageSeeded = true;
-    } catch (error) {
-      logger.warn(
-        { error: error instanceof Error ? error.message : error },
-        'Skipping storage service instance seed: storage configuration not available',
-      );
-    }
-  }
-
-  // ── Seed system VC service instance ───────────────────────────────────────
   let vcSeeded = false;
+  let vcOutcome: CategoryOutcome = 'skipped';
   let vcAdapterType: string | null = null;
   let vcConfig: unknown = null;
-  if (encryptionService) {
-    try {
-      const vcAdapters = adapterRegistry[ServiceType.VC];
-      const permittedVcTypes = Object.keys(vcAdapters) as Array<keyof typeof vcAdapters>;
-      const resolvedVcAdapterType = (process.env.SYSTEM_VC_ADAPTER_TYPE as keyof typeof vcAdapters) || 'VCKIT';
-      const vcRegistryEntry = vcAdapters[resolvedVcAdapterType];
-      if (!vcRegistryEntry) {
-        throw new Error(
-          `Unknown VC adapter type: "${resolvedVcAdapterType}". Permitted types: ${permittedVcTypes.join(', ')}`,
-        );
-      }
-      vcConfig = vcRegistryEntry.configSchema.parse({
-        baseUrl: process.env.SYSTEM_VC_BASE_URL,
-        apiKey: process.env.SYSTEM_VC_API_KEY,
-        apiVersion: process.env.SYSTEM_VC_API_VERSION || undefined,
-      });
-      vcAdapterType = resolvedVcAdapterType;
-      const vcServiceConfig = JSON.stringify(vcConfig);
-      const encryptedVcConfig = JSON.stringify(
-        encryptionService.encrypt(vcServiceConfig, EncryptionAlgorithm.AES_256_GCM),
-      );
+  let didOutcome: CategoryOutcome = 'skipped';
+  const templatesSkippedFiles: string[] = [];
+  let templatesCreatedCount = 0;
+  let renderTemplatesOutcome: CategoryOutcome = 'skipped';
+  // Set right before the storage upload for whichever core data model is
+  // currently being processed, and cleared once its database row commits.
+  // If the loop is interrupted in between, this names which item was mid
+  // flight, for the same reason `failedNamespaces` names which IDR
+  // namespaces did not register (Moderate finding 8).
+  let renderTemplateInterruptedItem: string | null = null;
+  const failedNamespaces: string[] = [];
+  const conflictedNamespaces: string[] = [];
+  let idrRegistrationFatalError: string | null = null;
+  let tenantOutcome: CategoryOutcome = 'skipped';
+  let dataModelsOutcome: CategoryOutcome = 'skipped';
+  let dataModelsCompletedCount = 0;
+  let customSeedOutcome: CategoryOutcome = 'skipped';
+  let customSeedPartialDetail: string | null = null;
 
-      await prisma.serviceInstance.upsert({
-        where: { id: SYSTEM_VC_SERVICE_ID },
-        update: { config: encryptedVcConfig },
-        create: {
-          id: SYSTEM_VC_SERVICE_ID,
-          tenantId: SYSTEM_TENANT_ID,
-          serviceType: PrismaServiceType.VC,
-          adapterType: resolvedVcAdapterType as unknown as PrismaAdapterType,
-          name: process.env.SYSTEM_VC_SERVICE_NAME || 'System Default VC',
-          description:
-            process.env.SYSTEM_VC_SERVICE_DESCRIPTION || 'System-wide default verifiable credential service instance',
-          config: encryptedVcConfig,
-          isPrimary: true,
-        },
-      });
-      vcSeeded = true;
-    } catch (error) {
-      logger.warn(
-        { error: error instanceof Error ? error.message : error },
-        'Skipping VC service instance seed: VC configuration not available',
-      );
-    }
-  }
+  // Marked the moment the run reaches the point of deciding whether to
+  // execute a category (whether that decision is "run it" or "skip it
+  // because its gate is unmet"), never only on success. A category whose
+  // flag is still unset when a failure is caught was never reached at all
+  // (an earlier, unrelated failure aborted the run before control got
+  // there), which `categoriesNotRun` reports distinctly from a category
+  // that was reached and genuinely skipped (Moderate finding 6).
+  const reachedCategories = new Set<SummaryCategoryName>();
 
-  // ── Seed system default DID via VC service ─────────────────────────────────
-  // Uses the DID adapter registry to resolve the correct DID adapter for the
-  // seeded VC service, creates the DID (if it doesn't already exist), resolves
-  // the key ID from the DID document, and records it in the database.
-
-  let defaultDid: string | null = null;
-  if (didConfig && vcSeeded && vcAdapterType && vcConfig) {
-    const { defaultDid: didString, defaultKeyId: envKeyId } = didConfig;
-
-    // 1. Validate DID format (parseDidMethod throws for invalid/unsupported methods)
-    parseDidMethod(didString);
-
-    // 2. Resolve the DID adapter from the registry using the seeded VC adapter type
-    const didRegistryEntry = didAdapterRegistry[vcAdapterType as keyof typeof didAdapterRegistry];
-    if (!didRegistryEntry) {
-      throw new Error(
-        `No DID adapter registered for VC adapter type: "${vcAdapterType}". ` +
-          `Permitted types: ${Object.keys(didAdapterRegistry).join(', ')}`,
-      );
-    }
-    const didAdapter = didRegistryEntry.factory(
-      vcConfig as Parameters<typeof didRegistryEntry.factory>[0],
-      logger.child({ service: 'DID - Seed' }),
-    );
-
-    // 3. Create DID via VC service (or confirm it already exists)
-    // Extract alias from the DID (everything after did:web:)
-    const alias = didString.replace(/^did:[^:]+:/, '');
-    let resolvedKeyId: string;
-
-    try {
-      const didRecord = await didAdapter.create({
-        type: ServiceDidType.SELF_MANAGED,
-        method: ServiceDidMethod.DID_WEB,
-        alias,
-      });
-      resolvedKeyId = didRecord.keyId;
-      logger.info({ did: didRecord.did, keyId: resolvedKeyId }, 'DID created via VC service');
-    } catch (error) {
-      if (error instanceof DidConflictError) {
-        // DID already exists on the upstream provider — fetch its document to resolve the key ID
-        logger.warn({ did: didString }, 'DID already exists in VC service — skipping creation');
-        const document = await didAdapter.getDocument(didString);
-        const verificationMethods: Array<{ id: string }> = document.verificationMethod ?? [];
-        if (verificationMethods.length === 0) {
-          throw new Error(
-            `No verification methods found in DID document for "${didString}" — ` +
-              'cannot resolve key ID. Set SYSTEM_DID_KEY_ID explicitly.',
-          );
-        }
-        resolvedKeyId = verificationMethods[0].id;
-        logger.info({ did: didString, keyId: resolvedKeyId }, 'Resolved key ID from existing DID document');
-      } else {
-        throw error;
-      }
-    }
-
-    // 4. If SYSTEM_DID_KEY_ID is set, validate it matches the resolved key
-    if (envKeyId && envKeyId !== resolvedKeyId) {
-      // Fetch document to check all verification methods
-      const document = await didAdapter.getDocument(didString);
-      const verificationMethods: Array<{ id: string }> = document.verificationMethod ?? [];
-      const found = verificationMethods.some((vm) => vm.id === envKeyId || vm.id.endsWith(`#${envKeyId}`));
-      if (!found) {
-        throw new Error(
-          `SYSTEM_DID_KEY_ID "${envKeyId}" not found in DID document for "${didString}". ` +
-            `Available verification methods: ${verificationMethods.map((vm) => vm.id).join(', ') || 'none'}`,
-        );
-      }
-      resolvedKeyId = envKeyId;
-      logger.info({ did: didString, keyId: resolvedKeyId }, 'Using explicitly configured key ID');
-    }
-
-    // 5. Record DID in database
-    await prisma.did.upsert({
-      where: { id: SYSTEM_DID_ID },
-      update: {
-        did: didString,
-        name: process.env.SYSTEM_DID_NAME || 'System Default DID',
-        description:
-          process.env.SYSTEM_DID_DESCRIPTION || 'System-wide default DID for the UNTP reference implementation',
-        keyId: resolvedKeyId,
-        status: DidStatus.ACTIVE,
-        isDefault: true,
-        serviceInstanceId: SYSTEM_VC_SERVICE_ID,
-      },
-      create: {
-        id: SYSTEM_DID_ID,
-        tenantId: SYSTEM_TENANT_ID,
-        did: didString,
-        type: DidType.DEFAULT,
-        method: DidMethod.DID_WEB,
-        name: process.env.SYSTEM_DID_NAME || 'System Default DID',
-        description:
-          process.env.SYSTEM_DID_DESCRIPTION || 'System-wide default DID for the UNTP reference implementation',
-        keyId: resolvedKeyId,
-        status: DidStatus.ACTIVE,
-        isDefault: true,
-        serviceInstanceId: SYSTEM_VC_SERVICE_ID,
-      },
-    });
-    defaultDid = didString;
-
-    logger.info({ did: didString, keyId: resolvedKeyId }, 'Default DID seeded and linked to VC service instance');
-  } else if (didConfig && !vcSeeded) {
-    logger.warn('Skipping default DID seed: VC service instance was not seeded (required for DID creation)');
-  }
-
-  // ── Seed core data model configs ────────────────────────────────────────────
-  // Static UUIDs ensure idempotent seeding — if the record already exists, skip.
-
-  const coreDataModels = [
-    {
-      id: 'cxuj555flzqtp4ldvklv6ya39',
-      templateId: 'ctehlnyxvdpmp4kv1cxa0tj0t',
-      credentialType: 'DigitalProductPassport',
-      version: '0.6.0',
-      name: 'Digital Product Passport v0.6.0',
-      shortCode: 'dpp',
-      templateDir: 'digital_product_passport',
-    },
-    {
-      id: 'c3imzyum0txv1y9xkww88aktp',
-      templateId: 'cb6ka4fhk68m1wqeitptm24z1',
-      credentialType: 'DigitalConformityCredential',
-      version: '0.6.0',
-      name: 'Digital Conformity Credential v0.6.0',
-      shortCode: 'dcc',
-      templateDir: 'digital_conformity_credential',
-    },
-    {
-      id: 'ctfgtrsuiwv1fedo9t5swxhnk',
-      templateId: 'c62zomihgkn6iimbv7dzhr1fj',
-      credentialType: 'DigitalFacilityRecord',
-      version: '0.6.0',
-      name: 'Digital Facility Record v0.6.0',
-      shortCode: 'dfr',
-      templateDir: 'digital_facility_record',
-    },
-    {
-      id: 'cz9raijqcay5nzmq59geoggrk',
-      templateId: 'cv2ldbzupwtbluam7nrfqqv1e',
-      credentialType: 'DigitalIdentityAnchor',
-      version: '0.6.0',
-      name: 'Digital Identity Anchor v0.6.0',
-      shortCode: 'dia',
-      templateDir: 'digital_identity_anchor',
-    },
-    {
-      id: 'crqvpwffc0k2p4bvr8za1ii6j',
-      templateId: 'c1fx8t9k9p6q8wcaxib6e6id1',
-      credentialType: 'DigitalTraceabilityEvent',
-      version: '0.6.0',
-      name: 'Digital Traceability Event v0.6.0',
-      shortCode: 'dte',
-      templateDir: 'digital_traceability_event',
-    },
-    {
-      id: 'c1pxfzzkeb86jgeel7hrvmcle',
-      templateId: 'co3tub0ndto2lzq9l4rsnw22y',
-      credentialType: 'DigitalProductPassport',
-      version: '0.6.1',
-      name: 'Digital Product Passport v0.6.1',
-      shortCode: 'dpp',
-      templateDir: 'digital_product_passport',
-    },
-    {
-      id: 'cttpz40pfgcfeue2wmbc3jti8',
-      templateId: 'cx5qp969tkboeem04szgwyb32',
-      credentialType: 'DigitalConformityCredential',
-      version: '0.6.1',
-      name: 'Digital Conformity Credential v0.6.1',
-      shortCode: 'dcc',
-      templateDir: 'digital_conformity_credential',
-    },
-    {
-      id: 'csrtste8ai2llop7ui8u6n11l',
-      templateId: 'c91eyblwyejyfoq1pfqsik0ty',
-      credentialType: 'DigitalFacilityRecord',
-      version: '0.6.1',
-      name: 'Digital Facility Record v0.6.1',
-      shortCode: 'dfr',
-      templateDir: 'digital_facility_record',
-    },
-    {
-      id: 'cn5u63huxvqgdwppebaxmqt9l',
-      templateId: 'c5khe5ju6ai3ptaw55r01vayo',
-      credentialType: 'DigitalIdentityAnchor',
-      version: '0.6.1',
-      name: 'Digital Identity Anchor v0.6.1',
-      shortCode: 'dia',
-      templateDir: 'digital_identity_anchor',
-    },
-    {
-      id: 'cwb7m3k0hpz9xqft6rjn2oe4s',
-      templateId: 'c8yvd2gnmr5w1kbjx4hq0zp7f',
-      credentialType: 'DigitalTraceabilityEvent',
-      version: '0.6.1',
-      name: 'Digital Traceability Event v0.6.1',
-      shortCode: 'dte',
-      templateDir: 'digital_traceability_event',
-    },
-    {
-      id: 'ca3frzta22f7lblxntvw6ukuh',
-      templateId: 'cb7bad861g78bcgovjrw98szt',
-      credentialType: 'DigitalProductPassport',
-      version: '0.7.0',
-      name: 'Digital Product Passport v0.7.0',
-      shortCode: 'dpp',
-      templateDir: 'digital_product_passport',
-    },
-    {
-      id: 'ca9ndkrc8lxmtsfzwynui40zy',
-      templateId: 'cpfsywtmlq5wthxc6w6al6e2b',
-      credentialType: 'DigitalConformityCredential',
-      version: '0.7.0',
-      name: 'Digital Conformity Credential v0.7.0',
-      shortCode: 'dcc',
-      templateDir: 'digital_conformity_credential',
-    },
-    {
-      id: 'cj3s37lt6pvh56ggspr9upt5m',
-      templateId: 'c7jafa80eu2wa35rly4eeqona',
-      credentialType: 'DigitalFacilityRecord',
-      version: '0.7.0',
-      name: 'Digital Facility Record v0.7.0',
-      shortCode: 'dfr',
-      templateDir: 'digital_facility_record',
-    },
-    {
-      id: 'cw0tzf723j1oql3u4s1r0c2g2',
-      templateId: 'ch4d269bf6szab6p955vfwj40',
-      credentialType: 'DigitalIdentityAnchor',
-      version: '0.7.0',
-      name: 'Digital Identity Anchor v0.7.0',
-      shortCode: 'dia',
-      templateDir: 'digital_identity_anchor',
-    },
-    {
-      id: 'cfhlj3bumipb74z8irp6uiuxn',
-      templateId: 'chv69r38brqzchvqc47v4qoqo',
-      credentialType: 'DigitalTraceabilityEvent',
-      version: '0.7.0',
-      name: 'Digital Traceability Event v0.7.0',
-      shortCode: 'dte',
-      templateDir: 'digital_traceability_event',
-    },
-  ];
-
-  for (const dm of coreDataModels) {
-    const exists = await prisma.dataModel.findUnique({ where: { id: dm.id } });
-    if (exists) {
-      await convergeCoreProvenance(prisma.dataModel, dm.id, exists.source);
-      logger.info({ dataModelId: dm.id, credentialType: dm.credentialType }, 'Data model already exists, skipping');
-      continue;
-    }
-
-    const { schemaUrl, contextUrl } = buildUntpArtefactUrls(dm.credentialType, dm.version);
-    const websiteUrl = buildSpecificationPageUrl(dm.credentialType, dm.version);
-
-    await prisma.dataModel.create({
-      data: {
-        id: dm.id,
-        tenantId: SYSTEM_TENANT_ID,
-        name: dm.name,
-        credentialType: dm.credentialType,
-        version: dm.version,
-        isExtension: false,
-        schemaUrl,
-        contextUrl,
-        websiteUrl,
-        source: RecordSource.CORE_SEED,
-      },
-    });
-
-    logger.info({ dataModelId: dm.id, credentialType: dm.credentialType }, 'Data model created');
-  }
-
-  // ── Seed the ConformityScheme data model row ────────────────────────────────
-  // The custom-seed `conformitySchemes` processor resolves the JSON Schema URL
-  // for ingestion by looking this row up via (credentialType, version).
-  // ConformityScheme was introduced in v0.7.0, so it always resolves to the
-  // v0.7.0+ artefacts layout (schema under `untp.unece.org/artefacts`, unified
-  // context on `vocabulary.uncefact.org`).
-  const CONFORMITY_SCHEME_DATA_MODEL_ID = 'c4fxk5o3sqrm6n0u7c7akm0sb';
-  const conformitySchemeExists = await prisma.dataModel.findUnique({
-    where: { id: CONFORMITY_SCHEME_DATA_MODEL_ID },
+  // Reads the state above at the moment they're called, whether that's
+  // after a clean finish or right after catching a mid-run failure.
+  const currentCategoryOutcomes = (): Record<SummaryCategoryName, CategoryOutcome> => ({
+    idr: idrOutcome,
+    storage: storageOutcome,
+    vc: vcOutcome,
+    did: didOutcome,
+    renderTemplates: renderTemplatesOutcome,
+    tenant: tenantOutcome,
+    dataModels: dataModelsOutcome,
+    customSeed: customSeedOutcome,
   });
-  if (conformitySchemeExists) {
-    await convergeCoreProvenance(prisma.dataModel, CONFORMITY_SCHEME_DATA_MODEL_ID, conformitySchemeExists.source);
-    logger.info(
-      { dataModelId: CONFORMITY_SCHEME_DATA_MODEL_ID, credentialType: 'ConformityScheme' },
-      'Data model already exists, skipping',
-    );
-  } else {
-    const { schemaUrl, contextUrl } = buildUntpArtefactUrls('ConformityScheme', '0.7.0');
-    const websiteUrl = buildSpecificationPageUrl('ConformityScheme', '0.7.0');
-    await prisma.dataModel.create({
-      data: {
-        id: CONFORMITY_SCHEME_DATA_MODEL_ID,
-        tenantId: SYSTEM_TENANT_ID,
-        name: 'Conformity Scheme v0.7.0',
-        credentialType: 'ConformityScheme',
-        version: '0.7.0',
-        isExtension: false,
-        schemaUrl,
-        contextUrl,
-        websiteUrl,
-        source: RecordSource.CORE_SEED,
+  const currentNotRunCategories = (): SummaryCategoryName[] =>
+    [...EXECUTION_CATEGORIES, ...ALWAYS_RUN_CATEGORIES].filter(
+      (category) => !reachedCategories.has(category as SummaryCategoryName),
+    ) as SummaryCategoryName[];
+  const currentPartialDetails = (): Record<string, string[]> => {
+    const details: Record<string, string[]> = {};
+    const idrDetails = [
+      ...failedNamespaces,
+      ...conflictedNamespaces.map((ns) => `${ns} (IDR returned a conflict; existing registration not verified)`),
+    ];
+    if (idrRegistrationFatalError) idrDetails.push(`registration aborted: ${idrRegistrationFatalError}`);
+    if (idrDetails.length > 0) details.idr = idrDetails;
+    const templateDetails = [...templatesSkippedFiles];
+    if (renderTemplateInterruptedItem)
+      templateDetails.push(`${renderTemplateInterruptedItem} (interrupted mid upload)`);
+    if (templateDetails.length > 0) details.renderTemplates = templateDetails;
+    if (dataModelsOutcome === 'partial') {
+      details.dataModels = [`completed ${dataModelsCompletedCount} data model row(s) before failing`];
+    }
+    if (customSeedPartialDetail) details.customSeed = [customSeedPartialDetail];
+    return details;
+  };
+
+  try {
+    // Resolved before any write: divergent DATA_ENCRYPTION_KEY and
+    // SERVICE_ENCRYPTION_KEY values throw here, so the seed cannot
+    // re-encrypt service instance configurations under a key that splits
+    // the database. Resolved inside the try (not at module load) so this
+    // failure is covered by the same summary-and-rethrow the rest of a
+    // mid-run failure gets, instead of an uncaught exception at import
+    // time with no summary at all.
+    const resolvedEncryptionKey = resolveDataEncryptionKey();
+    warnIfDeprecatedEncryptionKeyName(resolvedEncryptionKey, logger);
+
+    // Upsert the system tenant (used for system-wide defaults)
+    reachedCategories.add('tenant');
+    await prisma.tenant.upsert({
+      where: { id: SYSTEM_TENANT_ID },
+      update: {},
+      create: {
+        id: SYSTEM_TENANT_ID,
+        name: 'System',
       },
     });
-    logger.info(
-      { dataModelId: CONFORMITY_SCHEME_DATA_MODEL_ID, credentialType: 'ConformityScheme' },
-      'Data model created',
-    );
-  }
+    tenantOutcome = 'seeded';
 
-  // ── Seed default render templates ───────────────────────────────────────────
-  // Upload .hbs templates to the storage service and record the returned URIs.
-  // Requires the storage service to be available (skipped otherwise).
-
-  let templatesSeeded = false;
-  if (storageSeeded && storageRegistryEntry && storageConfig) {
+    // Read DID configuration (DID creation happens after VC service is available).
+    // The failure is reported below, alongside the other reasons a default
+    // DID can end up not seeded, so every skip logs exactly once. The
+    // presence check is done here, against the same normalisation
+    // preflight used, rather than trusting `getDidConfig()`'s own weaker
+    // (empty-string-only) check: a whitespace-only SYSTEM_DID would
+    // otherwise pass it and fail much later, somewhere less clear, when a
+    // blank value reaches `parseDidMethod` or the VC service.
     try {
-      const storageService = storageRegistryEntry.factory(
-        storageConfig as Parameters<typeof storageRegistryEntry.factory>[0],
-        logger.child({ service: 'Storage - Seed' }),
+      if (!normalizeEnvValue(process.env.SYSTEM_DID)) {
+        throw new Error('Missing required DID configuration: SYSTEM_DID. Set this in your .env file or environment.');
+      }
+      didConfig = getDidConfig();
+    } catch (error) {
+      didConfigError = error instanceof Error ? error.message : String(error);
+    }
+
+    // ── Seed service instances (requires DATA_ENCRYPTION_KEY) ───────────────────
+
+    const ENCRYPTION_KEY = normalizeEnvValue(resolvedEncryptionKey.key);
+    if (ENCRYPTION_KEY) {
+      // Refuse (or warn, in local development) the .env.example placeholder
+      // before touching any existing envelope, then confirm the key can
+      // actually decrypt what is already stored — same preflight the
+      // backfill:decryption-keys script runs, so a wrong key is caught here
+      // rather than after this seed re-encrypts the system service instances
+      // under it.
+      assertNotPlaceholderEncryptionKey(ENCRYPTION_KEY, { deploymentEnvironment: process.env.DEPLOYMENT_ENVIRONMENT });
+      encryptionService = new AesGcmEncryptionAdapter(ENCRYPTION_KEY, logger);
+      await validateEncryptionKeyAtStartup(prisma, encryptionService);
+    } else {
+      logger.warn(
+        'DATA_ENCRYPTION_KEY not set; skipping service instance seeds (IDR, storage, VC). ' +
+          'These can be configured later via the application UI.',
       );
+    }
 
-      const TEMPLATES_BASE = path.resolve(__dirname, '../src/templates');
+    // ── Seed system Pyx IDR service instance ────────────────────────────────────
 
-      for (const dm of coreDataModels) {
-        const exists = await prisma.renderTemplate.findUnique({ where: { id: dm.templateId } });
-        if (exists) {
-          await convergeCoreProvenance(prisma.renderTemplate, dm.templateId, exists.source);
-          logger.info(
-            { templateId: dm.templateId, credentialType: dm.credentialType },
-            'Template already exists, skipping',
+    reachedCategories.add('idr');
+    if (encryptionService) {
+      try {
+        const idrAdapters = adapterRegistry[ServiceType.IDR];
+        const permittedIdrTypes = Object.keys(idrAdapters) as Array<keyof typeof idrAdapters>;
+        const resolvedIdrAdapterType = (process.env.SYSTEM_IDR_ADAPTER_TYPE as keyof typeof idrAdapters) || 'PYX_IDR';
+        idrAdapterType = resolvedIdrAdapterType;
+        const idrRegistryEntry = idrAdapters[resolvedIdrAdapterType];
+        if (!idrRegistryEntry) {
+          throw new Error(
+            `Unknown IDR adapter type: "${idrAdapterType}". Permitted types: ${permittedIdrTypes.join(', ')}`,
           );
-          continue;
         }
-
-        const templatePath = path.join(TEMPLATES_BASE, `v${dm.version}`, dm.templateDir, 'template.hbs');
-        if (!fs.existsSync(templatePath)) {
-          logger.warn({ templatePath, credentialType: dm.credentialType }, 'Template file not found, skipping');
-          continue;
-        }
-
-        const templateContent = fs.readFileSync(templatePath, 'utf-8');
-
-        // Upload template to storage via the seeded storage service adapter
-        const storageRecord = await storageService.storeBinary(
-          templateContent,
-          `${dm.shortCode}-template.hbs`,
-          'text/html',
+        idrConfig = idrRegistryEntry.configSchema.parse({
+          baseUrl: normalizeEnvValue(process.env.SYSTEM_IDR_BASE_URL),
+          apiKey: normalizeEnvValue(process.env.SYSTEM_IDR_API_KEY),
+          apiVersion: normalizeEnvValue(process.env.SYSTEM_IDR_API_VERSION),
+          defaultLinkType: normalizeEnvValue(process.env.SYSTEM_IDR_DEFAULT_LINK_TYPE),
+          defaultMimeType: normalizeEnvValue(process.env.SYSTEM_IDR_DEFAULT_MIME_TYPE),
+          defaultIanaLanguage: normalizeEnvValue(process.env.SYSTEM_IDR_DEFAULT_LANGUAGE),
+          defaultContext: normalizeEnvValue(process.env.SYSTEM_IDR_DEFAULT_CONTEXT),
+          defaultFwqs: process.env.SYSTEM_IDR_DEFAULT_FWQS === 'true',
+        });
+        const idrServiceConfig = JSON.stringify(idrConfig);
+        const encryptedIdrConfig = JSON.stringify(
+          encryptionService.encrypt(idrServiceConfig, EncryptionAlgorithm.AES_256_GCM),
         );
 
-        await prisma.renderTemplate.create({
-          data: {
-            id: dm.templateId,
+        await prisma.serviceInstance.upsert({
+          where: { id: SYSTEM_IDR_SERVICE_ID },
+          update: { config: encryptedIdrConfig },
+          create: {
+            id: SYSTEM_IDR_SERVICE_ID,
             tenantId: SYSTEM_TENANT_ID,
-            dataModelId: dm.id,
-            name: `${dm.name} Default Template`,
-            storageUrl: storageRecord.uri,
-            digestMultibase:
-              storageRecord.digestMultibase ??
-              (
-                await MultibaseDigest.fromText(templateContent, { algorithm: 'sha2-256', base: 'base58btc' })
-              ).toString(),
-            isDefault: true,
-            renderMethodType: RenderMethodType.RenderTemplate2024,
-            inline: false,
-            mediaType: 'text/html',
-            storageExternalId: storageRecord.externalId,
-            storageBucket: storageRecord.bucket,
-            storageContentType: 'text/html',
-            storageServiceInstanceId: SYSTEM_STORAGE_SERVICE_ID,
-            source: RecordSource.CORE_SEED,
+            serviceType: PrismaServiceType.IDR,
+            adapterType: idrAdapterType as unknown as PrismaAdapterType,
+            name: process.env.SYSTEM_IDR_SERVICE_NAME || 'System Default IDR',
+            description:
+              process.env.SYSTEM_IDR_SERVICE_DESCRIPTION || 'System-wide default Identity Resolver service instance',
+            config: encryptedIdrConfig,
+            isPrimary: true,
           },
         });
-
-        logger.info(
-          { templateId: dm.templateId, uri: storageRecord.uri, credentialType: dm.credentialType },
-          'Template uploaded and seeded',
+        idrSeeded = true;
+        idrOutcome = 'seeded';
+      } catch (error) {
+        logger.warn(
+          { error: error instanceof Error ? error.message : error },
+          'IDR service instance seed did not complete; skipping. See the attached error for the cause.',
         );
       }
-      templatesSeeded = true;
-    } catch (error) {
-      logger.warn(
-        { error: error instanceof Error ? error.message : error },
-        'Skipping render template seed: storage service not available',
-      );
     }
-  } else {
-    logger.warn('Skipping render template seed: storage service was not seeded');
-  }
 
-  // ── Run custom seed (deployer-provided data) ──────────────────────────────
-  // Environment variables:
-  //   SKIP_CUSTOM_SEED=true   - Skip custom seed (deployer-provided data from /app/seed/custom/)
-  if (process.env.SKIP_CUSTOM_SEED !== 'true') {
-    const { runCustomSeed } = await import('./custom-seed');
+    // ── Seed system UNCEFACT storage service instance ───────────────────────────
 
-    await runCustomSeed({
-      logger: logger.child({ module: 'custom-seed' }),
-      prisma,
-      systemTenantId: SYSTEM_TENANT_ID,
-      customSeedDir: '/app/seed/custom',
-      storageService:
-        storageSeeded && storageRegistryEntry && storageConfig
-          ? storageRegistryEntry.factory(
-              storageConfig as Parameters<typeof storageRegistryEntry.factory>[0],
-              logger.child({ service: 'Storage - Custom Seed' }),
-            )
-          : null,
-      storageServiceInstanceId: SYSTEM_STORAGE_SERVICE_ID,
-    });
-  } else {
-    logger.info('Skipping custom seed (SKIP_CUSTOM_SEED is set)');
-  }
+    reachedCategories.add('storage');
+    if (encryptionService) {
+      try {
+        const storageAdapters = adapterRegistry[ServiceType.STORAGE];
+        const permittedStorageTypes = Object.keys(storageAdapters) as Array<keyof typeof storageAdapters>;
+        const storageAdapterType =
+          (process.env.SYSTEM_STORAGE_ADAPTER_TYPE as keyof typeof storageAdapters) || 'UNCEFACT_STORAGE';
+        const resolvedStorageEntry = storageAdapters[storageAdapterType];
+        if (!resolvedStorageEntry) {
+          throw new Error(
+            `Unknown storage adapter type: "${storageAdapterType}". Permitted types: ${permittedStorageTypes.join(
+              ', ',
+            )}`,
+          );
+        }
+        const parsedStorageConfig = resolvedStorageEntry.configSchema.parse({
+          baseUrl: normalizeEnvValue(process.env.SYSTEM_STORAGE_BASE_URL),
+          apiKey: normalizeEnvValue(process.env.SYSTEM_STORAGE_API_KEY),
+          apiVersion: normalizeEnvValue(process.env.SYSTEM_STORAGE_API_VERSION),
+          publicBucket: normalizeEnvValue(process.env.SYSTEM_STORAGE_PUBLIC_BUCKET),
+          privateBucket: normalizeEnvValue(process.env.SYSTEM_STORAGE_PRIVATE_BUCKET),
+        });
+        storageConfig = parsedStorageConfig;
+        storageRegistryEntry = resolvedStorageEntry;
+        const storageServiceConfig = JSON.stringify(parsedStorageConfig);
+        const encryptedStorageConfig = JSON.stringify(
+          encryptionService.encrypt(storageServiceConfig, EncryptionAlgorithm.AES_256_GCM),
+        );
 
-  // ── Register identifier schemes with IDR service ────────────────────────────
-  // In the dev environment, the RI operates the Pyx IDR — register seeded schemes.
-  if (idrSeeded && idrAdapterType === 'PYX_IDR') {
-    try {
-      const { PyxIdentityResolverAdapter } = await import('@uncefact/untp-ri-services/server');
-      const pyxAdapter = new PyxIdentityResolverAdapter(
-        idrConfig as ConstructorParameters<typeof PyxIdentityResolverAdapter>[0],
-        logger.child({ service: 'IDR - Seed' }),
+        await prisma.serviceInstance.upsert({
+          where: { id: SYSTEM_STORAGE_SERVICE_ID },
+          update: { config: encryptedStorageConfig },
+          create: {
+            id: SYSTEM_STORAGE_SERVICE_ID,
+            tenantId: SYSTEM_TENANT_ID,
+            serviceType: PrismaServiceType.STORAGE,
+            adapterType: storageAdapterType as unknown as PrismaAdapterType,
+            name: process.env.SYSTEM_STORAGE_SERVICE_NAME || 'System Default Storage',
+            description:
+              process.env.SYSTEM_STORAGE_SERVICE_DESCRIPTION || 'System-wide default storage service instance',
+            config: encryptedStorageConfig,
+            isPrimary: true,
+          },
+        });
+        storageSeeded = true;
+        storageOutcome = 'seeded';
+      } catch (error) {
+        logger.warn(
+          { error: error instanceof Error ? error.message : error },
+          'Storage service instance seed did not complete; skipping. See the attached error for the cause.',
+        );
+      }
+    }
+
+    // ── Seed system VC service instance ───────────────────────────────────────
+    reachedCategories.add('vc');
+    if (encryptionService) {
+      try {
+        const vcAdapters = adapterRegistry[ServiceType.VC];
+        const permittedVcTypes = Object.keys(vcAdapters) as Array<keyof typeof vcAdapters>;
+        const resolvedVcAdapterType = (process.env.SYSTEM_VC_ADAPTER_TYPE as keyof typeof vcAdapters) || 'VCKIT';
+        const vcRegistryEntry = vcAdapters[resolvedVcAdapterType];
+        if (!vcRegistryEntry) {
+          throw new Error(
+            `Unknown VC adapter type: "${resolvedVcAdapterType}". Permitted types: ${permittedVcTypes.join(', ')}`,
+          );
+        }
+        vcConfig = vcRegistryEntry.configSchema.parse({
+          baseUrl: normalizeEnvValue(process.env.SYSTEM_VC_BASE_URL),
+          apiKey: normalizeEnvValue(process.env.SYSTEM_VC_API_KEY),
+          apiVersion: normalizeEnvValue(process.env.SYSTEM_VC_API_VERSION),
+        });
+        vcAdapterType = resolvedVcAdapterType;
+        const vcServiceConfig = JSON.stringify(vcConfig);
+        const encryptedVcConfig = JSON.stringify(
+          encryptionService.encrypt(vcServiceConfig, EncryptionAlgorithm.AES_256_GCM),
+        );
+
+        await prisma.serviceInstance.upsert({
+          where: { id: SYSTEM_VC_SERVICE_ID },
+          update: { config: encryptedVcConfig },
+          create: {
+            id: SYSTEM_VC_SERVICE_ID,
+            tenantId: SYSTEM_TENANT_ID,
+            serviceType: PrismaServiceType.VC,
+            adapterType: resolvedVcAdapterType as unknown as PrismaAdapterType,
+            name: process.env.SYSTEM_VC_SERVICE_NAME || 'System Default VC',
+            description:
+              process.env.SYSTEM_VC_SERVICE_DESCRIPTION || 'System-wide default verifiable credential service instance',
+            config: encryptedVcConfig,
+            isPrimary: true,
+          },
+        });
+        vcSeeded = true;
+        vcOutcome = 'seeded';
+      } catch (error) {
+        logger.warn(
+          { error: error instanceof Error ? error.message : error },
+          'VC service instance seed did not complete; skipping. See the attached error for the cause.',
+        );
+      }
+    }
+
+    // ── Seed system default DID via VC service ─────────────────────────────────
+    // Uses the DID adapter registry to resolve the correct DID adapter for the
+    // seeded VC service, creates the DID (if it doesn't already exist), resolves
+    // the key ID from the DID document, and records it in the database.
+
+    reachedCategories.add('did');
+    if (didConfig && vcSeeded && vcAdapterType && vcConfig) {
+      const { defaultDid: didString, defaultKeyId: envKeyId } = didConfig;
+
+      // 1. Validate DID format (parseDidMethod throws for invalid/unsupported methods)
+      parseDidMethod(didString);
+
+      // 2. Resolve the DID adapter from the registry using the seeded VC adapter type
+      const didRegistryEntry = didAdapterRegistry[vcAdapterType as keyof typeof didAdapterRegistry];
+      if (!didRegistryEntry) {
+        throw new Error(
+          `No DID adapter registered for VC adapter type: "${vcAdapterType}". ` +
+            `Permitted types: ${Object.keys(didAdapterRegistry).join(', ')}`,
+        );
+      }
+      const didAdapter = didRegistryEntry.factory(
+        vcConfig as Parameters<typeof didRegistryEntry.factory>[0],
+        logger.child({ service: 'DID - Seed' }),
       );
 
-      // Fetch seeded schemes grouped by registrar namespace
-      const schemes = await prisma.identifierScheme.findMany({
-        where: { tenantId: SYSTEM_TENANT_ID },
-        include: { registrar: true, qualifiers: { orderBy: { order: 'asc' } } },
-      });
+      // 3. Create DID via VC service (or confirm it already exists)
+      // Extract alias from the DID (everything after did:web:)
+      const alias = didString.replace(/^did:[^:]+:/, '');
+      let resolvedKeyId: string;
 
-      // Group by registrar namespace
-      const grouped = new Map<string, typeof schemes>();
-      for (const scheme of schemes) {
-        const ns = scheme.registrar.namespace;
-        if (!grouped.has(ns)) grouped.set(ns, []);
-        grouped.get(ns)!.push(scheme);
-      }
-
-      const failedNamespaces: string[] = [];
-      for (const [namespace, nsSchemes] of grouped) {
-        const applicationIdentifiers = nsSchemes.flatMap((s) => {
-          const primary = {
-            title: s.name,
-            label: s.primaryKey,
-            shortcode: s.primaryKey,
-            ai: s.primaryKey,
-            type: 'I' as const,
-            regex: s.validationPattern,
-            qualifiers: s.qualifiers.map((q) => q.key),
-          };
-          const quals = s.qualifiers.map((q) => ({
-            title: q.description,
-            label: q.key,
-            shortcode: q.key,
-            ai: q.key,
-            type: 'Q' as const,
-            regex: q.validationPattern,
-          }));
-          return [primary, ...quals];
+      try {
+        const didRecord = await didAdapter.create({
+          type: ServiceDidType.SELF_MANAGED,
+          method: ServiceDidMethod.DID_WEB,
+          alias,
         });
-
-        try {
-          await pyxAdapter.registerSchemes([{ namespace, applicationIdentifiers }]);
-          logger.info({ namespace, count: applicationIdentifiers.length }, 'Registered schemes with IDR');
-        } catch (error) {
-          const status = (error as { context?: { httpStatus?: number } })?.context?.httpStatus;
-          const message = error instanceof Error ? error.message : String(error);
-
-          if (status === 409) {
-            logger.warn(
-              { namespace },
-              'IDR returned a conflict for this namespace, skipping registration. Pyx IDR 4.0 upserts on registration and is not expected to return a conflict; inspect the existing namespace in the IDR before changing it. See the custom seed operations documentation.',
+        resolvedKeyId = didRecord.keyId;
+        logger.info({ did: didRecord.did, keyId: resolvedKeyId }, 'DID created via VC service');
+      } catch (error) {
+        if (error instanceof DidConflictError) {
+          // DID already exists on the upstream provider — fetch its document to resolve the key ID
+          logger.warn({ did: didString }, 'DID already exists in VC service — skipping creation');
+          const document = await didAdapter.getDocument(didString);
+          const verificationMethods: Array<{ id: string }> = document.verificationMethod ?? [];
+          if (verificationMethods.length === 0) {
+            throw new Error(
+              `No verification methods found in DID document for "${didString}" — ` +
+                'cannot resolve key ID. Set SYSTEM_DID_KEY_ID explicitly.',
             );
-          } else if (status === 400 || status === 422) {
-            failedNamespaces.push(namespace);
-            logger.error(
-              { namespace, error: message },
-              'IDR scheme registration validation error — skipping namespace',
-            );
-          } else {
-            // Fatal: auth errors (401/403), server errors (5xx), network errors
-            throw error;
           }
+          resolvedKeyId = verificationMethods[0].id;
+          logger.info({ did: didString, keyId: resolvedKeyId }, 'Resolved key ID from existing DID document');
+        } else {
+          throw error;
         }
       }
 
-      if (failedNamespaces.length > 0) {
-        logger.warn(
-          { failedNamespaces },
-          'IDR scheme registration completed with failures — some namespaces were not registered',
-        );
-      } else {
-        logger.info('IDR scheme registration complete');
+      // The DID now exists at the VC service (newly created, or confirmed
+      // already present), whether or not the database write below
+      // succeeds: an interruption from here on is a real side effect
+      // already performed, not nothing having happened, so the outcome is
+      // upgraded from 'skipped' now rather than only on full success.
+      didOutcome = 'partial';
+
+      // 4. If SYSTEM_DID_KEY_ID is set, validate it matches the resolved key
+      if (envKeyId && envKeyId !== resolvedKeyId) {
+        // Fetch document to check all verification methods
+        const document = await didAdapter.getDocument(didString);
+        const verificationMethods: Array<{ id: string }> = document.verificationMethod ?? [];
+        const found = verificationMethods.some((vm) => vm.id === envKeyId || vm.id.endsWith(`#${envKeyId}`));
+        if (!found) {
+          throw new Error(
+            `SYSTEM_DID_KEY_ID "${envKeyId}" not found in DID document for "${didString}". ` +
+              `Available verification methods: ${verificationMethods.map((vm) => vm.id).join(', ') || 'none'}`,
+          );
+        }
+        resolvedKeyId = envKeyId;
+        logger.info({ did: didString, keyId: resolvedKeyId }, 'Using explicitly configured key ID');
       }
-    } catch (error) {
-      logger.error({ error: error instanceof Error ? error.message : error }, 'IDR scheme registration failed');
-      throw error;
+
+      // 5. Record DID in database
+      await prisma.did.upsert({
+        where: { id: SYSTEM_DID_ID },
+        update: {
+          did: didString,
+          name: process.env.SYSTEM_DID_NAME || 'System Default DID',
+          description:
+            process.env.SYSTEM_DID_DESCRIPTION || 'System-wide default DID for the UNTP reference implementation',
+          keyId: resolvedKeyId,
+          status: DidStatus.ACTIVE,
+          isDefault: true,
+          serviceInstanceId: SYSTEM_VC_SERVICE_ID,
+        },
+        create: {
+          id: SYSTEM_DID_ID,
+          tenantId: SYSTEM_TENANT_ID,
+          did: didString,
+          type: DidType.DEFAULT,
+          method: DidMethod.DID_WEB,
+          name: process.env.SYSTEM_DID_NAME || 'System Default DID',
+          description:
+            process.env.SYSTEM_DID_DESCRIPTION || 'System-wide default DID for the UNTP reference implementation',
+          keyId: resolvedKeyId,
+          status: DidStatus.ACTIVE,
+          isDefault: true,
+          serviceInstanceId: SYSTEM_VC_SERVICE_ID,
+        },
+      });
+      didOutcome = 'seeded';
+
+      logger.info({ did: didString, keyId: resolvedKeyId }, 'Default DID seeded and linked to VC service instance');
+    } else if (didConfig && !vcSeeded) {
+      logger.warn('Skipping default DID seed: VC service instance was not seeded (required for DID creation)');
+    } else if (!didConfig) {
+      logger.warn({ error: didConfigError }, 'DID configuration not available; skipping default DID seed');
     }
-  } else if (idrSeeded) {
-    logger.info({ adapterType: idrAdapterType }, 'Non-Pyx IDR adapter — skipping scheme registration');
+
+    // ── Seed core data model configs ────────────────────────────────────────────
+    // Static UUIDs ensure idempotent seeding — if the record already exists, skip.
+    // Left at its default 'skipped' outcome until the first row is
+    // confirmed (created, or found already present) — not before the loop
+    // starts, which would report 'partial' even when zero rows had been
+    // touched (Moderate finding 6) — then upgraded to 'partial' after that
+    // first row and to 'seeded' once every model, including the
+    // ConformityScheme row below, is confirmed done.
+    reachedCategories.add('dataModels');
+
+    const coreDataModels = [
+      {
+        id: 'cxuj555flzqtp4ldvklv6ya39',
+        templateId: 'ctehlnyxvdpmp4kv1cxa0tj0t',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.0',
+        name: 'Digital Product Passport v0.6.0',
+        shortCode: 'dpp',
+        templateDir: 'digital_product_passport',
+      },
+      {
+        id: 'c3imzyum0txv1y9xkww88aktp',
+        templateId: 'cb6ka4fhk68m1wqeitptm24z1',
+        credentialType: 'DigitalConformityCredential',
+        version: '0.6.0',
+        name: 'Digital Conformity Credential v0.6.0',
+        shortCode: 'dcc',
+        templateDir: 'digital_conformity_credential',
+      },
+      {
+        id: 'ctfgtrsuiwv1fedo9t5swxhnk',
+        templateId: 'c62zomihgkn6iimbv7dzhr1fj',
+        credentialType: 'DigitalFacilityRecord',
+        version: '0.6.0',
+        name: 'Digital Facility Record v0.6.0',
+        shortCode: 'dfr',
+        templateDir: 'digital_facility_record',
+      },
+      {
+        id: 'cz9raijqcay5nzmq59geoggrk',
+        templateId: 'cv2ldbzupwtbluam7nrfqqv1e',
+        credentialType: 'DigitalIdentityAnchor',
+        version: '0.6.0',
+        name: 'Digital Identity Anchor v0.6.0',
+        shortCode: 'dia',
+        templateDir: 'digital_identity_anchor',
+      },
+      {
+        id: 'crqvpwffc0k2p4bvr8za1ii6j',
+        templateId: 'c1fx8t9k9p6q8wcaxib6e6id1',
+        credentialType: 'DigitalTraceabilityEvent',
+        version: '0.6.0',
+        name: 'Digital Traceability Event v0.6.0',
+        shortCode: 'dte',
+        templateDir: 'digital_traceability_event',
+      },
+      {
+        id: 'c1pxfzzkeb86jgeel7hrvmcle',
+        templateId: 'co3tub0ndto2lzq9l4rsnw22y',
+        credentialType: 'DigitalProductPassport',
+        version: '0.6.1',
+        name: 'Digital Product Passport v0.6.1',
+        shortCode: 'dpp',
+        templateDir: 'digital_product_passport',
+      },
+      {
+        id: 'cttpz40pfgcfeue2wmbc3jti8',
+        templateId: 'cx5qp969tkboeem04szgwyb32',
+        credentialType: 'DigitalConformityCredential',
+        version: '0.6.1',
+        name: 'Digital Conformity Credential v0.6.1',
+        shortCode: 'dcc',
+        templateDir: 'digital_conformity_credential',
+      },
+      {
+        id: 'csrtste8ai2llop7ui8u6n11l',
+        templateId: 'c91eyblwyejyfoq1pfqsik0ty',
+        credentialType: 'DigitalFacilityRecord',
+        version: '0.6.1',
+        name: 'Digital Facility Record v0.6.1',
+        shortCode: 'dfr',
+        templateDir: 'digital_facility_record',
+      },
+      {
+        id: 'cn5u63huxvqgdwppebaxmqt9l',
+        templateId: 'c5khe5ju6ai3ptaw55r01vayo',
+        credentialType: 'DigitalIdentityAnchor',
+        version: '0.6.1',
+        name: 'Digital Identity Anchor v0.6.1',
+        shortCode: 'dia',
+        templateDir: 'digital_identity_anchor',
+      },
+      {
+        id: 'cwb7m3k0hpz9xqft6rjn2oe4s',
+        templateId: 'c8yvd2gnmr5w1kbjx4hq0zp7f',
+        credentialType: 'DigitalTraceabilityEvent',
+        version: '0.6.1',
+        name: 'Digital Traceability Event v0.6.1',
+        shortCode: 'dte',
+        templateDir: 'digital_traceability_event',
+      },
+      {
+        id: 'ca3frzta22f7lblxntvw6ukuh',
+        templateId: 'cb7bad861g78bcgovjrw98szt',
+        credentialType: 'DigitalProductPassport',
+        version: '0.7.0',
+        name: 'Digital Product Passport v0.7.0',
+        shortCode: 'dpp',
+        templateDir: 'digital_product_passport',
+      },
+      {
+        id: 'ca9ndkrc8lxmtsfzwynui40zy',
+        templateId: 'cpfsywtmlq5wthxc6w6al6e2b',
+        credentialType: 'DigitalConformityCredential',
+        version: '0.7.0',
+        name: 'Digital Conformity Credential v0.7.0',
+        shortCode: 'dcc',
+        templateDir: 'digital_conformity_credential',
+      },
+      {
+        id: 'cj3s37lt6pvh56ggspr9upt5m',
+        templateId: 'c7jafa80eu2wa35rly4eeqona',
+        credentialType: 'DigitalFacilityRecord',
+        version: '0.7.0',
+        name: 'Digital Facility Record v0.7.0',
+        shortCode: 'dfr',
+        templateDir: 'digital_facility_record',
+      },
+      {
+        id: 'cw0tzf723j1oql3u4s1r0c2g2',
+        templateId: 'ch4d269bf6szab6p955vfwj40',
+        credentialType: 'DigitalIdentityAnchor',
+        version: '0.7.0',
+        name: 'Digital Identity Anchor v0.7.0',
+        shortCode: 'dia',
+        templateDir: 'digital_identity_anchor',
+      },
+      {
+        id: 'cfhlj3bumipb74z8irp6uiuxn',
+        templateId: 'chv69r38brqzchvqc47v4qoqo',
+        credentialType: 'DigitalTraceabilityEvent',
+        version: '0.7.0',
+        name: 'Digital Traceability Event v0.7.0',
+        shortCode: 'dte',
+        templateDir: 'digital_traceability_event',
+      },
+    ];
+
+    for (const dm of coreDataModels) {
+      const exists = await prisma.dataModel.findUnique({ where: { id: dm.id } });
+      if (exists) {
+        await convergeCoreProvenance(prisma.dataModel, dm.id, exists.source);
+        dataModelsCompletedCount += 1;
+        dataModelsOutcome = 'partial';
+        logger.info({ dataModelId: dm.id, credentialType: dm.credentialType }, 'Data model already exists, skipping');
+        continue;
+      }
+
+      const { schemaUrl, contextUrl } = buildUntpArtefactUrls(dm.credentialType, dm.version);
+      const websiteUrl = buildSpecificationPageUrl(dm.credentialType, dm.version);
+
+      await prisma.dataModel.create({
+        data: {
+          id: dm.id,
+          tenantId: SYSTEM_TENANT_ID,
+          name: dm.name,
+          credentialType: dm.credentialType,
+          version: dm.version,
+          isExtension: false,
+          schemaUrl,
+          contextUrl,
+          websiteUrl,
+          source: RecordSource.CORE_SEED,
+        },
+      });
+
+      dataModelsCompletedCount += 1;
+      dataModelsOutcome = 'partial';
+      logger.info({ dataModelId: dm.id, credentialType: dm.credentialType }, 'Data model created');
+    }
+
+    // ── Seed the ConformityScheme data model row ────────────────────────────────
+    // The custom-seed `conformitySchemes` processor resolves the JSON Schema URL
+    // for ingestion by looking this row up via (credentialType, version).
+    // ConformityScheme was introduced in v0.7.0, so it always resolves to the
+    // v0.7.0+ artefacts layout (schema under `untp.unece.org/artefacts`, unified
+    // context on `vocabulary.uncefact.org`).
+    const CONFORMITY_SCHEME_DATA_MODEL_ID = 'c4fxk5o3sqrm6n0u7c7akm0sb';
+    const conformitySchemeExists = await prisma.dataModel.findUnique({
+      where: { id: CONFORMITY_SCHEME_DATA_MODEL_ID },
+    });
+    if (conformitySchemeExists) {
+      await convergeCoreProvenance(prisma.dataModel, CONFORMITY_SCHEME_DATA_MODEL_ID, conformitySchemeExists.source);
+      dataModelsCompletedCount += 1;
+      logger.info(
+        { dataModelId: CONFORMITY_SCHEME_DATA_MODEL_ID, credentialType: 'ConformityScheme' },
+        'Data model already exists, skipping',
+      );
+    } else {
+      const { schemaUrl, contextUrl } = buildUntpArtefactUrls('ConformityScheme', '0.7.0');
+      const websiteUrl = buildSpecificationPageUrl('ConformityScheme', '0.7.0');
+      await prisma.dataModel.create({
+        data: {
+          id: CONFORMITY_SCHEME_DATA_MODEL_ID,
+          tenantId: SYSTEM_TENANT_ID,
+          name: 'Conformity Scheme v0.7.0',
+          credentialType: 'ConformityScheme',
+          version: '0.7.0',
+          isExtension: false,
+          schemaUrl,
+          contextUrl,
+          websiteUrl,
+          source: RecordSource.CORE_SEED,
+        },
+      });
+      dataModelsCompletedCount += 1;
+      logger.info(
+        { dataModelId: CONFORMITY_SCHEME_DATA_MODEL_ID, credentialType: 'ConformityScheme' },
+        'Data model created',
+      );
+    }
+    dataModelsOutcome = 'seeded';
+
+    // ── Seed default render templates ───────────────────────────────────────────
+    // Upload .hbs templates to the storage service and record the returned URIs.
+    // Requires the storage service to be available (skipped otherwise).
+
+    reachedCategories.add('renderTemplates');
+    if (storageSeeded && storageRegistryEntry && storageConfig) {
+      try {
+        const storageService = storageRegistryEntry.factory(
+          storageConfig as Parameters<typeof storageRegistryEntry.factory>[0],
+          logger.child({ service: 'Storage - Seed' }),
+        );
+
+        const TEMPLATES_BASE = path.resolve(scriptDir, '../src/templates');
+
+        for (const dm of coreDataModels) {
+          const exists = await prisma.renderTemplate.findUnique({ where: { id: dm.templateId } });
+          if (exists) {
+            await convergeCoreProvenance(prisma.renderTemplate, dm.templateId, exists.source);
+            logger.info(
+              { templateId: dm.templateId, credentialType: dm.credentialType },
+              'Template already exists, skipping',
+            );
+            continue;
+          }
+
+          const templatePath = path.join(TEMPLATES_BASE, `v${dm.version}`, dm.templateDir, 'template.hbs');
+          if (!fs.existsSync(templatePath)) {
+            logger.warn({ templatePath, credentialType: dm.credentialType }, 'Template file not found, skipping');
+            templatesSkippedFiles.push(`${dm.credentialType} v${dm.version} (${templatePath})`);
+            continue;
+          }
+
+          const templateContent = fs.readFileSync(templatePath, 'utf-8');
+
+          // Named before the upload, and cleared only once the database
+          // row commits, so a failure anywhere in between (including the
+          // database write itself) is reported against the item that was
+          // mid flight rather than silently dropped (Moderate finding 8).
+          renderTemplateInterruptedItem = `${dm.credentialType} v${dm.version}`;
+
+          // Upload template to storage via the seeded storage service adapter
+          const storageRecord = await storageService.storeBinary(
+            templateContent,
+            `${dm.shortCode}-template.hbs`,
+            'text/html',
+          );
+
+          // Counted as soon as the external upload succeeds, not only
+          // after the database row is written below: an upload that
+          // succeeds and is then followed by a failed database write is a
+          // real orphaned side effect, not nothing having happened, so the
+          // interrupted-run summary must already see it as progress
+          // (Major finding 4).
+          templatesCreatedCount += 1;
+
+          await prisma.renderTemplate.create({
+            data: {
+              id: dm.templateId,
+              tenantId: SYSTEM_TENANT_ID,
+              dataModelId: dm.id,
+              name: `${dm.name} Default Template`,
+              storageUrl: storageRecord.uri,
+              digestMultibase:
+                storageRecord.digestMultibase ??
+                (
+                  await MultibaseDigest.fromText(templateContent, { algorithm: 'sha2-256', base: 'base58btc' })
+                ).toString(),
+              isDefault: true,
+              renderMethodType: RenderMethodType.RenderTemplate2024,
+              inline: false,
+              mediaType: 'text/html',
+              storageExternalId: storageRecord.externalId,
+              storageBucket: storageRecord.bucket,
+              storageContentType: 'text/html',
+              storageServiceInstanceId: SYSTEM_STORAGE_SERVICE_ID,
+              source: RecordSource.CORE_SEED,
+            },
+          });
+
+          renderTemplateInterruptedItem = null;
+          logger.info(
+            { templateId: dm.templateId, uri: storageRecord.uri, credentialType: dm.credentialType },
+            'Template uploaded and seeded',
+          );
+        }
+        renderTemplatesOutcome = templatesSkippedFiles.length > 0 ? 'partial' : 'seeded';
+      } catch (error) {
+        // The loop can be interrupted after some templates already
+        // uploaded successfully (a real side effect), some already
+        // recorded as missing files, or while an item's upload was in
+        // flight (`renderTemplateInterruptedItem` still set, whether that
+        // upload itself is what threw or a later database write did); any
+        // of those means the category only partially completed, not that
+        // nothing happened. Without the last condition, an item whose
+        // storeBinary call throws before templatesCreatedCount increments
+        // left the outcome 'skipped' while partialDetails.renderTemplates
+        // still named that item — outcome and details disagreeing about
+        // whether the run touched this category.
+        renderTemplatesOutcome =
+          templatesCreatedCount > 0 || templatesSkippedFiles.length > 0 || renderTemplateInterruptedItem
+            ? 'partial'
+            : 'skipped';
+        logger.warn(
+          { error: error instanceof Error ? error.message : error },
+          'Render template seed did not complete; skipping. See the attached error for the cause.',
+        );
+      }
+    } else {
+      logger.warn('Skipping render template seed: storage service was not seeded');
+    }
+
+    // ── Run custom seed (deployer-provided data) ──────────────────────────────
+    // Environment variables:
+    //   SKIP_CUSTOM_SEED=true   - Skip custom seed (deployer-provided data from /app/seed/custom/)
+    reachedCategories.add('customSeed');
+    if (process.env.SKIP_CUSTOM_SEED !== 'true') {
+      const { runCustomSeed, CustomSeedPartialProgressError } = await import('./custom-seed');
+
+      // Configuration-level problems (unparseable YAML, a schema
+      // violation, reference errors, render templates requested with no
+      // storage service configured) are thrown as typed errors rather
+      // than terminating the process directly, so they reach this catch
+      // and the summary this function already builds, instead of
+      // bypassing `main()` and `seed-cli.ts`'s disconnect entirely
+      // (Blocker finding 1).
+      try {
+        const customSeedResult = await runCustomSeed({
+          logger: logger.child({ module: 'custom-seed' }),
+          prisma,
+          systemTenantId: SYSTEM_TENANT_ID,
+          customSeedDir: '/app/seed/custom',
+          storageService:
+            storageSeeded && storageRegistryEntry && storageConfig
+              ? storageRegistryEntry.factory(
+                  storageConfig as Parameters<typeof storageRegistryEntry.factory>[0],
+                  logger.child({ service: 'Storage - Custom Seed' }),
+                )
+              : null,
+          storageServiceInstanceId: SYSTEM_STORAGE_SERVICE_ID,
+        });
+        if (!customSeedResult.ran) {
+          customSeedOutcome = 'skipped';
+        } else if (customSeedResult.conformityFailed > 0) {
+          // Individual conformity-scheme failures do not throw; the
+          // custom seed logs and counts them, then returns successfully.
+          // Reported as 'partial' rather than unconditionally upgraded to
+          // 'seeded', so an acknowledged failure is not overstated as a
+          // clean run (Major finding 5).
+          customSeedOutcome = 'partial';
+          customSeedPartialDetail = `${customSeedResult.conformityFailed} conformity scheme reconciliation(s) failed`;
+        } else {
+          customSeedOutcome = 'seeded';
+        }
+      } catch (error) {
+        if (error instanceof CustomSeedPartialProgressError) {
+          // A template was already uploaded, or the transaction already
+          // committed, before the failure — a real side effect, not
+          // nothing having happened.
+          customSeedOutcome = 'partial';
+          customSeedPartialDetail = error.message;
+        }
+        throw error;
+      }
+    } else {
+      customSeedOutcome = 'skipped';
+      logger.info('Skipping custom seed (SKIP_CUSTOM_SEED is set)');
+    }
+
+    // ── Register identifier schemes with IDR service ────────────────────────────
+    // In the dev environment, the RI operates the Pyx IDR — register seeded schemes.
+    if (idrSeeded && idrAdapterType === 'PYX_IDR') {
+      try {
+        const { PyxIdentityResolverAdapter } = await import('@uncefact/untp-ri-services/server');
+        const pyxAdapter = new PyxIdentityResolverAdapter(
+          idrConfig as ConstructorParameters<typeof PyxIdentityResolverAdapter>[0],
+          logger.child({ service: 'IDR - Seed' }),
+        );
+
+        // Fetch seeded schemes grouped by registrar namespace
+        const schemes = await prisma.identifierScheme.findMany({
+          where: { tenantId: SYSTEM_TENANT_ID },
+          include: { registrar: true, qualifiers: { orderBy: { order: 'asc' } } },
+        });
+
+        // Group by registrar namespace
+        const grouped = new Map<string, typeof schemes>();
+        for (const scheme of schemes) {
+          const ns = scheme.registrar.namespace;
+          if (!grouped.has(ns)) grouped.set(ns, []);
+          grouped.get(ns)!.push(scheme);
+        }
+
+        for (const [namespace, nsSchemes] of grouped) {
+          const applicationIdentifiers = nsSchemes.flatMap((s) => {
+            const primary = {
+              title: s.name,
+              label: s.primaryKey,
+              shortcode: s.primaryKey,
+              ai: s.primaryKey,
+              type: 'I' as const,
+              regex: s.validationPattern,
+              qualifiers: s.qualifiers.map((q) => q.key),
+            };
+            const quals = s.qualifiers.map((q) => ({
+              title: q.description,
+              label: q.key,
+              shortcode: q.key,
+              ai: q.key,
+              type: 'Q' as const,
+              regex: q.validationPattern,
+            }));
+            return [primary, ...quals];
+          });
+
+          try {
+            await pyxAdapter.registerSchemes([{ namespace, applicationIdentifiers }]);
+            logger.info({ namespace, count: applicationIdentifiers.length }, 'Registered schemes with IDR');
+          } catch (error) {
+            const status = (error as { context?: { httpStatus?: number } })?.context?.httpStatus;
+            const message = error instanceof Error ? error.message : String(error);
+
+            if (status === 409) {
+              // Not registered, and the existing namespace's contents are
+              // unverified against what this run would have sent, so the
+              // category cannot be reported fully seeded on the strength
+              // of this namespace alone (Moderate finding 7).
+              conflictedNamespaces.push(namespace);
+              logger.warn(
+                { namespace },
+                'IDR returned a conflict for this namespace, skipping registration. Pyx IDR 4.0 upserts on registration and is not expected to return a conflict; inspect the existing namespace in the IDR before changing it. See the custom seed operations documentation.',
+              );
+            } else if (status === 400 || status === 422) {
+              failedNamespaces.push(namespace);
+              logger.error(
+                { namespace, error: message },
+                'IDR scheme registration validation error — skipping namespace',
+              );
+            } else {
+              // Fatal: auth errors (401/403), server errors (5xx), network errors
+              throw error;
+            }
+          }
+        }
+
+        if (failedNamespaces.length > 0 || conflictedNamespaces.length > 0) {
+          idrOutcome = 'partial';
+          logger.warn(
+            { failedNamespaces, conflictedNamespaces },
+            'IDR scheme registration completed with failures — some namespaces were not registered or not verified',
+          );
+        } else {
+          logger.info('IDR scheme registration complete');
+        }
+      } catch (error) {
+        // The service instance itself already seeded successfully before
+        // registration was attempted; a fatal registration failure (an
+        // auth error, a server error) is a real, incomplete outcome for
+        // the category as a whole, not the "fully seeded" `idrSeeded`
+        // alone would otherwise imply.
+        idrOutcome = 'partial';
+        idrRegistrationFatalError = error instanceof Error ? error.message : String(error);
+        logger.error({ error: idrRegistrationFatalError }, 'IDR scheme registration failed');
+        throw error;
+      }
+    } else if (idrSeeded) {
+      logger.info({ adapterType: idrAdapterType }, 'Non-Pyx IDR adapter — skipping scheme registration');
+    }
+  } catch (error) {
+    // A failure here happened after preflight passed: some categories may
+    // already have been seeded and others never reached. The summary
+    // reflects exactly that state (ADR-043 decision 6 holds on a mid-run
+    // failure too, not only on the default-mode preflight abort and on
+    // success), and the original error still propagates so seed-cli.ts
+    // exits non-zero; this does not swallow it.
+    const summary = buildOutcomeSummary(
+      allowPartial ? 'partial' : 'default',
+      preflight.missingByCategory,
+      currentCategoryOutcomes(),
+      currentPartialDetails(),
+      preflight.otherIssuesByCategory,
+      currentNotRunCategories(),
+    );
+    logger.error({ summary, err: error }, 'Seed failed partway through; the summary reflects what did complete');
+    throw error;
   }
 
-  logger.info(
-    'Seed complete: system tenant' +
-      (defaultDid ? ', default DID' : '') +
-      ', data models' +
-      (templatesSeeded ? ', render templates' : '') +
-      ', custom seed' +
-      (idrSeeded ? ', IDR service instance' : '') +
-      (storageSeeded ? ', storage service instance' : '') +
-      (vcSeeded ? ', VC service instance' : '') +
-      ' upserted',
+  // One structured summary on every exit path, success included (ADR-043
+  // decision 6), naming what ran, what only partially ran and how, what
+  // was skipped, and the variables responsible, so an operator reads the
+  // same record confirming a good deployment as one diagnosing a bad one.
+  const summary = buildOutcomeSummary(
+    allowPartial ? 'partial' : 'default',
+    preflight.missingByCategory,
+    currentCategoryOutcomes(),
+    currentPartialDetails(),
+    preflight.otherIssuesByCategory,
+    currentNotRunCategories(),
   );
+
+  if (summary.categoriesPartial.length > 0 || summary.categoriesSkipped.length > 0) {
+    logger.warn({ summary }, 'Seed complete with categories skipped or incomplete');
+  } else {
+    logger.info({ summary }, 'Seed complete');
+  }
 }
 
-main()
-  .catch((e) => {
-    logger.error({ err: e }, 'Seed failed');
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+// This module never invokes main() itself. `seed-cli.ts` is the executable
+// entrypoint (imports `main` and `prisma` from here and runs them); a test
+// driving `main()` directly against the rig owns its own control flow and
+// must not have this file call `process.exit` out from under it.

--- a/packages/reference-implementation/src/lib/encryption/resolve-data-encryption-key.test.ts
+++ b/packages/reference-implementation/src/lib/encryption/resolve-data-encryption-key.test.ts
@@ -54,4 +54,27 @@ describe('resolveDataEncryptionKey', () => {
       deprecatedName: 'absent',
     });
   });
+
+  // A whitespace-only value has no legitimate meaning (the same rule
+  // seed-preflight's normalizeEnvValue applies) and must not be treated as
+  // a real, divergent alias value.
+  it('treats a whitespace-only DATA_ENCRYPTION_KEY as unset, not as diverging from a set SERVICE_ENCRYPTION_KEY', () => {
+    const resolved = resolveDataEncryptionKey(
+      asEnv({
+        DATA_ENCRYPTION_KEY: '   ',
+        SERVICE_ENCRYPTION_KEY: SERVICE_KEY,
+      }),
+    );
+    expect(resolved).toEqual({ key: SERVICE_KEY, deprecatedName: 'source' });
+  });
+
+  it('treats a whitespace-only SERVICE_ENCRYPTION_KEY as unset, not as diverging from a set DATA_ENCRYPTION_KEY', () => {
+    const resolved = resolveDataEncryptionKey(
+      asEnv({
+        DATA_ENCRYPTION_KEY: DATA_KEY,
+        SERVICE_ENCRYPTION_KEY: '   ',
+      }),
+    );
+    expect(resolved).toEqual({ key: DATA_KEY, deprecatedName: 'absent' });
+  });
 });

--- a/packages/reference-implementation/src/lib/encryption/resolve-data-encryption-key.ts
+++ b/packages/reference-implementation/src/lib/encryption/resolve-data-encryption-key.ts
@@ -24,9 +24,19 @@ export type ResolvedDataEncryptionKey = {
   deprecatedName: 'absent' | 'source' | 'duplicate';
 };
 
+/**
+ * A whitespace-only value has no legitimate meaning here, the same rule
+ * `seed-preflight.ts`'s `normalizeEnvValue` applies; duplicated rather than
+ * imported because `seed-preflight.ts` already imports this module, and a
+ * cross-import back would be circular.
+ */
+function normalizeWhitespaceOnly(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim() !== '' ? value : undefined;
+}
+
 export function resolveDataEncryptionKey(env: NodeJS.ProcessEnv = process.env): ResolvedDataEncryptionKey {
-  const dataKey = env.DATA_ENCRYPTION_KEY || undefined;
-  const serviceKey = env.SERVICE_ENCRYPTION_KEY || undefined;
+  const dataKey = normalizeWhitespaceOnly(env.DATA_ENCRYPTION_KEY);
+  const serviceKey = normalizeWhitespaceOnly(env.SERVICE_ENCRYPTION_KEY);
 
   if (dataKey && serviceKey && dataKey !== serviceKey) {
     throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,7 +182,7 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@storybook/addon-docs':
         specifier: ^10.0.2
-        version: 10.3.6(@types/react@19.2.4)(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 10.3.6(@types/react@19.2.4)(esbuild@0.28.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       '@storybook/addon-links':
         specifier: ^10.0.2
         version: 10.3.6(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -194,7 +194,7 @@ importers:
         version: 10.3.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^10.0.2
-        version: 10.3.6(esbuild@0.27.7)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 10.3.6(esbuild@0.28.2)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@testing-library/jest-dom':
         specifier: ^6.1.3
         version: 6.9.1
@@ -215,13 +215,13 @@ importers:
         version: 19.2.3(@types/react@19.2.4)
       babel-loader:
         specifier: ^9.1.3
-        version: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       babel-plugin-named-exports-order:
         specifier: ^0.0.2
         version: 0.0.2
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.4(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 7.1.4(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@24.6.1)(ts-node@10.9.2(@types/node@24.6.1)(typescript@5.9.3))
@@ -233,7 +233,7 @@ importers:
         version: 3.0.3
       postcss-loader:
         specifier: ^8.2.0
-        version: 8.2.1(postcss@8.5.14)(typescript@5.9.3)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 8.2.1(postcss@8.5.14)(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -242,7 +242,7 @@ importers:
         version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       style-loader:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 4.0.0(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.17
@@ -257,7 +257,7 @@ importers:
         version: 2.1.4
       webpack:
         specifier: ^5.104.1
-        version: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+        version: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   packages/reference-implementation:
     dependencies:
@@ -325,8 +325,8 @@ importers:
         specifier: ^3.3.1
         version: 3.6.0
       tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
+        specifier: ^4.23.12
+        version: 4.23.12
       yaml:
         specifier: ^2.8.2
         version: 2.9.0
@@ -351,7 +351,7 @@ importers:
         version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.4)(react@19.2.4))(@types/react@19.2.4)(react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/addon-docs':
         specifier: ^10.0.2
-        version: 10.3.6(@types/react@19.2.4)(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 10.3.6(@types/react@19.2.4)(esbuild@0.28.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       '@storybook/addon-links':
         specifier: ^10.0.2
         version: 10.3.6(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -363,7 +363,7 @@ importers:
         version: 10.3.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^10.0.2
-        version: 10.3.6(esbuild@0.27.7)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 10.3.6(esbuild@0.28.2)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.1.16
         version: 4.3.0
@@ -405,7 +405,7 @@ importers:
         version: 1.0.0-beta.7
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.4(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 7.1.4(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -435,7 +435,7 @@ importers:
         version: 0.4.1(next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(openapi-types@12.1.3)
       postcss-loader:
         specifier: ^8.2.0
-        version: 8.2.1(postcss@8.5.14)(typescript@5.9.3)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 8.2.1(postcss@8.5.14)(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -453,7 +453,7 @@ importers:
         version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       style-loader:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+        version: 4.0.0(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       swagger-ui-react:
         specifier: 5.17.14
         version: 5.17.14(@types/react@19.2.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -616,7 +616,7 @@ importers:
         version: 3.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.12)(yaml@2.9.0))
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.0
@@ -668,7 +668,7 @@ importers:
         version: 4.0.2(webpack@5.106.2(postcss@8.5.14))
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
+        version: 3.4.19(tsx@4.23.12)(yaml@2.9.0)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.10.6)(typescript@5.9.3)
@@ -2081,8 +2081,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -2093,8 +2093,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2105,8 +2105,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -2117,8 +2117,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2129,8 +2129,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -2141,8 +2141,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2153,8 +2153,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -2165,8 +2165,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2177,8 +2177,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -2189,8 +2189,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2201,8 +2201,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -2213,8 +2213,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2225,8 +2225,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -2237,8 +2237,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2249,8 +2249,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -2261,8 +2261,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2273,8 +2273,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -2285,8 +2285,8 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2297,8 +2297,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -2309,8 +2309,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2321,8 +2321,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -2333,8 +2333,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2345,8 +2345,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -2357,8 +2357,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2369,8 +2369,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -2381,8 +2381,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -6580,8 +6580,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10124,8 +10124,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -14046,157 +14046,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -16632,10 +16632,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.3.6(@types/react@19.2.4)(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))':
+  '@storybook/addon-docs@10.3.6(@types/react@19.2.4)(esbuild@0.28.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.4)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.28.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -16660,22 +16660,22 @@ snapshots:
     dependencies:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/builder-webpack5@10.3.6(esbuild@0.27.7)(postcss@8.5.14)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@10.3.6(esbuild@0.28.2)(postcss@8.5.14)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/core-webpack': 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.4(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+      css-loader: 7.1.4(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
-      html-webpack-plugin: 5.6.7(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
+      html-webpack-plugin: 5.6.7(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       magic-string: 0.30.21
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      style-loader: 4.0.0(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
-      terser-webpack-plugin: 5.6.0(esbuild@0.27.7)(postcss@8.5.14)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+      style-loader: 4.0.0(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
+      terser-webpack-plugin: 5.6.0(esbuild@0.28.2)(postcss@8.5.14)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       ts-dedent: 2.2.0
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
-      webpack-dev-middleware: 6.1.3(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
+      webpack-dev-middleware: 6.1.3(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -16701,13 +16701,13 @@ snapshots:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))':
+  '@storybook/csf-plugin@10.3.6(esbuild@0.28.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))':
     dependencies:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.27.7
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      esbuild: 0.28.2
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   '@storybook/global@5.0.0': {}
 
@@ -16716,10 +16716,10 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/preset-react-webpack@10.3.6(esbuild@0.27.7)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@10.3.6(esbuild@0.28.2)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/core-webpack': 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       '@types/semver': 7.7.1
       magic-string: 0.30.21
       react: 19.2.4
@@ -16729,7 +16729,7 @@ snapshots:
       semver: 7.8.0
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16748,7 +16748,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       endent: 2.1.0
@@ -16758,7 +16758,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
     transitivePeerDependencies:
       - supports-color
 
@@ -16768,10 +16768,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-webpack5@10.3.6(esbuild@0.27.7)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/react-webpack5@10.3.6(esbuild@0.28.2)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
-      '@storybook/builder-webpack5': 10.3.6(esbuild@0.27.7)(postcss@8.5.14)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 10.3.6(esbuild@0.27.7)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 10.3.6(esbuild@0.28.2)(postcss@8.5.14)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 10.3.6(esbuild@0.28.2)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@storybook/react': 10.3.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.1.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -18303,12 +18303,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -18829,7 +18829,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@7.1.4(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  css-loader@7.1.4(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.14)
       postcss: 8.5.14
@@ -18840,7 +18840,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   css-select@4.3.0:
     dependencies:
@@ -19365,34 +19365,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
-  esbuild@0.27.7:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -19903,7 +19903,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -19918,7 +19918,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   form-data@4.0.5:
     dependencies:
@@ -20223,7 +20223,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.47.1
 
-  html-webpack-plugin@5.6.7(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  html-webpack-plugin@5.6.7(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -20231,7 +20231,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   html5-qrcode@2.3.8: {}
 
@@ -22110,23 +22110,23 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.14
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.14
-      tsx: 4.21.0
+      tsx: 4.23.12
       yaml: 2.9.0
 
-  postcss-loader@8.2.1(postcss@8.5.14)(typescript@5.9.3)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  postcss-loader@8.2.1(postcss@8.5.14)(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.7.0
       postcss: 8.5.14
       semver: 7.8.0
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
     transitivePeerDependencies:
       - typescript
 
@@ -23394,9 +23394,9 @@ snapshots:
 
   strnum@2.3.0: {}
 
-  style-loader@4.0.0(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  style-loader@4.0.0(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@19.2.4):
     dependencies:
@@ -23521,11 +23521,11 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
+      tailwindcss: 3.4.19(tsx@4.23.12)(yaml@2.9.0)
 
-  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0):
+  tailwindcss@3.4.19(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23544,7 +23544,7 @@ snapshots:
       postcss: 8.5.14
       postcss-import: 15.1.0(postcss@8.5.14)
       postcss-js: 4.1.0(postcss@8.5.14)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.23.12)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -23559,15 +23559,15 @@ snapshots:
 
   terminal-columns@1.4.1: {}
 
-  terser-webpack-plugin@5.6.0(esbuild@0.27.7)(postcss@8.5.14)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  terser-webpack-plugin@5.6.0(esbuild@0.28.2)(postcss@8.5.14)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
     optionalDependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.2
       postcss: 8.5.14
 
   terser-webpack-plugin@5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)):
@@ -23808,10 +23808,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.21.0:
+  tsx@4.23.12:
     dependencies:
-      esbuild: 0.27.7
-      get-tsconfig: 4.14.0
+      esbuild: 0.28.2
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -24050,7 +24049,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@6.1.3(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14)):
+  webpack-dev-middleware@6.1.3(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -24058,7 +24057,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.2(esbuild@0.27.7)(postcss@8.5.14)
+      webpack: 5.106.2(esbuild@0.28.2)(postcss@8.5.14)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -24070,7 +24069,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14):
+  webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -24093,7 +24092,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.27.7)(postcss@8.5.14)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.14))
+      terser-webpack-plugin: 5.6.0(esbuild@0.28.2)(postcss@8.5.14)(webpack@5.106.2(esbuild@0.28.2)(postcss@8.5.14))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:


### PR DESCRIPTION
This PR makes the seed fail loudly when configuration it needs is missing, which means a misconfigured deployment is caught at deploy time instead of surfacing much later as a failed credential issuance.

Until now every missing-configuration case was a warning and a skip. The container started, reported healthy, and the only trace was a log line nobody reads at the moment it matters. An operator who mistyped a variable name, or whose secret injection quietly failed, got a running system that could not do its job.

The seed now resolves every category's configuration before it writes anything or calls any external service. In the default mode, a missing required variable stops the run before the first write, naming every missing variable grouped by the category it gates, so one boot cycle tells the operator everything they need to fix rather than revealing the next problem on each redeploy. Empty and whitespace-only values count as missing, since that is how people ordinarily write "not set" in a `.env`. `SEED_ALLOW_PARTIAL=true` restores the previous behaviour as a deliberate choice, for a deployment brought up with only some services configured.

Only genuinely absent variables trigger this. A storage service that is unreachable, an invalid value, or a database error keeps the behaviour it has today, because Compose starts storage without waiting for it to be healthy and making that fatal would break a documented startup path intermittently. Where a category has both a missing variable and an invalid one, the missing variable still fails the run and the invalid sibling is named in the same message; otherwise making configuration worse would have made validation weaker.

Every run now ends with one structured summary naming what was seeded, what was partial, what was skipped, what was never reached, and the variables responsible. That holds on success, on the opt-in path, and on failure, so an operator confirming a good deployment reads the same record as one diagnosing a bad one.

The decision is recorded in ADR-043. Two structural consequences are worth knowing: `prisma/seed.ts` now exports `main` and no longer runs itself, with a new `prisma/seed-cli.ts` owning process termination, and `runCustomSeed` throws typed errors rather than calling `process.exit`, so no path can bypass the summary. The `tsx` bump comes along because the pinned version loses named exports across the repository's ESM-to-CommonJS boundary, which is why `pnpm prisma db seed` could not run locally at all.

Reviewers: read `prisma/seed.ts` with `-w`. Wrapping its body in a try/catch re-indented about 600 lines; ignoring whitespace the change is roughly 149 insertions and 55 deletions.

Closes #771
Related to #762

## Test plan

- [x] 211 unit tests and 54 integration tests, including the preflight classification rules, the summary shapes, and the entrypoint's disconnect-before-exit ordering
- [x] Verified against a real container image: an unconfigured boot exits non-zero with exactly one summary and no rows written anywhere, including the system tenant
- [x] `SEED_ALLOW_PARTIAL=true` starts, seeds the tenant and data models, and names every skipped category
- [x] Every variable set with the IDR, storage and VC services on dead ports still starts, confirming an unreachable service is not treated as missing configuration
- [x] A whitespace-only `SYSTEM_DID` is reported as missing and stops the boot
- [x] Divergent `DATA_ENCRYPTION_KEY` and `SERVICE_ENCRYPTION_KEY` values now exit with the summary rather than a bare stack trace
- [x] `pnpm prisma db seed` runs locally for the first time
