### PR TITLE
feat(ri): validate and tighten products endpoint inputs at the route boundary

### DIFF
--- a/documentation/docs/reference-implementation/api/products.md
+++ b/documentation/docs/reference-implementation/api/products.md
@@ -90,6 +90,8 @@ Creates one or more products in bulk. The request body is an array of product ob
 
 The [hierarchy rules](#product-hierarchy) are enforced for each item. If any item violates the rules, the entire request is rejected.
 
+Omit an optional field to skip it rather than sending it as `null`. There is nothing to clear on a product that does not exist yet, so an explicit `null` on create is rejected with a 400.
+
 ```mermaid
 sequenceDiagram
     participant Client
@@ -136,7 +138,7 @@ Returns products for the authenticated tenant with optional filtering. Results a
 | `parentId` | string | — | Filter by parent product ID |
 | `organisationId` | string | — | Filter by producing organisation ID |
 | `facilityId` | string | — | Filter by manufacturing facility ID |
-| `limit` | integer | `20` | Maximum results per page (clamped to 100) |
+| `limit` | integer | Defaults to 20, or the [configured maximum](../operations/api-pagination#maximum-page-size) when it is lower | A value above the maximum is rejected with a 400 that names the maximum |
 | `offset` | integer | `0` | Number of results to skip |
 
 ---
@@ -162,12 +164,12 @@ Updates one or more fields of an existing product. The product `level` is **immu
 | Updatable Field | Description |
 |-----------------|-------------|
 | `name` | Product name (must be non-empty if provided) |
-| `description` | Free-text description |
-| `parentId` | Parent product ID (subject to [hierarchy rules](#product-hierarchy)) |
+| `description` | Free-text description (set to `null` to clear) |
+| `parentId` | Parent product ID (subject to [hierarchy rules](#product-hierarchy); set to `null` to clear) |
 | `producedByOrganisationId` | ID of the producing organisation (set to `null` to clear) |
 | `manufacturingFacilityId` | ID of the manufacturing facility (set to `null` to clear) |
 | `primaryIdentifierId` | ID of the primary identifier (set to `null` to clear) |
-| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing) |
+| `secondaryIdentifierIds` | Array of secondary identifier IDs (replaces existing; send an empty array to clear them all, or omit the field to leave them unchanged) |
 
 ---
 

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.test.ts
@@ -130,7 +130,7 @@ describe('PATCH /api/v1/products/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('At least one updatable field must be provided');
+    expect(json.error).toContain('At least one updatable field is required');
   });
 
   it('returns 404 when product not found', async () => {
@@ -180,7 +180,7 @@ describe('PATCH /api/v1/products/:id', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name must be a non-empty string');
+    expect(json.error).toMatch(/^name:/);
   });
 
   it('returns 500 on unexpected error', async () => {
@@ -211,6 +211,130 @@ describe('PATCH /api/v1/products/:id', () => {
       expect.anything(),
       expect.objectContaining({ primaryIdentifierId: 'ident-1' }),
     );
+  });
+
+  // The previous handler probed the body with `field in body` before checking
+  // it was an object. Any JSON primitive parses fine, so `in` threw a
+  // TypeError that reached the client as a 500 carrying the raw message.
+  it.each([[null], [42], ['x'], [true]])(
+    'returns 400 for a non-object PATCH body of %p and does not reach the repository',
+    async (body) => {
+      const req = createFakeRequest({ method: 'PATCH', body });
+      const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+      expect(res.status).toBe(400);
+      expect(mockUpdateProduct).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns 400 when the body carries only unrecognised keys', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { nmae: 'typo', level: 'ITEM' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain('At least one updatable field is required');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  // level is immutable, so it is stripped rather than rejected when it
+  // accompanies a field that can be updated (ADR-037 decision point 4).
+  it('strips an immutable level and updates the rest', async () => {
+    mockUpdateProduct.mockResolvedValue({ id: 'p-1', name: 'Renamed' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Renamed', level: 'ITEM' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProduct).toHaveBeenCalledWith('p-1', 'org-1', { name: 'Renamed' });
+  });
+
+  // Each of these columns is nullable and an explicit null clears it, so the
+  // schema must forward the null rather than reject it or drop it.
+  it.each([
+    ['description'],
+    ['parentId'],
+    ['producedByOrganisationId'],
+    ['manufacturingFacilityId'],
+    ['primaryIdentifierId'],
+  ])('forwards an explicit null %s as a clear', async (field) => {
+    mockUpdateProduct.mockResolvedValue({ id: 'p-1' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { [field]: null } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProduct).toHaveBeenCalledWith('p-1', 'org-1', { [field]: null });
+  });
+
+  // An empty array is the clear; omitting the field leaves the links alone.
+  it('forwards an empty secondaryIdentifierIds array as a clear', async () => {
+    mockUpdateProduct.mockResolvedValue({ id: 'p-1' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: [] } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProduct).toHaveBeenCalledWith('p-1', 'org-1', { secondaryIdentifierIds: [] });
+  });
+
+  it('returns 400 for a whitespace-only name', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { name: '   ' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('name: must not be only whitespace');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for duplicate secondary identifiers', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: ['id-1', 'id-1'] } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('secondaryIdentifierIds: must not contain duplicate identifiers');
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  it.each([[''], ['   ']])('returns 400 for a description of %p on update', async (description) => {
+    const req = createFakeRequest({ method: 'PATCH', body: { description } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  // An empty string iterated zero times, so it reached the repository as a
+  // clear. Only an array expresses that now.
+  it('returns 400 for an empty-string secondaryIdentifierIds', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: '' } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  // A null entered the repository's `!== undefined` branch and then iterated
+  // over null, which threw a TypeError the client received as a 500.
+  it('returns 400 for a null secondaryIdentifierIds', async () => {
+    const req = createFakeRequest({ method: 'PATCH', body: { secondaryIdentifierIds: null } });
+    const res = await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateProduct).not.toHaveBeenCalled();
+  });
+
+  // Omitting the field leaves the existing links untouched, so it must not
+  // reach the repository as an empty array.
+  it('leaves secondaryIdentifierIds out of the update when it is omitted', async () => {
+    mockUpdateProduct.mockResolvedValue({ id: 'p-1', name: 'Renamed' });
+
+    const req = createFakeRequest({ method: 'PATCH', body: { name: 'Renamed' } });
+    await PATCH(req, createContext('p-1') as unknown as Parameters<typeof PATCH>[1]);
+
+    expect(mockUpdateProduct).toHaveBeenCalledWith('p-1', 'org-1', { name: 'Renamed' });
   });
 });
 

--- a/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/[id]/route.ts
@@ -1,22 +1,12 @@
 import { NextResponse } from 'next/server';
 import { NotFoundError } from '@/lib/api/errors';
-import { ValidationError, isNonEmptyString } from '@/lib/api/validation';
+import { parseRequestBody, definedFields } from '@/lib/api/validation';
+import { updateProductRequestSchema } from '@/lib/api/request-schemas/product';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { getProductById, updateProduct, deleteProduct, UpdateProductInput } from '@/lib/prisma/repositories';
+import { getProductById, updateProduct, deleteProduct } from '@/lib/prisma/repositories';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/products/[id]' });
-
-/** Fields that may be updated via PATCH. Level is immutable. */
-const UPDATABLE_FIELDS = [
-  'name',
-  'description',
-  'parentId',
-  'producedByOrganisationId',
-  'manufacturingFacilityId',
-  'primaryIdentifierId',
-  'secondaryIdentifierIds',
-] as const;
 
 /**
  * @swagger
@@ -94,28 +84,48 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
  *             properties:
  *               name:
  *                 type: string
+ *                 minLength: 1
  *                 description: Updated product name
  *               description:
  *                 type: string
- *                 description: Updated product description
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: Updated product description. Send null to clear it.
  *               parentId:
  *                 type: string
- *                 description: Updated parent product ID
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: Updated parent product ID. Send null to clear it.
  *               producedByOrganisationId:
  *                 type: string
- *                 description: Updated producing organisation ID
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: Updated producing organisation ID. Send null to clear it.
  *               manufacturingFacilityId:
  *                 type: string
- *                 description: Updated manufacturing facility ID
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: Updated manufacturing facility ID. Send null to clear it.
  *               primaryIdentifierId:
  *                 type: string
- *                 description: Updated primary identifier ID
+ *                 minLength: 1
+ *                 nullable: true
+ *                 description: Updated primary identifier ID. Send null to clear it.
  *               secondaryIdentifierIds:
  *                 type: array
+ *                 uniqueItems: true
  *                 items:
  *                   type: string
- *                 description: Updated secondary identifier IDs
- *             minProperties: 1
+ *                   minLength: 1
+ *                 description: Updated secondary identifier IDs. Send an empty array to clear them all; omit the field to leave them unchanged.
+ *             anyOf:
+ *               - required: [name]
+ *               - required: [description]
+ *               - required: [parentId]
+ *               - required: [producedByOrganisationId]
+ *               - required: [manufacturingFacilityId]
+ *               - required: [primaryIdentifierId]
+ *               - required: [secondaryIdentifierIds]
  *     responses:
  *       200:
  *         description: Product updated successfully
@@ -155,35 +165,12 @@ export const GET = withTenantAuth(async (_req, { tenantId, params }) => {
 export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
   const { id } = await params;
 
-  logger.info({ productId: id }, 'Parsing request body');
-  let body: Record<string, unknown>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
   logger.info({ productId: id }, 'Validating update fields');
-  const hasUpdatableField = UPDATABLE_FIELDS.some((field) => field in body);
-  if (!hasUpdatableField) {
-    throw new ValidationError(`At least one updatable field must be provided: ${UPDATABLE_FIELDS.join(', ')}`);
-  }
+  const body = await parseRequestBody(req, updateProductRequestSchema);
+  const fields = definedFields(body);
 
-  if (body.name !== undefined && !isNonEmptyString(body.name)) {
-    throw new ValidationError('name must be a non-empty string');
-  }
-
-  // Pick only known updatable fields (level is immutable and silently excluded)
-  const updateData: Record<string, unknown> = {};
-  for (const field of UPDATABLE_FIELDS) {
-    if (field in body) {
-      updateData[field] = body[field];
-    }
-  }
-
-  logger.info({ productId: id }, 'Updating product');
-  const updated = await updateProduct(id, tenantId, updateData as UpdateProductInput);
+  logger.info({ productId: id, fields: Object.keys(fields) }, 'Updating product');
+  const updated = await updateProduct(id, tenantId, fields);
 
   logger.info({ productId: id }, 'Product updated');
   return NextResponse.json(updated);

--- a/packages/reference-implementation/src/app/api/v1/products/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.test.ts
@@ -33,6 +33,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
 }));
 
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
+import { MAX_PAGE_LIMIT } from '@/lib/api/pagination';
 import { POST, GET } from './route';
 
 function createFakeRequest(options: { method?: string; body?: unknown; url?: string }): Request {
@@ -63,6 +64,8 @@ function createBadJsonRequest(): Request {
 }
 
 const AUTH_CONTEXT = { tenantId: 'org-1', params: Promise.resolve({}) };
+
+const VALID_ITEM = { name: 'Widget', level: 'MODEL' };
 
 describe('POST /api/v1/products', () => {
   beforeEach(() => {
@@ -113,7 +116,7 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('name is required for all items');
+    expect(json.error).toMatch(/^0\.name:/);
   });
 
   it('returns 400 when level is missing', async () => {
@@ -122,7 +125,7 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('level is required for all items');
+    expect(json.error).toMatch(/^0\.level:/);
   });
 
   it('returns 400 when level is not a valid enum value', async () => {
@@ -131,7 +134,7 @@ describe('POST /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('level must be one of: MODEL, BATCH, ITEM');
+    expect(json.error).toMatch(/^0\.level:/);
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -183,6 +186,108 @@ describe('POST /api/v1/products', () => {
       expect.anything(),
       expect.arrayContaining([expect.objectContaining({ primaryIdentifierId: 'ident-1' })]),
     );
+  });
+
+  // The previous handler read `item.name` straight off each array element, so
+  // a null item threw a TypeError that reached the client as a 500 carrying
+  // the raw JavaScript message. Only null did this: a string or array element
+  // yields undefined on property access and failed cleanly.
+  it('returns 400 for a null array item and does not reach the repository', async () => {
+    const req = createFakeRequest({ body: [null] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^0:/);
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a whitespace-only name', async () => {
+    const req = createFakeRequest({ body: [{ name: '   ', level: 'MODEL' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('0.name: must not be only whitespace');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  // Create has no null-to-clear contract, so an optional field sent as null is
+  // rejected rather than stored as null. Omitting it is how a client skips it.
+  it.each([
+    ['description'],
+    ['parentId'],
+    ['producedByOrganisationId'],
+    ['manufacturingFacilityId'],
+    ['primaryIdentifierId'],
+    ['secondaryIdentifierIds'],
+  ])('returns 400 when the optional %s is sent as null on create', async (field) => {
+    const req = createFakeRequest({ body: [{ name: 'Widget', level: 'MODEL', [field]: null }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(new RegExp(`^0\\.${field}:`));
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for duplicate secondary identifiers in one item', async () => {
+    const req = createFakeRequest({
+      body: [{ name: 'Widget', level: 'MODEL', secondaryIdentifierIds: ['id-1', 'id-1'] }],
+    });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe('0.secondaryIdentifierIds: must not contain duplicate identifiers');
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a non-array secondaryIdentifierIds', async () => {
+    const req = createFakeRequest({ body: [{ name: 'Widget', level: 'MODEL', secondaryIdentifierIds: 'id-1' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid item with every optional field omitted', async () => {
+    mockCreateProducts.mockResolvedValue([{ id: 'p-1', name: 'Widget', level: 'MODEL' }]);
+
+    const req = createFakeRequest({ body: [VALID_ITEM] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateProducts).toHaveBeenCalledWith('org-1', [VALID_ITEM]);
+  });
+
+  it.each([[''], ['   ']])('returns 400 for a description of %p on create', async (description) => {
+    const req = createFakeRequest({ body: [{ ...VALID_ITEM, description }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  // An empty string reached the repository's `?.length` check as zero and was
+  // treated as "no secondary identifiers", so this created a product. It is
+  // now a type error at the boundary.
+  it('returns 400 for an empty-string secondaryIdentifierIds on create', async () => {
+    const req = createFakeRequest({ body: [{ ...VALID_ITEM, secondaryIdentifierIds: '' }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockCreateProducts).not.toHaveBeenCalled();
+  });
+
+  // These reached the repository's `?.length` check as falsy, so the old code
+  // treated them as "no secondary identifiers" and created the product.
+  it.each([[false], [0]])('returns 400 for a falsy non-array secondaryIdentifierIds of %p', async (value) => {
+    const req = createFakeRequest({ body: [{ ...VALID_ITEM, secondaryIdentifierIds: value }] });
+    const res = await POST(req, AUTH_CONTEXT as unknown as Parameters<typeof POST>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockCreateProducts).not.toHaveBeenCalled();
   });
 });
 
@@ -250,7 +355,7 @@ describe('GET /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('level must be one of: MODEL, BATCH, ITEM');
+    expect(json.error).toMatch(/^level:/);
   });
 
   it('returns 400 for non-numeric limit', async () => {
@@ -262,7 +367,7 @@ describe('GET /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('limit must be a positive integer');
+    expect(json.error).toBe('limit: must be a positive integer');
   });
 
   it('returns 400 for negative offset', async () => {
@@ -274,7 +379,7 @@ describe('GET /api/v1/products', () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toContain('offset must be a non-negative integer');
+    expect(json.error).toBe('offset: must be a non-negative integer');
   });
 
   it('returns pagination metadata with custom limit and offset', async () => {
@@ -299,5 +404,93 @@ describe('GET /api/v1/products', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('Database error');
+  });
+
+  // The route rejects an over-maximum limit rather than clamping it, so the
+  // client is told the bound instead of receiving a quietly smaller page.
+  it('returns 400 when limit exceeds the maximum and does not query', async () => {
+    const req = createFakeRequest({
+      method: 'GET',
+      url: `http://localhost/api/v1/products?limit=${MAX_PAGE_LIMIT + 1}`,
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe(`limit: must not exceed the maximum of ${MAX_PAGE_LIMIT}`);
+    expect(mockListProducts).not.toHaveBeenCalled();
+  });
+
+  // parseInt read the leading digits of each of these, so most were accepted
+  // as a smaller number. `0x10` is the exception on `limit`: it parsed to 0
+  // and already failed the positive check, though it was accepted as an
+  // `offset`. The strict parser rejects the whole set, which is the
+  // tightening #795 asks for.
+  it.each([['1abc'], ['5.5'], ['10.0'], ['1e1'], ['0x10']])('returns 400 for a limit of %s', async (value) => {
+    const req = createFakeRequest({ method: 'GET', url: `http://localhost/api/v1/products?limit=${value}` });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockListProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a repeated query key', async () => {
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/products?limit=5&limit=6' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockListProducts).not.toHaveBeenCalled();
+  });
+
+  // A bad filter is reported ahead of a bad pagination value, which is the
+  // parameter this route named before the migration.
+  it('names the level filter when both level and limit are invalid', async () => {
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/products?level=NOPE&limit=abc' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^level:/);
+  });
+
+  // Empty filter values are accepted today and stay accepted: `search` is
+  // skipped by a falsy check, and the id filters match by exact equality.
+  it('accepts empty filter values and forwards them unchanged', async () => {
+    mockListProducts.mockResolvedValue({ data: [], total: 0 });
+
+    const req = createFakeRequest({
+      method: 'GET',
+      url: 'http://localhost/api/v1/products?search=&parentId=&organisationId=&facilityId=',
+    });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(200);
+    expect(mockListProducts).toHaveBeenCalledWith('org-1', {
+      search: '',
+      level: undefined,
+      parentId: '',
+      organisationId: '',
+      facilityId: '',
+      limit: undefined,
+      offset: undefined,
+    });
+  });
+
+  // `offset=0x10` is the case the old radix-10 parseInt accepted as 0.
+  it.each([['1abc'], ['5.5'], ['0x10']])('returns 400 for an offset of %s', async (value) => {
+    const req = createFakeRequest({ method: 'GET', url: `http://localhost/api/v1/products?offset=${value}` });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+
+    expect(res.status).toBe(400);
+    expect(mockListProducts).not.toHaveBeenCalled();
+  });
+
+  it('names limit ahead of offset when both are invalid', async () => {
+    const req = createFakeRequest({ method: 'GET', url: 'http://localhost/api/v1/products?limit=abc&offset=xyz' });
+    const res = await GET(req, AUTH_CONTEXT as unknown as Parameters<typeof GET>[1]);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/^limit:/);
   });
 });

--- a/packages/reference-implementation/src/app/api/v1/products/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/products/route.ts
@@ -1,19 +1,12 @@
 import { NextResponse } from 'next/server';
-import {
-  ValidationError,
-  isNonEmptyString,
-  parsePositiveInt,
-  parseNonNegativeInt,
-  validateEnum,
-} from '@/lib/api/validation';
+import { parseRequestBody, parseQueryParams } from '@/lib/api/validation';
+import { createProductsRequestSchema, listProductsQuerySchema } from '@/lib/api/request-schemas/product';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
-import { createProducts, listProducts, CreateProductInput } from '@/lib/prisma/repositories';
-import { buildPaginatedResponse, MAX_PAGE_LIMIT } from '@/lib/api/pagination';
+import { createProducts, listProducts } from '@/lib/prisma/repositories';
+import { buildPaginatedResponse } from '@/lib/api/pagination';
 import { apiLogger } from '@/lib/api/logger';
 
 const logger = apiLogger.child({ route: '/api/v1/products' });
-
-const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
 
 /**
  * @swagger
@@ -29,6 +22,8 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *         application/json:
  *           schema:
  *             type: array
+ *             minItems: 1
+ *             description: Optional fields are omitted rather than sent as null; an explicit null is rejected with a 400.
  *             items:
  *               type: object
  *               required:
@@ -37,6 +32,7 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *               properties:
  *                 name:
  *                   type: string
+ *                   minLength: 1
  *                   description: The product name
  *                 level:
  *                   type: string
@@ -44,23 +40,30 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *                   description: The product level
  *                 description:
  *                   type: string
+ *                   minLength: 1
  *                   description: Optional product description
  *                 parentId:
  *                   type: string
+ *                   minLength: 1
  *                   description: Optional parent product ID
  *                 producedByOrganisationId:
  *                   type: string
+ *                   minLength: 1
  *                   description: ID of the producing organisation
  *                 manufacturingFacilityId:
  *                   type: string
+ *                   minLength: 1
  *                   description: ID of the manufacturing facility
  *                 primaryIdentifierId:
  *                   type: string
+ *                   minLength: 1
  *                   description: ID of the primary identifier
  *                 secondaryIdentifierIds:
  *                   type: array
+ *                   uniqueItems: true
  *                   items:
  *                     type: string
+ *                     minLength: 1
  *                   description: IDs of secondary identifiers
  *     responses:
  *       201:
@@ -72,7 +75,7 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *               items:
  *                 $ref: '#/components/schemas/Product'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. a body that is not a non-empty array, a missing or empty name, an invalid level, an optional field sent as null, a non-array or duplicated secondaryIdentifierIds)
  *         content:
  *           application/json:
  *             schema:
@@ -101,41 +104,11 @@ const PRODUCT_LEVELS = ['MODEL', 'BATCH', 'ITEM'] as const;
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const POST = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing request body');
-  let body: Array<{
-    name?: string;
-    level?: string;
-    description?: string;
-    parentId?: string;
-  }>;
-
-  try {
-    body = await req.json();
-  } catch {
-    throw new ValidationError('Invalid JSON body');
-  }
-
-  logger.info('Validating input parameters');
-  if (!Array.isArray(body)) {
-    throw new ValidationError('Request body must be an array');
-  }
-
-  if (body.length === 0) {
-    throw new ValidationError('Request body must not be empty');
-  }
-
-  for (const item of body) {
-    if (!isNonEmptyString(item.name)) {
-      throw new ValidationError('name is required for all items');
-    }
-    if (!isNonEmptyString(item.level)) {
-      throw new ValidationError('level is required for all items');
-    }
-    validateEnum(item.level, PRODUCT_LEVELS, 'level');
-  }
+  logger.info('Validating request body');
+  const body = await parseRequestBody(req, createProductsRequestSchema);
 
   logger.info({ count: body.length }, 'Creating products');
-  const products = await createProducts(tenantId, body as CreateProductInput[]);
+  const products = await createProducts(tenantId, body);
 
   logger.info({ count: products.length }, 'Products created');
   return NextResponse.json(products, { status: 201 });
@@ -181,7 +154,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *         schema:
  *           type: integer
  *           minimum: 1
- *         description: Maximum number of products to return
+ *         description: Number of products to return per page. Defaults to 20 unless the deployment maximum is lower. Values above the deployment maximum are rejected with a 400 naming the maximum.
  *       - in: query
  *         name: offset
  *         schema:
@@ -203,7 +176,7 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *                 pagination:
  *                   $ref: '#/components/schemas/PaginationMeta'
  *       400:
- *         description: Validation error
+ *         description: Validation error (e.g. a non-integer limit/offset, a negative offset, a limit above the maximum, an invalid level, a repeated query parameter)
  *         content:
  *           application/json:
  *             schema:
@@ -220,16 +193,9 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 export const GET = withTenantAuth(async (req, { tenantId }) => {
-  logger.info('Parsing query filters');
-  const url = new URL(req.url);
-  const search = url.searchParams.get('search') ?? undefined;
-  const level = validateEnum(url.searchParams.get('level') ?? undefined, PRODUCT_LEVELS, 'level');
-  const parentId = url.searchParams.get('parentId') ?? undefined;
-  const organisationId = url.searchParams.get('organisationId') ?? undefined;
-  const facilityId = url.searchParams.get('facilityId') ?? undefined;
-  const rawLimit = parsePositiveInt(url.searchParams.get('limit'), 'limit');
-  const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_PAGE_LIMIT) : undefined;
-  const offset = parseNonNegativeInt(url.searchParams.get('offset'), 'offset');
+  logger.info('Parsing query parameters');
+  const query = parseQueryParams(new URL(req.url), listProductsQuerySchema);
+  const { search, level, parentId, organisationId, facilityId, limit, offset } = query;
 
   logger.info({ filters: { search, level, parentId, organisationId, facilityId, limit, offset } }, 'Querying products');
   const { data, total } = await listProducts(tenantId, {

--- a/packages/reference-implementation/src/lib/api/request-schemas/product.ts
+++ b/packages/reference-implementation/src/lib/api/request-schemas/product.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import type { ProductLevel } from '@/lib/prisma/generated';
+import { idSchema, nonBlankString, nonEmptyArraySchema, paginationQuerySchema, requireAtLeastOneField } from './shared';
+
+/**
+ * The product hierarchy levels accepted on the wire, keyed by the generated
+ * Prisma `ProductLevel` so the accepted set tracks the column that stores it.
+ * The import is type-only, so nothing from the generated client reaches the
+ * bundle. That is also why the values are written out and passed to `z.enum`
+ * rather than handed to `z.nativeEnum`, which would need the runtime enum
+ * object a type-only import deliberately does not bring in.
+ *
+ * The `Record` is what keeps the list honest: adding a level to the Prisma
+ * enum fails to compile here as a missing property, and renaming or removing
+ * one fails as an unknown property. A level added to the enum but not to the
+ * repository's own input type is caught in turn where the parsed body is
+ * handed to `createProducts`.
+ */
+const PRODUCT_LEVEL_KEYS: Record<ProductLevel, true> = { MODEL: true, BATCH: true, ITEM: true };
+const productLevelSchema = z.enum(Object.keys(PRODUCT_LEVEL_KEYS) as [ProductLevel, ...ProductLevel[]]);
+
+/**
+ * A set of identifier ids carried on a product, rejecting an in-array
+ * duplicate as a well-formedness issue at the boundary. The repository's
+ * `validateNoPrimarySecondaryOverlap` already rejects duplicates, so this
+ * closes no defect. What it adds is a field-prefixed message and an earlier
+ * rejection: on create, ahead of the repository's per-identifier ownership
+ * lookups, and on update, ahead of its transaction (that path already checks
+ * for duplicates before its own ownership loop). The cross-field and
+ * existing-data checks stay in the repository (ADR-036/037).
+ */
+const secondaryIdentifierIdsSchema = z
+  .array(idSchema)
+  .refine((val) => new Set(val).size === val.length, { message: 'must not contain duplicate identifiers' });
+
+/**
+ * A single item in the POST /products bulk-create request body.
+ *
+ * No field is nullable. There is nothing to clear on a record that does not
+ * exist yet, so create has no null-to-clear contract, matching the decision
+ * facilities and organisations already record. This is a change: the previous
+ * handler validated only `name` and `level` and cast the rest through, so an
+ * explicit `null` on any optional field was stored as null. Clients omit an
+ * optional field to skip it rather than sending `null`.
+ *
+ * `level` is accepted here and stripped on update, because a product's place
+ * in the hierarchy is fixed at creation.
+ */
+const productItemSchema = z.object({
+  name: nonBlankString,
+  level: productLevelSchema,
+  description: nonBlankString.optional(),
+  parentId: idSchema.optional(),
+  producedByOrganisationId: idSchema.optional(),
+  manufacturingFacilityId: idSchema.optional(),
+  primaryIdentifierId: idSchema.optional(),
+  secondaryIdentifierIds: secondaryIdentifierIdsSchema.optional(),
+});
+
+/** Request body for POST /products: a non-empty array of product items. */
+export const createProductsRequestSchema = nonEmptyArraySchema(productItemSchema);
+
+/**
+ * Request body for PATCH /products/{id}.
+ *
+ * The four relation ids and `description` are `.nullable()` because each is a
+ * nullable column whose explicit `null` the repository forwards as a clear.
+ * Clearing `parentId` on a BATCH product still fails the hierarchy rule in
+ * the repository, which is a domain check rather than a shape one.
+ *
+ * `secondaryIdentifierIds` is a replacement command rather than a nullable
+ * column, so it is not nullable and carries no `.min()`: an empty array is
+ * the established way to clear every secondary identifier, and omitting the
+ * field leaves them untouched.
+ *
+ * `level` is absent, so a client that sends it back has it stripped rather
+ * than rejected (ADR-037 decision point 4). A body whose only keys are
+ * unrecognised, `level` among them, fails the at-least-one-field check.
+ */
+export const updateProductRequestSchema = requireAtLeastOneField(
+  z.object({
+    name: nonBlankString.optional(),
+    description: nonBlankString.nullable().optional(),
+    parentId: idSchema.nullable().optional(),
+    producedByOrganisationId: idSchema.nullable().optional(),
+    manufacturingFacilityId: idSchema.nullable().optional(),
+    primaryIdentifierId: idSchema.nullable().optional(),
+    secondaryIdentifierIds: secondaryIdentifierIdsSchema.optional(),
+  }),
+  'At least one updatable field is required: name, description, parentId, producedByOrganisationId, manufacturingFacilityId, primaryIdentifierId, secondaryIdentifierIds',
+);
+
+/**
+ * Query parameters for GET /products. The filters merge ahead of pagination
+ * so a malformed filter is reported before a pagination issue, matching the
+ * sibling resources and what this route reported before the migration.
+ *
+ * `search`, `parentId`, `organisationId` and `facilityId` stay unconstrained
+ * strings rather than `idSchema` (#795 keeps them accepted unchanged). An
+ * empty value is meaningful today: `search` is skipped by a falsy check and
+ * returns the unfiltered list, while the three id filters match by exact
+ * equality and return an empty page. Tightening them would turn both into a
+ * 400.
+ */
+export const listProductsQuerySchema = z
+  .object({
+    search: z.string().optional(),
+    level: productLevelSchema.optional(),
+    parentId: z.string().optional(),
+    organisationId: z.string().optional(),
+    facilityId: z.string().optional(),
+  })
+  .merge(paginationQuerySchema);

--- a/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/product.repository.ts
@@ -70,7 +70,9 @@ export type CreateProductInput = {
  */
 export type UpdateProductInput = {
   name?: string;
-  description?: string;
+  // Nullable like the relation ids below: `description` is a nullable column
+  // and an explicit null is forwarded as a clear.
+  description?: string | null;
   parentId?: string | null;
   producedByOrganisationId?: string | null;
   manufacturingFacilityId?: string | null;

--- a/packages/reference-implementation/src/lib/swagger/schemas.test.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.test.ts
@@ -343,3 +343,104 @@ describe('generateOpenAPISchemas — Conformity Vocabulary Catalogue components'
     expect(topicItem?.properties?.definition).toBeDefined();
   });
 });
+
+describe('generateOpenAPISchemas — Product component', () => {
+  type JsonSchema = {
+    type?: string;
+    properties?: Record<string, JsonSchema>;
+    required?: string[];
+    items?: JsonSchema;
+    nullable?: boolean;
+  };
+
+  const product = generateOpenAPISchemas().Product as JsonSchema;
+
+  it('requires every product column that every handler returns', () => {
+    expect(product.required).toEqual(
+      expect.arrayContaining([
+        'id',
+        'tenantId',
+        'name',
+        'level',
+        'description',
+        'batchNumber',
+        'serialNumber',
+        'parentId',
+        'producedByOrganisationId',
+        'manufacturingFacilityId',
+        'primaryIdentifierId',
+        'createdAt',
+        'updatedAt',
+      ]),
+    );
+  });
+
+  it('declares but does not require the list-versus-detail asymmetric fields', () => {
+    const asymmetricFields = [
+      'secondaryIdentifierIds',
+      'primaryIdentifier',
+      'secondaryIdentifiers',
+      'producedByOrganisation',
+      'manufacturingFacility',
+      'parent',
+    ];
+    for (const field of asymmetricFields) {
+      expect(product.properties).toHaveProperty(field);
+      expect(product.required).not.toContain(field);
+    }
+  });
+
+  it('marks each nullable relation nullable', () => {
+    expect(product.properties?.primaryIdentifier?.nullable).toBe(true);
+    expect(product.properties?.producedByOrganisation?.nullable).toBe(true);
+    expect(product.properties?.manufacturingFacility?.nullable).toBe(true);
+    expect(product.properties?.parent?.nullable).toBe(true);
+  });
+
+  it("embeds the primary identifier's scheme without qualifiers, with registrar required", () => {
+    const primaryIdentifier = product.properties?.primaryIdentifier;
+    expect(primaryIdentifier?.required).toContain('scheme');
+
+    const scheme = primaryIdentifier?.properties?.scheme;
+    expect(scheme?.properties).not.toHaveProperty('qualifiers');
+    expect(scheme?.required).toContain('registrar');
+  });
+
+  it('requires productId, identifierId, and identifier on each secondary identifier link', () => {
+    const link = product.properties?.secondaryIdentifiers?.items;
+    expect(link?.required).toEqual(expect.arrayContaining(['productId', 'identifierId', 'identifier']));
+  });
+
+  it.each([
+    ['primaryIdentifier', () => product.properties?.primaryIdentifier?.properties?.scheme],
+    [
+      'secondaryIdentifiers',
+      () => product.properties?.secondaryIdentifiers?.items?.properties?.identifier?.properties?.scheme,
+    ],
+  ])('gives the %s scheme a registrar with no schemes array', (_path, getScheme) => {
+    const registrar = getScheme()?.properties?.registrar;
+    expect(registrar?.properties).toBeDefined();
+    expect(registrar?.properties).not.toHaveProperty('schemes');
+  });
+
+  // PRODUCT_DETAIL_INCLUDE fetches these two relations with `true`, so only
+  // their own columns come back. Publishing their identifier relations would
+  // promise a shape no product response returns.
+  it.each([['producedByOrganisation'], ['manufacturingFacility']])('embeds %s as its own columns only', (relation) => {
+    const embedded = product.properties?.[relation];
+    expect(embedded?.properties).toHaveProperty('name');
+    expect(embedded?.properties).not.toHaveProperty('primaryIdentifier');
+    expect(embedded?.properties).not.toHaveProperty('secondaryIdentifiers');
+  });
+
+  // The parent is fetched with its primary identifier and nothing else, so the
+  // component must stop there rather than recursing into another parent.
+  it('embeds the parent with its primary identifier and no deeper relations', () => {
+    const parent = product.properties?.parent;
+    expect(parent?.properties).toHaveProperty('primaryIdentifier');
+    expect(parent?.properties).not.toHaveProperty('parent');
+    expect(parent?.properties).not.toHaveProperty('secondaryIdentifiers');
+    expect(parent?.properties).not.toHaveProperty('producedByOrganisation');
+    expect(parent?.properties).not.toHaveProperty('manufacturingFacility');
+  });
+});

--- a/packages/reference-implementation/src/lib/swagger/schemas.ts
+++ b/packages/reference-implementation/src/lib/swagger/schemas.ts
@@ -138,22 +138,112 @@ export const renderTemplateSchema = z.object({
 // Master Data Schemas
 // ============================================================================
 
-export const productSchema = z.object({
-  id: z.string(),
-  tenantId: z.string(),
-  name: z.string(),
-  level: z.enum(['MODEL', 'BATCH', 'ITEM']),
-  description: z.string().nullable(),
-  batchNumber: z.string().nullable(),
-  serialNumber: z.string().nullable(),
-  parentId: z.string().nullable(),
-  producedByOrganisationId: z.string().nullable(),
-  manufacturingFacilityId: z.string().nullable(),
-  primaryIdentifierId: z.string().nullable(),
-  secondaryIdentifierIds: z.array(z.string()).describe('IDs of secondary identifiers'),
-  createdAt: z.string().describe('ISO 8601 timestamp'),
-  updatedAt: z.string().describe('ISO 8601 timestamp'),
-});
+/**
+ * Builds the Product response schema, including its nested identifier,
+ * organisation, facility, and parent relations.
+ */
+function buildProductSchema() {
+  /**
+   * Identifier scheme as embedded in a product's identifier relations.
+   * PRODUCT_DETAIL_INCLUDE's `scheme` include fetches `registrar` but not
+   * `qualifiers`, so `qualifiers` is omitted (never returned via this path)
+   * and `registrar` is required (always returned via this path).
+   */
+  const productIdentifierSchemeSchema = identifierSchemeSchema.omit({ qualifiers: true }).required({ registrar: true });
+
+  /**
+   * Identifier as embedded in a product's `primaryIdentifier` and secondary
+   * identifier relations, which eagerly load the owning scheme and its
+   * registrar; mirrors IDENTIFIER_INCLUDE in product.repository.ts.
+   */
+  const productIdentifierWithSchemeSchema = identifierSchema.extend({
+    scheme: productIdentifierSchemeSchema,
+  });
+
+  /** A product's secondary-identifier join record, as returned by the detail endpoints. */
+  const productSecondaryIdentifierLinkSchema = z.object({
+    productId: z.string(),
+    identifierId: z.string(),
+    identifier: productIdentifierWithSchemeSchema,
+  });
+
+  /** The producing organisation, embedded via `producedByOrganisation: true`: its own columns only. */
+  const productOrganisationSchema = z.object({
+    id: z.string(),
+    tenantId: z.string(),
+    name: z.string(),
+    description: z.string().nullable(),
+    location: z.record(z.unknown()).nullable().describe('UNTP location object'),
+    primaryIdentifierId: z.string().nullable(),
+    createdAt: z.string().describe('ISO 8601 timestamp'),
+    updatedAt: z.string().describe('ISO 8601 timestamp'),
+  });
+
+  /** The manufacturing facility, embedded via `manufacturingFacility: true`: its own columns only. */
+  const productFacilitySchema = z.object({
+    id: z.string(),
+    tenantId: z.string(),
+    name: z.string(),
+    description: z.string().nullable(),
+    location: z.record(z.unknown()).nullable().describe('UNTP location object'),
+    operatingOrganisationId: z.string().nullable(),
+    primaryIdentifierId: z.string().nullable(),
+    createdAt: z.string().describe('ISO 8601 timestamp'),
+    updatedAt: z.string().describe('ISO 8601 timestamp'),
+  });
+
+  const productOwnColumns = {
+    id: z.string(),
+    tenantId: z.string(),
+    name: z.string(),
+    level: z.enum(['MODEL', 'BATCH', 'ITEM']),
+    description: z.string().nullable(),
+    batchNumber: z.string().nullable(),
+    serialNumber: z.string().nullable(),
+    parentId: z.string().nullable(),
+    producedByOrganisationId: z.string().nullable(),
+    manufacturingFacilityId: z.string().nullable(),
+    primaryIdentifierId: z.string().nullable(),
+    createdAt: z.string().describe('ISO 8601 timestamp'),
+    updatedAt: z.string().describe('ISO 8601 timestamp'),
+  };
+
+  /**
+   * The parent product, embedded via `parent: { include: { primaryIdentifier } }`:
+   * its own columns plus its primary identifier, and no deeper nesting.
+   */
+  const productParentSchema = z.object({
+    ...productOwnColumns,
+    primaryIdentifier: productIdentifierWithSchemeSchema.nullable(),
+  });
+
+  // The create, get-by-id, and update handlers return the full nested
+  // relations (PRODUCT_DETAIL_INCLUDE); the list handler returns the lighter
+  // `secondaryIdentifierIds` and omits every nested relation
+  // (PRODUCT_LIST_INCLUDE). Each group is optional to match that asymmetry
+  // rather than promising a field some endpoints never return.
+  return z.object({
+    ...productOwnColumns,
+    secondaryIdentifierIds: z.array(z.string()).optional().describe('IDs of secondary identifiers (list items only)'),
+    primaryIdentifier: productIdentifierWithSchemeSchema
+      .nullable()
+      .optional()
+      .describe('Primary identifier with its scheme and registrar (detail responses only)'),
+    secondaryIdentifiers: z
+      .array(productSecondaryIdentifierLinkSchema)
+      .optional()
+      .describe('Secondary identifier links, each with its identifier, scheme, and registrar (detail responses only)'),
+    producedByOrganisation: productOrganisationSchema
+      .nullable()
+      .optional()
+      .describe('Producing organisation (detail responses only)'),
+    manufacturingFacility: productFacilitySchema
+      .nullable()
+      .optional()
+      .describe('Manufacturing facility (detail responses only)'),
+    parent: productParentSchema.nullable().optional().describe('Parent product (detail responses only)'),
+  });
+}
 
 /**
  * Builds the Organisation response schema, including its nested
@@ -392,7 +482,7 @@ export function generateOpenAPISchemas(): Record<string, OpenAPISchema> {
     ServiceInstance: serviceInstanceResponseSchema,
     DataModel: dataModelSchema,
     RenderTemplate: renderTemplateSchema,
-    Product: productSchema,
+    Product: buildProductSchema(),
     Organisation: buildOrganisationSchema(),
     Facility: buildFacilitySchema(),
     ConformityScheme: conformitySchemeSummarySchema,


### PR DESCRIPTION
The products endpoints validated by hand: a loop over the POST array that checked `name` and `level` and passed everything else through, and a PATCH that probed the body with the `in` operator and copied whatever it found. This PR moves both to the Zod route-boundary schemas that ADR-037 established and every sibling resource already uses, which also closes three reachable 500s.

Closes #795

## Three live defects this closes

Each of these returned a 500 whose body carried the raw JavaScript error message, because the thrown `TypeError` reached `handleRouteError`'s unmapped branch:

- `POST /products` with a null array item, which dereferenced `item.name` on null. Only null did this; a string or array element yields `undefined` on property access and failed cleanly with a 400.
- `PATCH /products/{id}` with a body of `null`, `42`, `"x"` or `true`, each valid JSON, so the `req.json()` catch never fired and `'name' in body` then threw.
- `PATCH /products/{id}` with `secondaryIdentifierIds: null`, which entered the repository's `!== undefined` branch and iterated over null.

Each has a regression test. Reverting either route to its previous shape fails exactly those tests.

## Requests that work today and now return 400

The acceptance criteria require unchanged behaviour for valid input, so every flip is listed rather than left to be discovered:

| Request | Before | Now |
|---|---|---|
| `name` of only whitespace | stored verbatim | 400 |
| `description` empty or only whitespace | stored | 400 |
| Any optional field sent as `null` on create | stored as null, or skipped | 400, omit the field instead |
| `secondaryIdentifierIds` as `""`, `false` or `0` | read as falsy, so treated as none | 400 |
| `limit` or `offset` of `1abc`, `5.5`, `10.0`, `1e1` | `parseInt` read the leading digits | 400 |
| `offset` of `0x10` | parsed as 0 | 400 |
| A repeated query key | first value won | 400 |
| `limit` above the maximum | clamped to a smaller page | 400 naming the maximum |

The last row is the direction #834 and ADR-037 settled, and the operator-facing pagination page already documents it. Creating with an explicit `null` follows what facilities and organisations decided: there is nothing to clear on a record that does not exist yet, so an optional field is omitted rather than sent as null.

The null-to-clear relations and the empty-array clear on update are unchanged, and each is now pinned by a test asserting the value reaches the repository.

## Contract congruence

Per the ADR-037 update of 2026-07-15, the migration carries an API-contract pass. The `Product` response component was wrong in both directions: it required `secondaryIdentifierIds`, which only the list route returns, and omitted the five nested relations that create, get and update all return. It is now built like the organisation and facility components, with the list-versus-detail asymmetry explicit and a test suite pinning it, including the depth of the `parent` relation. The PATCH body's `minProperties: 1` became an `anyOf` over the seven updatable fields, the clearable fields are marked nullable, and the request bodies gained the `minLength` and `uniqueItems` constraints the schemas actually enforce.

`products.md` said an over-cap limit is clamped to 100, which this change makes false.
