### PR TITLE
feat(services): pin did:web resolution to the validated address

### DIFF
--- a/documentation/docs/reference-implementation/api/dids.md
+++ b/documentation/docs/reference-implementation/api/dids.md
@@ -82,7 +82,7 @@ The [verify endpoint](#verify-a-did) runs the following checks in order. All che
 
 | Check | Description |
 |-------|-------------|
-| **Resolve** | Fetches the DID document from the URL the DID identifier resolves to (e.g., `https://example.com/.well-known/did.json` for `did:web:example.com`). Fails if the document cannot be retrieved or returns a non-success HTTP status. |
+| **Resolve** | Fetches the DID document from the URL the DID identifier resolves to (e.g., `https://example.com/.well-known/did.json` for `did:web:example.com`). Fails if the document cannot be retrieved or returns a non-success HTTP status. The fetch is bounded: the response body is capped at 1 MiB, the request is subject to a 10-second timeout, at most 3 redirects are followed, and every redirect hop must resolve to a publicly routable address. Exceeding a bound fails the check. |
 | **HTTPS** | Confirms the DID document was served over HTTPS. Checks the final URL after any redirects; if a redirect lands on an insecure connection, this check fails. |
 | **Structure** | Validates the retrieved DID document against the [DID Document](https://www.w3.org/TR/did-core/) schema. Fails if required fields are missing or malformed. |
 | **Identity match** | Confirms that the `id` field in the DID document matches the DID identifier. Fails if they differ (e.g., the document was served from the wrong location). |

--- a/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
+++ b/packages/reference-implementation/src/app/api/v1/dids/[id]/verify/route.ts
@@ -21,6 +21,11 @@ const logger = apiLogger.child({ route: '/api/v1/dids/[id]/verify' });
  *       Status changes only when verification runs to completion and returns a result; a pre-verification
  *       failure (the DEFAULT-type guard, or a DID whose format or method cannot be parsed) leaves the DID's
  *       current status unchanged.
+ *
+ *       Resolution of the DID document is bounded: the response body is capped at 1 MiB, the fetch is
+ *       subject to a 10-second timeout from connection onwards, at most 3 redirects are followed, and every hop must resolve to a
+ *       publicly routable address. A document that exceeds a bound fails the resolve check with a message
+ *       naming the limit.
  *     tags:
  *       - DIDs
  *     parameters:

--- a/packages/services/__tests__/mocks/resolvers.ts
+++ b/packages/services/__tests__/mocks/resolvers.ts
@@ -1,0 +1,51 @@
+/**
+ * Test stub for `@uncefact/untp-utils/resolvers`.
+ *
+ * Wired up via `moduleNameMapper` in `jest.config.js` because the real
+ * package ships as ESM-only, which this package's Jest CJS resolver cannot
+ * load, and because the resolver performs DNS resolution and pinned network
+ * connections that unit tests must never reach. Production code still
+ * imports and uses the real package; only tests see this stub.
+ *
+ * The error classes mirror the real hierarchy's shape (`ResolverError` base,
+ * `ResolverHttpError` with `status`) so production `instanceof` checks work
+ * against errors constructed in tests. The fetch functions throw: a suite
+ * that exercises resolution must `jest.mock('@uncefact/untp-utils/resolvers', ...)`
+ * with its own behaviour (see verify-did-web.test.ts); a suite that merely
+ * imports a module which transitively reaches the resolver never calls them.
+ */
+
+export class ResolverError extends Error {}
+
+export class ResolverHttpError extends ResolverError {
+  readonly status: number;
+  readonly url: string;
+  constructor(url: string, status: number) {
+    super(`${url} returned status ${status}.`);
+    this.status = status;
+    this.url = url;
+  }
+}
+
+export class ResolverNetworkError extends ResolverError {}
+export class ResolverTooLargeError extends ResolverError {}
+export class ResolverTooManyRedirectsError extends ResolverError {}
+export class ResolverTimedOutError extends ResolverError {}
+export class ResolverRedirectMissingLocationError extends ResolverError {}
+export class ResolverInvalidJsonError extends ResolverError {
+  readonly url: string;
+  constructor(url: string, cause?: unknown) {
+    super(`Response body for ${url} is not valid JSON.`, cause !== undefined ? { cause } : undefined);
+    this.url = url;
+  }
+}
+
+function notMocked(): never {
+  throw new Error(
+    '@uncefact/untp-utils/resolvers is stubbed in tests; jest.mock the module with per-test behaviour to exercise resolution',
+  );
+}
+
+export const resolveDocument = notMocked;
+export const resolveJsonDocument = notMocked;
+export const resolveDocumentIfChanged = notMocked;

--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -23,7 +23,9 @@ const jestConfig = {
     // the SSRF guard run for real in verify-did-web's tests); ts-jest
     // transforms it like this package's own sources.
     '^@uncefact/untp-utils/node$': '<rootDir>/../untp-utils/src/node/index.ts',
-    '^@uncefact/untp-utils/resolvers$': '<rootDir>/../untp-utils/build/resolvers/index.js',
+    // Mapped to a CJS stub (not the ESM build) so suites that transitively
+    // import the resolver can load; see the stub's header for the contract.
+    '^@uncefact/untp-utils/resolvers$': '<rootDir>/__tests__/mocks/resolvers.ts',
     '^@uncefact/untp-utils/validation$': '<rootDir>/../untp-utils/build/validation/index.js',
     '^@uncefact/untp-utils/conformity-vocabulary$': '<rootDir>/../untp-utils/build/conformity-vocabulary/index.js',
     '^@uncefact/untp-utils$': '<rootDir>/../untp-utils/build/index.js',

--- a/packages/services/src/did-manager/common/verify-did-web.test.ts
+++ b/packages/services/src/did-manager/common/verify-did-web.test.ts
@@ -9,29 +9,56 @@ jest.mock('@uncefact/untp-utils/node', () => ({
   validatePublicUrl: (...args: unknown[]) => mockValidatePublicUrl(...args),
 }));
 
+// The pinned transport is mocked wholesale: its own guard, pinning, redirect
+// and size behaviour is covered by @uncefact/untp-utils' resolver suite, and
+// its ESM build cannot be loaded by this package's CJS test runner. The
+// factory's error classes stand in for the real hierarchy; production code
+// resolves the same mocked module, so instanceof checks line up.
+const mockResolveJsonDocument = jest.fn();
+jest.mock('@uncefact/untp-utils/resolvers', () => {
+  class ResolverError extends Error {}
+  class ResolverHttpError extends ResolverError {
+    readonly status: number;
+    readonly url: string;
+    constructor(url: string, status: number) {
+      super(`${url} returned status ${status}.`);
+      this.status = status;
+      this.url = url;
+    }
+  }
+  class ResolverInvalidJsonError extends ResolverError {
+    readonly url: string;
+    constructor(url: string) {
+      super(`Response body for ${url} is not valid JSON.`);
+      this.url = url;
+    }
+  }
+  return {
+    ResolverError,
+    ResolverHttpError,
+    ResolverInvalidJsonError,
+    resolveJsonDocument: (...args: unknown[]) => mockResolveJsonDocument(...args),
+  };
+});
+
 import { verifyDidWeb } from './verify-did-web';
 import { DidVerificationCheckName } from '../types';
+
+const { ResolverError, ResolverHttpError, ResolverInvalidJsonError } = jest.requireMock(
+  '@uncefact/untp-utils/resolvers',
+);
+
+const C = DidVerificationCheckName;
 
 function useRealGuardOnce(): void {
   mockValidatePublicUrl.mockImplementationOnce((url: string) => actualNode.validatePublicUrl(url));
 }
 
-const C = DidVerificationCheckName;
-
-function createMockResponse(
-  data: unknown,
-  ok = true,
-  status = 200,
-  responseUrl = 'https://example.com/.well-known/did.json',
-): Response {
-  return {
-    ok,
-    status,
-    statusText: ok ? 'OK' : 'Error',
-    url: responseUrl,
-    json: jest.fn().mockResolvedValue(data),
-    text: jest.fn().mockResolvedValue(JSON.stringify(data)),
-  } as unknown as Response;
+function resolvedDoc(
+  json: unknown,
+  finalUrl = 'https://example.com/org/abc/did.json',
+): { json: unknown; finalUrl: string } {
+  return { json, finalUrl };
 }
 
 const validDidDocument = {
@@ -75,27 +102,24 @@ const validDidDocument = {
 
 describe('verifyDidWeb', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    mockResolveJsonDocument.mockReset();
     mockValidatePublicUrl.mockReset();
     mockValidatePublicUrl.mockResolvedValue({ address: '203.0.113.10', family: 4 });
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('resolves a valid did:web document', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(validDidDocument));
+  it('resolves a valid did:web document over the pinned transport', async () => {
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument));
 
     const result = await verifyDidWeb('did:web:example.com:org:abc');
 
     expect(result.document).toEqual(validDidDocument);
     const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
     expect(resolveCheck?.passed).toBe(true);
+    expect(mockResolveJsonDocument).toHaveBeenCalledWith('https://example.com/org/abc/did.json');
   });
 
   it('returns RESOLVE failure for HTTP error', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(null, false, 404));
+    mockResolveJsonDocument.mockRejectedValueOnce(new ResolverHttpError('https://example.com/org/abc/did.json', 404));
 
     const result = await verifyDidWeb('did:web:example.com:org:abc');
 
@@ -103,10 +127,74 @@ describe('verifyDidWeb', () => {
     const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
     expect(resolveCheck?.passed).toBe(false);
     expect(resolveCheck?.message).toContain('HTTP 404');
+    // The error carries the final URL, so the HTTPS verdict is still stated.
+    const httpsCheck = result.checks.find((c) => c.name === C.HTTPS);
+    expect(httpsCheck?.passed).toBe(true);
+    expect(httpsCheck?.message).toBeUndefined();
+  });
+
+  it('fails the HTTPS check when an HTTP error arrives over an insecure final URL', async () => {
+    mockResolveJsonDocument.mockRejectedValueOnce(new ResolverHttpError('http://example.com/org/abc/did.json', 404));
+
+    const result = await verifyDidWeb('did:web:example.com:org:abc');
+
+    const httpsCheck = result.checks.find((c) => c.name === C.HTTPS);
+    expect(httpsCheck?.passed).toBe(false);
+    expect(httpsCheck?.message).toContain('insecure connection');
+  });
+
+  it('reports invalid JSON as a resolution failure while still judging HTTPS on the final URL', async () => {
+    mockResolveJsonDocument.mockRejectedValueOnce(new ResolverInvalidJsonError('https://example.com/org/abc/did.json'));
+
+    const result = await verifyDidWeb('did:web:example.com:org:abc');
+
+    expect(result.document).toBeNull();
+    const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
+    expect(resolveCheck?.passed).toBe(false);
+    expect(resolveCheck?.message).toContain('not valid JSON');
+    const httpsCheck = result.checks.find((c) => c.name === C.HTTPS);
+    expect(httpsCheck?.passed).toBe(true);
+  });
+
+  it('maps a redirect-hop private rejection to the same not-permitted outcome as the pre-fetch guard', async () => {
+    mockResolveJsonDocument.mockRejectedValueOnce(
+      new actualNode.PrivateAddressError('internal.example.com', ['10.0.0.5']),
+    );
+
+    const result = await verifyDidWeb('did:web:example.com:org:abc');
+
+    const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
+    expect(resolveCheck?.passed).toBe(false);
+    expect(resolveCheck?.message).toBe('Private or localhost URLs are not permitted for DID resolution');
+    const httpsCheck = result.checks.find((c) => c.name === C.HTTPS);
+    expect(httpsCheck?.passed).toBe(false);
+    expect(httpsCheck?.message).toBe('Could not verify HTTPS (resolution failed)');
+  });
+
+  it('maps a redirect-hop private-hostname rejection to the same not-permitted outcome', async () => {
+    mockResolveJsonDocument.mockRejectedValueOnce(new actualNode.PrivateHostnameError('intranet.internal'));
+
+    const result = await verifyDidWeb('did:web:example.com:org:abc');
+
+    const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
+    expect(resolveCheck?.passed).toBe(false);
+    expect(resolveCheck?.message).toBe('Private or localhost URLs are not permitted for DID resolution');
+  });
+
+  it('maps a non-private redirect-hop guard rejection to a resolution failure', async () => {
+    mockResolveJsonDocument.mockRejectedValueOnce(
+      new actualNode.ResolutionFailedError('gone.example.com', new Error('ENOTFOUND')),
+    );
+
+    const result = await verifyDidWeb('did:web:example.com:org:abc');
+
+    const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
+    expect(resolveCheck?.passed).toBe(false);
+    expect(resolveCheck?.message).toContain('Resolution failed');
   });
 
   it('returns RESOLVE failure for network error', async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+    mockResolveJsonDocument.mockRejectedValueOnce(new ResolverError('Network error'));
 
     const result = await verifyDidWeb('did:web:example.com:org:abc');
 
@@ -117,8 +205,8 @@ describe('verifyDidWeb', () => {
   });
 
   it('passes HTTPS check when final response URL is HTTPS', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      createMockResponse(validDidDocument, true, 200, 'https://example.com/org/abc/did.json'),
+    mockResolveJsonDocument.mockResolvedValueOnce(
+      resolvedDoc(validDidDocument, 'https://example.com/org/abc/did.json'),
     );
 
     const result = await verifyDidWeb('did:web:example.com:org:abc');
@@ -129,9 +217,7 @@ describe('verifyDidWeb', () => {
   });
 
   it('fails HTTPS check when response was downgraded to HTTP', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      createMockResponse(validDidDocument, true, 200, 'http://example.com/org/abc/did.json'),
-    );
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument, 'http://example.com/org/abc/did.json'));
 
     const result = await verifyDidWeb('did:web:example.com:org:abc');
 
@@ -141,7 +227,7 @@ describe('verifyDidWeb', () => {
   });
 
   it('fails HTTPS check when resolution fails (no response to verify)', async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+    mockResolveJsonDocument.mockRejectedValueOnce(new ResolverError('fail'));
 
     const result = await verifyDidWeb('did:web:example.com:org:abc');
 
@@ -151,7 +237,7 @@ describe('verifyDidWeb', () => {
   });
 
   it('returns exactly two checks (RESOLVE and HTTPS)', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(validDidDocument));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument));
 
     const result = await verifyDidWeb('did:web:example.com:org:abc');
 
@@ -167,7 +253,7 @@ describe('verifyDidWeb', () => {
       const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
       expect(resolveCheck?.passed).toBe(false);
       expect(resolveCheck?.message).toContain('not permitted');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
 
     it('blocks 127.x.x.x URLs', async () => {
@@ -176,7 +262,7 @@ describe('verifyDidWeb', () => {
       const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
       expect(resolveCheck?.passed).toBe(false);
       expect(resolveCheck?.message).toContain('not permitted');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
 
     it('blocks 10.x.x.x URLs', async () => {
@@ -185,7 +271,7 @@ describe('verifyDidWeb', () => {
       const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
       expect(resolveCheck?.passed).toBe(false);
       expect(resolveCheck?.message).toContain('not permitted');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
 
     it('blocks 192.168.x.x URLs', async () => {
@@ -194,7 +280,7 @@ describe('verifyDidWeb', () => {
       const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
       expect(resolveCheck?.passed).toBe(false);
       expect(resolveCheck?.message).toContain('not permitted');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
 
     it('blocks the cloud metadata literal (missed by the previous in-package guard)', async () => {
@@ -203,7 +289,7 @@ describe('verifyDidWeb', () => {
       const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
       expect(resolveCheck?.passed).toBe(false);
       expect(resolveCheck?.message).toContain('not permitted');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
 
     it('blocks an IPv6 unique-local literal (missed by the previous in-package guard)', async () => {
@@ -212,7 +298,7 @@ describe('verifyDidWeb', () => {
       const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
       expect(resolveCheck?.passed).toBe(false);
       expect(resolveCheck?.message).toContain('not permitted');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
 
     it('maps a private-hostname rejection to the not-permitted message', async () => {
@@ -221,14 +307,20 @@ describe('verifyDidWeb', () => {
       const resolveCheck = result.checks.find((c) => c.name === C.RESOLVE);
       expect(resolveCheck?.passed).toBe(false);
       expect(resolveCheck?.message).toContain('not permitted');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
 
     it('rethrows errors outside the guard hierarchy instead of reporting a failed check', async () => {
       const bug = new TypeError('validatePublicUrl exploded');
       mockValidatePublicUrl.mockRejectedValueOnce(bug);
       await expect(verifyDidWeb('did:web:example.com')).rejects.toBe(bug);
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
+    });
+
+    it('rethrows transport errors outside the resolver hierarchy instead of reporting a failed check', async () => {
+      const bug = new TypeError('resolveJsonDocument exploded');
+      mockResolveJsonDocument.mockRejectedValueOnce(bug);
+      await expect(verifyDidWeb('did:web:example.com')).rejects.toBe(bug);
     });
 
     it('surfaces a non-private guard failure with the structured error message', async () => {
@@ -242,7 +334,7 @@ describe('verifyDidWeb', () => {
       const httpsCheck = result.checks.find((c) => c.name === C.HTTPS);
       expect(httpsCheck?.passed).toBe(false);
       expect(httpsCheck?.message).toBe('Could not verify HTTPS (resolution blocked)');
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockResolveJsonDocument).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/services/src/did-manager/common/verify-did-web.ts
+++ b/packages/services/src/did-manager/common/verify-did-web.ts
@@ -4,7 +4,12 @@ import {
   UrlValidationError,
   validatePublicUrl,
 } from '@uncefact/untp-utils/node';
-import { httpFetch } from '../../http/client.js';
+import {
+  resolveJsonDocument,
+  ResolverError,
+  ResolverHttpError,
+  ResolverInvalidJsonError,
+} from '@uncefact/untp-utils/resolvers';
 import type { DidDocument, DidVerificationCheck, MethodVerificationResult } from '../types.js';
 import { DidVerificationCheckName } from '../types.js';
 import { didWebToUrl } from './utils.js';
@@ -20,10 +25,22 @@ const C = DidVerificationCheckName;
  *
  * The resolution URL is validated with the canonical SSRF guard before any
  * request is made; see `validatePublicUrl` in `@uncefact/untp-utils/node`
- * for the rejection classes. The subsequent fetch connects via the hostname
- * rather than the validated IP: a pinned-fetch path that closes the DNS
- * rebinding window already exists in `@uncefact/untp-utils/resolvers`, and
- * this call site does not yet use it.
+ * for the rejection classes. The fetch itself goes through
+ * `resolveJsonDocument` from `@uncefact/untp-utils/resolvers`, which
+ * validates every redirect hop independently and pins each hop's connection
+ * to the IP its validation resolved, closing the DNS rebinding window
+ * between check and connect across the whole chain. The resolver's defaults
+ * bound the resolution (1 MiB body, a 10 s timeout governing the fetch from connect onwards, 3 redirects), and
+ * on the wire it sends `Accept: application/json` and a `User-Agent`
+ * (default or the RI_HTTP_USER_AGENT override); it adds no
+ * request-correlation header, so internal request identifiers stay within
+ * the operator's services when contacting the DID's own domain (#654).
+ *
+ * An HTTP-error response and an unparseable body still receive an HTTPS
+ * verdict on the final URL, which those two error classes carry; every
+ * other failure (network, timeout, size, redirect caps, including one that
+ * strikes mid-body after a response arrived) reports that HTTPS could not
+ * be verified, because those error classes carry no final URL to judge.
  *
  * @see https://w3c-ccg.github.io/did-method-web/
  * @see https://www.w3.org/TR/did-1.0/
@@ -34,6 +51,9 @@ export async function verifyDidWeb(did: string): Promise<MethodVerificationResul
 
   const url = didWebToUrl(did);
 
+  // The pre-fetch guard is what turns a private target into the explicit
+  // "not permitted" verification outcome below; resolveJsonDocument would
+  // also reject it, but as a generic resolution failure.
   try {
     await validatePublicUrl(url);
   } catch (error) {
@@ -50,28 +70,43 @@ export async function verifyDidWeb(did: string): Promise<MethodVerificationResul
     return { document, checks };
   }
 
-  // Check 1: Resolve — fetch the DID document
-  let response: Response | null = null;
+  // Check 1: Resolve — fetch the DID document over the pinned transport.
+  let finalUrl: string | null = null;
   try {
-    // Third-party host (the DID's own domain): no correlation header, so
-    // internal request identifiers stay within the operator's services (#654).
-    response = await httpFetch(url, { correlate: false });
-
-    if (!response.ok) {
-      checks.push({ name: C.RESOLVE, passed: false, message: `HTTP ${response.status} from ${url}` });
-    } else {
-      document = await response.json();
-      checks.push({ name: C.RESOLVE, passed: true });
-    }
+    const result = await resolveJsonDocument(url);
+    finalUrl = result.finalUrl;
+    document = result.json as DidDocument;
+    checks.push({ name: C.RESOLVE, passed: true });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    checks.push({ name: C.RESOLVE, passed: false, message: `Resolution failed: ${message}` });
+    if (error instanceof ResolverHttpError) {
+      checks.push({ name: C.RESOLVE, passed: false, message: `HTTP ${error.status} from ${url}` });
+      finalUrl = error.url;
+    } else if (error instanceof ResolverInvalidJsonError) {
+      checks.push({ name: C.RESOLVE, passed: false, message: `Resolution failed: ${error.message}` });
+      finalUrl = error.url;
+    } else if (error instanceof PrivateHostnameError || error instanceof PrivateAddressError) {
+      // A redirect hop resolved to a private target: the same SSRF outcome
+      // as the pre-fetch guard, worded the same way.
+      checks.push({
+        name: C.RESOLVE,
+        passed: false,
+        message: 'Private or localhost URLs are not permitted for DID resolution',
+      });
+    } else if (error instanceof ResolverError || error instanceof UrlValidationError) {
+      // ResolverError covers network, timeout, size and redirect-cap
+      // failures; UrlValidationError here means a redirect hop was rejected
+      // by the guard for a non-private reason. All are properties of the
+      // resolved DID, not of this system, so they are verification
+      // outcomes. Anything else is a programming error and rethrows.
+      checks.push({ name: C.RESOLVE, passed: false, message: `Resolution failed: ${error.message}` });
+    } else {
+      throw error;
+    }
   }
 
   // Check 2: HTTPS — did:web requires HTTPS by spec.
   // Verify the final response URL (after any redirects) is still HTTPS.
-  if (response) {
-    const finalUrl = response.url || url;
+  if (finalUrl) {
     const isHttps = finalUrl.startsWith('https://');
     checks.push({
       name: C.HTTPS,

--- a/packages/services/src/did-manager/common/verify.test.ts
+++ b/packages/services/src/did-manager/common/verify.test.ts
@@ -7,26 +7,49 @@ jest.mock('@uncefact/untp-utils/node', () => ({
   validatePublicUrl: jest.fn().mockResolvedValue({ address: '203.0.113.10', family: 4 }),
 }));
 
+// The pinned transport is mocked for the same reason (and because its ESM
+// build cannot load under this package's CJS test runner); transport-level
+// behaviour is covered by verify-did-web.test.ts and the resolver suite.
+const mockResolveJsonDocument = jest.fn();
+jest.mock('@uncefact/untp-utils/resolvers', () => {
+  class ResolverError extends Error {}
+  class ResolverHttpError extends ResolverError {
+    readonly status: number;
+    readonly url: string;
+    constructor(url: string, status: number) {
+      super(`${url} returned status ${status}.`);
+      this.status = status;
+      this.url = url;
+    }
+  }
+  class ResolverInvalidJsonError extends ResolverError {
+    readonly url: string;
+    constructor(url: string) {
+      super(`Response body for ${url} is not valid JSON.`);
+      this.url = url;
+    }
+  }
+  return {
+    ResolverError,
+    ResolverHttpError,
+    ResolverInvalidJsonError,
+    resolveJsonDocument: (...args: unknown[]) => mockResolveJsonDocument(...args),
+  };
+});
+
+const { ResolverError: MockResolverError } = jest.requireMock('@uncefact/untp-utils/resolvers');
+
 import { verifyDid } from './verify';
 import { DidVerificationCheckName } from '../types';
 import { DidInputError, DidMethodNotSupportedError } from '../errors';
 
 // -- Helpers -----------------------------------------------------------------
 
-function createMockResponse(
-  data: unknown,
-  ok = true,
-  status = 200,
-  responseUrl = 'https://example.com/.well-known/did.json',
-): Response {
-  return {
-    ok,
-    status,
-    statusText: ok ? 'OK' : 'Error',
-    url: responseUrl,
-    json: jest.fn().mockResolvedValue(data),
-    text: jest.fn().mockResolvedValue(JSON.stringify(data)),
-  } as unknown as Response;
+function resolvedDoc(
+  json: unknown,
+  finalUrl = 'https://example.com/org/abc/did.json',
+): { json: unknown; finalUrl: string } {
+  return { json, finalUrl };
 }
 
 const C = DidVerificationCheckName;
@@ -74,15 +97,11 @@ const validDidDocument = {
 
 describe('verifyDid', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
+    mockResolveJsonDocument.mockReset();
   });
 
   it('returns verified=true for a valid DID document (all checks pass)', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(validDidDocument));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument));
 
     const result = await verifyDid('did:web:example.com:org:abc', {
       providerKeys: [{ kid: 'abc123def456' }],
@@ -95,7 +114,7 @@ describe('verifyDid', () => {
 
   it('returns structure failure when document is missing required fields', async () => {
     const badDoc = { id: 'did:web:example.com:org:abc' }; // missing @context
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(badDoc));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(badDoc));
 
     const result = await verifyDid('did:web:example.com:org:abc', { providerKeys: [] });
 
@@ -107,7 +126,7 @@ describe('verifyDid', () => {
 
   it('returns identity_match failure for id mismatch', async () => {
     const mismatchDoc = { ...validDidDocument, id: 'did:web:other.com' };
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(mismatchDoc));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(mismatchDoc));
 
     const result = await verifyDid('did:web:example.com:org:abc', { providerKeys: [] });
 
@@ -118,7 +137,7 @@ describe('verifyDid', () => {
   });
 
   it('skips jsonld_validity check (expansion disabled)', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(validDidDocument));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument));
 
     const result = await verifyDid('did:web:example.com:org:abc', { providerKeys: [] });
 
@@ -128,7 +147,7 @@ describe('verifyDid', () => {
   });
 
   it('handles resolution failure gracefully', async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+    mockResolveJsonDocument.mockRejectedValueOnce(new MockResolverError('Network error'));
 
     const result = await verifyDid('did:web:example.com:org:abc', { providerKeys: [] });
 
@@ -143,7 +162,7 @@ describe('verifyDid', () => {
   });
 
   it('fails HTTPS check when resolution fails (no response to inspect)', async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+    mockResolveJsonDocument.mockRejectedValueOnce(new MockResolverError('Network error'));
 
     const result = await verifyDid('did:web:example.com:org:abc', { providerKeys: [] });
 
@@ -153,7 +172,7 @@ describe('verifyDid', () => {
   });
 
   it('passes key_material check with message when providerKeys is empty', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(validDidDocument));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument));
 
     const result = await verifyDid('did:web:example.com:org:abc', {
       providerKeys: [],
@@ -166,7 +185,7 @@ describe('verifyDid', () => {
   });
 
   it('runs key_material check when providerKeys provided and keys match', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(validDidDocument));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument));
 
     const result = await verifyDid('did:web:example.com:org:abc', {
       providerKeys: [{ kid: 'abc123def456' }],
@@ -178,7 +197,7 @@ describe('verifyDid', () => {
   });
 
   it('returns key_material failure when keys do not match', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(createMockResponse(validDidDocument));
+    mockResolveJsonDocument.mockResolvedValueOnce(resolvedDoc(validDidDocument));
 
     const result = await verifyDid('did:web:example.com:org:abc', {
       providerKeys: [{ kid: 'non-existent-key' }],

--- a/packages/untp-utils/src/resolvers/errors.ts
+++ b/packages/untp-utils/src/resolvers/errors.ts
@@ -22,9 +22,14 @@ export class ResolverNetworkError extends ResolverError {
   }
 }
 
-/** The remote returned a non-success HTTP status. */
+/**
+ * The remote returned a non-success HTTP status. `url` is the URL of the hop
+ * that produced the status (the end of the redirect chain), exposed so
+ * callers can still report on the final URL of a failed resolution.
+ */
 export class ResolverHttpError extends ResolverError {
   readonly status: number;
+  readonly url: string;
   constructor(url: string, status: number) {
     super({
       code: 'resolver.http-error',
@@ -33,6 +38,7 @@ export class ResolverHttpError extends ResolverError {
       expected: '2xx',
     });
     this.status = status;
+    this.url = url;
   }
 }
 
@@ -91,8 +97,13 @@ export class ResolverRedirectMissingLocationError extends ResolverError {
   }
 }
 
-/** The response body was fetched but could not be parsed as JSON. */
+/**
+ * The response body was fetched but could not be parsed as JSON. `url` is
+ * the final URL the body was fetched from (after redirect chasing), exposed
+ * so callers can still report on the final URL of a failed resolution.
+ */
 export class ResolverInvalidJsonError extends ResolverError {
+  readonly url: string;
   constructor(url: string, cause: unknown) {
     super({
       code: 'resolver.invalid-json',
@@ -101,5 +112,6 @@ export class ResolverInvalidJsonError extends ResolverError {
       expected: 'a JSON document',
       cause,
     });
+    this.url = url;
   }
 }

--- a/packages/untp-utils/src/resolvers/resolve-document.test.ts
+++ b/packages/untp-utils/src/resolvers/resolve-document.test.ts
@@ -12,10 +12,18 @@ import {
 
 const undiciFetch = jest.fn();
 let lastAgentClose: jest.Mock = jest.fn(() => Promise.resolve());
+// Constructor options of every Agent created during a test, in creation
+// order. The `connect.lookup` inside is the IP pin under test.
+let agentOptions: unknown[] = [];
+// The FakeAgent instances themselves, so tests can assert the dispatcher
+// passed to fetch IS the pinned agent, not merely that a pinned agent exists.
+let agentInstances: FakeAgent[] = [];
 
 class FakeAgent {
   close: jest.Mock;
-  constructor() {
+  constructor(options?: unknown) {
+    agentOptions.push(options);
+    agentInstances.push(this);
     this.close = jest.fn(() => Promise.resolve());
     lastAgentClose = this.close;
   }
@@ -69,6 +77,8 @@ function resolvedAddress(address = '1.1.1.1', family: 4 | 6 = 4) {
 
 describe('resolveDocument', () => {
   beforeEach(() => {
+    agentOptions = [];
+    agentInstances = [];
     undiciFetch.mockReset();
     validatePublicUrl.mockReset();
   });
@@ -114,6 +124,20 @@ describe('resolveDocument', () => {
     });
   });
 
+  describe('outbound headers', () => {
+    it('sends only Accept-free defaults with a User-Agent and no correlation header', async () => {
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch.mockResolvedValue(makeResponse({ body: 'ok' }) as never);
+
+      await resolveDocument('https://example.com/doc');
+
+      const headers = (undiciFetch.mock.calls[0][1] as { headers: Record<string, string> }).headers;
+      const names = Object.keys(headers).map((name) => name.toLowerCase());
+      expect(names).toContain('user-agent');
+      expect(names).not.toContain('x-correlation-id');
+    });
+  });
+
   describe('HTTP errors', () => {
     it('throws ResolverHttpError for a 4xx response with status attached', async () => {
       validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
@@ -124,6 +148,20 @@ describe('resolveDocument', () => {
       )) as ResolverHttpError;
       expect(error).toBeInstanceOf(ResolverHttpError);
       expect(error.status).toBe(404);
+      expect(error.url).toBe('https://example.com/missing');
+    });
+
+    it('carries the failing hop URL, not the original, when a redirect ends in an HTTP error', async () => {
+      validatePublicUrl.mockResolvedValue(resolvedAddress() as never);
+      undiciFetch
+        .mockResolvedValueOnce(
+          makeResponse({ status: 301, headers: { location: 'https://example.com/moved' }, body: null }) as never,
+        )
+        .mockResolvedValueOnce(makeResponse({ status: 404, ok: false, body: 'gone' }) as never);
+
+      const error = (await resolveDocument('https://example.com/start').catch((e: unknown) => e)) as ResolverHttpError;
+      expect(error).toBeInstanceOf(ResolverHttpError);
+      expect(error.url).toBe('https://example.com/moved');
     });
 
     it('throws ResolverHttpError for a 5xx response', async () => {
@@ -200,6 +238,43 @@ describe('resolveDocument', () => {
       expect(result.finalUrl).toBe('https://example.com/next');
       expect(new TextDecoder().decode(result.body)).toBe('final');
       expect(undiciFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('pins each hop connection to the address validatePublicUrl resolved', async () => {
+      validatePublicUrl
+        .mockResolvedValueOnce({ address: '203.0.113.10', family: 4 } as never)
+        .mockResolvedValueOnce({ address: '2606:4700:4700::1111', family: 6 } as never);
+      undiciFetch
+        .mockResolvedValueOnce(
+          makeResponse({ status: 301, headers: { location: 'https://example.com/next' }, body: null }) as never,
+        )
+        .mockResolvedValueOnce(makeResponse({ body: 'final' }) as never);
+
+      await resolveDocument('https://example.com/start');
+
+      expect(agentOptions).toHaveLength(2);
+      // Each hop's request must be dispatched through the agent that holds
+      // that hop's pin; constructing a pinned agent and fetching without it
+      // would satisfy the lookup assertions alone.
+      expect(undiciFetch.mock.calls[0][1]).toMatchObject({ dispatcher: agentInstances[0] });
+      expect(undiciFetch.mock.calls[1][1]).toMatchObject({ dispatcher: agentInstances[1] });
+      const pins = await Promise.all(
+        agentOptions.map(
+          (options) =>
+            new Promise((resolve, reject) => {
+              const lookup = (
+                options as {
+                  connect: { lookup: (host: string, opts: object, cb: (err: unknown, addrs: unknown) => void) => void };
+                }
+              ).connect.lookup;
+              lookup('example.com', {}, (err: unknown, addresses: unknown) => (err ? reject(err) : resolve(addresses)));
+            }),
+        ),
+      );
+      // Each hop's lookup must return exactly the address its own
+      // validatePublicUrl call resolved, never a fresh DNS answer.
+      expect(pins[0]).toEqual([{ address: '203.0.113.10', family: 4 }]);
+      expect(pins[1]).toEqual([{ address: '2606:4700:4700::1111', family: 6 }]);
     });
 
     it('re-validates each redirect target through validatePublicUrl', async () => {

--- a/packages/untp-utils/src/resolvers/resolve-json-document.test.ts
+++ b/packages/untp-utils/src/resolvers/resolve-json-document.test.ts
@@ -89,7 +89,11 @@ describe('resolveJsonDocument', () => {
   it('throws ResolverInvalidJsonError when the body is not valid JSON', async () => {
     resolveDocument.mockResolvedValue({ body: encode('not json'), finalUrl: 'https://ex.test/doc' } as never);
 
-    await expect(resolveJsonDocument('https://ex.test/doc')).rejects.toBeInstanceOf(ResolverInvalidJsonError);
+    const error = (await resolveJsonDocument('https://ex.test/doc').catch(
+      (e: unknown) => e,
+    )) as ResolverInvalidJsonError;
+    expect(error).toBeInstanceOf(ResolverInvalidJsonError);
+    expect(error.url).toBe('https://ex.test/doc');
   });
 
   it('propagates resolveDocument errors (SSRF guard, HTTP, timeout) unchanged', async () => {


### PR DESCRIPTION
This PR routes did:web resolution through the pinned-IP resolver from `@uncefact/untp-utils/resolvers`, so the DID document is fetched from the exact address the SSRF guard validated, closing the DNS rebinding window between check and connect.

`verifyDidWeb` keeps its explicit pre-fetch guard (so a private target still fails with the "not permitted" message) and swaps the transport from the package's plain `httpFetch` to `resolveJsonDocument`, which re-validates every redirect hop and pins each hop's connection.
`ResolverHttpError` and `ResolverInvalidJsonError` gain a `url` field carrying the failing hop, so the HTTPS verification check still receives a verdict on the final URL for those two failure classes.
Redirect-hop private rejections now produce the same "not permitted" message as the pre-fetch guard.
The pinning itself is now asserted where it lives: the resolver suite captures each undici agent, checks its `connect.lookup` returns exactly the address that hop's validation resolved, and checks each fetch dispatches through that very agent.

Behaviour changes visible through the verify endpoint, now stated in its OpenAPI description and the DIDs docs page: resolution is bounded (1 MiB body, a 10-second timeout from connection onwards, 3 redirects, every hop must resolve publicly), the request carries `Accept: application/json` and the resolver's User-Agent, an unparseable DID document reports the resolver's "not valid JSON" message instead of raw parser text, and a failure that strikes mid-body after a response arrived reports that HTTPS could not be verified rather than judging the final URL.

Closes #968

## Test plan

- [x] Each hop's connection target is the address its own validation resolved, and each request dispatches through the agent holding that pin
- [x] Outbound requests carry a User-Agent and no correlation header
- [x] HTTP errors and invalid JSON keep their HTTPS verdict on the final URL (including a redirect chain ending in an error); other failures report HTTPS could not be verified
- [x] Redirect-hop private rejections match the pre-fetch guard's message; non-private hop rejections report a resolution failure
- [x] Errors outside the resolver and guard hierarchies propagate instead of reading as failed checks
- [x] Full suites pass: untp-utils 495, services 1390, reference implementation 2781; no test reaches live DNS or a real network
