### PR TITLE
chore(release): @uncefact/untp-utils v0.2.0

### DIFF
--- a/packages/untp-utils/CHANGELOG.md
+++ b/packages/untp-utils/CHANGELOG.md
@@ -18,7 +18,7 @@ numbers follow semantic versioning. The package ships via the
 - **cache:** bound `createInMemoryTtlCache` with an optional `maxEntries`, evicting expired entries first then least-recently-used ([#891](https://github.com/uncefact/tests-untp/pull/891)) ([0d7bfc42f](https://github.com/uncefact/tests-untp/commit/0d7bfc42f))
 - **conformity-vocabulary:** add the sub-entry with a scheme parser and claim validator ([#667](https://github.com/uncefact/tests-untp/pull/667)) ([d94ac72ac](https://github.com/uncefact/tests-untp/commit/d94ac72ac))
 - **conformity-vocabulary:** add `parseConformityCatalogue` and extract shared parser helpers ([#684](https://github.com/uncefact/tests-untp/pull/684)) ([779e0ecf4](https://github.com/uncefact/tests-untp/commit/779e0ecf4))
-- **conformity-vocabulary:** throw `ConformitySchemeError` subclasses instead of returning coded outcomes (ADR-035) ([#683](https://github.com/uncefact/tests-untp/pull/683)) ([711090e55](https://github.com/uncefact/tests-untp/commit/711090e55))
+- **conformity-vocabulary:** throw `ConformityVocabularyError` subclasses instead of returning coded outcomes (ADR-035) ([#683](https://github.com/uncefact/tests-untp/pull/683)) ([711090e55](https://github.com/uncefact/tests-untp/commit/711090e55))
 - **http-headers:** add the `./http-headers` sub-entry and send a `User-Agent` on every guarded fetch, overridable per call or by environment ([#891](https://github.com/uncefact/tests-untp/pull/891)) ([0d7bfc42f](https://github.com/uncefact/tests-untp/commit/0d7bfc42f))
 - **multibase-digest:** add the `fromText` and `fromHex` static factories ([#655](https://github.com/uncefact/tests-untp/pull/655)) ([8c04d01cb](https://github.com/uncefact/tests-untp/commit/8c04d01cb))
 - **node:** add the `./node` sub-entry with the `validatePublicUrl` SSRF guard ([#674](https://github.com/uncefact/tests-untp/pull/674)) ([d0fb379e9](https://github.com/uncefact/tests-untp/commit/d0fb379e9))
@@ -33,12 +33,12 @@ numbers follow semantic versioning. The package ships via the
 
 - **conformity-vocabulary:** validate every conformity topic each criterion declares ([#700](https://github.com/uncefact/tests-untp/pull/700)) ([e6a5b8c33](https://github.com/uncefact/tests-untp/commit/e6a5b8c33))
 - **conformity-vocabulary:** align v0.7.0 DCC conformity topic extraction and validation with the published spec artefacts ([#752](https://github.com/uncefact/tests-untp/pull/752)) ([c16b87235](https://github.com/uncefact/tests-untp/commit/c16b87235))
-- **conformity-vocabulary:** resolve warning pointers against the submitted credential ([#919](https://github.com/uncefact/tests-untp/pull/919)) ([c978d8443](https://github.com/uncefact/tests-untp/commit/c978d8443))
 - **validation:** guard JSON-LD `@context` and JSON Schema fetches against SSRF ([#733](https://github.com/uncefact/tests-untp/pull/733)) ([479065749](https://github.com/uncefact/tests-untp/commit/479065749))
 - **validation:** surface SSRF rejections from JSON-LD expansion on the native error cause chain ([#838](https://github.com/uncefact/tests-untp/pull/838)) ([a76c30ebd](https://github.com/uncefact/tests-untp/commit/a76c30ebd))
 
 ### Miscellaneous
 
+- document that `validateConformityClaim`'s warning pointers are relative to the claim, so a consumer that synthesises the claim rather than taking it as a sub-document maps each field to its own source path instead of assuming a prefix ([#919](https://github.com/uncefact/tests-untp/pull/919)) ([c978d8443](https://github.com/uncefact/tests-untp/commit/c978d8443))
 - rename the `./schema-loaders` subpath to `./loaders`, and the `make*` factories to `create*`. Neither name shipped in a release, so no published import path changes ([227049ff7](https://github.com/uncefact/tests-untp/commit/227049ff7))
 
 ### Notes

--- a/packages/untp-utils/CHANGELOG.md
+++ b/packages/untp-utils/CHANGELOG.md
@@ -6,6 +6,46 @@ numbers follow semantic versioning. The package ships via the
 `untp-utils-v<X.Y.Z>` tag-triggered publish workflow described in
 [ADR 031](../../docs/adrs/031-per-package-tag-triggered-npm-release.md).
 
+## [0.2.0](https://github.com/uncefact/tests-untp/compare/untp-utils-v0.1.0...untp-utils-v0.2.0) (2026-08-17)
+
+### ⚠ BREAKING CHANGES
+
+- **root entry:** the package root no longer re-exports `MultibaseDigest`. Import it from `@uncefact/untp-utils/multibase-digest` instead. The subpath, the class and its exported types are unchanged; only the root barrel dropped the re-export ([#682](https://github.com/uncefact/tests-untp/pull/682)) ([c8e67e968](https://github.com/uncefact/tests-untp/commit/c8e67e968))
+
+### Features
+
+- **artefacts:** add the `./artefacts` sub-entry with UNTP schema, context and docs URL helpers, and move `detectVersionFromContext` into it ([#693](https://github.com/uncefact/tests-untp/pull/693)) ([0cb93b76e](https://github.com/uncefact/tests-untp/commit/0cb93b76e))
+- **cache:** bound `createInMemoryTtlCache` with an optional `maxEntries`, evicting expired entries first then least-recently-used ([#891](https://github.com/uncefact/tests-untp/pull/891)) ([0d7bfc42f](https://github.com/uncefact/tests-untp/commit/0d7bfc42f))
+- **conformity-vocabulary:** add the sub-entry with a scheme parser and claim validator ([#667](https://github.com/uncefact/tests-untp/pull/667)) ([d94ac72ac](https://github.com/uncefact/tests-untp/commit/d94ac72ac))
+- **conformity-vocabulary:** add `parseConformityCatalogue` and extract shared parser helpers ([#684](https://github.com/uncefact/tests-untp/pull/684)) ([779e0ecf4](https://github.com/uncefact/tests-untp/commit/779e0ecf4))
+- **conformity-vocabulary:** throw `ConformitySchemeError` subclasses instead of returning coded outcomes (ADR-035) ([#683](https://github.com/uncefact/tests-untp/pull/683)) ([711090e55](https://github.com/uncefact/tests-untp/commit/711090e55))
+- **http-headers:** add the `./http-headers` sub-entry and send a `User-Agent` on every guarded fetch, overridable per call or by environment ([#891](https://github.com/uncefact/tests-untp/pull/891)) ([0d7bfc42f](https://github.com/uncefact/tests-untp/commit/0d7bfc42f))
+- **multibase-digest:** add the `fromText` and `fromHex` static factories ([#655](https://github.com/uncefact/tests-untp/pull/655)) ([8c04d01cb](https://github.com/uncefact/tests-untp/commit/8c04d01cb))
+- **node:** add the `./node` sub-entry with the `validatePublicUrl` SSRF guard ([#674](https://github.com/uncefact/tests-untp/pull/674)) ([d0fb379e9](https://github.com/uncefact/tests-untp/commit/d0fb379e9))
+- **node:** throw `UrlValidationError` subclasses instead of returning an outcome (ADR-035) ([#680](https://github.com/uncefact/tests-untp/pull/680)) ([9499fe54a](https://github.com/uncefact/tests-untp/commit/9499fe54a))
+- **resolvers:** add the `./resolvers` sub-entry with IP-pinned fetch and a conditional-fetch skip chain ([#675](https://github.com/uncefact/tests-untp/pull/675)) ([ecdb546c3](https://github.com/uncefact/tests-untp/commit/ecdb546c3))
+- **root:** add the `StructuredError` base class for the ADR-035 rollout ([#679](https://github.com/uncefact/tests-untp/pull/679)) ([b0f577078](https://github.com/uncefact/tests-untp/commit/b0f577078))
+- **validation:** add the `./validation` and `./loaders` sub-entries, migrating the JSON-LD and JSON Schema primitives out of the services package ([#668](https://github.com/uncefact/tests-untp/pull/668)) ([6f144a7f5](https://github.com/uncefact/tests-untp/commit/6f144a7f5))
+- **validation:** throw `JsonLdValidationError` and `SchemaValidationError` subclasses instead of returning coded outcomes, and add the `./cache` sub-entry (ADR-035) ([#681](https://github.com/uncefact/tests-untp/pull/681)) ([eeeae718b](https://github.com/uncefact/tests-untp/commit/eeeae718b))
+- **validation:** add `describeJsonLdFailure`, which turns a JSON-LD expansion error into one plain sentence naming what failed ([#898](https://github.com/uncefact/tests-untp/pull/898)) ([3d915ea98](https://github.com/uncefact/tests-untp/commit/3d915ea98))
+
+### Bug Fixes
+
+- **conformity-vocabulary:** validate every conformity topic each criterion declares ([#700](https://github.com/uncefact/tests-untp/pull/700)) ([e6a5b8c33](https://github.com/uncefact/tests-untp/commit/e6a5b8c33))
+- **conformity-vocabulary:** align v0.7.0 DCC conformity topic extraction and validation with the published spec artefacts ([#752](https://github.com/uncefact/tests-untp/pull/752)) ([c16b87235](https://github.com/uncefact/tests-untp/commit/c16b87235))
+- **conformity-vocabulary:** resolve warning pointers against the submitted credential ([#919](https://github.com/uncefact/tests-untp/pull/919)) ([c978d8443](https://github.com/uncefact/tests-untp/commit/c978d8443))
+- **validation:** guard JSON-LD `@context` and JSON Schema fetches against SSRF ([#733](https://github.com/uncefact/tests-untp/pull/733)) ([479065749](https://github.com/uncefact/tests-untp/commit/479065749))
+- **validation:** surface SSRF rejections from JSON-LD expansion on the native error cause chain ([#838](https://github.com/uncefact/tests-untp/pull/838)) ([a76c30ebd](https://github.com/uncefact/tests-untp/commit/a76c30ebd))
+
+### Miscellaneous
+
+- rename the `./schema-loaders` subpath to `./loaders`, and the `make*` factories to `create*`. Neither name shipped in a release, so no published import path changes ([227049ff7](https://github.com/uncefact/tests-untp/commit/227049ff7))
+
+### Notes
+
+- The dependency footprint grew from one runtime dependency to six. `multiformats` is joined by `ajv`, `ajv-formats`, `jsonld`, `ipaddr.js` and `undici`, installed for every consumer regardless of which subpath they import.
+- Still ESM only, and still no `engines` constraint.
+
 ## [0.1.0] - 2026-05-15
 
 Initial public release.
@@ -41,3 +81,4 @@ imported independently without expanding the top-level barrel.
   bundler with ESM interop.
 
 [0.1.0]: https://github.com/uncefact/tests-untp/releases/tag/untp-utils-v0.1.0
+[0.2.0]: https://github.com/uncefact/tests-untp/releases/tag/untp-utils-v0.2.0

--- a/packages/untp-utils/README.md
+++ b/packages/untp-utils/README.md
@@ -8,12 +8,34 @@ Shared utility primitives for UNTP packages and consumers.
 yarn add @uncefact/untp-utils
 ```
 
+## Sub-entries
+
+The package root exports only `StructuredError`, the base class every
+sub-entry throws from. Each capability is imported from its own subpath so a
+consumer only pulls in the dependencies it needs.
+
+| Subpath                                      | Provides                                                                                      |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `@uncefact/untp-utils/multibase-digest`      | `MultibaseDigest`: encode, decode and verify multibase-encoded multihashes.                   |
+| `@uncefact/untp-utils/artefacts`             | UNTP schema, context and docs URL helpers, and `detectVersionFromContext`.                    |
+| `@uncefact/untp-utils/conformity-vocabulary` | Parses a UNTP conformity scheme or catalogue and validates a conformity claim against it.     |
+| `@uncefact/untp-utils/validation`            | Validates a payload against JSON Schema and expands it as JSON-LD, both guarded against SSRF. |
+| `@uncefact/untp-utils/loaders`               | The schema and JSON-LD document loaders `validation` runs on.                                 |
+| `@uncefact/untp-utils/resolvers`             | IP-pinned document fetching with a conditional-fetch skip chain.                              |
+| `@uncefact/untp-utils/node`                  | `validatePublicUrl`, the SSRF guard the other sub-entries fetch through.                      |
+| `@uncefact/untp-utils/cache`                 | `createInMemoryTtlCache`, a bounded in-memory TTL cache.                                      |
+| `@uncefact/untp-utils/http-headers`          | HTTP header parsing, and the default `User-Agent` guarded fetches send.                       |
+
+Every sub-entry throws a typed error class on failure rather than returning
+an outcome object. See [RELEASE_NOTES.md](./RELEASE_NOTES.md) for what each
+release changes and [CHANGELOG.md](./CHANGELOG.md) for the full history.
+
 ## MultibaseDigest
 
 Encode, decode and verify multibase-encoded multihashes.
 
 ```ts
-import { MultibaseDigest } from '@uncefact/untp-utils';
+import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest';
 
 // Hash some data, wrap as a multihash, encode as a multibase string.
 const digest = await MultibaseDigest.fromData(new TextEncoder().encode('hello'), {

--- a/packages/untp-utils/RELEASE_NOTES.md
+++ b/packages/untp-utils/RELEASE_NOTES.md
@@ -4,6 +4,50 @@ User-facing release notes for `@uncefact/untp-utils`. Each entry frames what
 the release lets you do, not how it does it. For a technical, per-change
 record see [CHANGELOG.md](./CHANGELOG.md).
 
+## 0.2.0 - 2026-08-17
+
+0.1.0 published one class, for content digests. 0.2.0 is the release where this package becomes the shared toolkit the UNTP projects actually build on, carrying the pieces that were previously duplicated in the reference implementation and the services package.
+
+The headline changes: every remote document this package fetches now goes through an SSRF guard that resolves the hostname, checks it against private and reserved ranges, and pins the connection to the address it checked. Validation of JSON-LD and JSON Schema moved here, and reports failures precisely enough to tell a caller which field broke which rule. Conformity schemes and catalogues can be parsed and claims validated against them. And every sub-entry now signals failure by throwing a typed error class rather than returning an outcome object, which is the one change that touches code written against 0.1.0.
+
+- Package: [@uncefact/untp-utils on npm](https://www.npmjs.com/package/@uncefact/untp-utils) (`npm install @uncefact/untp-utils@0.2.0`)
+- Upgrading from 0.1.0: one import path changes. `MultibaseDigest` is no longer re-exported from the package root, so `import { MultibaseDigest } from '@uncefact/untp-utils'` becomes `import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest'`. Nothing else that 0.1.0 published moved.
+- Install footprint: the package now declares six runtime dependencies where 0.1.0 declared one. `multiformats` is joined by `ajv`, `ajv-formats`, `jsonld`, `ipaddr.js` and `undici`, and npm installs all of them whichever subpath you import. The package is still ESM only.
+
+### The root entry carries the error base class, not the digest
+
+0.1.0's root entry existed to re-export `MultibaseDigest`, so `@uncefact/untp-utils` and `@uncefact/untp-utils/multibase-digest` were interchangeable. With nine sub-entries now in the package, a root barrel that re-exported them all would pull `ajv`, `jsonld` and `undici` into a consumer who only wanted a digest.
+
+The root now exports `StructuredError` and its companion types, the base class every sub-entry throws from, and nothing else. `MultibaseDigest` is reached through its own subpath, where it has always also been available, with the same class, the same factory methods, and the same exported types it had at 0.1.0. It gained two new factories, `fromText` and `fromHex`.
+
+### Remote documents are fetched through a guard
+
+A library that fetches a URL a credential handed it is a library that can be pointed at the network it is running inside. Anything in this package that fetches a remote document now goes through a single guarded path. The hostname is resolved first and checked against private and reserved ranges, and the connection is pinned to the address that was checked, so neither a redirect nor a DNS change between the check and the connect can reach an internal address.
+
+That covers JSON-LD `@context` fetches and JSON Schema fetches made on your behalf during validation, and anything fetched directly through `@uncefact/untp-utils/resolvers`, which also carries a conditional-fetch skip chain so an unchanged document costs a `304` rather than a download. Fetches send a `User-Agent`, overridable per call or by environment. `@uncefact/untp-utils/node` exposes the check on its own as `validatePublicUrl` for a URL you want to vet without fetching.
+
+### Validation failures say what failed and where
+
+`@uncefact/untp-utils/validation` validates a payload against JSON Schema and expands it as JSON-LD. Both were previously inside the services package, where nothing else could reach them.
+
+A failure throws an error carrying a code, the value it received, what it expected, and a JSON pointer to the part of the document at fault. That is enough to put the field and the reason into your own response rather than a stack trace. Where the underlying JSON-LD processor buries the real cause in its own proprietary error shape, it is rehydrated onto the native `cause` chain, so an SSRF rejection during expansion is reachable by walking `error.cause` like any other error. `describeJsonLdFailure` reduces one of those to a single plain sentence.
+
+### Conformity schemes and catalogues parse into typed results
+
+`@uncefact/untp-utils/conformity-vocabulary` parses a UNTP conformity scheme or a catalogue of them, and validates a conformity claim against the parsed result, reporting every criterion and topic that does not line up. Topic validation checks every topic a criterion declares rather than the first, and v0.7.0 DCC extraction follows the published spec artefacts rather than the v0.6 shape.
+
+### Failure is thrown, not returned
+
+At 0.1.0 there was nothing here to fail. As the package grew, its sub-entries returned outcome objects that every caller had to unpack and translate before it could act, and the same three lines appeared at every call site.
+
+Every sub-entry now throws a typed error class instead. Catch a concrete class to handle one case, a sub-entry's base class to handle a family, or `StructuredError` for anything this package reports. The structured payload is preserved on the thrown class, so nothing is lost in the change. The reasoning is recorded in ADR 035.
+
+### Smaller changes
+
+- **The in-memory cache takes a size bound.** `createInMemoryTtlCache` accepts an optional `maxEntries` and evicts expired entries first, then the least recently used, so a long-running process caching contexts has a ceiling.
+- **`./artefacts` builds UNTP URLs.** Schema, context and specification-page URLs for a given UNTP version, rather than string-concatenating them at each call site. `detectVersionFromContext` moved here from the root entry.
+- **`./schema-loaders` was renamed to `./loaders`,** and its `make*` factories to `create*`. Neither name appeared in a published release, so no import that ever shipped is affected.
+
 ## 0.1.0 — 2026-05-15
 
 First public release.

--- a/packages/untp-utils/package.json
+++ b/packages/untp-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncefact/untp-utils",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared utility primitives for UNTP packages and consumers.",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",


### PR DESCRIPTION
This PR bumps `@uncefact/untp-utils` to 0.2.0 and adds its changelog entry and release notes, so the tag that publishes it points at a commit whose `package.json` already matches.

0.2.0 is where the package stops being a single digest utility and becomes the shared toolkit the reference implementation and the services package build on. Twenty commits have landed since `untp-utils-v0.1.0`, bringing guarded fetching, JSON-LD and JSON Schema validation, conformity vocabulary parsing, and the ADR-035 structured error hierarchy.

It is a minor bump rather than a major one, which is worth a second look, because two of those commits carry a `!` marker. Both migrate sub-entries to throwing errors, and neither breaks anyone: 0.1.0's exports map was only `"."` and `"./multibase-digest"`, so the sub-entries they change never existed in a published release. The same applies to the `./schema-loaders` to `./loaders` rename.

Exactly one change does break a 0.1.0 consumer. The root entry no longer re-exports `MultibaseDigest`, so `import { MultibaseDigest } from '@uncefact/untp-utils'` becomes `import { MultibaseDigest } from '@uncefact/untp-utils/multibase-digest'`. Nothing else that 0.1.0 published moved. That break leads both the changelog and the release notes.

The second commit fixes the README, whose only code example still used the broken root import. That example is the package's front page on npmjs.com, so it would have shipped telling every new reader to write the one import this release removes. The README also gained a table of the nine sub-entries, since it previously read as though `MultibaseDigest` were the whole package.

Once this merges, the release itself is the annotated tag on the merge commit, per `docs/RELEASES.md`. Nothing reaches npm until that tag is pushed.

## Test plan

- [x] `node scripts/check-tag-version-match.mjs untp-utils-v packages/untp-utils untp-utils-v0.2.0` exits 0, and the same check rejects `untp-utils-v0.1.0` against the bumped package
- [x] `repository.url` matches the GitHub repository and carries the monorepo `directory`, which npm cross-validates against the provenance attestation
- [x] Every commit hash, PR number and exported symbol named in the changelog checked against the source at HEAD
- [x] Repository-wide search for a bare `from '@uncefact/untp-utils'` import: the only remaining occurrence is the migration sentence in the release notes describing the old pattern
- [x] Prettier clean on all changed files
