### PR TITLE
fix(docker): make the local stack rebuildable from scratch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,11 @@ pnpm lint:check               # ESLint across packages
 ```bash
 pnpm storybook:components                  # Component library docs
 pnpm storybook:reference-implementation    # RI component docs
-pnpm build-clean                           # Remove all artifacts and node_modules
+# build-clean removes node_modules and build artifacts from every workspace package
+# (including each package's e2e/ subdirectory), but leaves documentation/node_modules
+# alone. That install runs under a Docker bind mount, and removing it while the stack
+# is running fails with EACCES.
+pnpm build-clean
 ```
 
 ## Architecture Patterns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,10 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-agent:4317}
       DEPLOYMENT_ENVIRONMENT: ${DEPLOYMENT_ENVIRONMENT:-local}
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--spider", "http://localhost:3003/api/health"]
+      # IPv4 literal, unlike the localhost probe on vckit-api: this image sets
+      # HOSTNAME=0.0.0.0, so the server listens on IPv4 only, and BusyBox wget
+      # resolves localhost to ::1 first.
+      test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:3003/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/documentation/.dockerignore
+++ b/documentation/.dockerignore
@@ -1,0 +1,23 @@
+# This image builds with context ./documentation, so the repository root's
+# .dockerignore does not apply. It must not be copied here either: the root
+# file excludes *.md, which would drop the docs tree itself.
+
+# The Dockerfile installs into /app before COPY . ., so a host install here
+# would be merged over pnpm's symlink tree and fail the build.
+node_modules
+
+build
+.docusaurus
+.cache-loader
+
+# Compose supplies .env at run time via env_file, so the builder never needs
+# any of these.
+.env*
+
+.git
+.gitignore
+Dockerfile
+.dockerignore
+**/.DS_Store
+*-debug.log*
+*-error.log*

--- a/documentation/docs/reference-implementation/authentication/authentication.md
+++ b/documentation/docs/reference-implementation/authentication/authentication.md
@@ -76,7 +76,7 @@ In [open mode](./tenant-modes#open-mode), a service account that has not previou
 
 Not all routes require authentication. The following are publicly accessible without a session or token:
 
-- **Health check** (`/api/v1/health`) — used by load balancers and monitoring tools to confirm the application is running
+- **Health check** (`/api/health`) — used by load balancers and monitoring tools to confirm the application is running. It sits outside `/api/v1`, which is authenticated
 - **Credential verification API** (`/api/v1/credentials/verify`) — accepts a credential URL and returns the verification result
 - **Verify page** (`/verify`) — a web UI for verifying credentials, intended for end users and specification readers following links to example credentials. See [Verify Page](../verify-page) for details.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:components": "pnpm --filter @reference-implementation/components run build",
     "build:ri": "pnpm --filter untp-reference-implementation run build",
     "build:playground": "pnpm --filter untp-playground run build",
-    "build-clean": "rimraf --glob ./node_modules ./packages/*/tsconfig.tsbuildinfo ./packages/*/build ./packages/*/node_modules",
+    "build-clean": "rimraf --glob ./node_modules ./packages/*/tsconfig.tsbuildinfo ./packages/*/build ./packages/*/node_modules ./packages/*/e2e/node_modules",
     "test": "pnpm -r --workspace-concurrency=1 test",
     "test:coverage": "pnpm -r --workspace-concurrency=1 run test --coverage && rm -rf coverage && istanbul-merge --out coverage/coverage-final.json packages/*/coverage/coverage-final.json && nyc report --temp-dir=./coverage --reporter=html --reporter=json-summary",
     "test:components": "pnpm --filter @reference-implementation/components run test",


### PR DESCRIPTION
This PR fixes three defects that stop the local stack being rebuilt from a clean machine, so the documented quick start works on a fresh checkout.

All three were found by destroying the local environment completely, every container, image, project volume, `node_modules` and `.env`, then rebuilding from nothing. None of them is visible when a cache or a prior install is present, which is why they have survived.

**`docker compose build` fails outright when `documentation/node_modules` exists.** That service builds with `context: ./documentation`, so the repository root `.dockerignore` does not apply to it, and there was no `.dockerignore` at that context root. The Dockerfile installs its own dependencies before `COPY . .`, so a host install gets merged over pnpm's symlink tree and the build stops with `cannot copy to non-directory: .../@types/eslint`. The service also declares an anonymous volume at `/app/node_modules` over a `./documentation:/app` bind mount, so Docker recreates that host directory whenever the stack runs. That means anyone who has ever started the stack hits this on their next build, not just anyone who has run the docs site.

**The `ri` container reported `unhealthy` forever while serving correctly.** Its healthcheck probed `http://localhost:3003/api/health`. The image sets `HOSTNAME=0.0.0.0`, so the server listens on IPv4 only; the container's `/etc/hosts` maps `localhost` to both `127.0.0.1` and `::1`; and BusyBox wget tries `::1` first. The sibling `vckit-api` probe uses the same `localhost` form and is fine, because that container binds `:::3332` and so answers on IPv6. Only the RI has the IPv4-only bind, which is why the two probes now differ and why the change carries a comment.

**`pnpm build-clean` silently left two installs behind.** `pnpm-workspace.yaml` declares `packages/*/e2e` as workspace members, but the script only globbed `./packages/*/node_modules`, so `packages/reference-implementation/e2e/node_modules` and `packages/untp-playground/e2e/node_modules` survived a clean. `documentation/node_modules` is deliberately still not in that glob: it is a live Docker mount point while the stack is up, and including it made the whole script fail with `EACCES` before removing anything else. `CLAUDE.md` records that constraint.

The documentation change is unrelated to the build but was found on the way: the authentication page told load balancers and monitoring tools to probe `/api/v1/health`, which returns 401 because it falls under the authenticated `/api/v1` middleware. The real unauthenticated route is `/api/health`.

## Test plan
- [x] `docker compose build documentation` succeeds with a `documentation/node_modules/@types/eslint` planted, and fails with the original error when the new `.dockerignore` is removed and nothing else changes
- [x] The built docs image serves HTTP 200 with a rendered page when run standalone with no bind mount, confirming the exclusions take nothing the image needs
- [x] The `ri` container goes from `unhealthy` to `healthy` with no application change, and `wget` to `127.0.0.1:3003/api/health` inside it returns the health JSON where `localhost` is refused
- [x] `vckit-api` verified as genuinely safe rather than accidentally so: it binds `:::3332`, and a `localhost` probe inside it succeeds
- [x] `build-clean`'s new glob removes both `e2e/node_modules` directories, with the stack running, exit 0
- [x] Full stack verified up from scratch: 10 containers, `ri`, `ri-db` and `vckit-api` healthy, seed producing 1 tenant, 1 DID, 3 service instances and 15 render templates
- [x] `/api/health` returns 200 and `/api/v1/health` returns 401, confirming the documented path was wrong

## Known gap, not addressed here
`ghcr.io/uncefact/project-vckit:1.2.1` publishes no `linux/arm64` manifest and no compose service sets `platform:`, so a clean Apple Silicon machine cannot complete `docker compose up -d --build` without first pulling that image with an explicit `--platform linux/amd64`. Every other pinned image is multi-arch. Left out of this PR deliberately.

The `documentation` and `untp-playground` services have the same IPv4-only bind as the RI but nothing probes them today. If a healthcheck is added to either, it needs `127.0.0.1` for the same reason.
