### PR TITLE
feat(playground): show failing and verifying indicators in the tab meta

### DIFF
--- a/packages/untp-playground/README.md
+++ b/packages/untp-playground/README.md
@@ -14,6 +14,8 @@ The homepage has three tabs: Credentials, Conformity Schemes, and Link Sets.
 
 Drop a credential JSON or JWT file, or paste a URL, on the Credentials tab to validate it. Uploading a conformity scheme's JSON-LD file or URL on the Conformity Schemes tab validates it the same way. Each tab keeps validating in the background even while another tab is selected. Uploading content with the same hash as an artefact already loaded replaces that artefact in place. Different content is always added as a new one. Where a credential type or scheme appears more than once, the matching instances are grouped together under a shared header.
 
+A tab's label shows a count of its loaded instances, and a small red dot next to the count if any of them has failed. The Credentials tab also shows a spinner while any credential is still being validated, so background progress on an inactive tab stays visible without switching to it. A tab with no loaded instances shows no count.
+
 The Link Sets tab is a placeholder for a future release and does not yet accept uploads.
 
 ## Deployment

--- a/packages/untp-playground/__tests__/app/page.test.tsx
+++ b/packages/untp-playground/__tests__/app/page.test.tsx
@@ -10,9 +10,12 @@ import {
 } from '@/lib/credentialService';
 import { detectExtension, validateCredentialSchema } from '@/lib/schemaValidation';
 import { ArtefactUploader } from '@/components/ArtefactUploader';
+import { SchemeTestResults } from '@/components/SchemeTestResults';
+import { TestResults } from '@/components/TestResults';
+import { beginRun, commitResult, remove } from '@/lib/artefactCollection';
 import Home from '@/app/page';
 import { mockCredential } from '../mocks/vc';
-import { ArtefactKind, permittedCredentialTypes } from '../../constants';
+import { ArtefactKind, permittedCredentialTypes, TestCaseStatus } from '../../constants';
 
 // Mock the dependencies
 jest.mock('sonner', () => ({
@@ -53,11 +56,11 @@ jest.mock('@/components/Footer', () => ({
 }));
 
 jest.mock('@/components/TestResults', () => ({
-  TestResults: () => <div data-testid='mock-test-results'>Test Results</div>,
+  TestResults: jest.fn(() => <div data-testid='mock-test-results'>Test Results</div>),
 }));
 
 jest.mock('@/components/SchemeTestResults', () => ({
-  SchemeTestResults: () => <div data-testid='mock-scheme-test-results'>Scheme Test Results</div>,
+  SchemeTestResults: jest.fn(() => <div data-testid='mock-scheme-test-results'>Scheme Test Results</div>),
 }));
 
 jest.mock('@/components/ArtefactUploader', () => ({
@@ -230,7 +233,42 @@ describe('Home Component', () => {
 describe('Tabbed artefact surface (#809)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks resets calls but not implementations, so an override installed by any earlier
+    // test would otherwise leak into the next one. Reinstall the defaults to keep every test
+    // order-independent.
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() =>
+            onArtefactUpload({ verifiableCredential: { type: ['VerifiableCredential', 'DigitalProductPassport'] } })
+          }
+        >
+          Upload
+        </button>
+      ),
+    );
+    (TestResults as jest.Mock).mockImplementation(() => <div data-testid='mock-test-results'>Test Results</div>);
+    (SchemeTestResults as jest.Mock).mockImplementation(() => (
+      <div data-testid='mock-scheme-test-results'>Scheme Test Results</div>
+    ));
   });
+
+  // Shared ArtefactUploader stand-in for the scheme tab-meta tests below: uploading always
+  // produces a single ConformityScheme instance, which each test then drives to a result via its
+  // own SchemeTestResults mock.
+  function mockSchemeArtefactUploader() {
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() => onArtefactUpload({ verifiableCredential: { type: ['ConformityScheme'] } })}
+        >
+          Upload
+        </button>
+      ),
+    );
+  }
 
   it('renders a tab for each artefact family', () => {
     render(<Home />);
@@ -385,7 +423,7 @@ describe('Tabbed artefact surface (#809)', () => {
 
     // The Credentials tab count reflects the number of loaded instances, matching the Conformity
     // Schemes tab (#845).
-    expect(await screen.findByRole('tab', { name: /Credentials\s*2/ })).toBeInTheDocument();
+    expect(await screen.findByRole('tab', { name: /Credentials(\s*verifying)?\s*2/ })).toBeInTheDocument();
   });
 
   it('replaces in place when the same credential content is uploaded twice (#810)', async () => {
@@ -417,7 +455,7 @@ describe('Tabbed artefact surface (#809)', () => {
     fireEvent.click(uploader);
     fireEvent.click(uploader);
 
-    expect(await screen.findByRole('tab', { name: /Credentials\s*1/ })).toBeInTheDocument();
+    expect(await screen.findByRole('tab', { name: /Credentials(\s*verifying)?\s*1/ })).toBeInTheDocument();
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('Replaced'));
     });
@@ -458,7 +496,7 @@ describe('Tabbed artefact surface (#809)', () => {
     fireEvent.click(uploader);
 
     // One instance, and the second upload was a replace rather than an append.
-    expect(await screen.findByRole('tab', { name: /Credentials\s*1/ })).toBeInTheDocument();
+    expect(await screen.findByRole('tab', { name: /Credentials(\s*verifying)?\s*1/ })).toBeInTheDocument();
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('Replaced'));
     });
@@ -486,5 +524,298 @@ describe('Tabbed artefact surface (#809)', () => {
     await userEvent.click(screen.getByRole('tab', { name: 'Link Sets' }));
 
     expect(screen.getByText('No link sets yet')).toBeInTheDocument();
+  });
+
+  it('shows a red failing dot on the Conformity Schemes tab when one of several schemes fails, without switching tabs', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue({ kind: ArtefactKind.SCHEME, type: 'ConformityScheme' });
+    // Two distinct schemes, so the dot must fire on "any instance failing", not "all failing".
+    let marker = 0;
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() => onArtefactUpload({ verifiableCredential: { type: ['ConformityScheme'], marker: marker++ } })}
+        >
+          Upload
+        </button>
+      ),
+    );
+    // The mocked results panel settles the first scheme as passing and the second as failing,
+    // exercising the same collection dispatch path the real pipeline uses.
+    (SchemeTestResults as jest.Mock).mockImplementation(({ collection, dispatch }: any) => (
+      <button
+        data-testid='mock-scheme-fail'
+        onClick={() => {
+          collection.items.forEach((item: any, index: number) => {
+            const { runId } = dispatch((state: any) => beginRun(state, item.instanceId, [], () => `run-${index}`));
+            dispatch((state: any) =>
+              commitResult(state, {
+                instanceId: item.instanceId,
+                runId,
+                result: [
+                  {
+                    id: 'schema-validation',
+                    name: 'Schema Validation',
+                    status: index === 0 ? TestCaseStatus.SUCCESS : TestCaseStatus.FAILURE,
+                  },
+                ],
+              }),
+            );
+          });
+        }}
+      >
+        Fail scheme
+      </button>
+    ));
+
+    render(<Home />);
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+
+    expect(screen.queryByTestId('schemes-tab-failing-dot')).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('mock-scheme-fail'));
+
+    // The default tab (Credentials) is still active; the failing dot must be visible cross-tab.
+    expect(screen.getByRole('tab', { name: /Credentials/ })).toHaveAttribute('data-state', 'active');
+    expect(await screen.findByTestId('schemes-tab-failing-dot')).toBeInTheDocument();
+    // The dot itself is aria-hidden; the state must still reach assistive tech as text.
+    expect(screen.getByText('failing')).toBeInTheDocument();
+  });
+
+  it('does not show a failing dot for a warning-only scheme instance', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue({ kind: ArtefactKind.SCHEME, type: 'ConformityScheme' });
+    mockSchemeArtefactUploader();
+    (SchemeTestResults as jest.Mock).mockImplementation(({ collection, dispatch }: any) => (
+      <button
+        data-testid='mock-scheme-warn'
+        onClick={() => {
+          const item = collection.items[0];
+          const { runId } = dispatch((state: any) => beginRun(state, item.instanceId, [], () => 'run-warn'));
+          dispatch((state: any) =>
+            commitResult(state, {
+              instanceId: item.instanceId,
+              runId,
+              result: [{ id: 'schema-validation', name: 'Schema Validation', status: TestCaseStatus.WARNING }],
+            }),
+          );
+        }}
+      >
+        Warn scheme
+      </button>
+    ));
+
+    render(<Home />);
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+    fireEvent.click(await screen.findByTestId('mock-scheme-warn'));
+
+    // WARNING settles an instance without failing it: the count shows, no dot.
+    expect(await screen.findByRole('tab', { name: /Conformity Schemes\s*1/ })).toBeInTheDocument();
+    expect(screen.queryByTestId('schemes-tab-failing-dot')).not.toBeInTheDocument();
+  });
+
+  it('clears the schemes tab meta entirely when the last instance is removed', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue({ kind: ArtefactKind.SCHEME, type: 'ConformityScheme' });
+    mockSchemeArtefactUploader();
+    (SchemeTestResults as jest.Mock).mockImplementation(({ collection, dispatch }: any) => (
+      <div>
+        <button
+          data-testid='mock-scheme-fail'
+          onClick={() => {
+            const item = collection.items[0];
+            const { runId } = dispatch((state: any) => beginRun(state, item.instanceId, [], () => 'run-fail'));
+            dispatch((state: any) =>
+              commitResult(state, {
+                instanceId: item.instanceId,
+                runId,
+                result: [{ id: 'schema-validation', name: 'Schema Validation', status: TestCaseStatus.FAILURE }],
+              }),
+            );
+          }}
+        >
+          Fail scheme
+        </button>
+        <button
+          data-testid='mock-scheme-remove'
+          onClick={() => {
+            const item = collection.items[0];
+            dispatch((state: any) => remove(state, item.instanceId));
+          }}
+        >
+          Remove scheme
+        </button>
+      </div>
+    ));
+
+    render(<Home />);
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+    fireEvent.click(await screen.findByTestId('mock-scheme-fail'));
+    expect(await screen.findByTestId('schemes-tab-failing-dot')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mock-scheme-remove'));
+
+    // No lingering count or failing dot once the family is empty again.
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Conformity Schemes' })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('schemes-tab-failing-dot')).not.toBeInTheDocument();
+  });
+
+  it('shows a spinner on the Credentials tab while a credential verifies, and clears it when the run settles', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue(undefined);
+    (isEnvelopedProof as jest.Mock).mockReturnValue(false);
+    (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+    (detectExtension as jest.Mock).mockReturnValue(undefined);
+    (detectVersion as jest.Mock).mockReturnValue('0.6.0');
+    // Two distinct credentials, settled one at a time: the spinner must persist while any
+    // instance is non-terminal, and clear only when the last one settles.
+    let marker = 0;
+    (ArtefactUploader as jest.Mock).mockImplementation(
+      ({ onArtefactUpload }: { onArtefactUpload: (artefact: any) => void }) => (
+        <button
+          data-testid='mock-uploader'
+          onClick={() =>
+            onArtefactUpload({
+              verifiableCredential: { type: ['VerifiableCredential', 'DigitalProductPassport'], marker: marker++ },
+            })
+          }
+        >
+          Upload
+        </button>
+      ),
+    );
+    // The mocked results panel settles one still-unsettled instance per click, all-success.
+    (TestResults as jest.Mock).mockImplementation(({ collection, dispatch }: any) => (
+      <button
+        data-testid='mock-credential-settle'
+        onClick={() => {
+          const item = collection.items.find((candidate: any) => candidate.result === undefined);
+          const { runId } = dispatch((state: any) =>
+            beginRun(state, item.instanceId, [], () => `run-${item.instanceId}`),
+          );
+          dispatch((state: any) =>
+            commitResult(state, {
+              instanceId: item.instanceId,
+              runId,
+              result: [{ id: 'verification', name: 'Credential Verification', status: TestCaseStatus.SUCCESS }],
+            }),
+          );
+        }}
+      >
+        Settle
+      </button>
+    ));
+
+    render(<Home />);
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+
+    // Fresh instances have no result yet, so the family counts as verifying immediately.
+    expect(await screen.findByTestId('credentials-tab-verifying')).toBeInTheDocument();
+    // The spinner itself is aria-hidden; the state must still reach assistive tech as text.
+    expect(screen.getByText('verifying')).toBeInTheDocument();
+
+    // Settling one of the two instances must not clear the spinner: the other is still verifying.
+    fireEvent.click(screen.getByTestId('mock-credential-settle'));
+    expect(await screen.findByTestId('credentials-tab-verifying')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mock-credential-settle'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('credentials-tab-verifying')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('credentials-tab-failing-dot')).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Credentials\s*2/ })).toBeInTheDocument();
+  });
+
+  it('shows a red failing dot on the Credentials tab when a credential instance fails', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue(undefined);
+    (isEnvelopedProof as jest.Mock).mockReturnValue(false);
+    (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+    (detectExtension as jest.Mock).mockReturnValue(undefined);
+    (detectVersion as jest.Mock).mockReturnValue('0.6.0');
+    (TestResults as jest.Mock).mockImplementation(({ collection, dispatch }: any) => (
+      <button
+        data-testid='mock-credential-fail'
+        onClick={() => {
+          const item = collection.items[0];
+          const { runId } = dispatch((state: any) => beginRun(state, item.instanceId, [], () => 'run-fail'));
+          dispatch((state: any) =>
+            commitResult(state, {
+              instanceId: item.instanceId,
+              runId,
+              result: [{ id: 'verification', name: 'Credential Verification', status: TestCaseStatus.FAILURE }],
+            }),
+          );
+        }}
+      >
+        Fail credential
+      </button>
+    ));
+
+    render(<Home />);
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+    fireEvent.click(await screen.findByTestId('mock-credential-fail'));
+
+    expect(await screen.findByTestId('credentials-tab-failing-dot')).toBeInTheDocument();
+    // Settled (terminal) result: the spinner must be gone even though the instance failed.
+    expect(screen.queryByTestId('credentials-tab-verifying')).not.toBeInTheDocument();
+  });
+
+  it('keeps the spinner while a committed step is still in progress', async () => {
+    (detectArtefact as jest.Mock).mockReturnValue(undefined);
+    (isEnvelopedProof as jest.Mock).mockReturnValue(false);
+    (detectCredentialType as jest.Mock).mockReturnValue('DigitalProductPassport');
+    (detectExtension as jest.Mock).mockReturnValue(undefined);
+    (detectVersion as jest.Mock).mockReturnValue('0.6.0');
+    // First click commits a non-empty result whose step is still IN_PROGRESS (must stay
+    // verifying); second click settles the same run to SUCCESS (must clear). The settle phase is
+    // what makes a silently no-op commit path fail this test: the spinner would then never clear.
+    (TestResults as jest.Mock).mockImplementation(({ collection, dispatch }: any) => (
+      <>
+        <button
+          data-testid='mock-credential-progress'
+          onClick={() => {
+            const item = collection.items[0];
+            const { runId } = dispatch((state: any) => beginRun(state, item.instanceId, [], () => 'run-mid'));
+            dispatch((state: any) =>
+              commitResult(state, {
+                instanceId: item.instanceId,
+                runId,
+                result: [{ id: 'verification', name: 'Credential Verification', status: TestCaseStatus.IN_PROGRESS }],
+              }),
+            );
+          }}
+        >
+          Progress
+        </button>
+        <button
+          data-testid='mock-credential-finish'
+          onClick={() => {
+            const item = collection.items[0];
+            dispatch((state: any) =>
+              commitResult(state, {
+                instanceId: item.instanceId,
+                runId: 'run-mid',
+                result: [{ id: 'verification', name: 'Credential Verification', status: TestCaseStatus.SUCCESS }],
+              }),
+            );
+          }}
+        >
+          Finish
+        </button>
+      </>
+    ));
+
+    render(<Home />);
+    fireEvent.click(screen.getByTestId('mock-uploader'));
+    fireEvent.click(await screen.findByTestId('mock-credential-progress'));
+
+    expect(await screen.findByTestId('credentials-tab-verifying')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mock-credential-finish'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('credentials-tab-verifying')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/untp-playground/src/app/page.tsx
+++ b/packages/untp-playground/src/app/page.tsx
@@ -15,7 +15,13 @@ import { TestResults } from '@/components/TestResults';
 import { TestReportProvider } from '@/contexts/TestReportContext';
 import { useArtefactCollection } from '@/hooks/useArtefactCollection';
 import { upsert } from '@/lib/artefactCollection';
-import { credentialContentHash, credentialGroupType, credentialTitle } from '@/lib/credentialCollection';
+import {
+  credentialContentHash,
+  credentialGroupType,
+  credentialIsTerminal,
+  credentialTitle,
+  instanceStatus,
+} from '@/lib/credentialCollection';
 import { newId } from '@/lib/id';
 import { schemeContentHash, schemeTitle } from '@/lib/schemeCollection';
 import { decodeEnvelopedCredential, detectArtefact, isEnvelopedProof } from '@/lib/credentialService';
@@ -24,8 +30,57 @@ import type { PermittedCredentialType, StoredCredential, StoredScheme, TestStep 
 import { useError } from '@/contexts/ErrorContext';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { FileText, Link2, Server } from 'lucide-react';
-import { ArtefactKind, permittedCredentialTypes } from '../../constants';
+import { FileText, Link2, Loader2, Server } from 'lucide-react';
+import { ArtefactKind, permittedCredentialTypes, TestCaseStatus } from '../../constants';
+
+/**
+ * Quiet per-tab meta (final hi-fi, canvas section 08): a muted tabular-nums instance count, a
+ * small red dot before it when any instance in the family is failing, and a spinner (with the
+ * count tinted to the in-progress colour) while the family is still verifying — wired up for
+ * Credentials only, per the ticket and handoff. Renders nothing while the family is empty, so an
+ * empty tab carries no meta at all.
+ */
+function TabMeta({
+  family,
+  count,
+  failing = false,
+  verifying = false,
+}: {
+  family: string;
+  count: number;
+  failing?: boolean;
+  verifying?: boolean;
+}) {
+  if (count === 0) return null;
+  return (
+    // blue-700, not the StatusIcon spinner's blue-500: the tinted count is 12px text and must
+    // clear WCAG 1.4.3's 4.5:1 on the white background (blue-500 is ~3.7:1; the handoff's
+    // running-meta colour hsl(217 72% 42%) and blue-700 both clear it).
+    <span
+      className={`inline-flex items-center gap-1.5 text-xs tabular-nums ${
+        verifying ? 'text-blue-700' : 'text-muted-foreground'
+      }`}
+    >
+      {failing && (
+        <>
+          <span
+            data-testid={`${family}-tab-failing-dot`}
+            aria-hidden='true'
+            className='h-1.5 w-1.5 rounded-full bg-red-500'
+          />
+          <span className='sr-only'>failing</span>
+        </>
+      )}
+      {verifying && (
+        <>
+          <Loader2 data-testid={`${family}-tab-verifying`} aria-hidden='true' className='h-3 w-3 animate-spin' />
+          <span className='sr-only'>verifying</span>
+        </>
+      )}
+      {count}
+    </span>
+  );
+}
 
 export default function Home() {
   const credential = useArtefactCollection<StoredCredential, TestStep[]>();
@@ -41,6 +96,15 @@ export default function Home() {
   const credentialsCount = credential.state.items.length;
   const schemesCount = scheme.state.items.length;
   const linkSetsCount = 0; // Link Sets family lands in #811.
+
+  // Cross-tab signals for the tab meta: a family with any failing instance shows a red dot from
+  // any tab, and the Credentials tab shows a spinner while any credential is still verifying
+  // (a fresh instance with no result yet counts as verifying — its pipeline is about to run).
+  const credentialsFailing = credential.state.items.some(
+    (item) => instanceStatus(item.result) === TestCaseStatus.FAILURE,
+  );
+  const schemesFailing = scheme.state.items.some((item) => instanceStatus(item.result) === TestCaseStatus.FAILURE);
+  const credentialsVerifying = credential.state.items.some((item) => !credentialIsTerminal(item.result ?? []));
 
   // Recomputed only when the instances change (add, replace, remove, or a result commit), so an
   // unrelated re-render does not create a fresh array and re-run the report-reset effect.
@@ -144,19 +208,20 @@ export default function Home() {
             <TabsList>
               <TabsTrigger value='credentials'>
                 Credentials
-                {credentialsCount > 0 && (
-                  <span className='text-xs tabular-nums text-muted-foreground'>{credentialsCount}</span>
-                )}
+                <TabMeta
+                  family='credentials'
+                  count={credentialsCount}
+                  failing={credentialsFailing}
+                  verifying={credentialsVerifying}
+                />
               </TabsTrigger>
               <TabsTrigger value='schemes'>
                 Conformity Schemes
-                {schemesCount > 0 && <span className='text-xs tabular-nums text-muted-foreground'>{schemesCount}</span>}
+                <TabMeta family='schemes' count={schemesCount} failing={schemesFailing} />
               </TabsTrigger>
               <TabsTrigger value='linksets'>
                 Link Sets
-                {linkSetsCount > 0 && (
-                  <span className='text-xs tabular-nums text-muted-foreground'>{linkSetsCount}</span>
-                )}
+                <TabMeta family='linksets' count={linkSetsCount} />
               </TabsTrigger>
             </TabsList>
 


### PR DESCRIPTION
This PR adds the per-tab meta indicators from the phase-2 design handoff (canvas section 08), which results in a failing family being visible from any tab and background credential verification showing live progress on the tab bar. A family's tab label shows a muted count of loaded instances, a small red dot before the count when any instance in that family is failing, and, on the Credentials tab, a spinner with the count tinted blue while any credential is still verifying. Both indicator states carry screen-reader text, and an empty family shows no meta at all. The verifying tint uses blue-700 rather than the in-progress icon's blue-500 because the count is 12px text and must clear WCAG 1.4.3's 4.5:1 contrast on the white background.

Closes #809

## Test plan
- [x] A failing scheme shows a red dot on the Conformity Schemes tab while the Credentials tab is active
- [x] One failing instance among several passing ones is enough to show the dot
- [x] A warning-only instance shows no dot
- [x] The Credentials spinner appears while any instance is non-terminal and clears only when the last one settles
- [x] Removing a family's last instance clears its count and dot entirely
- [x] The dot and spinner reach assistive technology as "failing" / "verifying" in the tab name
- [x] Full playground suite and production build pass
