### PR TITLE
fix(ri): correct two error-response defects and publish real error examples

### DIFF
--- a/documentation/docs/reference-implementation/api/services.md
+++ b/documentation/docs/reference-implementation/api/services.md
@@ -169,9 +169,9 @@ sequenceDiagram
 DELETE /api/v1/services/{id}
 ```
 
-Permanently deletes a service instance owned by the tenant. System defaults cannot be deleted.
+Permanently deletes a service instance owned by the tenant. A system default is visible to the tenant (see [Get a service instance](#get-a-service-instance)), but deleting one is rejected with a `403 Forbidden`, before any reference check runs.
 
-If the instance is referenced by other records (DIDs, registrars, or identifier schemes), the request is rejected with a `409 Conflict` unless `force=true` is set. When forced, the foreign keys on referencing records are set to `null`.
+If the caller's own DIDs, registrars, or identifier schemes reference the instance, the request is rejected with a `409 Conflict` unless `force=true` is set. The counts in the response cover only the caller's own referencing records. When forced, the foreign keys on referencing records are set to `null`.
 
 | Parameter | Type   | Default | Description                                                                                                                       |
 | --------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -186,8 +186,11 @@ sequenceDiagram
     Client->>RI: DELETE /api/v1/services/{id}
     RI->>DB: Fetch service instance
     DB-->>RI: Existing record
+    alt instance is a system default
+        RI-->>Client: 403 Forbidden
+    end
     alt force ≠ true
-        RI->>DB: Count references (DIDs, registrars, schemes)
+        RI->>DB: Count caller's own references (DIDs, registrars, schemes)
         DB-->>RI: Reference counts
         alt references exist
             RI-->>Client: 409 Conflict (details of referencing records)

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.test.ts
@@ -110,7 +110,14 @@ jest.mock('@uncefact/untp-ri-services', () => ({
   // The real implementation, so the warning-pointer assertions below exercise
   // the actual rewriting rather than a stub of it.
   remapWarningPointers: jest.requireActual('@uncefact/untp-ri-services').remapWarningPointers,
+  // The real class, because the route classifies a publish failure by
+  // instanceof and reads the upstream status off the instance. A hand-shaped
+  // stand-in lets the route read a field the real error never carries, which
+  // is how the two drifted apart previously.
+  IdrPublishError: jest.requireActual('@uncefact/untp-ri-services').IdrPublishError,
 }));
+
+const { IdrPublishError: RealIdrPublishError } = jest.requireActual('@uncefact/untp-ri-services');
 
 // Repository mocks
 const mockUpdateCredentialPublished = jest.fn();
@@ -1063,10 +1070,12 @@ describe('POST /api/v1/credentials', () => {
 
     it('distinguishes a resolver rejection from an unconfirmed publish, and never leaks the upstream body', async () => {
       setupPublishingHappyPath();
-      const rejection = Object.assign(new Error('HTTP 409: {"detail":"duplicate response for /gtin/095"}'), {
-        name: 'IdrPublishError',
-        details: { httpStatus: 409 },
-      });
+      const rejection = new RealIdrPublishError(
+        'gtin',
+        '09520123456788',
+        409,
+        '{"detail":"duplicate response for /gtin/095"}',
+      );
       mockPublishLinks.mockRejectedValueOnce(rejection);
 
       let res = await POST(
@@ -1097,10 +1106,7 @@ describe('POST /api/v1/credentials', () => {
 
       // A resolver 5xx may still have committed, so it is unknown, not refused.
       mockPublishLinks.mockRejectedValueOnce(
-        Object.assign(new Error('HTTP 503: upstream unavailable'), {
-          name: 'IdrPublishError',
-          details: { httpStatus: 503 },
-        }),
+        new RealIdrPublishError('gtin', '09520123456788', 503, 'upstream unavailable'),
       );
       res = await POST(
         createFakeRequest(validBody({ publishingOptions: { publish: true } })),

--- a/packages/reference-implementation/src/app/api/v1/credentials/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/credentials/route.ts
@@ -22,7 +22,7 @@ import { resolveStorageService } from '@/lib/services/resolve-storage-service';
 import { resolveIdrService } from '@/lib/services/resolve-idr-service';
 import { resolvePublishTarget } from '@/lib/credentials/resolve-publish-target';
 import { getDidByDid, findConformitySchemeByCanonicalId } from '@/lib/prisma/repositories';
-import { buildPublishLinks, remapWarningPointers } from '@uncefact/untp-ri-services';
+import { buildPublishLinks, remapWarningPointers, IdrPublishError } from '@uncefact/untp-ri-services';
 import type { CredentialPayload, ExtractedRefs } from '@uncefact/untp-ri-services';
 import { validateConformityClaim } from '@uncefact/untp-utils/conformity-vocabulary';
 
@@ -429,15 +429,13 @@ export const POST = withTenantAuth(async (req, { tenantId }) => {
             // A 4xx is the resolver stating it did not accept the links. A 5xx,
             // or a failure of the call itself, may still have committed upstream,
             // so it is reported as unknown rather than as a refusal.
-            // The upstream status is in details.httpStatus; the error's own
-            // statusCode is this service's 502 for any upstream failure.
-            const status = (error as { details?: { httpStatus?: number } })?.details?.httpStatus;
-            const rejected =
-              error instanceof Error &&
-              error.name === 'IdrPublishError' &&
-              typeof status === 'number' &&
-              status >= 400 &&
-              status < 500;
+            // The upstream status rides on ServiceError's `context`, which is
+            // where IdrPublishError puts it; the error's own statusCode is this
+            // service's 502 for any upstream failure. Read it through an
+            // instanceof rather than a cast, so a future rename of the field
+            // fails the build instead of silently reclassifying every failure.
+            const status = error instanceof IdrPublishError ? error.context?.httpStatus : undefined;
+            const rejected = typeof status === 'number' && status >= 400 && status < 500;
             warnings.push(
               rejected
                 ? {

--- a/packages/reference-implementation/src/app/api/v1/dids/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/route.ts
@@ -103,6 +103,15 @@ function assertSupported<T extends string>(field: string, value: T, supported: r
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               rootDidForSystemDomain:
+ *                 summary: The alias would claim the system VC service's own domain
+ *                 value:
+ *                   error: Cannot create a root DID for the system VC service domain "vckit.example.com"
+ *               noTenantForUser:
+ *                 summary: The authenticated user maps to no tenant
+ *                 value:
+ *                   error: No tenant found for user
  *       409:
  *         description: |
  *           Conflict. Any of:

--- a/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/schemes/[id]/route.ts
@@ -41,7 +41,7 @@ const logger = apiLogger.child({ route: '/api/v1/schemes/[id]' });
  *       403:
  *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
- *         description: Scheme not found
+ *         description: Identifier scheme not found
  *         content:
  *           application/json:
  *             schema:
@@ -231,7 +231,7 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       403:
  *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
  *       404:
- *         description: Scheme not found
+ *         description: Identifier scheme not found
  *         content:
  *           application/json:
  *             schema:

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.test.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.test.ts
@@ -10,7 +10,8 @@ jest.mock('next/server', () => ({
 
 // Mock withTenantAuth to mirror handleRouteError behaviour
 jest.mock('@/lib/api/with-tenant-auth', () => {
-  const { NotFoundError, ConflictError, errorMessage, ServiceRegistryError } = jest.requireActual('@/lib/api/errors');
+  const { NotFoundError, ForbiddenError, ConflictError, errorMessage, ServiceRegistryError } =
+    jest.requireActual('@/lib/api/errors');
   const { ValidationError } = jest.requireActual('@/lib/api/validation');
   const { ServiceError } = jest.requireActual('@uncefact/untp-ri-services');
 
@@ -26,6 +27,12 @@ jest.mock('@/lib/api/with-tenant-auth', () => {
         } catch (e: unknown) {
           if (e instanceof ValidationError) {
             return jsonResponse({ error: (e as Error).message }, { status: 400 });
+          }
+          // Ordered as handleRouteError orders them: Forbidden ahead of
+          // NotFound, so the mock cannot answer 404 where the real mapper
+          // answers 403.
+          if (e instanceof ForbiddenError) {
+            return jsonResponse({ error: (e as Error).message }, { status: 403 });
           }
           if (e instanceof NotFoundError) {
             return jsonResponse({ error: (e as Error).message }, { status: 404 });
@@ -63,7 +70,7 @@ jest.mock('@/lib/prisma/repositories', () => ({
   updateServiceInstance: (id: string, tenantId: string, input: unknown) =>
     mockUpdateServiceInstance(id, tenantId, input),
   deleteServiceInstance: (id: string, tenantId: string) => mockDeleteServiceInstance(id, tenantId),
-  countServiceInstanceReferences: (id: string) => mockCountServiceInstanceReferences(id),
+  countServiceInstanceReferences: (id: string, tenantId: string) => mockCountServiceInstanceReferences(id, tenantId),
 }));
 
 // ---------------------------------------------------------------------------
@@ -113,6 +120,7 @@ jest.mock('@/lib/api/logger', () => ({
 // ---------------------------------------------------------------------------
 
 import { GET, PATCH, DELETE } from './route';
+import { SYSTEM_TENANT_ID } from '@/lib/prisma/constants';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -508,8 +516,39 @@ describe('DELETE /api/v1/services/:id', () => {
     expect(res.status).toBe(204);
     expect((res as unknown as { body: unknown }).body).toBeNull();
     expect(mockGetServiceInstanceById).toHaveBeenCalledWith('svc-123', 'org-1');
-    expect(mockCountServiceInstanceReferences).toHaveBeenCalledWith('svc-123');
+    expect(mockCountServiceInstanceReferences).toHaveBeenCalledWith('svc-123', 'org-1');
     expect(mockDeleteServiceInstance).toHaveBeenCalledWith('svc-123', 'org-1');
+  });
+
+  // The lookup admits system defaults so every tenant can read them, but only
+  // the owning tenant may delete. Refusing after the count would hand a
+  // non-owner the number of records referencing a shared instance, which for a
+  // system default is other tenants' data.
+  it('refuses a system-default instance with 403 before counting anything', async () => {
+    mockGetServiceInstanceById.mockResolvedValue({ ...MOCK_INSTANCE, tenantId: SYSTEM_TENANT_ID });
+
+    const req = createFakeRequest({ method: 'DELETE' });
+    const res = await DELETE(req, createContext('svc-123') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain('system default');
+    expect(json.error).not.toMatch(/\d/);
+    expect(mockCountServiceInstanceReferences).not.toHaveBeenCalled();
+    expect(mockDeleteServiceInstance).not.toHaveBeenCalled();
+  });
+
+  it('refuses a system-default instance even with force=true, without deleting', async () => {
+    mockGetServiceInstanceById.mockResolvedValue({ ...MOCK_INSTANCE, tenantId: SYSTEM_TENANT_ID });
+
+    const req = createFakeRequest({
+      method: 'DELETE',
+      url: 'http://localhost/api/v1/services/svc-123?force=true',
+    });
+    const res = await DELETE(req, createContext('svc-123') as unknown as Parameters<typeof DELETE>[1]);
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteServiceInstance).not.toHaveBeenCalled();
   });
 
   it('returns 409 when references exist and force is not set', async () => {
@@ -574,7 +613,7 @@ describe('DELETE /api/v1/services/:id', () => {
     const res = await DELETE(req, createContext('svc-123') as unknown as Parameters<typeof DELETE>[1]);
 
     expect(res.status).toBe(204);
-    expect(mockCountServiceInstanceReferences).toHaveBeenCalledWith('svc-123');
+    expect(mockCountServiceInstanceReferences).toHaveBeenCalledWith('svc-123', 'org-1');
   });
 
   it('returns 404 when instance not found', async () => {

--- a/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/services/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { NotFoundError, ConflictError } from '@/lib/api/errors';
+import { NotFoundError, ConflictError, ForbiddenError } from '@/lib/api/errors';
 import { assertPublicUrl, ValidationError, parseRequestBody, parseQueryParams } from '@/lib/api/validation';
 import { deleteServiceQuerySchema, updateServiceRequestSchema } from '@/lib/api/request-schemas/service';
 import { withTenantAuth } from '@/lib/api/with-tenant-auth';
@@ -279,7 +279,24 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *       401:
  *         $ref: '#/components/responses/UnauthorisedResponse'
  *       403:
- *         $ref: '#/components/responses/TenantAssignmentForbiddenResponse'
+ *         description: >-
+ *           Forbidden - either the authenticated principal has no resolvable
+ *           tenant assignment, or the instance is a system default, which is
+ *           readable by every tenant but deletable by none. The refusal is
+ *           returned before any reference check, so no counts accompany it
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             examples:
+ *               systemDefaultInstance:
+ *                 summary: The instance is a system default, readable by every tenant and deletable by none
+ *                 value:
+ *                   error: Service instance is a system default and cannot be deleted by a tenant
+ *               noTenantForUser:
+ *                 summary: The authenticated user maps to no tenant
+ *                 value:
+ *                   error: No tenant found for user
  *       404:
  *         description: Service instance not found
  *         content:
@@ -287,7 +304,9 @@ export const PATCH = withTenantAuth(async (req, { tenantId, params }) => {
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       409:
- *         description: Conflict - service instance is referenced by other records
+ *         description: >-
+ *           Conflict - the caller's own DIDs, registrars or identifier schemes
+ *           reference this instance. The counts name only the caller's records
  *         content:
  *           application/json:
  *             schema:
@@ -309,9 +328,19 @@ export const DELETE = withTenantAuth(async (req, { tenantId, params }) => {
     throw new NotFoundError('Service instance not found');
   }
 
+  // The lookup above admits system defaults, which every tenant can read, but
+  // deleteServiceInstance only ever removes the caller's own rows. Refuse here,
+  // ahead of the reference check, so a caller who cannot delete the instance
+  // never receives a count of the records referencing it. A 403 rather than a
+  // 404 because GET returns this same instance to this same caller, so denying
+  // its existence would contradict what they have already been shown.
+  if (existing.tenantId !== tenantId) {
+    throw new ForbiddenError('Service instance is a system default and cannot be deleted by a tenant');
+  }
+
   if (!force) {
     logger.info({ serviceInstanceId: id }, 'Checking for referencing records');
-    const refs = await countServiceInstanceReferences(id);
+    const refs = await countServiceInstanceReferences(id, tenantId);
     const total = refs.dids + refs.registrars + refs.schemes;
 
     if (total > 0) {

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.test.ts
@@ -157,7 +157,7 @@ describe('withTenantAuth — open mode, session path', () => {
     const res = await wrapped(fakeRequest(), emptyRouteContext);
 
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    expect(await res.json()).toEqual({ error: 'Unauthorised' });
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -280,7 +280,7 @@ describe('withTenantAuth — open mode, service account path', () => {
     const res = await wrapped(req, emptyRouteContext);
 
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    expect(await res.json()).toEqual({ error: 'Unauthorised' });
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -402,7 +402,7 @@ describe('withTenantAuth — closed mode, session path', () => {
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual(
       expect.objectContaining({
-        error: 'Session expired — please sign in again',
+        error: 'Session expired. Please sign in again',
       }),
     );
     expect(handler).not.toHaveBeenCalled();
@@ -455,7 +455,7 @@ describe('withTenantAuth — closed mode, session path', () => {
     const res = await wrapped(fakeRequest(), emptyRouteContext);
 
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    expect(await res.json()).toEqual({ error: 'Unauthorised' });
   });
 });
 

--- a/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
+++ b/packages/reference-implementation/src/lib/api/with-tenant-auth.ts
@@ -124,7 +124,7 @@ async function handleClosedMode(
         { method, path, userId: session.user.id, durationMs: Date.now() - start },
         'Unauthorised — session token refresh failed',
       );
-      return NextResponse.json({ error: 'Session expired — please sign in again' }, { status: 401 });
+      return NextResponse.json({ error: 'Session expired. Please sign in again' }, { status: 401 });
     }
 
     if (!session.group_claim) {
@@ -189,7 +189,7 @@ async function handleClosedMode(
         { method, path, error: validationResult.error, durationMs: Date.now() - start },
         'Unauthorised — invalid bearer token',
       );
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorised' }, { status: 401 });
     }
 
     const payload = validationResult.payload;
@@ -238,7 +238,7 @@ async function handleClosedMode(
   }
 
   apiLogger.warn({ method, path, durationMs: Date.now() - start }, 'Unauthorised — no session or bearer token');
-  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({ error: 'Unauthorised' }, { status: 401 });
 }
 
 async function handleOpenMode(
@@ -293,7 +293,7 @@ async function handleOpenMode(
         { method, path, sub, durationMs: Date.now() - start },
         'Unauthorised — service account user resolution failed',
       );
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorised' }, { status: 401 });
     }
 
     return executeHandler(
@@ -313,7 +313,7 @@ async function handleOpenMode(
   }
 
   apiLogger.warn({ method, path, durationMs: Date.now() - start }, 'Unauthorised — no session or service account');
-  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({ error: 'Unauthorised' }, { status: 401 });
 }
 
 /**

--- a/packages/reference-implementation/src/lib/auth/adapter-wrapper.ts
+++ b/packages/reference-implementation/src/lib/auth/adapter-wrapper.ts
@@ -1,5 +1,9 @@
 import type { Adapter, AdapterUser } from 'next-auth/adapters';
-import type { PrismaClient } from '@prisma/client';
+// From the generated client, not from `@prisma/client`. The schema sets a
+// custom `output`, so the package is a stub that exports no types and this
+// file was the only one importing from it; every sibling, `prisma.ts`
+// included, imports from the generated location.
+import type { PrismaClient } from '@/lib/prisma/generated';
 import { createLogger } from '@uncefact/untp-ri-services/logging';
 
 const logger = createLogger().child({ module: 'adapter-wrapper' });

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.test.ts
@@ -500,16 +500,25 @@ describe('service-instance.repository', () => {
   });
 
   describe('countServiceInstanceReferences', () => {
-    it('counts references across all related models', async () => {
+    // Every count carries the tenant condition. These numbers reach the caller
+    // in the pre-delete 409, so an unscoped count reports how many of other
+    // tenants' records point at the instance.
+    it('counts references across all related models, scoped to the tenant', async () => {
       (prisma.did.count as jest.Mock).mockResolvedValue(3);
       (prisma.registrar.count as jest.Mock).mockResolvedValue(1);
       (prisma.identifierScheme.count as jest.Mock).mockResolvedValue(2);
 
-      const result = await countServiceInstanceReferences('instance-1');
+      const result = await countServiceInstanceReferences('instance-1', 'tenant-1');
 
-      expect(prisma.did.count).toHaveBeenCalledWith({ where: { serviceInstanceId: 'instance-1' } });
-      expect(prisma.registrar.count).toHaveBeenCalledWith({ where: { idrServiceInstanceId: 'instance-1' } });
-      expect(prisma.identifierScheme.count).toHaveBeenCalledWith({ where: { idrServiceInstanceId: 'instance-1' } });
+      expect(prisma.did.count).toHaveBeenCalledWith({
+        where: { serviceInstanceId: 'instance-1', tenantId: 'tenant-1' },
+      });
+      expect(prisma.registrar.count).toHaveBeenCalledWith({
+        where: { idrServiceInstanceId: 'instance-1', tenantId: 'tenant-1' },
+      });
+      expect(prisma.identifierScheme.count).toHaveBeenCalledWith({
+        where: { idrServiceInstanceId: 'instance-1', tenantId: 'tenant-1' },
+      });
       expect(result).toEqual({ dids: 3, registrars: 1, schemes: 2 });
     });
 
@@ -518,7 +527,7 @@ describe('service-instance.repository', () => {
       (prisma.registrar.count as jest.Mock).mockResolvedValue(0);
       (prisma.identifierScheme.count as jest.Mock).mockResolvedValue(0);
 
-      const result = await countServiceInstanceReferences('instance-1');
+      const result = await countServiceInstanceReferences('instance-1', 'tenant-1');
 
       expect(result).toEqual({ dids: 0, registrars: 0, schemes: 0 });
     });

--- a/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
+++ b/packages/reference-implementation/src/lib/prisma/repositories/service-instance.repository.ts
@@ -225,16 +225,22 @@ export async function deleteServiceInstance(id: string, tenantId: string): Promi
 }
 
 /**
- * Counts records that reference a given service instance.
+ * Counts the given tenant's records that reference a service instance.
  * Used for pre-delete referential integrity checks.
+ *
+ * Every count is scoped to `tenantId`. These numbers reach the caller in the
+ * pre-delete conflict message, so an unscoped count reports how many of other
+ * tenants' records point at the instance. That matters most for a system
+ * default, which every tenant can read and therefore attempt to delete.
  */
 export async function countServiceInstanceReferences(
   id: string,
+  tenantId: string,
 ): Promise<{ dids: number; registrars: number; schemes: number }> {
   const [dids, registrars, schemes] = await Promise.all([
-    prisma.did.count({ where: { serviceInstanceId: id } }),
-    prisma.registrar.count({ where: { idrServiceInstanceId: id } }),
-    prisma.identifierScheme.count({ where: { idrServiceInstanceId: id } }),
+    prisma.did.count({ where: { serviceInstanceId: id, tenantId } }),
+    prisma.registrar.count({ where: { idrServiceInstanceId: id, tenantId } }),
+    prisma.identifierScheme.count({ where: { idrServiceInstanceId: id, tenantId } }),
   ]);
 
   return { dids, registrars, schemes };

--- a/packages/reference-implementation/src/lib/swagger/auth-responses.test.ts
+++ b/packages/reference-implementation/src/lib/swagger/auth-responses.test.ts
@@ -16,13 +16,20 @@ const UNAUTHORISED_REF = '#/components/responses/UnauthorisedResponse';
 const FORBIDDEN_REF = '#/components/responses/TenantAssignmentForbiddenResponse';
 
 /**
- * `POST /dids` documents a combined 403: the tenant-assignment case shared
- * with every route, plus a business rule the handler itself enforces
- * (a tenant may not claim the system VC service's root DID). Referencing the
- * shared component alone would delete half of that contract, so this
- * operation keeps an inline response and is checked for both causes instead.
+ * Some operations document a combined 403: the tenant-assignment case shared
+ * with every route, plus a business rule the handler itself enforces.
+ * Referencing the shared component alone would delete half of that contract,
+ * so these operations keep an inline response and are checked for both causes.
+ * Each entry names a phrase that must appear for the operation's own rule,
+ * so an inline 403 cannot quietly drop it and still pass.
  */
-const COMBINED_FORBIDDEN_OPERATIONS = new Set(['post /dids']);
+const COMBINED_FORBIDDEN_OPERATIONS = new Map([
+  // A tenant may not claim the system VC service's root DID.
+  ['post /dids', 'root DID'],
+  // A tenant may not delete a system-default service instance, and is refused
+  // before the reference count so the counts never reach a non-owner.
+  ['delete /services/{id}', 'system default'],
+]);
 
 // This exemption can only go stale in the safe direction: an entry for a route
 // that changed simply stops matching. Nothing detects that an operation has
@@ -184,10 +191,11 @@ describe('shared auth responses', () => {
       }
 
       const forbidden = responses?.['403'];
-      if (COMBINED_FORBIDDEN_OPERATIONS.has(id)) {
+      const ownRulePhrase = COMBINED_FORBIDDEN_OPERATIONS.get(id);
+      if (ownRulePhrase !== undefined) {
         // Both causes must survive: the shared wording plus its own rule.
         expect(forbidden?.description).toContain('no resolvable tenant assignment');
-        expect(forbidden?.description).toContain('root DID');
+        expect(forbidden?.description).toContain(ownRulePhrase);
         // Staying inline costs this operation the component's body shape, so
         // the schema it carries is asserted here instead.
         expect(forbidden?.content?.['application/json']?.schema?.$ref).toBe('#/components/schemas/ErrorResponse');

--- a/packages/reference-implementation/src/lib/swagger/error-examples.test.ts
+++ b/packages/reference-implementation/src/lib/swagger/error-examples.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Guards the example bodies on the published error responses.
+ *
+ * Without examples, Swagger UI prints each property's type name, so every
+ * error response reads `{"error": "string", "code": "string"}`. That is both
+ * uninformative and wrong about `code`, which most error bodies omit. These
+ * tests pin the statuses that are covered, so a new route cannot reintroduce
+ * the placeholder on them, and record which statuses are still bare.
+ */
+
+import { getApiDocs } from './swagger';
+import { SHARED_STATUS_EXAMPLES } from './error-examples';
+
+type MediaType = { schema?: { $ref?: string }; examples?: Record<string, { summary: string; value: unknown }> };
+type ResponseObject = { $ref?: string; description?: string; content?: Record<string, MediaType> };
+type Spec = {
+  paths?: Record<string, Record<string, { responses?: Record<string, ResponseObject> }>>;
+  components?: { responses?: Record<string, ResponseObject> };
+};
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+/** Every (operation, status, response) triple for a 4xx or 5xx in the document. */
+function errorResponses(spec: Spec): Array<{ id: string; status: string; response: ResponseObject }> {
+  const found: Array<{ id: string; status: string; response: ResponseObject }> = [];
+  for (const [route, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const method of HTTP_METHODS) {
+      const responses = pathItem[method]?.responses;
+      if (!responses) continue;
+      for (const [status, response] of Object.entries(responses)) {
+        if (/^[45]/.test(status)) found.push({ id: `${method} ${route}`, status, response });
+      }
+    }
+  }
+  return found;
+}
+
+describe('published error response examples', () => {
+  let spec: Spec;
+
+  beforeAll(async () => {
+    spec = (await getApiDocs()) as Spec;
+  });
+
+  it('finds error responses to check, so a broken walk cannot pass vacuously', () => {
+    expect(errorResponses(spec).length).toBeGreaterThan(100);
+  });
+
+  it.each([
+    ['UnauthorisedResponse', 'Unauthorised'],
+    ['TenantAssignmentForbiddenResponse', 'No tenant found for user'],
+  ])('gives %s examples carrying the wording the wrapper actually returns', (name, expectedMessage) => {
+    const examples = spec.components?.responses?.[name]?.content?.['application/json']?.examples;
+    expect(examples).toBeDefined();
+
+    const messages = Object.values(examples!).map((e) => (e.value as { error: string }).error);
+    expect(messages).toContain(expectedMessage);
+    // None of these bodies carries a code: the wrapper returns them directly
+    // rather than through the error mapper's coded branches.
+    for (const example of Object.values(examples!)) {
+      expect(example.value).not.toHaveProperty('code');
+    }
+  });
+
+  it.each(Object.keys(SHARED_STATUS_EXAMPLES))(
+    'gives every documented %s an example, so none renders as a type-name placeholder',
+    (status) => {
+      const bare = errorResponses(spec)
+        .filter((r) => r.status === status && r.response.$ref === undefined)
+        .filter((r) => r.response.content?.['application/json']?.examples === undefined)
+        .map((r) => `${r.id} ${r.status}`);
+
+      expect(bare).toEqual([]);
+    },
+  );
+
+  it('attaches examples to responses whose schema is a $ref, where a sibling key is legal', () => {
+    const decorated = errorResponses(spec).filter(
+      (r) =>
+        r.response.content?.['application/json']?.schema?.$ref?.endsWith('/ErrorResponse') &&
+        r.response.content?.['application/json']?.examples !== undefined,
+    );
+
+    expect(decorated.length).toBeGreaterThan(0);
+  });
+
+  it('never adds a sibling key to a response that is itself a $ref, which OpenAPI 3.0 ignores', () => {
+    const violations = errorResponses(spec)
+      .filter((r) => r.response.$ref !== undefined)
+      .filter((r) => Object.keys(r.response).length > 1)
+      .map((r) => `${r.id} ${r.status}`);
+
+    expect(violations).toEqual([]);
+  });
+
+  // Not an aspiration, a record. Every response below documents more than one
+  // cause, so no single body is the example: a multi-cause 404 that published
+  // one of its causes would state the wrong message for the others. Covering
+  // them needs a per-cause source of truth.
+  //
+  // Pinned exactly, in both directions. Coverage cannot regress without this
+  // failing, and it cannot be widened by publishing a guess without this
+  // failing either.
+  it('records exactly which responses still have no example', () => {
+    const bare = errorResponses(spec)
+      .filter((r) => r.response.$ref === undefined)
+      .filter((r) => r.response.content?.['application/json']?.examples === undefined)
+      .map((r) => `${r.id} ${r.status}`)
+      .sort();
+
+    expect(bare).toEqual([
+      'delete /identifiers/{id}/links/{linkId} 404',
+      'delete /services/{id} 404',
+      'delete /services/{id} 409',
+      'get /dids/{id}/document 404',
+      'get /dids/{id}/document 502',
+      'get /identifiers/{id}/links/{linkId} 404',
+      'get /services/{id} 404',
+      'patch /facilities/{id} 404',
+      'patch /facilities/{id} 409',
+      'patch /identifiers/{id}/links/{linkId} 404',
+      'patch /identifiers/{id}/links/{linkId} 409',
+      'patch /organisations/{id} 404',
+      'patch /organisations/{id} 409',
+      'patch /products/{id} 409',
+      'patch /registrars/{id} 404',
+      'patch /render-templates/{id} 404',
+      'patch /schemes/{id} 404',
+      'patch /schemes/{id} 409',
+      'patch /services/{id} 404',
+      'post /credentials 404',
+      'post /credentials/verify 422',
+      'post /credentials/verify 502',
+      'post /dids 404',
+      'post /dids 409',
+      'post /dids 502',
+      'post /dids/import 404',
+      'post /dids/{id}/verify 404',
+      'post /facilities 404',
+      'post /identifiers 404',
+      'post /organisations 404',
+      'post /products 404',
+      'post /registrars 404',
+      'post /render-templates 404',
+      'post /schemes 404',
+    ]);
+  });
+
+  it('publishes only messages the code actually throws', () => {
+    // Every quoted-message example must equal its response description, which
+    // is what makes it a quotation rather than a composition.
+    const quoted = errorResponses(spec).filter((r) => ['404', '409'].includes(r.status));
+
+    for (const { id, status, response } of quoted) {
+      const examples = response.content?.['application/json']?.examples;
+      if (!examples) continue;
+      for (const example of Object.values(examples)) {
+        expect(`${id} ${status} ${(example.value as { error: string }).error}`).toBe(
+          `${id} ${status} ${response.description?.trim()}`,
+        );
+      }
+    }
+  });
+});

--- a/packages/reference-implementation/src/lib/swagger/error-examples.ts
+++ b/packages/reference-implementation/src/lib/swagger/error-examples.ts
@@ -1,0 +1,214 @@
+/**
+ * Example error bodies for the published OpenAPI document.
+ *
+ * Swagger UI fills a response's example pane from the examples the document
+ * attaches. With none, it prints each property's type name instead, which is
+ * why every error response on the docs page reads `{"error": "string", "code":
+ * "string"}`. That placeholder also implies a `code` on responses that never
+ * carry one: the route error mapper attaches `code` only for validation errors
+ * constructed with one and for service-layer errors, so a forbidden,
+ * not-found, conflict or unprocessable body is `error` alone.
+ *
+ * Every string below is a literal the code actually produces, quoted from its
+ * source rather than composed here. Message text is easy to get wrong from
+ * memory: zod's enum message quotes each member and joins with `" | "`, and
+ * the unmapped 500 carries a correlation-id sentence that is easy to omit.
+ * When adding an example, copy the literal from the code that emits it.
+ *
+ * Two sources feed the examples. `SHARED_STATUS_EXAMPLES` covers the statuses
+ * whose body is the same on every route. A 404 or 409 instead takes its
+ * example from its own documented description, but only where that
+ * description is exactly a message the code throws, so the example is a
+ * quotation rather than a composition. A response documenting several causes
+ * matches nothing and is left bare, because publishing one of its causes would
+ * state the wrong message for the others. The sibling test pins the bare set
+ * exactly, in both directions, so coverage can neither regress nor be widened
+ * by a guess.
+ */
+
+/** A JSON error body as the route error mapper serialises it. */
+export type ErrorExample = { summary: string; value: { error: string; code?: string } };
+
+/**
+ * The 401 bodies `withTenantAuth` returns before a handler runs. Quoted from
+ * the returns in `src/lib/api/with-tenant-auth.ts`.
+ */
+export const UNAUTHORISED_EXAMPLES: Record<string, ErrorExample> = {
+  missingOrInvalidCredentials: {
+    summary: 'No session or bearer token resolved',
+    value: { error: 'Unauthorised' },
+  },
+  sessionExpired: {
+    summary: 'The interactive session could not be refreshed, so the caller signs in again',
+    value: { error: 'Session expired. Please sign in again' },
+  },
+  tokenMissingSub: {
+    summary: 'A bearer token passed validation but carries no subject claim',
+    value: { error: 'Token missing required sub claim' },
+  },
+};
+
+/**
+ * The 403 bodies `withTenantAuth` returns when a caller authenticates but no
+ * tenant can be resolved for them. Quoted from the same file.
+ */
+export const TENANT_FORBIDDEN_EXAMPLES: Record<string, ErrorExample> = {
+  noTenantForUser: {
+    summary: 'The authenticated user maps to no tenant',
+    value: { error: 'No tenant found for user' },
+  },
+  noGroupAssignment: {
+    summary: 'The identity provider returned no group assignment',
+    value: { error: 'No group assignment found' },
+  },
+  noTenantForGroup: {
+    summary: "The caller's group maps to no tenant",
+    value: { error: 'No tenant found for group' },
+  },
+};
+
+/**
+ * Bodies whose shape is identical on every route that documents the status.
+ *
+ * 400: `parseRequestBody` and `parseQueryParams` render the first failure as
+ * `field: message`, and a body that is not JSON at all short-circuits to a
+ * fixed sentence. Both are in `src/lib/api/validation.ts`.
+ *
+ * 500: `unexpectedErrorMessage` in `src/lib/api/errors.ts` appends the
+ * correlation id whenever a request context exists, which `withTenantAuth`
+ * establishes for every request, so the suffixed form is what callers see.
+ */
+export const SHARED_STATUS_EXAMPLES: Record<string, Record<string, ErrorExample>> = {
+  '400': {
+    fieldValidationFailure: {
+      summary: 'A field failed validation; the message names it',
+      value: { error: 'limit: must be a positive integer' },
+    },
+    malformedJsonBody: {
+      summary: 'The request body did not parse as JSON',
+      value: { error: 'Invalid JSON body' },
+    },
+  },
+  '500': {
+    unexpectedFailure: {
+      summary: 'An unhandled failure, with the id that ties the request to its server-side logs',
+      value: {
+        error:
+          'An unexpected error has occurred. If the issue persists, please contact support and quote correlation id "01JD8Z2Q6R7K3M4N5P6Q7R8S9T".',
+      },
+    },
+  },
+};
+
+/**
+ * Messages the routes and repositories actually throw for a 404 or a 409.
+ *
+ * Where an operation's documented description is exactly one of these, the
+ * description is quoting the thrown message, so it can be published as that
+ * response's example without composing anything. A description that says
+ * something else, usually because the operation has several causes, matches
+ * nothing here and is left without an example rather than given a plausible
+ * one, which is the whole point: a wrong example is worse than none, because
+ * an integrator writes code against it.
+ *
+ * To refresh, collect the `new NotFoundError('...')` and
+ * `new ConflictError('...')` arguments under `src/app/api/v1`, plus the
+ * `notFound`, `conflict` and `invalidReference` values handed to
+ * `mapDatabaseError` in the repositories.
+ */
+const VERIFIED_ERROR_MESSAGES = new Set([
+  'A DID record with this DID already exists',
+  'A data model with this name already exists for the credential type and version',
+  'A qualifier with this key already exists for the scheme',
+  'An identifier in this request is already the primary identifier of another facility',
+  'An identifier in this request is already the primary identifier of another organisation',
+  'An identifier in this request is already the primary identifier of another product',
+  'An identifier scheme with this primary key already exists for the registrar',
+  'An identifier with this value already exists for the scheme',
+  'Credential not found',
+  'DID not found',
+  'Data model not found',
+  'Facility not found',
+  'Identifier not found',
+  'Identifier scheme not found',
+  'Link registration not found',
+  'Organisation not found',
+  'Parent data model configuration not found',
+  'Product not found',
+  'Registrar not found',
+  'Render template not found',
+  'The identifier is already the primary identifier of another facility',
+  'The identifier is already the primary identifier of another organisation',
+  'The identifier is already the primary identifier of another product',
+  'The identifier scheme has identifiers and cannot be deleted',
+  'The registrar has schemes with identifiers and cannot be deleted',
+]);
+
+/**
+ * Verified messages that must not be matched automatically, because more than
+ * one distinct body carries the same wording.
+ *
+ * `ServiceInstanceNotFoundError` appends the requested id
+ * (`Service instance not found: si-123`) while the service routes throw the
+ * bare `NotFoundError('Service instance not found')`. An operation documenting
+ * "Service instance not found" may mean either, so publishing one form would
+ * state the wrong body for the routes that emit the other.
+ */
+const AMBIGUOUS_ERROR_MESSAGES = new Set(['Service instance not found']);
+
+type MediaType = { schema?: unknown; examples?: Record<string, ErrorExample> };
+type ResponseObject = { $ref?: string; description?: string; content?: Record<string, MediaType> };
+type Operation = { responses?: Record<string, ResponseObject> };
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'];
+
+/**
+ * The example for a response whose description quotes the message the code
+ * throws, or undefined when it quotes nothing verifiable.
+ */
+function quotedMessageExample(description: string | undefined): Record<string, ErrorExample> | undefined {
+  const message = description?.trim();
+  if (!message || !VERIFIED_ERROR_MESSAGES.has(message) || AMBIGUOUS_ERROR_MESSAGES.has(message)) {
+    return undefined;
+  }
+  return { ['default']: { summary: message, value: { error: message } } };
+}
+
+/**
+ * Attaches the shared examples to every operation response that declares its
+ * own content and has none.
+ *
+ * Responses that are a `$ref` to a shared response component are skipped: in
+ * OpenAPI 3.0 a Reference Object cannot be extended, and any sibling property
+ * added beside `$ref` is ignored, so those are covered by putting the examples
+ * on the components themselves. Where the response is declared inline and only
+ * its `schema` is a `$ref`, `examples` is a sibling of `schema` rather than of
+ * `$ref`, so it attaches normally.
+ */
+export function attachErrorExamples(spec: Record<string, unknown>): void {
+  const paths = spec.paths as Record<string, Record<string, Operation>> | undefined;
+  if (!paths) return;
+
+  for (const pathItem of Object.values(paths)) {
+    for (const method of HTTP_METHODS) {
+      const responses = pathItem[method]?.responses;
+      if (!responses) continue;
+
+      for (const [status, response] of Object.entries(responses)) {
+        if (response.$ref !== undefined) continue;
+
+        const mediaType = response.content?.['application/json'];
+        if (!mediaType || mediaType.examples !== undefined) continue;
+
+        const shared = SHARED_STATUS_EXAMPLES[status];
+        if (shared) {
+          mediaType.examples = shared;
+          continue;
+        }
+
+        const quoted = quotedMessageExample(response.description);
+        if (quoted) mediaType.examples = quoted;
+      }
+    }
+  }
+}

--- a/packages/reference-implementation/src/lib/swagger/swagger.ts
+++ b/packages/reference-implementation/src/lib/swagger/swagger.ts
@@ -1,5 +1,6 @@
 import { createSwaggerSpec } from 'next-swagger-doc';
 import { generateOpenAPISchemas } from './schemas';
+import { attachErrorExamples, UNAUTHORISED_EXAMPLES, TENANT_FORBIDDEN_EXAMPLES } from './error-examples';
 
 export const getApiDocs = async (): Promise<Record<string, unknown>> => {
   // Generate schemas from Zod definitions
@@ -31,6 +32,11 @@ export const getApiDocs = async (): Promise<Record<string, unknown>> => {
             content: {
               'application/json': {
                 schema: { $ref: '#/components/schemas/ErrorResponse' },
+                // Operations reference this component rather than declaring
+                // their own 401, and a Reference Object cannot carry sibling
+                // properties in OpenAPI 3.0, so the examples for all of them
+                // live here.
+                examples: UNAUTHORISED_EXAMPLES,
               },
             },
           },
@@ -39,6 +45,7 @@ export const getApiDocs = async (): Promise<Record<string, unknown>> => {
             content: {
               'application/json': {
                 schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: TENANT_FORBIDDEN_EXAMPLES,
               },
             },
           },
@@ -75,5 +82,10 @@ export const getApiDocs = async (): Promise<Record<string, unknown>> => {
       ],
     },
   });
+
+  // Runs after the JSDoc blocks are assembled, because the responses it
+  // decorates are declared in those blocks rather than here.
+  attachErrorExamples(spec as Record<string, unknown>);
+
   return spec as Record<string, unknown>;
 };

--- a/packages/reference-implementation/src/middleware.test.ts
+++ b/packages/reference-implementation/src/middleware.test.ts
@@ -234,7 +234,7 @@ describe('middleware', () => {
       await (middleware as any)(req);
 
       expect(mockNextResponseJson).toHaveBeenCalledWith(
-        { error: 'Unauthorized', message: 'Authentication required' },
+        { error: 'Unauthorised', message: 'Authentication required' },
         expect.objectContaining({ status: 401 }),
       );
     });

--- a/packages/reference-implementation/src/middleware.ts
+++ b/packages/reference-implementation/src/middleware.ts
@@ -103,7 +103,7 @@ export default auth(async (req) => {
         // sub is required for the service account flow to work
         if (!payload.sub) {
           return NextResponse.json(
-            { error: 'Unauthorized', message: 'Token missing required "sub" claim' },
+            { error: 'Unauthorised', message: 'Token missing required "sub" claim' },
             { status: 401, headers: { 'x-correlation-id': correlationId } },
           );
         }
@@ -133,7 +133,7 @@ export default auth(async (req) => {
 
       // User is unauthorised
       return NextResponse.json(
-        { error: 'Unauthorized', message: 'Authentication required' },
+        { error: 'Unauthorised', message: 'Authentication required' },
         { status: 401, headers: { 'x-correlation-id': correlationId } },
       );
     }


### PR DESCRIPTION
This PR fixes two defects that gave API callers wrong information, and replaces the placeholder error examples in the published API documentation with real ones.

The defects came out of a sweep prompted by the docs page showing `{"error": "string", "code": "string"}` for every error response. Chasing why led to two things that were wrong in the API itself rather than in its documentation.

**A resolver rejection was reported as an unknown outcome.** `POST /credentials` chooses between two publish warnings by reading the upstream HTTP status off the caught error. It read `error.details.httpStatus`, but `ServiceError` has no `details` field; `IdrPublishError` carries that value on `context`. The status was therefore always `undefined`, the 4xx branch was unreachable, and every publish failure returned `IDR_PUBLISH_UNCONFIRMED`. That matters because the two warnings advise opposite actions. A resolver 4xx means nothing was committed and re-issuing after fixing the cause is correct, while the warning the caller actually received told them the resolver could not be reached and warned that a second publish is rejected as a duplicate. The existing tests passed because they built synthetic errors carrying a `details` object, so the test and the route agreed with each other and both disagreed with the class the service throws. They now construct a real `IdrPublishError`.

**Deleting a service instance disclosed other tenants' data.** `countServiceInstanceReferences` counted referencing DIDs, registrars and identifier schemes filtered on the instance id alone, and the 409 reports those counts. The lookup guarding that route admits system-default instances to every tenant, while `deleteServiceInstance` is already scoped to the caller, so a tenant who could not delete a shared instance could still read the global reference breakdown for it. The route now refuses with a 403 before any counting, and the counts carry the tenant condition. A 403 rather than a 404 because `GET /services/{id}` returns that same instance to that same caller, so denying its existence would contradict what they have already been shown.

**Error responses now carry examples.** The document declared 312 error responses across 66 operations and not one example, so Swagger UI printed each property's type name instead. That placeholder also implied a `code` on the many responses that never carry one. 278 of the 312 now have a realistic body. Examples for 404 and 409 are published only where the response description is exactly a message the code throws, checked against literals extracted from the source, so a multi-cause response is left without one rather than given a plausible-looking guess. The remaining 34 are pinned individually in a test, in both directions, so coverage cannot regress and cannot be widened by an invented example.

Two smaller fixes ride along. `adapter-wrapper.ts` was the only file importing `PrismaClient` from `@prisma/client`, which is a stub because the schema sets a custom `output`; it now imports from the generated client like every sibling, which is why one suite could not run in a fresh worktree. And the 401 and 403 wire strings lost an em-dash and four American spellings that the earlier Swagger sweep corrected in the descriptions but not in the responses themselves.

## Test plan

- [x] Full reference-implementation suite: 143 suites, 2773 tests, all passing
- [x] Each fix red-checked by reverting it and confirming the new tests fail with the production symptom. Restoring the `details` read flips the assertion to `IDR_PUBLISH_UNCONFIRMED`; removing the ownership guard reaches the counts; dropping the tenant condition fails the repository assertions; neutering the example attachment leaves the responses bare
- [x] The OpenAPI contract test asserts every published 404 and 409 example equals its own response description, which is what makes it a quotation rather than a composition
- [x] `tsc --noEmit` clean, Prettier clean

The API documentation for `DELETE /services/{id}` said only that system defaults "cannot be deleted", with no mechanism, and described the 409 counts as covering references "by other records" with no tenant scope. Both are corrected, including the sequence diagram.
