### PR TITLE
fix(docs): use the repository's package manager in the package READMEs

### DIFF
--- a/docker-compose.e2e-closed.yml
+++ b/docker-compose.e2e-closed.yml
@@ -1,7 +1,7 @@
 # Docker Compose override for closed mode E2E tests.
 # Usage:
 #   docker compose -f docker-compose.e2e.yml -f docker-compose.e2e-closed.yml --profile ri up -d --build
-#   yarn test:e2e:ri:closed
+#   pnpm test:e2e:ri:closed
 #   docker compose -f docker-compose.e2e.yml -f docker-compose.e2e-closed.yml --profile ri down -v
 services:
   app:

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -11,7 +11,7 @@ Make sure your machine has Node.js version 18 or later installed.
 To install the project dependencies, run the following command:
 
 ```bash
-yarn install
+pnpm install
 ```
 
 ## Storybook
@@ -21,7 +21,7 @@ Explore and interact with the components using Storybook.
 ### Run Storybook
 
 ```bash
-yarn run storybook
+pnpm storybook
 ```
 
 Visit http://localhost:6006/ in your browser to view Storybook.
@@ -31,5 +31,5 @@ Visit http://localhost:6006/ in your browser to view Storybook.
 Run unit tests using Jest.
 
 ```bash
-yarn test
+pnpm test
 ```

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -7,6 +7,6 @@ This directory contains the source code for the services that are used by the ap
 Build the project and run the tests with the following command:
 
 ```bash
-$ yarn run build
-$ yarn run test
+$ pnpm build
+$ pnpm test
 ```

--- a/packages/untp-test-suite/README.md
+++ b/packages/untp-test-suite/README.md
@@ -61,13 +61,13 @@ Follow the [Prerequisites section](../../README.md#prerequisites) in the root RE
 
    ```bash
    # From the repository root directory
-   yarn install
+   pnpm install
    ```
 
 2. **Build the package**:
    ```bash
    cd packages/untp-test-suite
-   yarn build
+   pnpm build
    ```
 
 After building, you can use the CLI commands with `npx` to pick up the local build.
@@ -214,8 +214,8 @@ the same tests with the same test runner, in a browser environment.
 
 ```bash
 cd packages/untp-test-suite
-yarn build:browser
-yarn browser-test
+pnpm build:browser
+pnpm browser-test
 ```
 
 2. Open `http://localhost:8080` in your browser

--- a/packages/untp-utils/README.md
+++ b/packages/untp-utils/README.md
@@ -5,7 +5,7 @@ Shared utility primitives for UNTP packages and consumers.
 ## Installation
 
 ```bash
-yarn add @uncefact/untp-utils
+npm install @uncefact/untp-utils
 ```
 
 ## Sub-entries


### PR DESCRIPTION
Four package READMEs and one Compose comment still tell the reader to run `yarn`, which does not work here. The repository pins `pnpm@9.15.4` through Corepack and has no `yarn.lock`, so anyone following them is stopped at the first command.

Every replacement command was checked against the relevant `package.json`, so each one exists: `storybook` and `test` in components, `build` and `test` in services, `build`, `build:browser` and `browser-test` in untp-test-suite, and `test:e2e:ri:closed` at the root.

The untp-utils line is the one exception. It is a consumer install instruction for a published package rather than a command for this repository, so `pnpm add` would presume the reader's tooling just as `yarn add` did. It now reads `npm install`.

The `yarn` references left in `docs/adrs/` are deliberate. An ADR body records what was true when the decision was taken, and this repository's convention is to leave those bodies alone rather than rewrite history.
